### PR TITLE
Adds CORS headers to orchestration layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,21 @@ FireCloud Orchestration Service
 Run the assembly task to build a fat jar:
 ```
 sbt
-assembly
+> assembly
 ```
 
 Execute the jar with the path to the jar and path of the desired config file:
 
 ```
-java -Dconfig.file=src/main/resources/application.conf -jar target/scala-2.11/FireCloud-Orchestration-assembly-0.1-9-SNAPSHOT.jar
+java -Dconfig.file=src/main/resources/application.conf \
+  -jar $(ls target/scala-2.11/FireCloud-Orchestration-assembly-* | tail -n 1)
+```
+
+For incremental builds, compile and run from sbt:
+```
+sbt
+> compile
+> reStart
 ```
 
 ## Testing

--- a/build.sbt
+++ b/build.sbt
@@ -92,3 +92,6 @@ testOptions in Test += Tests.Setup(classLoader =>
     .getMethod("getLogger", classLoader.loadClass("java.lang.String"))
     .invoke(null, "ROOT")
 )
+
+// Uncomment to build without running tests.
+// test in assembly := {}

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/MethodsClient.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/MethodsClient.scala
@@ -5,8 +5,9 @@ import akka.event.Logging
 import org.broadinstitute.dsde.firecloud.MethodsClient.MethodsListRequest
 import org.broadinstitute.dsde.firecloud.model.MethodEntity
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
+import scala.reflect.classTag
 import spray.client.pipelining._
-import spray.http.HttpHeaders.Cookie
+import spray.http.HttpHeaders.{Cookie, Origin, RawHeader}
 import spray.http.StatusCodes._
 import spray.http.{HttpRequest, HttpResponse, RequestProcessingException, StatusCodes}
 import spray.httpx.SprayJsonSupport._
@@ -44,23 +45,41 @@ class MethodsClient(requestContext: RequestContext) extends Actor {
 
     val responseFuture: Future[HttpResponse] = pipeline { Get(FireCloudConfig.Methods.methodsListUrl) }
 
+    def isWhitelisted(origin: Origin): Boolean = {
+      // TODO(dmohs): Check this against a whitelist.
+      true
+    }
+
+    def addCorsHeaders(requestContext: RequestContext): RequestContext = {
+      requestContext.withHttpResponseHeadersMapped(h => {
+        val alwaysHeaders = RawHeader("Access-Control-Allow-Credentials", "true") :: RawHeader("Vary", "Origin") :: Nil
+        val origin = requestContext.request.header(classTag[Origin])
+        if (origin.isDefined && isWhitelisted(origin.get))
+          h ++: alwaysHeaders :+ RawHeader("Access-Control-Allow-Origin", origin.get.value)
+        else
+          h ++: alwaysHeaders
+      })
+    }
+
     responseFuture onComplete {
       case Success(response) =>
         response.status match {
           case OK =>
             log.debug("OK response")
-            requestContext.complete(unmarshal[List[MethodEntity]].apply(response))
+            addCorsHeaders(requestContext).complete(
+              unmarshal[List[MethodEntity]].apply(response))
             context.stop(self)
           case _ =>
             // Bubble up all other unmarshallable responses
             log.warning("Unanticipated response: " + response.status.defaultMessage)
-            requestContext.complete(response)
+            addCorsHeaders(requestContext).complete(response)
             context.stop(self)
         }
       case Failure(error) =>
         // Failure accessing service
         log.error(error, "Could not access the methods repository")
-        requestContext.failWith(new RequestProcessingException(StatusCodes.InternalServerError, error.getMessage))
+        addCorsHeaders(requestContext).failWith(
+          new RequestProcessingException(StatusCodes.InternalServerError, error.getMessage))
         context.stop(self)
     }
 


### PR DESCRIPTION
Task: https://broadinstitute.atlassian.net/browse/DSDEEPB-660

This is a provisional implementation to document the headers and help unblock local development. There is a follow-up task to refactor this into a correct implementation:
https://broadinstitute.atlassian.net/browse/DSDEEPB-667