### PR TITLE
Passthrough for workspace clone

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -212,6 +212,36 @@ paths:
           description: Workspace not found
         500:
           description: Internal Server Error
+  /workspaces/{workspaceNamespace}/{workspaceName}/clone:
+    post:
+      tags:
+        - Workspaces
+      operationId: cloneWorkspace
+      summary: Clone Workspace
+      produces:
+        - application/json
+      parameters:
+        - name: workspaceNamespace
+          description: Workspace Namespace
+          required: true
+          type: string
+          in: path
+        - name: workspaceName
+          description: Workspace Name
+          required: true
+          type: string
+          in: path
+      responses:
+        201:
+          description: Successful Request
+        400:
+          description: Unable to create resources for workspace
+        404:
+          description: Source workspace not found
+        409:
+          description: Destination workspace already exists
+        500:
+          description: Internal Server Error
   /workspaces/{workspaceNamespace}/{workspaceName}/entities_with_type:
     get:
       type: EntityWithType

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceService.scala
@@ -5,7 +5,6 @@ import java.util.Date
 
 import akka.actor.{Actor, Props}
 import org.slf4j.LoggerFactory
-import spray.client.pipelining.Post
 import spray.http.HttpMethods
 import spray.http.StatusCodes._
 import spray.json.DefaultJsonProtocol._
@@ -21,7 +20,6 @@ class WorkspaceServiceActor extends Actor with WorkspaceService {
 
 trait WorkspaceService extends HttpService with PerRequestCreator with FireCloudDirectives {
 
-  private final val ApiPrefix = "workspaces"
   private final val dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ")
   private implicit val executionContext = actorRefFactory.dispatcher
 
@@ -30,7 +28,7 @@ trait WorkspaceService extends HttpService with PerRequestCreator with FireCloud
   lazy val rawlsWorkspacesRoot = rawlsUrlRoot + "/workspaces"
 
   val routes: Route =
-    pathPrefix(ApiPrefix) {
+    pathPrefix("workspaces") {
       pathEnd {
         passthrough(rawlsWorkspacesRoot, HttpMethods.GET) ~
         post {
@@ -83,6 +81,9 @@ trait WorkspaceService extends HttpService with PerRequestCreator with FireCloud
         } ~
         path("acl") {
           passthrough(workspacePath + "/acl", HttpMethods.GET, HttpMethods.PATCH)
+        } ~
+        path("clone") {
+          passthrough(workspacePath + "/clone", HttpMethods.POST)
         }
       }
     }


### PR DESCRIPTION
As of now (Thursday 8/1 at 3:05PM) Rawls has a pair of bugs, one that bombs no matter what and one that bombs when the source workspace has data in it.  Fixes for both are in review and should be merged soon.  However, this code should be correct.