### PR TITLE
First pass at Swagger via YAML

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -48,8 +48,8 @@ libraryDependencies ++= {
     "io.spray"            %%  "spray-json"    % "1.3.1",
     "io.spray"            %%  "spray-client"  % sprayV,
     "io.spray"            %%  "spray-testkit" % sprayV    % "test",
-    "com.gettyimages"     %%  "spray-swagger" % "0.5.0",
-    "org.webjars"          %  "swagger-ui"    % "2.1.0",
+    "com.gettyimages"     %%  "spray-swagger" % "0.5.0", // TODO(dmohs): Remove
+    "org.webjars"          %  "swagger-ui"    % "2.1.1",
     "com.typesafe.akka"   %%  "akka-actor"    % akkaV,
     "com.typesafe.akka"   %%  "akka-contrib"  % akkaV,
     "com.typesafe.akka"   %%  "akka-testkit"  % akkaV     % "test",

--- a/src/main/resources/configurations.conf
+++ b/src/main/resources/configurations.conf
@@ -8,19 +8,6 @@ http {
   timeoutSeconds = 1
 }
 
-swagger {
-  apiDocs="api-docs"
-  apiVersion="0.1"
-  baseUrl=""
-  contact="silver@broadinstitute.org"
-  description="FireCloud Orchestration API services using spray and spray-swagger. Note that all operations require authentication, which can be provided via the OpenAM cookie: curl --cookie 'iPlanetDirectoryPro=AQIC5...' ..."
-  info="FireCloud Orchestration API"
-  license="BSD"
-  licenseUrl="http://opensource.org/licenses/BSD-3-Clause"
-  swaggerVersion="1.2"
-  termsOfServiceUrl="https://github.com/broadinstitute/firecloud-orchestration"
-}
-
 methods {
   methodsPath="/methods"
   configurationsPath="/configurations"

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -1,0 +1,30 @@
+swagger: '2.0'
+
+info:
+  title: FireCloud
+  description: |
+    Genome analysis execution service.
+  version: "0.0.1"
+  license:
+    name: BSD
+    url: http://opensource.org/licenses/BSD-3-Clause
+  termsOfService: https://github.com/broadinstitute/firecloud-orchestration
+
+# TODO(dmohs): Don't do this.
+host: %s
+basePath: /api
+
+paths:
+  /workspaces:
+    get:
+      tags:
+      - workspaces
+      operationId: listWorkspaces
+      summary: |
+        Lists workspaces.
+      produces:
+      - application/json
+      - text/plain
+      responses:
+        200:
+          description: List of workspaces.

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
@@ -14,20 +14,6 @@ object FireCloudConfig {
     lazy val timeoutSeconds = httpConfig.getLong("timeoutSeconds")
   }
 
-  object SwaggerConfig {
-    private val swagger = merged.getConfig("swagger")
-    lazy val apiVersion = swagger.getString("apiVersion")
-    lazy val swaggerVersion = swagger.getString("swaggerVersion")
-    lazy val info = swagger.getString("info")
-    lazy val description = swagger.getString("description")
-    lazy val termsOfServiceUrl = swagger.getString("termsOfServiceUrl")
-    lazy val contact = swagger.getString("contact")
-    lazy val license = swagger.getString("license")
-    lazy val licenseUrl = swagger.getString("licenseUrl")
-    lazy val baseUrl = swagger.getString("baseUrl")
-    lazy val apiDocs = swagger.getString("apiDocs")
-  }
-
   object Agora {
     private val methods = merged.getConfig("methods")
     lazy val baseUrl = methods.getString("baseUrl")


### PR DESCRIPTION
The new version of Swagger prefers the definition to be all in one file. This is not ideal, but because the YAML syntax is compact, I think it's okay for now.

There are some TODOs for fixing stuff, but I think this is a good place for us to review/discuss.

I think this will work in prod with the transparent proxy, since I tested it locally, but because the environments are slightly different, it might not. I will monitor the deploy.