### PR TITLE
Add methods and configurations swagger yml

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -26,3 +26,27 @@ paths:
       responses:
         200:
           description: List of workspaces.
+  /methods:
+    get:
+      tags:
+      - Method Repository
+      operationId: listMethodRepositoryMethods
+      summary: |
+        Lists Method Repository methods.
+      produces:
+      - application/json
+      responses:
+        200:
+          description: List of Method Repository methods.
+  /configurations:
+    get:
+      tags:
+      - Method Repository
+      operationId: listMethodRepositoryConfigurations
+      summary: |
+        List Method Repository configurations.
+      produces:
+      - application/json
+      responses:
+        200:
+          description: List of Method Repository configurations.


### PR DESCRIPTION
For DSDEEPB-1088
Notes:
* I put these two services into the same "tag" so they show up together in the UI. 
* We should standardize on naming convention and capitalization. Agora capitalizes the endpoint descriptions, Rawls does not. As this is user-facing, I like the Agora approach better.