### PR TITLE
change Exception to Throwable to eliminate compile warning

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/EntityClient.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/EntityClient.scala
@@ -115,8 +115,8 @@ class EntityClient (requestContext: RequestContext) extends Actor {
         case StatusCodes.Created => EntityCreateResult(entityType, entityName, true, "Entity created successfully")
         case _ => EntityCreateResult(entityType, entityName, false, s"Bad response from workspace service: ${response.message}")
       }
-      case Failure(e: Exception) => EntityCreateResult(entityType, entityName, false,
-        s"Error sending request to workspace service: ${e.getMessage}")
+      case Failure(t: Throwable) => EntityCreateResult(entityType, entityName, false,
+        s"Error sending request to workspace service: ${t.getMessage}")
     }
   }
 


### PR DESCRIPTION
compile would previously show:

```
[info] Compiling 19 Scala sources to /Users/davidan/work/src/firecloud-orchestration/target/scala-2.11/classes...
[warn] /Users/davidan/work/src/firecloud-orchestration/src/main/scala/org/broadinstitute/dsde/firecloud/EntityClient.scala:113: match may not be exhaustive.
[warn] It would fail on the following input: Failure((x: Throwable forSome x not in Exception))
[warn]     Try(Await.result(pipeline(externalRequest), Duration.Inf)) match {
[warn]        ^
[warn] one warning found
[success] Total time: 11 s, completed Aug 12, 2015 10:47:31 AM
```
but now it doesn't.