### PR TITLE
DSDEEPB-958: pass on new Google/OAuth headers

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/EntityClient.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/EntityClient.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.firecloud
 
 import java.text.SimpleDateFormat
 
-import org.broadinstitute.dsde.firecloud.service.FireCloudTransformers
+import org.broadinstitute.dsde.firecloud.service.FireCloudRequestBuilding
 
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, Future}
@@ -40,7 +40,7 @@ object EntityClient {
 
 }
 
-class EntityClient (requestContext: RequestContext) extends Actor with FireCloudTransformers {
+class EntityClient (requestContext: RequestContext) extends Actor with FireCloudRequestBuilding {
 
   import system.dispatcher
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/HttpClient.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/HttpClient.scala
@@ -4,7 +4,7 @@ import java.text.SimpleDateFormat
 
 import akka.actor.{Actor, Props}
 import org.broadinstitute.dsde.firecloud.HttpClient.PerformExternalRequest
-import org.broadinstitute.dsde.firecloud.service.FireCloudTransformers
+import org.broadinstitute.dsde.firecloud.service.FireCloudRequestBuilding
 import org.broadinstitute.dsde.firecloud.service.PerRequest.{RequestComplete, RequestCompleteWithHeaders}
 import org.slf4j.LoggerFactory
 import spray.client.pipelining
@@ -28,7 +28,7 @@ object HttpClient {
 
 }
 
-class HttpClient (requestContext: RequestContext) extends Actor with FireCloudTransformers {
+class HttpClient (requestContext: RequestContext) extends Actor with FireCloudRequestBuilding {
 
   import system.dispatcher
   implicit val system = context.system

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/core/GetEntitiesWithType.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/core/GetEntitiesWithType.scala
@@ -4,7 +4,7 @@ import akka.actor.{Actor, Props}
 import akka.contrib.pattern.Aggregator
 import akka.event.Logging
 import org.broadinstitute.dsde.firecloud.core.GetEntitiesWithType.{EntityWithType, ProcessUrl}
-import org.broadinstitute.dsde.firecloud.service.FireCloudTransformers
+import org.broadinstitute.dsde.firecloud.service.FireCloudRequestBuilding
 import org.broadinstitute.dsde.firecloud.service.PerRequest.RequestComplete
 import spray.client.pipelining._
 import spray.http.StatusCodes._
@@ -23,7 +23,7 @@ object GetEntitiesWithType {
   def props(requestContext: RequestContext): Props = Props(new GetEntitiesWithTypeActor(requestContext))
 }
 
-class GetEntitiesWithTypeActor(requestContext: RequestContext) extends Actor with Aggregator with FireCloudTransformers {
+class GetEntitiesWithTypeActor(requestContext: RequestContext) extends Actor with Aggregator with FireCloudRequestBuilding {
 
   implicit val system = context.system
   import system.dispatcher

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/FireCloudRequestBuilding.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/FireCloudRequestBuilding.scala
@@ -4,9 +4,7 @@ import spray.http.HttpHeaders.Authorization
 import spray.http.{HttpHeader, HttpCredentials, HttpRequest, OAuth2BearerToken}
 import spray.routing.RequestContext
 
-/**
- * Created by davidan on 9/1/15.
- */
+
 trait FireCloudRequestBuilding extends spray.httpx.RequestBuilding {
 
   // TODO: would be much better to make requestContext implicit, so callers don't have to always pass it in

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/FireCloudRequestBuilding.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/FireCloudRequestBuilding.scala
@@ -7,7 +7,7 @@ import spray.routing.RequestContext
 /**
  * Created by davidan on 9/1/15.
  */
-trait FireCloudTransformers extends spray.httpx.RequestBuilding {
+trait FireCloudRequestBuilding extends spray.httpx.RequestBuilding {
 
   // TODO: would be much better to make requestContext implicit, so callers don't have to always pass it in
   // TODO: this could probably be rewritten more tersely in idiomatic scala - for instance, don't create

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/FireCloudTransformers.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/FireCloudTransformers.scala
@@ -1,0 +1,45 @@
+package org.broadinstitute.dsde.firecloud.service
+
+import spray.http.HttpHeaders.Authorization
+import spray.http.{HttpHeader, HttpCredentials, HttpRequest, OAuth2BearerToken}
+import spray.routing.RequestContext
+
+/**
+ * Created by davidan on 9/1/15.
+ */
+trait FireCloudTransformers extends spray.httpx.RequestBuilding {
+
+  // TODO: would be much better to make requestContext implicit, so callers don't have to always pass it in
+  // TODO: this could probably be rewritten more tersely in idiomatic scala - for instance, don't create
+    // the OAuth2BearerToken if we're not going to use it. I'm leaving all this longhand for better comprehension.
+  def authHeaders(requestContext: RequestContext) = {
+
+    // inspect headers for a pre-existing Authorization: header
+    val authorizationHeader:Option[HttpCredentials] = (requestContext.request.headers collect {
+        case Authorization(h) => h
+    }).headOption
+
+    // inspect headers for a custom OIDC_access_token: header, coming from the mod_auth_openidc Apache proxy.
+    // take its value and create an OAuth2 bearer token from it.
+    val accessTokenHeader:Option[HttpCredentials] = (requestContext.request.headers collect {
+      case h:HttpHeader if h.name.equals("OIDC_access_token") => OAuth2BearerToken(h.value)
+    }).headOption
+
+    // prefer the Authorization: header over the OIDC_access_token
+    val creds = authorizationHeader orElse accessTokenHeader
+
+    creds match {
+      // if we have authorization credentials, apply them to the outgoing request
+      case Some(c) => addCredentials(c)
+      // else, noop. But the noop needs to return an identity function in order to compile.
+      // alternately, we could throw an error here, since we assume some authorization should exist.
+      case None => (r:HttpRequest)=>r
+    }
+
+  }
+
+  def dummyAuthHeaders = {
+    addCredentials(OAuth2BearerToken("mF_9.B5f-4.1JqM"))
+  }
+
+}

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceService.scala
@@ -39,7 +39,12 @@ trait WorkspaceService extends HttpService with PerRequestCreator with FireCloud
         } ~
           post {
             entity(as[String]) { ingest =>
-              commonNameFromOptionalCookie() { username => requestContext =>
+              // TODO: replace with a directive that pulls the username from the Google info!
+              // TODO: rawls should populate createdBy/createdDate/attributes on its own!
+              // commonNameFromOptionalCookie() { username => requestContext =>
+              requestContext =>
+              val username = Option("FIXME!")
+
                 username match {
                   case Some(x) =>
                     val params = ingest.parseJson.convertTo[Map[String, JsValue]]
@@ -55,7 +60,7 @@ trait WorkspaceService extends HttpService with PerRequestCreator with FireCloud
                     log.error("No authenticated username provided.")
                     requestContext.complete(Unauthorized)
                 }
-              }
+              // }
             }
           }
       } ~

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockMethodsServer.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockMethodsServer.scala
@@ -66,7 +66,7 @@ object MockMethodsServer {
         request()
           .withMethod("GET")
           .withPath("/methods")
-          .withCookies(cookie)
+          .withHeader(authHeader)
       ).respond(
         response()
           .withHeaders(header)
@@ -93,7 +93,7 @@ object MockMethodsServer {
         request()
           .withMethod("GET")
           .withPath("/configurations")
-          .withCookies(cookie)
+          .withHeader(authHeader)
       ).respond(
         response()
           .withHeaders(header)

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockUtils.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockUtils.scala
@@ -3,12 +3,12 @@ package org.broadinstitute.dsde.firecloud.mock
 import java.text.SimpleDateFormat
 import java.util.Date
 
-import org.mockserver.model.{Cookie, Header}
+import org.mockserver.model.Header
 
 object MockUtils {
 
    val isoDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZZ")
-   val cookie = new Cookie("iPlanetDirectoryPro", ".*")
+   val authHeader = new Header("Authorization", "Bearer dummytoken")
    val header = new Header("Content-Type", "application/json")
 
    def randomPositiveInt(): Int = {

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockUtils.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockUtils.scala
@@ -8,7 +8,7 @@ import org.mockserver.model.Header
 object MockUtils {
 
    val isoDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZZ")
-   val authHeader = new Header("Authorization", "Bearer dummytoken")
+   val authHeader = new Header("Authorization", "Bearer mF_9.B5f-4.1JqM")
    val header = new Header("Content-Type", "application/json")
 
    def randomPositiveInt(): Int = {

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockWorkspaceServer.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockWorkspaceServer.scala
@@ -156,7 +156,7 @@ object MockWorkspaceServer {
           .withMethod("POST")
           .withPath(s"/workspaces/%s/%s/submissions"
             .format(mockValidWorkspace.namespace.get, mockValidWorkspace.name.get))
-          .withCookies(cookie))
+          .withHeader(authHeader))
       .callback(
         callback().
           withCallbackClass("org.broadinstitute.dsde.firecloud.mock.ValidSubmissionCallback")
@@ -180,7 +180,7 @@ object MockWorkspaceServer {
           .withMethod("GET")
           .withPath(s"/workspaces/%s/%s/submissions"
           .format(mockValidWorkspace.namespace.get, mockValidWorkspace.name.get))
-          .withCookies(cookie))
+          .withHeader(authHeader))
       .respond(
         response()
           .withHeaders(header)
@@ -193,7 +193,7 @@ object MockWorkspaceServer {
           .withMethod("GET")
           .withPath(s"/workspaces/%s/%s/submissions/%s"
             .format(mockValidWorkspace.namespace.get, mockValidWorkspace.name.get, mockValidId))
-          .withCookies(cookie))
+          .withHeader(authHeader))
       .respond(
         response()
           .withHeaders(header)
@@ -207,7 +207,7 @@ object MockWorkspaceServer {
           .withMethod("DELETE")
           .withPath(s"/workspaces/%s/%s/submissions/%s"
           .format(mockValidWorkspace.namespace.get, mockValidWorkspace.name.get, mockValidId))
-          .withCookies(cookie))
+          .withHeader(authHeader))
       .respond(
         response()
           .withHeaders(header)
@@ -222,8 +222,8 @@ object MockWorkspaceServer {
         request()
           .withMethod("POST")
           .withPath("/workspaces")
-          .withCookies(cookie)
-      ).callback(
+          .withHeader(authHeader))
+      .callback(
         callback().
           withCallbackClass("org.broadinstitute.dsde.firecloud.mock.ValidWorkspaceCallback")
       )
@@ -245,8 +245,8 @@ object MockWorkspaceServer {
         request()
           .withMethod("GET")
           .withPath("/workspaces")
-          .withCookies(cookie)
-      ).respond(
+          .withHeader(authHeader))
+      .respond(
         response()
           .withHeaders(header)
           .withBody(mockWorkspaces.toJson.prettyPrint)
@@ -261,8 +261,8 @@ object MockWorkspaceServer {
           .withMethod("GET")
           .withPath(s"/workspaces/%s/%s/methodconfigs"
             .format(mockInvalidWorkspace.namespace.get, mockInvalidWorkspace.name.get))
-          .withCookies(cookie)).
-      respond(
+          .withHeader(authHeader))
+      .respond(
         response()
           .withHeaders(header)
           .withStatusCode(NotFound.intValue))
@@ -273,8 +273,8 @@ object MockWorkspaceServer {
           .withMethod("GET")
           .withPath(s"/workspaces/%s/%s/methodconfigs".
             format(mockValidWorkspace.namespace.get, mockValidWorkspace.name.get))
-          .withCookies(cookie)).
-      respond(
+          .withHeader(authHeader))
+      .respond(
         response()
           .withHeaders(header)
           .withBody(mockMethodConfigs.toJson.prettyPrint)
@@ -292,8 +292,8 @@ object MockWorkspaceServer {
             mockValidWorkspace.namespace.get,
             mockValidWorkspace.name.get))
           .withBody(mockMethodConfigs.head.toJson.prettyPrint)
-          .withCookies(cookie)).
-      respond(
+          .withHeader(authHeader))
+      .respond(
         response()
           .withHeaders(header)
           .withStatusCode(OK.intValue))
@@ -308,8 +308,8 @@ object MockWorkspaceServer {
             mockValidWorkspace.name.get,
             mockValidWorkspace.namespace.get,
             mockValidWorkspace.name.get))
-          .withCookies(cookie)).
-      respond(
+          .withHeader(authHeader))
+      .respond(
         response()
           .withHeaders(header)
           .withBody(mockMethodConfigs.head.toJson.prettyPrint)
@@ -367,8 +367,8 @@ object MockWorkspaceServer {
           .withMethod("PUT")
           .withPath(s"/workspaces/${mockValidWorkspace.namespace.get}/${mockValidWorkspace.name.get}/methodconfigs")
           .withBody("")
-          .withCookies(cookie)
-      ).respond(
+          .withHeader(authHeader))
+      .respond(
         response()
           .withHeaders(header)
           .withStatusCode(OK.intValue)
@@ -382,8 +382,8 @@ object MockWorkspaceServer {
           .withMethod("POST")
           .withPath(s"/workspaces/${mockSampleValid.wsNamespace.get}/${mockSampleValid.wsName.get}/entities")
           .withBody(mockSampleValid.toJson.compactPrint)
-          .withCookies(cookie)
-      ).respond(
+          .withHeader(authHeader))
+      .respond(
         response()
           .withHeaders(header)
           .withStatusCode(Created.intValue)
@@ -394,8 +394,8 @@ object MockWorkspaceServer {
         request()
           .withMethod("GET")
           .withPath(entitiesWithTypeBasePath + "entities")
-          .withCookies(cookie)
-      ).respond(
+          .withHeader(authHeader))
+      .respond(
         response()
           .withHeaders(header)
           .withBody(List("participant", "sample", "Pair", "sampleset").toJson.compactPrint)
@@ -407,8 +407,8 @@ object MockWorkspaceServer {
         request()
           .withMethod("GET")
           .withPath(entitiesWithTypeBasePath + "entities/participant")
-          .withCookies(cookie)
-      ).respond(
+          .withHeader(authHeader))
+      .respond(
         response()
           .withHeaders(header)
           .withBody(List(EntityWithType("participant_01", "participant", Option.empty), EntityWithType("participant_02", "participant", Option.empty)).toJson.compactPrint)
@@ -420,8 +420,8 @@ object MockWorkspaceServer {
         request()
           .withMethod("GET")
           .withPath(entitiesWithTypeBasePath + "entities/sample")
-          .withCookies(cookie)
-      ).respond(
+          .withHeader(authHeader))
+      .respond(
         response()
           .withHeaders(header)
           .withBody(List(EntityWithType("sample_01", "sample", Option.empty), EntityWithType("sample_02", "sample", Option.empty)).toJson.compactPrint)
@@ -433,8 +433,8 @@ object MockWorkspaceServer {
         request()
           .withMethod("GET")
           .withPath(entitiesWithTypeBasePath + "entities/Pair")
-          .withCookies(cookie)
-      ).respond(
+          .withHeader(authHeader))
+      .respond(
         response()
           .withHeaders(header)
           .withBody(List(EntityWithType("pair_01", "Pair", Option.empty)).toJson.compactPrint)
@@ -446,8 +446,8 @@ object MockWorkspaceServer {
         request()
           .withMethod("GET")
           .withPath(entitiesWithTypeBasePath + "entities/sampleset")
-          .withCookies(cookie)
-      ).respond(
+          .withHeader(authHeader))
+      .respond(
         response()
           .withHeaders(header)
           .withBody(List(EntityWithType("sampleset_01", "sampleset", Option.empty), EntityWithType("sampleset_02", "sampleset", Option.empty)).toJson.compactPrint)
@@ -460,8 +460,8 @@ object MockWorkspaceServer {
           .withMethod("POST")
           .withPath(s"/workspaces/${mockPairValid.wsNamespace.get}/${mockPairValid.wsName.get}/entities")
           .withBody(mockPairValid.toJson.compactPrint)
-          .withCookies(cookie)
-      ).respond(
+          .withHeader(authHeader))
+      .respond(
         response()
           .withHeaders(header)
           .withStatusCode(Created.intValue)
@@ -473,8 +473,8 @@ object MockWorkspaceServer {
           .withMethod("POST")
           .withPath(s"/workspaces/${mockSampleConflict.wsNamespace.get}/${mockSampleConflict.wsName.get}/entities")
           .withBody(mockSampleConflict.toJson.compactPrint)
-          .withCookies(cookie)
-      ).respond(
+          .withHeader(authHeader))
+      .respond(
         response()
           .withHeaders(header)
           .withStatusCode(Conflict.intValue)
@@ -485,8 +485,8 @@ object MockWorkspaceServer {
         request()
           .withMethod("POST")
           .withPath("/methodconfigs/copyFromMethodRepo")
-          .withCookies(cookie)
-      ).callback(
+          .withHeader(authHeader))
+      .callback(
         callback().
           withCallbackClass("org.broadinstitute.dsde.firecloud.mock.ValidMethodConfigurationFromRepoCallback")
       )
@@ -508,8 +508,8 @@ object MockWorkspaceServer {
         request()
           .withMethod("POST")
           .withPath(s"/workspaces/${mockValidWorkspace.namespace.get}/${mockValidWorkspace.name.get}/entities/batchUpsert")
-          .withCookies(cookie)
-      ).respond(
+          .withHeader(authHeader))
+      .respond(
         response()
           .withHeaders(header)
           .withStatusCode(NoContent.intValue)
@@ -520,8 +520,8 @@ object MockWorkspaceServer {
         request()
           .withMethod("POST")
           .withPath(s"/workspaces/${mockValidWorkspace.namespace.get}/${mockValidWorkspace.name.get}/entities/batchUpdate")
-          .withCookies(cookie)
-      ).respond(
+          .withHeader(authHeader))
+      .respond(
         response()
           .withHeaders(header)
           .withStatusCode(NoContent.intValue)

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/mock/ValidMethodConfigurationFromRepoCallback.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/mock/ValidMethodConfigurationFromRepoCallback.scala
@@ -15,37 +15,36 @@ class ValidMethodConfigurationFromRepoCallback extends ExpectationCallback {
   lazy val log = LoggerFactory.getLogger(getClass)
 
   override def handle(httpRequest: HttpRequest): HttpResponse = {
-    httpRequest.getCookies match {
-      case cookies if cookies.size() > 0 =>
-        log.debug(cookies.toString)
-        val jsonAst = httpRequest.getBodyAsString.parseJson
-        val config = jsonAst.convertTo[MethodConfigurationCopy]
-        config match {
-          case x if x.methodRepoName.isDefined
-            && x.methodRepoNamespace.isDefined
-            && x.methodRepoSnapshotId.isDefined
-            && x.destination.isDefined
-            && x.destination.get.name.isDefined
-            && x.destination.get.namespace.isDefined
-            && x.destination.get.workspaceName.isDefined
-            && x.destination.get.workspaceName.get.name.isDefined
-            && x.destination.get.workspaceName.get.namespace.isDefined =>
-            log.debug("Match valid method configuration copy object")
-            response()
-              .withHeaders(header)
-              .withStatusCode(Created.intValue)
-          case _ =>
-            log.debug("Match invalid method configuration copy object")
-            response()
-              .withHeaders(header)
-              .withStatusCode(BadRequest.intValue)
-        }
-      case _ =>
-        log.debug("No authentication cookie provided")
-        response()
-          .withHeaders(header)
-          .withBody("Authentication is possible but has failed or not yet been provided.")
-          .withStatusCode(Unauthorized.intValue)
+    if (httpRequest.containsHeader("Authorization")) {
+      log.debug(httpRequest.getHeaders.toString)
+      val jsonAst = httpRequest.getBodyAsString.parseJson
+      val config = jsonAst.convertTo[MethodConfigurationCopy]
+      config match {
+        case x if x.methodRepoName.isDefined
+          && x.methodRepoNamespace.isDefined
+          && x.methodRepoSnapshotId.isDefined
+          && x.destination.isDefined
+          && x.destination.get.name.isDefined
+          && x.destination.get.namespace.isDefined
+          && x.destination.get.workspaceName.isDefined
+          && x.destination.get.workspaceName.get.name.isDefined
+          && x.destination.get.workspaceName.get.namespace.isDefined =>
+          log.debug("Match valid method configuration copy object")
+          response()
+            .withHeaders(header)
+            .withStatusCode(Created.intValue)
+        case _ =>
+          log.debug("Match invalid method configuration copy object")
+          response()
+            .withHeaders(header)
+            .withStatusCode(BadRequest.intValue)
+      }
+    } else {
+      log.debug("No authentication header provided")
+      response()
+        .withHeaders(header)
+        .withBody("Authentication is possible but has failed or not yet been provided.")
+        .withStatusCode(Unauthorized.intValue)
     }
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/EntityServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/EntityServiceSpec.scala
@@ -12,7 +12,7 @@ import spray.httpx.SprayJsonSupport._
 import spray.json.DefaultJsonProtocol._
 
 class EntityServiceSpec extends FreeSpec with ScalaFutures with ScalatestRouteTest
-  with Matchers with EntityService with FireCloudTransformers {
+  with Matchers with EntityService with FireCloudRequestBuilding {
 
   def actorRefFactory = system
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/EntityServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/EntityServiceSpec.scala
@@ -2,19 +2,17 @@ package org.broadinstitute.dsde.firecloud.service
 
 import org.broadinstitute.dsde.firecloud.core.GetEntitiesWithType.EntityWithType
 import org.broadinstitute.dsde.firecloud.mock.MockWorkspaceServer
-import org.broadinstitute.dsde.vault.common.openam.OpenAMSession
 import org.scalatest.time.{Seconds, Span}
 import org.scalatest.{Matchers, FreeSpec}
 import org.scalatest.concurrent.ScalaFutures
-import spray.http.HttpCookie
-import spray.http.HttpHeaders.Cookie
 import spray.http.StatusCodes._
 import spray.testkit.ScalatestRouteTest
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
 import spray.httpx.SprayJsonSupport._
 import spray.json.DefaultJsonProtocol._
 
-class EntityServiceSpec extends FreeSpec with ScalaFutures with ScalatestRouteTest with Matchers with EntityService {
+class EntityServiceSpec extends FreeSpec with ScalaFutures with ScalatestRouteTest
+  with Matchers with EntityService with FireCloudTransformers {
 
   def actorRefFactory = system
 
@@ -28,13 +26,10 @@ class EntityServiceSpec extends FreeSpec with ScalaFutures with ScalatestRouteTe
 
   "EntityService" - {
 
-    val openAMSession = OpenAMSession(()).futureValue(timeout(Span(5, Seconds)), interval(scaled(Span(0.5, Seconds))))
-    val token = openAMSession.cookies.head.content
-
     "when calling GET on entities_with_type path with a valid workspace" - {
       "valid list of entity types are returned" in {
         val path = s"${MockWorkspaceServer.entitiesWithTypeBasePath}entities_with_type"
-        Get(path) ~> Cookie(HttpCookie("iPlanetDirectoryPro", token)) ~> sealRoute(routes) ~> check {
+        Get(path) ~> dummyAuthHeaders ~> sealRoute(routes) ~> check {
           status should be(OK)
           val entities = responseAs[List[EntityWithType]]
           entities shouldNot be(empty)

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/MethodConfigurationServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/MethodConfigurationServiceSpec.scala
@@ -3,17 +3,16 @@ package org.broadinstitute.dsde.firecloud.service
 import org.broadinstitute.dsde.firecloud.mock.MockWorkspaceServer
 import org.broadinstitute.dsde.firecloud.model.CopyConfigurationIngest
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
-import org.broadinstitute.dsde.vault.common.openam.OpenAMSession
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Seconds, Span}
 import org.scalatest.{FreeSpec, Matchers}
-import spray.http.HttpHeaders.Cookie
 import spray.http.StatusCodes._
 import spray.http._
 import spray.httpx.SprayJsonSupport._
 import spray.testkit.ScalatestRouteTest
 
-class MethodConfigurationServiceSpec extends FreeSpec with ScalaFutures with ScalatestRouteTest with Matchers with MethodConfigurationService {
+class MethodConfigurationServiceSpec extends FreeSpec with ScalaFutures with ScalatestRouteTest
+  with Matchers with MethodConfigurationService with FireCloudTransformers {
 
   def actorRefFactory = system
 
@@ -31,8 +30,6 @@ class MethodConfigurationServiceSpec extends FreeSpec with ScalaFutures with Sca
     MockWorkspaceServer.mockValidWorkspace.namespace.get,
     MockWorkspaceServer.mockValidWorkspace.name.get
   )
-  private final val openAMSession = OpenAMSession(()).futureValue(timeout(Span(5, Seconds)), interval(scaled(Span(0.5, Seconds))))
-  private final val token = openAMSession.cookies.head.content
   private final val validConfigurationCopyFormData = CopyConfigurationIngest(
     configurationNamespace = Option("namespace"),
     configurationName = Option("name"),
@@ -54,7 +51,7 @@ class MethodConfigurationServiceSpec extends FreeSpec with ScalaFutures with Sca
 
     "when calling DELETE on the /workspaces/*/*/method_configs/*/* with a valid path" - {
       "Successful Request (204, NoContent) response is returned" in {
-        Delete(validGetMethodConfigUrl) ~> Cookie(HttpCookie("iPlanetDirectoryPro", token)) ~> sealRoute(routes) ~> check {
+        Delete(validGetMethodConfigUrl) ~> dummyAuthHeaders ~> sealRoute(routes) ~> check {
           status should equal(NoContent)
         }
       }
@@ -62,7 +59,7 @@ class MethodConfigurationServiceSpec extends FreeSpec with ScalaFutures with Sca
 
     "when calling DELETE on the /workspaces/*/*/method_configs/*/* with an invalid path" - {
       "NotFound response is returned" in {
-        Delete("/workspaces/invalid/invalid/method_configs/invalid/invalid") ~> Cookie(HttpCookie("iPlanetDirectoryPro", token)) ~> sealRoute(routes) ~> check {
+        Delete("/workspaces/invalid/invalid/method_configs/invalid/invalid") ~> dummyAuthHeaders ~> sealRoute(routes) ~> check {
           status should equal(NotFound)
         }
       }
@@ -70,7 +67,7 @@ class MethodConfigurationServiceSpec extends FreeSpec with ScalaFutures with Sca
 
     "when calling PUT on the /workspaces/*/*/method_configs/*/* path with a valid method configuration" - {
       "OK response is returned" in {
-        Put(validUpdateMethodConfigUrl, MockWorkspaceServer.mockMethodConfigs.head) ~> Cookie(HttpCookie("iPlanetDirectoryPro", token)) ~> sealRoute(routes) ~> check {
+        Put(validUpdateMethodConfigUrl, MockWorkspaceServer.mockMethodConfigs.head) ~> dummyAuthHeaders ~> sealRoute(routes) ~> check {
           status should equal(OK)
         }
       }
@@ -78,7 +75,7 @@ class MethodConfigurationServiceSpec extends FreeSpec with ScalaFutures with Sca
 
     "when calling PUT on the /workspaces/*/*/method_configs/*/* path with a nonexistent method configuration" - {
       "OK response is returned" in {
-        Put(validUpdateMethodConfigUrl, MockWorkspaceServer.mockInvalidWorkspace) ~> Cookie(HttpCookie("iPlanetDirectoryPro", token)) ~> sealRoute(routes) ~> check {
+        Put(validUpdateMethodConfigUrl, MockWorkspaceServer.mockInvalidWorkspace) ~> dummyAuthHeaders ~> sealRoute(routes) ~> check {
           status should equal(NotFound)
         }
       }
@@ -86,7 +83,7 @@ class MethodConfigurationServiceSpec extends FreeSpec with ScalaFutures with Sca
 
     "when calling GET on the /workspaces/*/*/method_configs/*/* path" - {
       "OK respose is returned" in {
-        Get(validGetMethodConfigUrl) ~> Cookie(HttpCookie("iPlanetDirectoryPro", token)) ~> sealRoute(routes) ~> check {
+        Get(validGetMethodConfigUrl) ~> dummyAuthHeaders ~> sealRoute(routes) ~> check {
           status should equal(OK)
         }
       }
@@ -94,7 +91,7 @@ class MethodConfigurationServiceSpec extends FreeSpec with ScalaFutures with Sca
 
     "when calling GET on an invalid /workspaces/*/*/method_configs/*/* path" - {
       "Not Found respose is returned" in {
-        Get("/workspaces/invalid/invalid/method_configs/invalid/invalid") ~> Cookie(HttpCookie("iPlanetDirectoryPro", token)) ~> sealRoute(routes) ~> check {
+        Get("/workspaces/invalid/invalid/method_configs/invalid/invalid") ~> dummyAuthHeaders ~> sealRoute(routes) ~> check {
           status should equal(NotFound)
         }
       }
@@ -102,7 +99,7 @@ class MethodConfigurationServiceSpec extends FreeSpec with ScalaFutures with Sca
 
     "when calling POST on the /workspaces/*/*/method_configs/*/* path" - {
       "MethodNotAllowed error is returned" in {
-        Post(validUpdateMethodConfigUrl, MockWorkspaceServer.mockMethodConfigs.head) ~> Cookie(HttpCookie("iPlanetDirectoryPro", token)) ~> sealRoute(routes) ~> check {
+        Post(validUpdateMethodConfigUrl, MockWorkspaceServer.mockMethodConfigs.head) ~> dummyAuthHeaders ~> sealRoute(routes) ~> check {
           status should equal(MethodNotAllowed)
         }
       }
@@ -122,7 +119,7 @@ class MethodConfigurationServiceSpec extends FreeSpec with ScalaFutures with Sca
      */
     "when calling POST on the /workspaces*/*/method_configs/copyFromMethodRepo path with valid workspace and configuration data" - {
       "Created response is returned" in {
-        Post(validCopyFromRepoUrl, validConfigurationCopyFormData) ~> Cookie(HttpCookie("iPlanetDirectoryPro", token)) ~> sealRoute(routes) ~> check {
+        Post(validCopyFromRepoUrl, validConfigurationCopyFormData) ~> dummyAuthHeaders ~> sealRoute(routes) ~> check {
           status should equal(Created)
         }
       }
@@ -130,7 +127,7 @@ class MethodConfigurationServiceSpec extends FreeSpec with ScalaFutures with Sca
 
     "when calling POST on the /workspaces*/*/method_configs/copyFromMethodRepo path with invalid data" - {
       "BadRequest response is returned" in {
-        Post(validCopyFromRepoUrl, invalidConfigurationCopyFormData) ~> Cookie(HttpCookie("iPlanetDirectoryPro", token)) ~> sealRoute(routes) ~> check {
+        Post(validCopyFromRepoUrl, invalidConfigurationCopyFormData) ~> dummyAuthHeaders ~> sealRoute(routes) ~> check {
           status should equal(BadRequest)
         }
       }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/MethodConfigurationServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/MethodConfigurationServiceSpec.scala
@@ -12,7 +12,7 @@ import spray.httpx.SprayJsonSupport._
 import spray.testkit.ScalatestRouteTest
 
 class MethodConfigurationServiceSpec extends FreeSpec with ScalaFutures with ScalatestRouteTest
-  with Matchers with MethodConfigurationService with FireCloudTransformers {
+  with Matchers with MethodConfigurationService with FireCloudRequestBuilding {
 
   def actorRefFactory = system
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/MethodsServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/MethodsServiceSpec.scala
@@ -3,18 +3,16 @@ package org.broadinstitute.dsde.firecloud.service
 import org.broadinstitute.dsde.firecloud.mock.MockMethodsServer
 import org.broadinstitute.dsde.firecloud.model.MethodRepository.{Configuration, Method}
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
-import org.broadinstitute.dsde.vault.common.openam.OpenAMSession
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Seconds, Span}
 import org.scalatest.{FreeSpec, Matchers}
-import spray.http.HttpCookie
-import spray.http.HttpHeaders.Cookie
 import spray.http.StatusCodes._
 import spray.httpx.SprayJsonSupport._
 import spray.json.DefaultJsonProtocol._
 import spray.testkit.ScalatestRouteTest
 
-class MethodsServiceSpec extends FreeSpec with ScalaFutures with ScalatestRouteTest with Matchers with MethodsService {
+class MethodsServiceSpec extends FreeSpec with ScalaFutures with ScalatestRouteTest
+  with Matchers with MethodsService with FireCloudTransformers {
 
   def actorRefFactory = system
 
@@ -28,18 +26,9 @@ class MethodsServiceSpec extends FreeSpec with ScalaFutures with ScalatestRouteT
 
   "MethodsService" - {
 
-    val openAMSession = OpenAMSession(()).futureValue(timeout(Span(5, Seconds)), interval(scaled(Span(0.5, Seconds))))
-    val token = openAMSession.cookies.head.content
-
-    "when generating an OpenAM token" - {
-      "token should be valid" in {
-        token should endWith("*")
-      }
-    }
-
     "when calling GET on the /methods path" - {
       "valid methods are returned" in {
-        Get("/methods") ~> Cookie(HttpCookie("iPlanetDirectoryPro", token)) ~> sealRoute(routes) ~> check {
+        Get("/methods") ~> dummyAuthHeaders ~> sealRoute(routes) ~> check {
           status should equal(OK)
           val entities = responseAs[List[Method]]
           entities shouldNot be(empty)
@@ -80,7 +69,7 @@ class MethodsServiceSpec extends FreeSpec with ScalaFutures with ScalatestRouteT
 
     "when calling GET on the /configurations path" - {
       "valid methods are returned" in {
-        Get("/configurations") ~> Cookie(HttpCookie("iPlanetDirectoryPro", token)) ~> sealRoute(routes) ~> check {
+        Get("/configurations") ~> dummyAuthHeaders ~> sealRoute(routes) ~> check {
           status should equal(OK)
           val entities = responseAs[List[Configuration]]
           entities shouldNot be(empty)

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/MethodsServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/MethodsServiceSpec.scala
@@ -12,7 +12,7 @@ import spray.json.DefaultJsonProtocol._
 import spray.testkit.ScalatestRouteTest
 
 class MethodsServiceSpec extends FreeSpec with ScalaFutures with ScalatestRouteTest
-  with Matchers with MethodsService with FireCloudTransformers {
+  with Matchers with MethodsService with FireCloudRequestBuilding {
 
   def actorRefFactory = system
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/SubmissionServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/SubmissionServiceSpec.scala
@@ -11,7 +11,7 @@ import spray.httpx.SprayJsonSupport._
 import spray.testkit.ScalatestRouteTest
 
 class SubmissionServiceSpec extends FreeSpec with ScalaFutures with ScalatestRouteTest
-  with Matchers with SubmissionService with FireCloudTransformers {
+  with Matchers with SubmissionService with FireCloudRequestBuilding {
 
   def actorRefFactory = system
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceServiceSpec.scala
@@ -14,7 +14,7 @@ import spray.httpx.SprayJsonSupport._
 import spray.testkit.ScalatestRouteTest
 
 class WorkspaceServiceSpec extends FreeSpec with ScalaFutures with ScalatestRouteTest
-  with Matchers with WorkspaceService with FireCloudTransformers {
+  with Matchers with WorkspaceService with FireCloudRequestBuilding {
 
   def actorRefFactory = system
 


### PR DESCRIPTION
DO NOT MERGE without the new Google/OAuth proxy in place, and without reading through this description fully.

This is a *theoretical* and *untested* change. I haven't had a chance to spin up the new OAuth proxy locally, and rawls/agora don't support the new OAuth proxy yet, so I have no idea if this works. It'll be up to you to try it and see.

The heart of this change is the new FireCloudRequestBuilder trait and its authHeaders function. This looks for auth headers in the incoming request and copies those headers to the outgoing request.
**TODO: verify this is looking for the correct headers.**

_Other teams, like rawls, may want a copy of this trait!_

Then, I've modified all our endpoints to remove handling of the OpenAM cookie and replace with a call to the authHeaders function.

Finally, I did the same for all our tests, which use a dummy auth header instead of a real one.
**TODO: this means tests will only work against mock data; they'll fail against a real version of rawls/agora because the dummy auth header will be rejected as invalid.**
Alternately, we could choose to remove auth headers from our tests entirely, cleaning them up a bit.

The FireCloudRequestBuilding trait could probably be optimized from the pure Scala perspective.
