### PR TITLE
eliminate methodRepoConfig

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -899,9 +899,6 @@ definitions:
       methodRepoMethod:
         type: Map[String, String]
         description: Map with corresponding method-related information
-      methodRepoConfig:
-        type: Map[String, String]
-        description: Map with corresponding method-store-related information
       outputs:
         type: Map[String, String]
         description: Map with outputs information
@@ -917,7 +914,6 @@ definitions:
       - rootEntityType
       - workspaceName
       - methodRepoMethod
-      - methodRepoConfig
       - outputs
       - inputs
       - prerequisites
@@ -979,9 +975,6 @@ definitions:
       prerequisites:
         type: Map[string, string]
         description: Prerequisites map
-      methodRepoConfig:
-        type: Map
-        description: Method config ID
       methodRepoMethod:
         type: Map
         description: Method ID
@@ -992,7 +985,6 @@ definitions:
       - inputs
       - outputs
       - prerequisites
-      - methodRepoConfig
       - methodRepoMethod
   PublishConfigurationIngest:
     properties:

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
@@ -18,7 +18,7 @@ object ModelJsonProtocol {
   implicit val impEntityCopyDefinition = jsonFormat3(EntityCopyDefinition)
   implicit val impEntityCopyWithDestinationDefinition = jsonFormat4(EntityCopyWithDestinationDefinition)
 
-  implicit val impMethodConfiguration = jsonFormat9(MethodConfiguration)
+  implicit val impMethodConfiguration = jsonFormat8(MethodConfiguration)
   implicit val impMethodConfigurationRename = jsonFormat3(MethodConfigurationRename)
 
   implicit val impDestination = jsonFormat3(MethodConfigurationId)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/Workspace.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/Workspace.scala
@@ -53,8 +53,6 @@ case class MethodConfiguration(
   workspaceName: Option[Map[String, String]] = None,
   @(ApiModelProperty@field)(required = true, value = "map with corresponding method-related information")
   methodRepoMethod: Option[Map[String, String]] = None,
-  @(ApiModelProperty@field)(required = true, value = "map with corresponding method-store-related information")
-  methodRepoConfig: Option[Map[String, String]] = None,
   @(ApiModelProperty@field)(required = true, value = "map with outputs information")
   outputs: Option[Map[String, String]] = None,
   @(ApiModelProperty@field)(required = true, value = "map with inputs information")

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockWorkspaceServer.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockWorkspaceServer.scala
@@ -104,7 +104,6 @@ object MockWorkspaceServer {
           rootEntityType = Some(randomAlpha()),
           workspaceName = Some(Map.empty),
           methodRepoMethod = Some(Map.empty),
-          methodRepoConfig = Some(Map.empty),
           outputs = Some(Map.empty),
           inputs = Some(Map.empty),
           prerequisites = Some(Map.empty)


### PR DESCRIPTION
DSDEEPB-1343 directs us to remove methodRepoConfig from MethodConfiguration.  This is the corresponding part for orchestration.