### PR TITLE
Enforce java 8 in build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,7 @@ resolvers += "artifactory-releases" at artifactory + "libs-release"
 
 scalaVersion  := "2.11.6"
 
-scalacOptions := Seq("-unchecked", "-deprecation", "-encoding", "utf8")
+scalacOptions := Seq("-unchecked", "-deprecation", "-encoding", "utf8", "-target:jvm-1.8")
 
 libraryDependencies ++= {
   val akkaV = "2.3.9"


### PR DESCRIPTION
Note that this change will throw an error in Scala versions < 2.11.2.