### PR TITLE
Implement combined call for entities with type information

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/core/GetEntitiesWithType.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/core/GetEntitiesWithType.scala
@@ -1,0 +1,83 @@
+package org.broadinstitute.dsde.firecloud.core
+
+import akka.actor.{Actor, Props}
+import akka.event.Logging
+import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
+import org.broadinstitute.dsde.firecloud.core.GetEntitiesWithType.{AddEntities, EntityWithType, ProcessUrl}
+import spray.client.pipelining._
+import spray.http.HttpHeaders.Cookie
+import spray.http.StatusCodes._
+import spray.http.{HttpRequest, HttpResponse, RequestProcessingException, StatusCodes}
+import spray.httpx.SprayJsonSupport._
+import spray.json.DefaultJsonProtocol._
+import spray.routing.RequestContext
+
+import scala.concurrent.Future
+import scala.util.{Failure, Success}
+
+object GetEntitiesWithType {
+  case class ProcessUrl(url: String)
+  case class AddEntities(entities: List[EntityWithType])
+  case class EntityWithType(name: String, entityType: String)
+  def props(requestContext: RequestContext): Props = Props(new GetEntitiesWithTypeActor(requestContext))
+}
+
+class GetEntitiesWithTypeActor(requestContext: RequestContext) extends Actor {
+
+  implicit val system = context.system
+  import system.dispatcher
+  val log = Logging(system, getClass)
+
+  var results = List.empty[EntityWithType]
+
+  override def receive: Receive = {
+    case ProcessUrl(url: String) => processUrl(url)
+    case AddEntities(entities: List[EntityWithType]) => results = results ::: entities
+  }
+
+  def processUrl(url: String): Unit = {
+    log.debug("Processing entity type map for url: " + url)
+    val pipeline: HttpRequest => Future[HttpResponse] = addHeader(Cookie(requestContext.request.cookies)) ~> sendReceive
+    val entityTypesFuture: Future[HttpResponse] = pipeline { Get(url) }
+    val ffewt: Future[Future[List[EntityWithType]]] = entityTypesFuture map {
+      response =>
+        val entityTypes: List[String] = unmarshal[List[String]].apply(response)
+        val entityUrls: List[String] = entityTypes.map(s => s"$url/$s")
+        val entityFutures: List[Future[HttpResponse]] = entityUrls map { url => pipeline { Get(url) } }
+        Future.sequence(entityFutures) map {
+          responses =>
+            responses flatMap {
+              response =>
+                val entities = unmarshal[List[EntityWithType]].apply(response)
+                log.debug("Processed entities: " + entities)
+                self ! AddEntities(entities)
+                entities
+            }
+        }
+    }
+    // Unwrap the nested futures:
+    ffewt onComplete {
+      case Success(fewt) =>
+        fewt onComplete {
+          case Success(_) =>
+            requestContext.complete(OK, results)
+            context stop self
+          case Failure(e) =>
+            log.error(e.getMessage)
+            requestContext.failWith(
+              new RequestProcessingException(StatusCodes.InternalServerError, e.getMessage)
+            )
+            context stop self
+        }
+      case Failure(e) =>
+        log.error(e.getMessage)
+        requestContext.failWith(
+          new RequestProcessingException(StatusCodes.InternalServerError, e.getMessage)
+        )
+        context stop self
+    }
+
+  }
+
+}
+

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.firecloud.model
 
+import org.broadinstitute.dsde.firecloud.core.GetEntitiesWithType.EntityWithType
 import spray.json._
 import spray.json.DefaultJsonProtocol._
 
@@ -13,6 +14,7 @@ object ModelJsonProtocol {
 
   implicit val impEntity = jsonFormat5(Entity)
   implicit val impEntityCreateResult = jsonFormat4(EntityCreateResult)
+  implicit val impEntityWithType = jsonFormat2(EntityWithType)
 
   implicit val impMethodConfiguration = jsonFormat9(MethodConfiguration)
   implicit val impMethodConfigurationRename = jsonFormat3(MethodConfigurationRename)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/EntityService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/EntityService.scala
@@ -1,22 +1,15 @@
 package org.broadinstitute.dsde.firecloud.service
 
-/**
- * Created by mbemis on 7/10/15.
- */
-
 import javax.ws.rs.Path
 
-import akka.actor.{Props, Actor}
+import akka.actor.{Actor, Props}
 import com.wordnik.swagger.annotations._
-import org.broadinstitute.dsde.firecloud.{HttpClient, FireCloudConfig}
+import org.broadinstitute.dsde.firecloud.core.{GetEntitiesWithTypeActor, GetEntitiesWithType}
 import org.broadinstitute.dsde.firecloud.model.Entity
-import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
+import org.broadinstitute.dsde.firecloud.{FireCloudConfig, HttpClient}
 import org.slf4j.LoggerFactory
 import spray.client.pipelining._
-import spray.http.StatusCodes._
-import spray.httpx.SprayJsonSupport._
 import spray.routing._
-import org.broadinstitute.dsde.vault.common.directives.OpenAMDirectives._
 
 class EntityServiceActor extends Actor with EntityService {
   def actorRefFactory = context
@@ -31,10 +24,21 @@ class EntityServiceActor extends Actor with EntityService {
 trait EntityService extends HttpService with FireCloudDirectives {
 
   private implicit val executionContext = actorRefFactory.dispatcher
-
-  val routes = listEntityTypesRoute ~ listEntitiesPerTypeRoute
-
+  val routes = listEntityTypesRoute ~ listEntitiesPerTypeRoute ~ listEntitiesWithTypeRoute
   lazy val log = LoggerFactory.getLogger(getClass)
+
+  /**
+   * This endpoint collects all workspace entities and entity types into a list of EntityWithTypes.
+   */
+  def listEntitiesWithTypeRoute: Route =
+    path("workspaces" / Segment / Segment / "entities_with_type") {
+      (workspaceNamespace, workspaceName) =>
+        get { requestContext =>
+          val url = FireCloudConfig.Rawls.entityPathFromWorkspace(workspaceNamespace, workspaceName)
+          val ewtActor = actorRefFactory.actorOf(Props(new GetEntitiesWithTypeActor(requestContext)), "EntitiesWithTypeActor")
+          ewtActor ! GetEntitiesWithType.ProcessUrl(url)
+        }
+    }
 
   @ApiOperation(value = "list all entity types in a workspace",
     nickname = "listEntityTypes",

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockWorkspaceServer.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockWorkspaceServer.scala
@@ -1,5 +1,7 @@
 package org.broadinstitute.dsde.firecloud.mock
 
+import org.broadinstitute.dsde.firecloud.core.GetEntitiesWithType
+import GetEntitiesWithType.EntityWithType
 import org.broadinstitute.dsde.firecloud.mock.MockUtils._
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
 import org.broadinstitute.dsde.firecloud.model._
@@ -134,6 +136,8 @@ object MockWorkspaceServer {
     entityName = Option.empty,
     expression = Option.empty
   )
+
+  val entitiesWithTypeBasePath = "/workspaces/broad-dsde-dev/alexb_test_submission/"
 
   var workspaceServer: ClientAndServer = _
 
@@ -339,6 +343,71 @@ object MockWorkspaceServer {
         response()
           .withHeaders(header)
           .withStatusCode(Created.intValue)
+      )
+
+    MockWorkspaceServer.workspaceServer
+      .when(
+        request()
+          .withMethod("GET")
+          .withPath(entitiesWithTypeBasePath + "entities")
+          .withCookies(cookie)
+      ).respond(
+        response()
+          .withHeaders(header)
+          .withBody(List("participant", "sample", "Pair", "sampleset").toJson.compactPrint)
+          .withStatusCode(OK.intValue)
+      )
+
+    MockWorkspaceServer.workspaceServer
+      .when(
+        request()
+          .withMethod("GET")
+          .withPath(entitiesWithTypeBasePath + "entities/participant")
+          .withCookies(cookie)
+      ).respond(
+        response()
+          .withHeaders(header)
+          .withBody(List(EntityWithType("participant_01", "participant"), EntityWithType("participant_02", "participant")).toJson.compactPrint)
+          .withStatusCode(OK.intValue)
+      )
+
+    MockWorkspaceServer.workspaceServer
+      .when(
+        request()
+          .withMethod("GET")
+          .withPath(entitiesWithTypeBasePath + "entities/sample")
+          .withCookies(cookie)
+      ).respond(
+        response()
+          .withHeaders(header)
+          .withBody(List(EntityWithType("sample_01", "sample"), EntityWithType("sample_02", "sample")).toJson.compactPrint)
+          .withStatusCode(OK.intValue)
+      )
+
+    MockWorkspaceServer.workspaceServer
+      .when(
+        request()
+          .withMethod("GET")
+          .withPath(entitiesWithTypeBasePath + "entities/Pair")
+          .withCookies(cookie)
+      ).respond(
+        response()
+          .withHeaders(header)
+          .withBody(List(EntityWithType("pair_01", "Pair")).toJson.compactPrint)
+          .withStatusCode(OK.intValue)
+      )
+
+    MockWorkspaceServer.workspaceServer
+      .when(
+        request()
+          .withMethod("GET")
+          .withPath(entitiesWithTypeBasePath + "entities/sampleset")
+          .withCookies(cookie)
+      ).respond(
+        response()
+          .withHeaders(header)
+          .withBody(List(EntityWithType("sampleset_01", "sampleset"), EntityWithType("sampleset_02", "sampleset")).toJson.compactPrint)
+          .withStatusCode(OK.intValue)
       )
 
     MockWorkspaceServer.workspaceServer

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/EntityServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/EntityServiceSpec.scala
@@ -1,0 +1,46 @@
+package org.broadinstitute.dsde.firecloud.service
+
+import org.broadinstitute.dsde.firecloud.core.GetEntitiesWithType.EntityWithType
+import org.broadinstitute.dsde.firecloud.mock.MockWorkspaceServer
+import org.broadinstitute.dsde.vault.common.openam.OpenAMSession
+import org.scalatest.time.{Seconds, Span}
+import org.scalatest.{Matchers, FreeSpec}
+import org.scalatest.concurrent.ScalaFutures
+import spray.http.HttpCookie
+import spray.http.HttpHeaders.Cookie
+import spray.http.StatusCodes._
+import spray.testkit.ScalatestRouteTest
+import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
+import spray.httpx.SprayJsonSupport._
+import spray.json.DefaultJsonProtocol._
+
+class EntityServiceSpec extends FreeSpec with ScalaFutures with ScalatestRouteTest with Matchers with EntityService {
+
+  def actorRefFactory = system
+
+  override def beforeAll(): Unit = {
+    MockWorkspaceServer.startWorkspaceServer()
+  }
+
+  override def afterAll(): Unit = {
+    MockWorkspaceServer.stopWorkspaceServer()
+  }
+
+  "EntityService" - {
+
+    val openAMSession = OpenAMSession(()).futureValue(timeout(Span(5, Seconds)), interval(scaled(Span(0.5, Seconds))))
+    val token = openAMSession.cookies.head.content
+
+    "when calling GET on entities_with_type path with a valid workspace" - {
+      "valid list of entity types are returned" in {
+        val path = s"${MockWorkspaceServer.entitiesWithTypeBasePath}entities_with_type"
+        Get(path) ~> Cookie(HttpCookie("iPlanetDirectoryPro", token)) ~> sealRoute(routes) ~> check {
+          status should be(OK)
+          val entities = responseAs[List[EntityWithType]]
+          entities shouldNot be(empty)
+        }
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
Notes:
* This has been tested against Rawls-dev.
* There is a lot of entity information that comes back from rawls. This only captures the name and entity type. The model class can be expanded to capture more information if the UI requires it.
* Format of the response is a list of entity name and entity type for easy tabular display. This can be re-modeled into a map of type -> list of names if that is easier for the UI to work with.

My first approach was to implement the ask pattern for the various requests, but I ran into weirdness where the sender would not get the response back. When changing this to the tell pattern, the actor can handle the response itself and that works.

This (https://github.com/NET-A-PORTER/spray-actor-per-request/blob/master/src/main/scala/com/netaporter/core/DummyAppCore.scala) is another pattern that we could use. It is part of the Per Request pattern which we are not currently using, but might at some point. 

Example Output:
```
curl -X GET -H 'Content-type: application/json' --cookie 'iPlanetDirectoryPro=AQI...' http://local.broadinstitute.org:8080/workspaces/broad-dsde-dev/alexb_test_submission/entities_with_type
[{
  "name": "participant_01",
  "entityType": "participant"
}, {
  "name": "participant_02",
  "entityType": "participant"
}, {
  "name": "participant_03",
  "entityType": "participant"
}, {
  "name": "sample_01",
  "entityType": "sample"
}, {
  "name": "sample_02",
  "entityType": "sample"
}, {
  "name": "sample_03",
  "entityType": "sample"
}]
```