### PR TITLE
Implement orchestration call for export entities by type

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -427,6 +427,39 @@ paths:
           description: Workspace or entity type does not exist
         500:
           description: Internal Server Error
+  /workspaces/{workspaceNamespace}/{workspaceName}/entities/{entityType}/tsv:
+    get:
+      type: file
+      tags:
+      - Entities
+      operationId: downloadEntitiesTSV
+      summary: |
+        TSV file containing workspace entities of the specified type
+      produces:
+        - text/plain
+      parameters:
+        - name: workspaceNamespace
+          description: Workspace Namespace
+          required: true
+          type: string
+          in: path
+        - name: workspaceName
+          description: Workspace Name
+          required: true
+          type: string
+          in: path
+        - name: entityType
+          description: Entity Type
+          required: true
+          type: string
+          in: path
+      responses:
+        200:
+          description: Workspace entities of specified type in TSV format
+        404:
+          description: Workspace or entity type does not exist
+        500:
+          description: Internal Server Error
   /workspaces/{workspaceNamespace}/{workspaceName}/methodconfigs:
     get:
       tags:

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/core/ExportEntitiesByType.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/core/ExportEntitiesByType.scala
@@ -1,0 +1,60 @@
+package org.broadinstitute.dsde.firecloud.core
+
+import akka.actor.{Actor, Props}
+import akka.event.Logging
+import org.broadinstitute.dsde.firecloud.core.ExportEntitiesByType.ProcessEntities
+import org.broadinstitute.dsde.firecloud.core.GetEntitiesWithType.EntityWithType
+import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
+import org.broadinstitute.dsde.firecloud.service.FireCloudRequestBuilding
+import org.broadinstitute.dsde.firecloud.service.PerRequest.{RequestComplete, RequestCompleteWithHeaders}
+import org.broadinstitute.dsde.firecloud.utils.EntityMatrix
+import spray.client.pipelining._
+import spray.http.MediaTypes._
+import spray.http.StatusCodes._
+import spray.http.{HttpHeaders, StatusCodes}
+import spray.httpx.SprayJsonSupport._
+import spray.json.DefaultJsonProtocol._
+import spray.routing.RequestContext
+
+import scala.util.{Failure, Success}
+
+object ExportEntitiesByType {
+  case class ProcessEntities(url: String, filename: String, entityType: String)
+  def props(requestContext: RequestContext): Props = Props(new ExportEntitiesByTypeActor(requestContext))
+}
+
+class ExportEntitiesByTypeActor(requestContext: RequestContext) extends Actor with FireCloudRequestBuilding  {
+
+  implicit val system = context.system
+  import system.dispatcher
+  val log = Logging(system, getClass)
+
+  override def receive: Receive = {
+    case ProcessEntities(url: String, filename: String, entityType: String) =>
+      log.debug("Processing entities for url: " + url)
+      val pipeline = authHeaders(requestContext) ~> sendReceive
+      pipeline { Get(url) } onComplete {
+        case Success(response) if response.status == OK =>
+          val entities = unmarshal[List[EntityWithType]].apply(response)
+          log.debug("Processed entities: " + entities.toString)
+          val data = EntityMatrix.makeTsvString(entities, entityType)
+          context.parent ! RequestCompleteWithHeaders(
+            (OK, data),
+            HttpHeaders.`Content-Disposition`.apply("attachment", Map("filename" -> filename)),
+            HttpHeaders.`Content-Type`(`text/plain`))
+          context stop self
+        case Success(response) if response.status != OK =>
+          context.parent ! RequestComplete(response)
+          context stop self
+        case Failure(error) =>
+          context.parent ! RequestComplete(StatusCodes.InternalServerError, error.getMessage)
+          context stop self
+      }
+    case _ =>
+      context.parent ! RequestComplete(StatusCodes.BadRequest)
+      context stop self
+  }
+
+}
+
+

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/utils/EntityMatrix.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/utils/EntityMatrix.scala
@@ -1,0 +1,103 @@
+package org.broadinstitute.dsde.firecloud.utils
+
+import org.broadinstitute.dsde.firecloud.core.GetEntitiesWithType.EntityWithType
+import spray.json.JsValue
+
+import scala.collection.{immutable, mutable}
+
+object EntityMatrix {
+
+  def makeTsvString(entities: List[EntityWithType], entityType: String) = {
+    val entityHeader = "entity:" + entityType
+    val headers: immutable.IndexedSeq[String] = entityHeader +: entities.
+      filter { _.entityType == entityType }.
+      map { _.attributes.getOrElse(Map.empty) }.
+      flatMap(_.keySet).
+      distinct.
+      map { trimmedHeaderValue }.
+      toIndexedSeq
+    val rows: immutable.IndexedSeq[IndexedSeq[String]] = entities.filter { _.entityType == entityType }
+      .map { entity =>
+        makeRow(entity, headers)
+      }.toIndexedSeq
+    exportToString(headers, rows)
+  }
+
+  private def exportToString(headers: IndexedSeq[String], rows: IndexedSeq[IndexedSeq[String]]): String = {
+    val headerString:String = headers.mkString("\t") + "\n"
+    val rowsString:String = rows.map{ _.mkString("\t") }.mkString("\n")
+    headerString + rowsString + "\n"
+  }
+
+  /**
+   * All headers suffixed with "_id" need to have that suffix dropped
+   *
+   * @param value Value to check
+   * @return Trimmed value
+   */
+  private def trimmedHeaderValue(value:String): String = {
+    value match {
+      case x if x.endsWith("_id") => x dropRight 3
+      case x => x
+    }
+  }
+
+  /**
+   * Generate a row of values in the order of the headers.
+   *
+   * @param entity The EntityWithType object to extract data from
+   * @param headerValues List of header values to determine column position for
+   * @return The ordered data fields in an IndexedSeq
+   */
+  private def makeRow(entity: EntityWithType, headerValues: IndexedSeq[String]): IndexedSeq[String] = {
+    val row = mutable.IndexedSeq().padTo(headerValues.size, "")
+    row.update(0, entity.name)
+    entity.attributes.getOrElse(Map.empty).foreach { e =>
+      val columnPosition = headerValues.indexOf(trimmedHeaderValue(e._1))
+      makeCellValue(row, columnPosition, e._1, e._2)
+    }
+    row.toIndexedSeq
+  }
+
+  /**
+   * When adding a cell to a row, we need to check if the entry is an "_id" field. In that case,
+   * we have to parse the value as a json structure and look for "entityName"
+   *
+   * @param row The row to update
+   * @param columnPosition The column position of the inserted value
+   * @param header The header to check. "_id" headers require special processing
+   * @param value The value to insert/parse for real value
+   */
+  private def makeCellValue(
+    row: mutable.IndexedSeq[String],
+    columnPosition: Int,
+    header: String,
+    value: JsValue) = {
+    header match {
+      case x if x.endsWith("_id") || x.equals("case_sample") || x.equals("control_sample") =>
+        value match {
+          case y if y.asJsObject.fields.contains("entityName") =>
+            row.update(
+              columnPosition,
+              cleanJsValue(value.asJsObject.fields.getOrElse("entityName", value))
+            )
+          case _ =>
+            row.update(columnPosition, cleanJsValue(value))
+        }
+      case x =>
+        row.update(columnPosition, cleanJsValue(value))
+    }
+  }
+
+  /**
+   * JsValues are double-quoted. Need to remove them before putting them into a cell position
+   *
+   * @param value The JsValue to remove leading and trailing quotes from.
+   * @return Trimmed string value
+   */
+  private def cleanJsValue(value: JsValue): String = {
+    val regex = "^\"|\"$".r
+    regex.replaceAllIn(value.toString(), "")
+  }
+
+}

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/ExportEntitiesByTypeServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/ExportEntitiesByTypeServiceSpec.scala
@@ -1,0 +1,96 @@
+package org.broadinstitute.dsde.firecloud.service
+
+import org.broadinstitute.dsde.firecloud.FireCloudConfig
+import org.broadinstitute.dsde.firecloud.core.GetEntitiesWithType.EntityWithType
+import org.broadinstitute.dsde.firecloud.mock.{MockUtils, MockWorkspaceServer}
+import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
+import org.broadinstitute.dsde.firecloud.utils.EntityMatrix
+import org.mockserver.integration.ClientAndServer
+import org.mockserver.integration.ClientAndServer._
+import org.mockserver.model.HttpRequest._
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{FreeSpec, Matchers}
+import spray.http.StatusCodes._
+import spray.json.DefaultJsonProtocol._
+import spray.json._
+import spray.testkit.ScalatestRouteTest
+
+import scala.io.Source
+
+class ExportEntitiesByTypeServiceSpec extends FreeSpec with ScalaFutures with ScalatestRouteTest
+with Matchers with EntityService with FireCloudRequestBuilding {
+
+  def actorRefFactory = system
+
+  var workspaceServer: ClientAndServer = _
+  val validFireCloudEntitiesSampleTSVPath = "/workspaces/broad-dsde-dev/valid/entities/sample/tsv"
+  val invalidFireCloudEntitiesSampleTSVPath = "/workspaces/broad-dsde-dev/invalid/entities/sample/tsv"
+
+  def sampleAtts(): Map[String, JsValue] = {
+    Map(
+      "sample_type" -> "Blood".toJson,
+      "header_1" -> MockUtils.randomAlpha().toJson,
+      "header_2" -> MockUtils.randomAlpha().toJson,
+      "participant_id" -> """{"entityType":"participant","entityName":"participant_name"}""".parseJson
+    )
+  }
+
+  val validSampleEntities = List(
+    EntityWithType("sample_01", "sample", Some(sampleAtts())),
+    EntityWithType("sample_02", "sample", Some(sampleAtts())),
+    EntityWithType("sample_03", "sample", Some(sampleAtts())),
+    EntityWithType("sample_04", "sample", Some(sampleAtts()))
+  )
+
+  override def beforeAll(): Unit = {
+    workspaceServer = startClientAndServer(MockWorkspaceServer.workspaceServerPort)
+    // Valid Entities by sample type case
+    workspaceServer
+      .when(
+        request()
+          .withMethod("GET")
+          .withPath(FireCloudConfig.Rawls.entitiesPath.format("broad-dsde-dev", "valid") + "/sample")
+          .withHeader(MockUtils.authHeader))
+      .respond(
+        org.mockserver.model.HttpResponse.response()
+          .withHeaders(MockUtils.header)
+          .withBody(validSampleEntities.toJson.compactPrint)
+          .withStatusCode(OK.intValue)
+      )
+  }
+
+  override def afterAll(): Unit = {
+    workspaceServer.stop()
+  }
+
+  "EntityMatrix" - {
+    "should generate a TSV string with valid data" - {
+      val tsv = EntityMatrix.makeTsvString(validSampleEntities, "sample")
+      tsv shouldNot be(empty)
+      // Resultant data should have a header and one line per sample entity:
+      Source.fromString(tsv).getLines().size should equal(validSampleEntities.size + 1)
+    }
+  }
+
+  "EntityService-ExportEntitiesByType" - {
+
+    "when calling GET on exporting a valid entity type" - {
+      "OK response is returned" in {
+        Get(validFireCloudEntitiesSampleTSVPath) ~> dummyAuthHeaders ~> sealRoute(routes) ~> check {
+          status should be(OK)
+          response.entity shouldNot be(empty)
+        }
+      }
+    }
+
+    "when calling GET on exporting an invalid entity type" - {
+      "OK response is returned" in {
+        Get(invalidFireCloudEntitiesSampleTSVPath) ~> dummyAuthHeaders ~> sealRoute(routes) ~> check {
+          status should be(NotFound)
+        }
+      }
+    }
+
+  }
+
+}


### PR DESCRIPTION
This PR addresses exporting entities as a TSV file from the Orchestration layer: https://broadinstitute.atlassian.net/browse/DSDEEPB-1148

Notes:
* This does not fulfill all requirements of DSDEEPB-1148. If you take this PR, do not move the story along as there still needs to be a UI component to invoke this endpoint.
* Please look closely at EntityMatrix. As a class, it feels a bit more like java than scala and feedback on construction/implementation would be very much appreciated.
* I split out tests for this separately from EntityService due to the specialized nature of what it's doing.
* There are three cases of data conversion that happen on import and need to be reversed on export. participant_id, case_sample, and control_sample columns require special processing.
* I have not been able to test this from the UI (currently blocked), but this can be tested locally with curl. Add -OJ to the curl which will tell curl to respect the attachment filename. The rest of the curl command can be gotten from the swagger UI.