### PR TITLE
template config for actor logging

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -19,3 +19,25 @@ openam {
     value = "DataStore"
   }
 }
+
+akka {
+  loglevel = "INFO"
+
+  log-dead-letters = 10
+  log-dead-letters-during-shutdown = on
+
+  # Log the complete configuration at INFO level when the actor system is started.
+  # This is useful when you are uncertain of what configuration is used.
+  log-config-on-start = off
+
+  actor {
+    debug {
+      # enable DEBUG logging of all AutoReceiveMessages (Kill, PoisonPill et.c.)
+      autoreceive = off
+      # enable DEBUG logging of actor lifecycle changes
+      lifecycle = off
+      # enable DEBUG logging of subscription changes on the eventStream
+      event-stream = off
+    }
+  }
+}


### PR DESCRIPTION
with @dmohs ' changes in #47, I think we're in a good place:
* if you want to affect logging for our own log messages in our classes, change in logback.xml
* if you want to affect akka's internal logging, change in application.conf

while this means there are two files that would need editing under different conditions, I think this is a clear and understandable separation.

This PR should change nothing functionally - everything will log as it did before. The changes just provide a template for what you _would_ change if you wanted to affect akka logging.

The changes to application.conf will need to get deployed to jenkins, etc. to truly complete this story.