### PR TITLE
DSDEEPB-1164: change method config snapshot from String to Int

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/Workspace.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/Workspace.scala
@@ -75,7 +75,7 @@ case class MethodConfigurationCopy(
   @(ApiModelProperty@field)(required = true, value = "method configuration name")
   methodRepoName: Option[String] = None,
   @(ApiModelProperty@field)(required = true, value = "method configuration snapshot id")
-  methodRepoSnapshotId: Option[String] = None,
+  methodRepoSnapshotId: Option[Int] = None,
   @(ApiModelProperty@field)(required = true, value = "method configuration destination")
   destination: Option[Destination] = None)
 
@@ -86,7 +86,7 @@ case class CopyConfigurationIngest(
   @(ApiModelProperty@field)(required = true, value = "method configuration name")
   configurationName: Option[String],
   @(ApiModelProperty@field)(required = true, value = "method configuration snapshot id")
-  configurationSnapshotId: Option[String],
+  configurationSnapshotId: Option[Int],
   @(ApiModelProperty@field)(required = true, value = "method configuration destination namespace")
   destinationNamespace: Option[String],
   @(ApiModelProperty@field)(required = true, value = "method configuration destination name")


### PR DESCRIPTION
Agora and Rawls are both now using an int for config snapshot id. Orchestration was still using a String. This fixes that incompatibility.

*importing configs still has problems* but this unblocks development of those other problems. After this change, when I try to import a config, I get an error
```
{
message: "Error parsing Method Repo response: Object is missing required member 'methodRepoMethod'"
}
```
Which I'm guessing is going to require some UI changes.