### PR TITLE
DSDEEPB-1235: Move filtering of automatic headers from HttpClient to PerRequest

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/HttpClient.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/HttpClient.scala
@@ -53,19 +53,11 @@ class HttpClient (requestContext: RequestContext) extends Actor
     pipeline(externalRequest) onComplete {
       case Success(response) =>
         log.debug("Got response: " + response)
-        context.parent ! RequestCompleteWithHeaders(response, response.headers.filterNot(isAutomaticHeader):_*)
+        context.parent ! RequestCompleteWithHeaders(response, response.headers:_*)
       case Failure(error) =>
         log.error("External request failed", error)
         context.parent ! RequestComplete(StatusCodes.InternalServerError, error.getMessage)
     }
-  }
-
-  private def isAutomaticHeader(h: HttpHeader): Boolean = h match {
-    case _:HttpHeaders.Date => true
-    case _:HttpHeaders.Server => true
-    case _:HttpHeaders.`Content-Type` => true
-    case _:HttpHeaders.`Content-Length` => true
-    case _ => false
   }
 }
 


### PR DESCRIPTION
This should eliminate all the "Explicitly set response header 'Date: Wed, 09 Sep 2015 22:11:12 GMT' is ignored, the spray-can HTTP layer sets this header automatically!" messages in the orchestration layer log.