### PR TITLE
Bump Scala version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,7 @@ val artifactory = "https://artifactory.broadinstitute.org/artifactory/"
 
 resolvers += "artifactory-releases" at artifactory + "libs-release"
 
-scalaVersion  := "2.11.6"
+scalaVersion  := "2.11.7"
 
 javacOptions ++= Seq("-source", "1.8", "-target", "1.8")
 scalacOptions := Seq("-unchecked", "-deprecation", "-encoding", "utf8", "-target:jvm-1.8")


### PR DESCRIPTION
Incremental builds have been failing consistently for me. The error message is nearly identical to the one in this bug report:
https://issues.scala-lang.org/browse/SI-9356
Upgrading to 2.11.7 seems to fix the issue.