### PR TITLE
Support multiple configurations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,11 @@ FireCloud Orchestration Service
 
 ## Development Notes
 * Configuration is excluded from the build package:
-    - When running via sbt, start sbt with the config file ```sbt -Dconfig.file=src/main/resources/application.conf``` and the run command will pick up your local configuration.
-    - Alternatively, add an ```.sbotopts``` file to the root directory of the project with the first line being ```-Dconfig.file=src/main/resources/application.conf``` or pointing to whichever config file you prefer to use.
+    - When running via sbt, start sbt with the config file `sbt -Dconfig.file=src/main/resources/application.conf` and the run command will pick up your local configuration.
+    - Alternatively, add an `.sbotopts` file to the root directory of the project with the first line being `-Dconfig.file=src/main/resources/application.conf` or pointing to whichever config file you prefer to use.
     - When running via sbt/revolver (i.e. using the re-start command), you can just run in sbt normally - the config is preset for you in build.sbt.
 * We push new features to a feature-branch and make pull requests against master.
+* New paths to external endpoints should be added to `src/main/resources/configurations.conf`. Existing endpoint URLs are configured in `application.conf` and `test.conf`
 
 ## Building and Running
 

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,45 +1,10 @@
-akka {
-  loglevel = "INFO"
-  loggers = ["akka.event.slf4j.Slf4jLogger"]
-}
-
-spray.can.server {
-  request-timeout = infinite
-}
-
-http {
-  interface="0.0.0.0"
-  port=8080
-  timeoutSeconds = 1
-}
-
-swagger {
-  apiDocs="api-docs"
-  apiVersion="0.1"
-  baseUrl=""
-  contact="silver@broadinstitute.org"
-  description="FireCloud Orchestration API services using spray and spray-swagger. Note that all operations require authentication, which can be provided via the OpenAM cookie: curl --cookie 'iPlanetDirectoryPro=AQIC5...' ..."
-  info="FireCloud Orchestration API"
-  license="BSD"
-  licenseUrl="http://opensource.org/licenses/BSD-3-Clause"
-  swaggerVersion="1.2"
-  termsOfServiceUrl="https://github.com/broadinstitute/firecloud-orchestration"
-}
 
 methods {
   baseUrl="https://agora-prod.broadinstitute.org"
-  methodsPath="/methods"
-  configurationsPath="/configurations"
 }
 
 workspace {
-  model="model.json"
   baseUrl="https://rawls-dev.broadinstitute.org"
-  workspacesPath="/workspaces"
-  entitiesPath="/workspaces/%s/%s/entities"
-  methodConfigsListPath="/workspaces/%s/%s/methodconfigs"
-  copyFromMethodRepoConfig="/methodconfigs/copyFromMethodRepo"
-  importEntitiesPath="/workspaces/%s/%s/importEntities"
 }
 
 openam {

--- a/src/main/resources/configurations.conf
+++ b/src/main/resources/configurations.conf
@@ -1,0 +1,41 @@
+akka {
+  loglevel = "INFO"
+  loggers = ["akka.event.slf4j.Slf4jLogger"]
+}
+
+spray.can.server {
+  request-timeout = infinite
+}
+
+http {
+  interface="0.0.0.0"
+  port=8080
+  timeoutSeconds = 1
+}
+
+swagger {
+  apiDocs="api-docs"
+  apiVersion="0.1"
+  baseUrl=""
+  contact="silver@broadinstitute.org"
+  description="FireCloud Orchestration API services using spray and spray-swagger. Note that all operations require authentication, which can be provided via the OpenAM cookie: curl --cookie 'iPlanetDirectoryPro=AQIC5...' ..."
+  info="FireCloud Orchestration API"
+  license="BSD"
+  licenseUrl="http://opensource.org/licenses/BSD-3-Clause"
+  swaggerVersion="1.2"
+  termsOfServiceUrl="https://github.com/broadinstitute/firecloud-orchestration"
+}
+
+methods {
+  methodsPath="/methods"
+  configurationsPath="/configurations"
+}
+
+workspace {
+  model="model.json"
+  workspacesPath="/workspaces"
+  entitiesPath="/workspaces/%s/%s/entities"
+  methodConfigsListPath="/workspaces/%s/%s/methodconfigs"
+  copyFromMethodRepoConfig="/methodconfigs/copyFromMethodRepo"
+  importEntitiesPath="/workspaces/%s/%s/importEntities"
+}

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
@@ -4,16 +4,18 @@ import com.typesafe.config.ConfigFactory
 
 object FireCloudConfig {
   private val config = ConfigFactory.load()
+  private val configurations = ConfigFactory.load("configurations.conf")
+  private val merged = config.withFallback(configurations)
 
   object HttpConfig {
-    private val httpConfig = config.getConfig("http")
+    private val httpConfig = merged.getConfig("http")
     lazy val interface = httpConfig.getString("interface")
     lazy val port = httpConfig.getInt("port")
     lazy val timeoutSeconds = httpConfig.getLong("timeoutSeconds")
   }
 
   object SwaggerConfig {
-    private val swagger = config.getConfig("swagger")
+    private val swagger = merged.getConfig("swagger")
     lazy val apiVersion = swagger.getString("apiVersion")
     lazy val swaggerVersion = swagger.getString("swaggerVersion")
     lazy val info = swagger.getString("info")
@@ -27,7 +29,7 @@ object FireCloudConfig {
   }
 
   object Methods {
-    private val methods = config.getConfig("methods")
+    private val methods = merged.getConfig("methods")
     lazy val baseUrl = methods.getString("baseUrl")
     lazy val methodsPath = methods.getString("methodsPath")
     lazy val methodsListUrl = baseUrl + methodsPath
@@ -36,7 +38,7 @@ object FireCloudConfig {
   }
 
   object Workspace {
-    private val workspace = config.getConfig("workspace")
+    private val workspace = merged.getConfig("workspace")
     lazy val model = "/" + workspace.getString("model")
     lazy val baseUrl= workspace.getString("baseUrl")
     lazy val workspacesPath = workspace.getString("workspacesPath")

--- a/src/test/resources/test.conf
+++ b/src/test/resources/test.conf
@@ -1,45 +1,10 @@
-akka {
-  loglevel = "DEBUG"
-  loggers = ["akka.event.slf4j.Slf4jLogger"]
-}
-
-spray.can.server {
-  request-timeout = infinite
-}
-
-http {
-  interface="localhost"
-  port=8080
-  timeoutSeconds = 1
-}
-
-swagger {
-  apiDocs="api-docs"
-  apiVersion="0.1"
-  baseUrl=""
-  contact="silver@broadinstitute.org"
-  description="FireCloud Orchestration API services using spray and spray-swagger."
-  info="FireCloud Orchestration API"
-  license="BSD"
-  licenseUrl="http://opensource.org/licenses/BSD-3-Clause"
-  swaggerVersion="1.2"
-  termsOfServiceUrl="https://github.com/broadinstitute/firecloud-orchestration"
-}
 
 methods {
   baseUrl="http://localhost:8989"
-  methodsPath="/methods"
-  configurationsPath="/configurations"
 }
 
 workspace {
-  model="model.json"
   baseUrl="http://localhost:8990"
-  workspacesPath="/workspaces"
-  entitiesPath="/workspaces/%s/%s/entities"
-  methodConfigsListPath="/workspaces/%s/%s/methodconfigs"
-  copyFromMethodRepoConfig="/methodconfigs/copyFromMethodRepo"
-  importEntitiesPath="/workspaces/%s/%s/importEntities"
 }
 
 openam {


### PR DESCRIPTION
This PR breaks out secrets into the `test.conf` and `application.conf` files and adds another configuration file where we can hold all of the custom endpoint paths. Support for new endpoint paths should be placed in `configurations.conf`