### PR TITLE
Implement combined call for entities with type information

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -51,6 +51,7 @@ libraryDependencies ++= {
     "com.gettyimages"     %%  "spray-swagger" % "0.5.0",
     "org.webjars"          %  "swagger-ui"    % "2.1.0",
     "com.typesafe.akka"   %%  "akka-actor"    % akkaV,
+    "com.typesafe.akka"   %%  "akka-contrib"  % akkaV,
     "com.typesafe.akka"   %%  "akka-testkit"  % akkaV     % "test",
     "com.typesafe.akka"   %%  "akka-slf4j"    % akkaV,
     "org.specs2"          %%  "specs2-core"   % "2.3.11"  % "test",

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/core/GetEntitiesWithType.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/core/GetEntitiesWithType.scala
@@ -1,0 +1,94 @@
+package org.broadinstitute.dsde.firecloud.core
+
+import akka.actor.{Actor, Props}
+import akka.contrib.pattern.Aggregator
+import akka.event.Logging
+import org.broadinstitute.dsde.firecloud.core.GetEntitiesWithType.{EntityWithType, ProcessUrl, TimedOut}
+import spray.client.pipelining._
+import spray.http.HttpHeaders.Cookie
+import spray.http.StatusCodes._
+import spray.http.{HttpResponse, RequestProcessingException, StatusCodes}
+import spray.httpx.SprayJsonSupport._
+import spray.json.DefaultJsonProtocol._
+import spray.json.JsValue
+import spray.routing.RequestContext
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import scala.util.{Failure, Success}
+
+object GetEntitiesWithType {
+  case object TimedOut
+  case class ProcessUrl(url: String)
+  case class AddEntities(entities: List[EntityWithType])
+  case class EntityWithType(name: String, entityType: String, attributes: Option[Map[String, JsValue]])
+  def props(requestContext: RequestContext): Props = Props(new GetEntitiesWithTypeActor(requestContext))
+}
+
+class GetEntitiesWithTypeActor(requestContext: RequestContext) extends Actor with Aggregator {
+
+  implicit val system = context.system
+  import system.dispatcher
+  val log = Logging(system, getClass)
+
+  expectOnce {
+    case ProcessUrl(url: String) =>
+      log.debug("Processing entity type map for url: " + url)
+      val pipeline = addHeader(Cookie(requestContext.request.cookies)) ~> sendReceive
+      val entityTypesFuture: Future[HttpResponse] = pipeline { Get(url) }
+      entityTypesFuture onComplete {
+        case Success(response) =>
+          val entityTypes: List[String] = unmarshal[List[String]].apply(response)
+          new EntityAggregator(requestContext, url, entityTypes)
+        case Failure(e) =>
+          requestContext.failWith(new RequestProcessingException(StatusCodes.InternalServerError, e.getMessage))
+          context stop self
+      }
+    case _ =>
+      requestContext.complete(StatusCodes.BadRequest)
+      context stop self
+  }
+
+  class EntityAggregator(requestContext: RequestContext, baseUrl: String, entityTypes: List[String]) {
+
+    import context.dispatcher
+    import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
+    import spray.json.DefaultJsonProtocol._
+
+    import collection.mutable.ArrayBuffer
+
+    val values = ArrayBuffer.empty[EntityWithType]
+
+    if (entityTypes.nonEmpty) {
+      val pipeline = addHeader(Cookie(requestContext.request.cookies)) ~> sendReceive
+      val entityUrls: List[String] = entityTypes.map(s => s"$baseUrl/$s")
+      val entityFutures: List[Future[HttpResponse]] = entityUrls map { entitiesUrl => pipeline { Get(entitiesUrl) } }
+      val f: Future[List[HttpResponse]] = Future sequence entityFutures
+      f onComplete {
+        case Success(responses) =>
+          responses flatMap {
+            response =>
+              val entities = unmarshal[List[EntityWithType]].apply(response)
+              values ++= entities
+          }
+        case Failure(e) =>
+          requestContext.failWith(new RequestProcessingException(StatusCodes.InternalServerError, e.getMessage))
+          context stop self
+      }
+    }
+    else collectEntities()
+
+    context.system.scheduler.scheduleOnce(500.millisecond, self, TimedOut)
+    expect {
+      case TimedOut => collectEntities()
+    }
+
+    def collectEntities(): Unit = {
+      requestContext.complete(OK, values.toList)
+      context stop self
+    }
+
+  }
+
+}
+

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.firecloud.model
 
+import org.broadinstitute.dsde.firecloud.core.GetEntitiesWithType.EntityWithType
 import spray.json._
 import spray.json.DefaultJsonProtocol._
 
@@ -13,6 +14,7 @@ object ModelJsonProtocol {
 
   implicit val impEntity = jsonFormat5(Entity)
   implicit val impEntityCreateResult = jsonFormat4(EntityCreateResult)
+  implicit val impEntityWithType = jsonFormat3(EntityWithType)
 
   implicit val impMethodConfiguration = jsonFormat9(MethodConfiguration)
   implicit val impMethodConfigurationRename = jsonFormat3(MethodConfigurationRename)

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockWorkspaceServer.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockWorkspaceServer.scala
@@ -1,5 +1,7 @@
 package org.broadinstitute.dsde.firecloud.mock
 
+import org.broadinstitute.dsde.firecloud.core.GetEntitiesWithType
+import GetEntitiesWithType.EntityWithType
 import org.broadinstitute.dsde.firecloud.mock.MockUtils._
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
 import org.broadinstitute.dsde.firecloud.model._
@@ -134,6 +136,8 @@ object MockWorkspaceServer {
     entityName = Option.empty,
     expression = Option.empty
   )
+
+  val entitiesWithTypeBasePath = "/workspaces/broad-dsde-dev/alexb_test_submission/"
 
   var workspaceServer: ClientAndServer = _
 
@@ -339,6 +343,71 @@ object MockWorkspaceServer {
         response()
           .withHeaders(header)
           .withStatusCode(Created.intValue)
+      )
+
+    MockWorkspaceServer.workspaceServer
+      .when(
+        request()
+          .withMethod("GET")
+          .withPath(entitiesWithTypeBasePath + "entities")
+          .withCookies(cookie)
+      ).respond(
+        response()
+          .withHeaders(header)
+          .withBody(List("participant", "sample", "Pair", "sampleset").toJson.compactPrint)
+          .withStatusCode(OK.intValue)
+      )
+
+    MockWorkspaceServer.workspaceServer
+      .when(
+        request()
+          .withMethod("GET")
+          .withPath(entitiesWithTypeBasePath + "entities/participant")
+          .withCookies(cookie)
+      ).respond(
+        response()
+          .withHeaders(header)
+          .withBody(List(EntityWithType("participant_01", "participant", Option.empty), EntityWithType("participant_02", "participant", Option.empty)).toJson.compactPrint)
+          .withStatusCode(OK.intValue)
+      )
+
+    MockWorkspaceServer.workspaceServer
+      .when(
+        request()
+          .withMethod("GET")
+          .withPath(entitiesWithTypeBasePath + "entities/sample")
+          .withCookies(cookie)
+      ).respond(
+        response()
+          .withHeaders(header)
+          .withBody(List(EntityWithType("sample_01", "sample", Option.empty), EntityWithType("sample_02", "sample", Option.empty)).toJson.compactPrint)
+          .withStatusCode(OK.intValue)
+      )
+
+    MockWorkspaceServer.workspaceServer
+      .when(
+        request()
+          .withMethod("GET")
+          .withPath(entitiesWithTypeBasePath + "entities/Pair")
+          .withCookies(cookie)
+      ).respond(
+        response()
+          .withHeaders(header)
+          .withBody(List(EntityWithType("pair_01", "Pair", Option.empty)).toJson.compactPrint)
+          .withStatusCode(OK.intValue)
+      )
+
+    MockWorkspaceServer.workspaceServer
+      .when(
+        request()
+          .withMethod("GET")
+          .withPath(entitiesWithTypeBasePath + "entities/sampleset")
+          .withCookies(cookie)
+      ).respond(
+        response()
+          .withHeaders(header)
+          .withBody(List(EntityWithType("sampleset_01", "sampleset", Option.empty), EntityWithType("sampleset_02", "sampleset", Option.empty)).toJson.compactPrint)
+          .withStatusCode(OK.intValue)
       )
 
     MockWorkspaceServer.workspaceServer

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/EntityServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/EntityServiceSpec.scala
@@ -1,0 +1,46 @@
+package org.broadinstitute.dsde.firecloud.service
+
+import org.broadinstitute.dsde.firecloud.core.GetEntitiesWithType.EntityWithType
+import org.broadinstitute.dsde.firecloud.mock.MockWorkspaceServer
+import org.broadinstitute.dsde.vault.common.openam.OpenAMSession
+import org.scalatest.time.{Seconds, Span}
+import org.scalatest.{Matchers, FreeSpec}
+import org.scalatest.concurrent.ScalaFutures
+import spray.http.HttpCookie
+import spray.http.HttpHeaders.Cookie
+import spray.http.StatusCodes._
+import spray.testkit.ScalatestRouteTest
+import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
+import spray.httpx.SprayJsonSupport._
+import spray.json.DefaultJsonProtocol._
+
+class EntityServiceSpec extends FreeSpec with ScalaFutures with ScalatestRouteTest with Matchers with EntityService {
+
+  def actorRefFactory = system
+
+  override def beforeAll(): Unit = {
+    MockWorkspaceServer.startWorkspaceServer()
+  }
+
+  override def afterAll(): Unit = {
+    MockWorkspaceServer.stopWorkspaceServer()
+  }
+
+  "EntityService" - {
+
+    val openAMSession = OpenAMSession(()).futureValue(timeout(Span(5, Seconds)), interval(scaled(Span(0.5, Seconds))))
+    val token = openAMSession.cookies.head.content
+
+    "when calling GET on entities_with_type path with a valid workspace" - {
+      "valid list of entity types are returned" in {
+        val path = s"${MockWorkspaceServer.entitiesWithTypeBasePath}entities_with_type"
+        Get(path) ~> Cookie(HttpCookie("iPlanetDirectoryPro", token)) ~> sealRoute(routes) ~> check {
+          status should be(OK)
+          val entities = responseAs[List[EntityWithType]]
+          entities shouldNot be(empty)
+        }
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
Notes:
* This has been tested against Rawls-dev.
* There is a lot of entity information that comes back from rawls. This only captures the name and entity type. The model class can be expanded to capture more information if the UI requires it.
* Format of the response is a list of entity name and entity type for easy tabular display. This can be re-modeled into a map of type -> list of names if that is easier for the UI to work with.

This approach uses the aggregator pattern: http://doc.akka.io/docs/akka/snapshot/contrib/aggregator.html

This (https://github.com/NET-A-PORTER/spray-actor-per-request/blob/master/src/main/scala/com/netaporter/core/DummyAppCore.scala) is another pattern that we could use. It is part of the Per Request pattern which we are not currently using, but might at some point. 

Example Output:
```
curl -X GET -H 'Content-type: application/json' --cookie 'iPlanetDirectoryPro=AQI...' http://local.broadinstitute.org:8080/workspaces/broad-dsde-dev/alexb_test_submission/entities_with_type

[{
  "name": "participant_01",
  "entityType": "participant",
  "attributes": {

  }
}, {
  "name": "participant_02",
  "entityType": "participant",
  "attributes": {

  }
}, {
  "name": "participant_03",
  "entityType": "participant",
  "attributes": {

  }
}, {
  "name": "sample_01",
  "entityType": "sample",
  "attributes": {
    "sample_type": "primary_solid_tumor",
    "ref_fasta": "/Users/dshiga/wdl/Homo_sapiens_assembly19.fasta",
    "ref_dict": "/Users/dshiga/wdl/Homo_sapiens_assembly19.dict",
    "ref_ann": "/Users/dshiga/wdl/Homo_sapiens_assembly19.fasta.ann",
    "ref_sa": "/Users/dshiga/wdl/Homo_sapiens_assembly19.fasta.sa",
    "fastq2": "/Users/dshiga/wdl/NA12878.second.fastq",
    "ref_amb": "/Users/dshiga/wdl/Homo_sapiens_assembly19.fasta.amb",
    "fastq1": "/Users/dshiga/wdl/NA12878.first.fastq",
    "some_int": 8,
    "library": "library_name",
    "participant_id": {
      "entityType": "participant",
      "entityName": "participant_01"
    },
    "strip_unpaired": "true",
    "sample": "NA12878",
    "ref_bwt": "/Users/dshiga/wdl/Homo_sapiens_assembly19.fasta.bwt",
    "platform": "illumina",
    "bam": "foo.bam",
    "ref_pac": "/Users/dshiga/wdl/Homo_sapiens_assembly19.fasta.pac"
  }
}, {
  "name": "sample_02",
  "entityType": "sample",
  "attributes": {
    "participant": {
      "entityType": "participant",
      "entityName": "participant_02"
    },
    "sample_type": "primary_solid_tumor",
    "ref_fasta": "/Users/dshiga/wdl/Homo_sapiens_assembly19.fasta",
    "ref_dict": "/Users/dshiga/wdl/Homo_sapiens_assembly19.dict",
    "ref_ann": "/Users/dshiga/wdl/Homo_sapiens_assembly19.fasta.ann",
    "ref_sa": "/Users/dshiga/wdl/Homo_sapiens_assembly19.fasta.sa",
    "fastq2": "/Users/dshiga/wdl/NA12878.second.fastq",
    "ref_amb": "/Users/dshiga/wdl/Homo_sapiens_assembly19.fasta.amb",
    "fastq1": "/Users/dshiga/wdl/NA12878.first.fastq",
    "some_int": 4,
    "library": "library_name",
    "participant_id": {
      "entityType": "participant",
      "entityName": "participant_01"
    },
    "strip_unpaired": "true",
    "sample": "NA12878",
    "ref_bwt": "/Users/dshiga/wdl/Homo_sapiens_assembly19.fasta.bwt",
    "platform": "illumina",
    "bam": "foo.bam",
    "ref_pac": "/Users/dshiga/wdl/Homo_sapiens_assembly19.fasta.pac"
  }
}, {
  "name": "sample_03",
  "entityType": "sample",
  "attributes": {
    "sample_type": "primary_solid_tumor",
    "ref_fasta": "/Users/dshiga/wdl/Homo_sapiens_assembly19.fasta",
    "ref_dict": "/Users/dshiga/wdl/Homo_sapiens_assembly19.dict",
    "ref_ann": "/Users/dshiga/wdl/Homo_sapiens_assembly19.fasta.ann",
    "ref_sa": "/Users/dshiga/wdl/Homo_sapiens_assembly19.fasta.sa",
    "fastq2": "/Users/dshiga/wdl/NA12878.second.fastq",
    "ref_amb": "/Users/dshiga/wdl/Homo_sapiens_assembly19.fasta.amb",
    "fastq1": "/Users/dshiga/wdl/NA12878.first.fastq",
    "some_int": 4,
    "library": "library_name",
    "participant_id": {
      "entityType": "participant",
      "entityName": "participant_03"
    },
    "strip_unpaired": "true",
    "sample": "NA12878",
    "ref_bwt": "/Users/dshiga/wdl/Homo_sapiens_assembly19.fasta.bwt",
    "platform": "illumina",
    "bam": "foo.bam",
    "ref_pac": "/Users/dshiga/wdl/Homo_sapiens_assembly19.fasta.pac"
  }
}]
```