### PR TITLE
Passthrough API for copying entities from one workspace to another.

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -49,4 +49,5 @@ workspace {
   submissionsPath="/workspaces/%s/%s/submissions"
   submissionByIdPath="/workspaces/%s/%s/submissions/%s"
   workflowOutputsByIdPath="/workspaces/%s/%s/submissions/%s/workflows/%s/outputs"
+  workspacesEntitiesCopyPath="/workspaces/entities/copy"
 }

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -266,6 +266,43 @@ paths:
           description: Workspace does not exist
         500:
           description: Internal Server Error
+  /workspaces/{workspaceNamespace}/{workspaceName}/entities/copy:
+    post:
+      tags:
+      - Entities
+      operationId: copyEntities
+      summary: |
+        Copy entities from one workspace to another
+      produces:
+        - application/json
+      parameters:
+        - name: workspaceNamespace
+          description: Workspace Namespace
+          required: true
+          type: string
+          in: path
+        - name: workspaceName
+          description: Workspace Name
+          required: true
+          type: string
+          in: path
+        - name: body
+          description: Entity to Copy
+          required: true
+          in: body
+          schema:
+            $ref: CopyEntity
+      responses:
+        200:
+          description: No response was specified
+        201:
+          description: Successful Request
+        404:
+          description: Source Workspace or source entities does not exist
+        409:
+          description: One or more entities of that name/type already exist
+        500:
+          description: Internal Error
   /workspaces/{workspaceNamespace}/{workspaceName}/entities/{entityType}:
     get:
       type: Entity
@@ -990,6 +1027,32 @@ definitions:
     required:
       - op
       - attributeName
+  CopyEntity:
+    properties:
+      sourceWorkspace:
+        schema:
+          $ref: Namespace
+        description: Source Workspace Namespace
+      destinationWorkspace:
+        schema:
+          $ref: Namespace
+        description: Destination Workspace Namespace
+      entityType:
+        type: string
+        description: Entity Type
+      entityNames:
+        type: array
+        items:
+          type: string
+        description: List of entity names to be copied
+  Namespace:
+    properties:
+      namespace:
+        type: string
+        description: Entity namespace
+      name:
+        type: string
+        description: Entity name
   MethodID:
     properties:
       methodNamespace:

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -277,17 +277,17 @@ paths:
         - application/json
       parameters:
         - name: workspaceNamespace
-          description: Workspace Namespace
+          description: Destination Workspace Namespace
           required: true
           type: string
           in: path
         - name: workspaceName
-          description: Workspace Name
+          description: Destination Workspace Name
           required: true
           type: string
           in: path
         - name: body
-          description: Entity to Copy
+          description: Entities to Copy
           required: true
           in: body
           schema:
@@ -1033,10 +1033,6 @@ definitions:
         schema:
           $ref: Namespace
         description: Source Workspace Namespace
-      destinationWorkspace:
-        schema:
-          $ref: Namespace
-        description: Destination Workspace Namespace
       entityType:
         type: string
         description: Entity Type

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
@@ -48,6 +48,7 @@ object FireCloudConfig {
     lazy val submissionsPath = workspace.getString("submissionsPath")
     lazy val submissionByIdPath = workspace.getString("submissionByIdPath")
     lazy val workflowOutputsByIdPath = workspace.getString("workflowOutputsByIdPath")
+    lazy val workspacesEntitiesCopyUrl = baseUrl + workspace.getString("workspacesEntitiesCopyPath")
 
     def entityPathFromWorkspace(namespace: String, name: String) = baseUrl + workspace.getString("entitiesPath").format(namespace, name)
     def methodConfigPathFromWorkspace(namespace: String, name: String) = baseUrl + methodConfigsListPath.format(namespace, name)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
@@ -15,6 +15,8 @@ object ModelJsonProtocol {
   implicit val impEntity = jsonFormat5(Entity)
   implicit val impEntityCreateResult = jsonFormat4(EntityCreateResult)
   implicit val impEntityWithType = jsonFormat3(EntityWithType)
+  implicit val impEntityCopyDefinition = jsonFormat3(EntityCopyDefinition)
+  implicit val impEntityCopyWithDestinationDefinition = jsonFormat4(EntityCopyWithDestinationDefinition)
 
   implicit val impMethodConfiguration = jsonFormat9(MethodConfiguration)
   implicit val impMethodConfigurationRename = jsonFormat3(MethodConfigurationRename)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/Workspace.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/Workspace.scala
@@ -27,6 +27,19 @@ case class WorkspaceEntity(
 
 case class EntityCreateResult(entityType: String, entityName: String, succeeded: Boolean, message: String)
 
+case class EntityCopyDefinition(
+  sourceWorkspace: WorkspaceName,
+  entityType: String,
+  entityNames: Seq[String]
+  )
+
+case class EntityCopyWithDestinationDefinition(
+  sourceWorkspace: WorkspaceName,
+  destinationWorkspace: WorkspaceName,
+  entityType: String,
+  entityNames: Seq[String]
+  )
+
 // TODO: This is a stub case class until we know what we're returning from the batch entity create endpoint.
 @ApiModel(value = "method configuration entity")
 case class MethodConfiguration(

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/EntityService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/EntityService.scala
@@ -3,9 +3,11 @@ package org.broadinstitute.dsde.firecloud.service
 import akka.actor.{Actor, Props}
 import org.broadinstitute.dsde.firecloud.FireCloudConfig
 import org.broadinstitute.dsde.firecloud.core.{GetEntitiesWithType, GetEntitiesWithTypeActor}
-import org.broadinstitute.dsde.firecloud.model.{WorkspaceName, EntityCopyWithDestinationDefinition, EntityCopyDefinition}
+import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
+import org.broadinstitute.dsde.firecloud.model.{EntityCopyDefinition, EntityCopyWithDestinationDefinition, WorkspaceName}
 import org.slf4j.LoggerFactory
 import spray.http.HttpMethods
+import spray.httpx.SprayJsonSupport._
 import spray.routing._
 
 class EntityServiceActor extends Actor with EntityService {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/EntityService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/EntityService.scala
@@ -32,6 +32,9 @@ trait EntityService extends HttpService with PerRequestCreator with FireCloudDir
         pathEnd {
           passthrough(entityUrl, HttpMethods.GET)
         } ~
+        path("copy") {
+          passthrough(FireCloudConfig.Rawls.workspacesEntitiesCopyUrl, HttpMethods.POST)
+        } ~
         path(Segment) { entityType =>
           passthrough(entityUrl + "/" + entityType, HttpMethods.GET)
         }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/EntityService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/EntityService.scala
@@ -3,6 +3,7 @@ package org.broadinstitute.dsde.firecloud.service
 import akka.actor.{Actor, Props}
 import org.broadinstitute.dsde.firecloud.FireCloudConfig
 import org.broadinstitute.dsde.firecloud.core.{GetEntitiesWithType, GetEntitiesWithTypeActor}
+import org.broadinstitute.dsde.firecloud.model.{WorkspaceName, EntityCopyWithDestinationDefinition, EntityCopyDefinition}
 import org.slf4j.LoggerFactory
 import spray.http.HttpMethods
 import spray.routing._
@@ -33,7 +34,17 @@ trait EntityService extends HttpService with PerRequestCreator with FireCloudDir
           passthrough(entityUrl, HttpMethods.GET)
         } ~
         path("copy") {
-          passthrough(FireCloudConfig.Rawls.workspacesEntitiesCopyUrl, HttpMethods.POST)
+          post {
+            entity(as[EntityCopyDefinition]) { copyRequest => requestContext =>
+              val copyMethodConfig = new EntityCopyWithDestinationDefinition(
+                sourceWorkspace = copyRequest.sourceWorkspace,
+                destinationWorkspace = WorkspaceName(Some(workspaceNamespace), Some(workspaceName)),
+                entityType = copyRequest.entityType,
+                entityNames = copyRequest.entityNames)
+              val extReq = Post(FireCloudConfig.Rawls.workspacesEntitiesCopyUrl, copyMethodConfig)
+              externalHttpPerRequest(requestContext, extReq)
+            }
+          }
         } ~
         path(Segment) { entityType =>
           passthrough(entityUrl + "/" + entityType, HttpMethods.GET)


### PR DESCRIPTION
Orchestration pass-through to copy an entity from one workspace to another.

*Note*: Rawls is currently throwing exceptions for this endpoint and it is not usable with real data.