### PR TITLE
Update entity service and tests

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
@@ -45,7 +45,8 @@ object FireCloudConfig {
     lazy val templateUrl = baseUrl + templatePath
     lazy val importEntitiesPath = workspace.getString("importEntitiesPath")
     lazy val importEntitiesUrl = baseUrl + importEntitiesPath
-    lazy val workspacesEntitiesCopyUrl = baseUrl + workspace.getString("workspacesEntitiesCopyPath")
+    lazy val workspacesEntitiesCopyPath = workspace.getString("workspacesEntitiesCopyPath")
+    lazy val workspacesEntitiesCopyUrl = baseUrl + workspacesEntitiesCopyPath
 
     def entityPathFromWorkspace(namespace: String, name: String) = baseUrl + workspace.getString("entitiesPath").format(namespace, name)
     def methodConfigPathFromWorkspace(namespace: String, name: String) = baseUrl + methodConfigsListPath.format(namespace, name)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/EntityService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/EntityService.scala
@@ -23,17 +23,16 @@ trait EntityService extends HttpService with PerRequestCreator with FireCloudDir
 
   def entityRoutes: Route =
     pathPrefix("workspaces" / Segment / Segment) { (workspaceNamespace, workspaceName) =>
-      val url = FireCloudConfig.Rawls.entityPathFromWorkspace(workspaceNamespace, workspaceName)
+      val baseRawlsEntitiesUrl = FireCloudConfig.Rawls.entityPathFromWorkspace(workspaceNamespace, workspaceName)
       path("entities_with_type") {
         get { requestContext =>
           perRequest(requestContext, Props(new GetEntitiesWithTypeActor(requestContext)),
-            GetEntitiesWithType.ProcessUrl(url))
+            GetEntitiesWithType.ProcessUrl(baseRawlsEntitiesUrl))
         }
       } ~
       pathPrefix("entities") {
-        val entityUrl = url + "/entities"
         pathEnd {
-          passthrough(entityUrl, HttpMethods.GET)
+          passthrough(baseRawlsEntitiesUrl, HttpMethods.GET)
         } ~
         path("copy") {
           post {
@@ -49,7 +48,7 @@ trait EntityService extends HttpService with PerRequestCreator with FireCloudDir
           }
         } ~
         path(Segment) { entityType =>
-          passthrough(entityUrl + "/" + entityType, HttpMethods.GET)
+          passthrough(baseRawlsEntitiesUrl + "/" + entityType, HttpMethods.GET)
         }
       }
     }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockWorkspaceServer.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockWorkspaceServer.scala
@@ -1,7 +1,5 @@
 package org.broadinstitute.dsde.firecloud.mock
 
-import org.broadinstitute.dsde.firecloud.core.GetEntitiesWithType
-import GetEntitiesWithType.EntityWithType
 import org.broadinstitute.dsde.firecloud.mock.MockUtils._
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
 import org.broadinstitute.dsde.firecloud.model._
@@ -499,58 +497,6 @@ object MockWorkspaceServer {
         response()
           .withHeaders(header)
           .withBody(List("participant", "sample", "Pair", "sampleset").toJson.compactPrint)
-          .withStatusCode(OK.intValue)
-      )
-
-    MockWorkspaceServer.workspaceServer
-      .when(
-        request()
-          .withMethod("GET")
-          .withPath(entitiesWithTypeBasePath + "entities/participant")
-          .withHeader(authHeader))
-      .respond(
-        response()
-          .withHeaders(header)
-          .withBody(List(EntityWithType("participant_01", "participant", Option.empty), EntityWithType("participant_02", "participant", Option.empty)).toJson.compactPrint)
-          .withStatusCode(OK.intValue)
-      )
-
-    MockWorkspaceServer.workspaceServer
-      .when(
-        request()
-          .withMethod("GET")
-          .withPath(entitiesWithTypeBasePath + "entities/sample")
-          .withHeader(authHeader))
-      .respond(
-        response()
-          .withHeaders(header)
-          .withBody(List(EntityWithType("sample_01", "sample", Option.empty), EntityWithType("sample_02", "sample", Option.empty)).toJson.compactPrint)
-          .withStatusCode(OK.intValue)
-      )
-
-    MockWorkspaceServer.workspaceServer
-      .when(
-        request()
-          .withMethod("GET")
-          .withPath(entitiesWithTypeBasePath + "entities/Pair")
-          .withHeader(authHeader))
-      .respond(
-        response()
-          .withHeaders(header)
-          .withBody(List(EntityWithType("pair_01", "Pair", Option.empty)).toJson.compactPrint)
-          .withStatusCode(OK.intValue)
-      )
-
-    MockWorkspaceServer.workspaceServer
-      .when(
-        request()
-          .withMethod("GET")
-          .withPath(entitiesWithTypeBasePath + "entities/sampleset")
-          .withHeader(authHeader))
-      .respond(
-        response()
-          .withHeaders(header)
-          .withBody(List(EntityWithType("sampleset_01", "sampleset", Option.empty), EntityWithType("sampleset_02", "sampleset", Option.empty)).toJson.compactPrint)
           .withStatusCode(OK.intValue)
       )
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/EntityServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/EntityServiceSpec.scala
@@ -1,41 +1,120 @@
 package org.broadinstitute.dsde.firecloud.service
 
+import org.broadinstitute.dsde.firecloud.FireCloudConfig
 import org.broadinstitute.dsde.firecloud.core.GetEntitiesWithType.EntityWithType
-import org.broadinstitute.dsde.firecloud.mock.MockWorkspaceServer
-import org.scalatest.time.{Seconds, Span}
-import org.scalatest.{Matchers, FreeSpec}
-import org.scalatest.concurrent.ScalaFutures
-import spray.http.StatusCodes._
-import spray.testkit.ScalatestRouteTest
+import org.broadinstitute.dsde.firecloud.mock.{MockUtils, MockWorkspaceServer}
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
+import org.broadinstitute.dsde.firecloud.model.{EntityCopyDefinition, ModelJsonProtocol, WorkspaceName}
+import org.mockserver.integration.ClientAndServer
+import org.mockserver.integration.ClientAndServer._
+import org.mockserver.model.HttpRequest._
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{FreeSpec, Matchers}
+import spray.http.StatusCodes._
 import spray.httpx.SprayJsonSupport._
 import spray.json.DefaultJsonProtocol._
+import spray.json._
+import spray.testkit.ScalatestRouteTest
 
-class EntityServiceSpec extends FreeSpec with ScalaFutures with ScalatestRouteTest
-  with Matchers with EntityService with FireCloudRequestBuilding {
+class EntityServiceSpec extends FreeSpec with ScalaFutures with ScalatestRouteTest with Matchers
+  with EntityService with FireCloudRequestBuilding {
 
   def actorRefFactory = system
 
+  var workspaceServer: ClientAndServer = _
+  val validFireCloudEntitiesPath = "/workspaces/broad-dsde-dev/valid/entities"
+  val validFireCloudEntitiesSamplePath = "/workspaces/broad-dsde-dev/valid/entities/sample"
+  val validFireCloudEntitiesCopyPath = "/workspaces/broad-dsde-dev/valid/entities/copy"
+  val invalidFireCloudEntitiesPath = "/workspaces/broad-dsde-dev/invalid/entities"
+  val entityCopy = EntityCopyDefinition(
+    sourceWorkspace = WorkspaceName(namespace=Some("broad-dsde-dev"), name=Some("other-ws")),
+    entityType = "sample", Seq("sample_01"))
+  val sampleAtts = Map(
+    "sample_type" -> "Blood".toJson,
+    "ref_fasta" -> "gs://cancer-exome-pipeline-demo-data/Homo_sapiens_assembly19.fasta".toJson,
+    "ref_dict" -> "gs://cancer-exome-pipeline-demo-data/Homo_sapiens_assembly19.dict".toJson,
+    "participant_id" -> """{"entityType":"participant","entityName":"subject_HCC1143"}""".toJson
+  )
+  val validSampleEntities = List(EntityWithType("sample_01", "sample", Some(sampleAtts)))
+
   override def beforeAll(): Unit = {
-    MockWorkspaceServer.startWorkspaceServer()
+    workspaceServer = startClientAndServer(MockWorkspaceServer.workspaceServerPort)
+    // Valid Entities by sample type case
+    workspaceServer
+      .when(
+        request()
+          .withMethod("GET")
+          .withPath(FireCloudConfig.Rawls.entitiesPath.format("broad-dsde-dev", "valid") + "/sample")
+          .withHeader(MockUtils.authHeader))
+      .respond(
+        org.mockserver.model.HttpResponse.response()
+          .withHeaders(MockUtils.header)
+          .withBody(validSampleEntities.toJson.compactPrint)
+          .withStatusCode(OK.intValue)
+      )
+    // Valid entities case
+    workspaceServer
+      .when(
+        request()
+          .withMethod("GET")
+          .withPath(FireCloudConfig.Rawls.entitiesPath.format("broad-dsde-dev", "valid"))
+          .withHeader(MockUtils.authHeader))
+      .respond(
+        org.mockserver.model.HttpResponse.response()
+          .withHeaders(MockUtils.header).withStatusCode(OK.intValue)
+      )
+    // Valid Copy case
+    workspaceServer
+      .when(
+        request()
+          .withMethod("POST")
+          .withPath(FireCloudConfig.Rawls.workspacesEntitiesCopyPath)
+          .withHeader(MockUtils.authHeader))
+      .respond(
+        org.mockserver.model.HttpResponse.response()
+          .withHeaders(MockUtils.header).withStatusCode(Created.intValue)
+      )
   }
 
   override def afterAll(): Unit = {
-    MockWorkspaceServer.stopWorkspaceServer()
+    workspaceServer.stop()
   }
 
   "EntityService" - {
 
-    "when calling GET on entities_with_type path with a valid workspace" - {
-      "valid list of entity types are returned" in {
-        val path = s"${MockWorkspaceServer.entitiesWithTypeBasePath}entities_with_type"
-        Get(path) ~> dummyAuthHeaders ~> sealRoute(routes) ~> check {
+    "when calling GET on valid entity type" - {
+      "OK response is returned" in {
+        Get(validFireCloudEntitiesSamplePath) ~> dummyAuthHeaders ~> sealRoute(routes) ~> check {
           status should be(OK)
-          val entities = responseAs[List[EntityWithType]]
-          entities shouldNot be(empty)
+          response.entity shouldNot be(empty)
         }
       }
     }
+
+    "when calling GET on valid entities" - {
+      "OK response is returned" in {
+        Get(validFireCloudEntitiesPath) ~> dummyAuthHeaders ~> sealRoute(routes) ~> check {
+          status should be(OK)
+        }
+      }
+    }
+
+    "when calling GET on entities in an unknown workspace" - {
+      "Not Found response is returned" in {
+        Get(invalidFireCloudEntitiesPath) ~> dummyAuthHeaders ~> sealRoute(routes) ~> check {
+          status should be(NotFound)
+        }
+      }
+    }
+
+    "when calling POST on valid copy entities" - {
+      "Created response is returned" in {
+        Post(validFireCloudEntitiesCopyPath, entityCopy) ~> dummyAuthHeaders ~> sealRoute(routes) ~> check {
+          status should be(Created)
+        }
+      }
+    }
+
   }
 
 }


### PR DESCRIPTION
Addresses:
* Entity Service Failure: https://broadinstitute.atlassian.net/browse/DSDEEPB-1458
* Entity Service Tests: https://broadinstitute.atlassian.net/browse/DSDEEPB-824

This PR takes a slightly different approach to mock server tests. I've removed the entity-with-type tests (which will be addressed in an upcoming PR) and instead added mock responses in the same test class that are called by the service.