### PR TITLE
for methods and configs ACL translation and passthrough to Agora

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -33,6 +33,8 @@ http {
 methods {
   methodsPath="/methods"
   configurationsPath="/configurations"
+  methodsPermissionsPath = "/methods/%s/%s/%s/permissions"
+  configurationsPermissionsPath = "/methods/%s/%s/%s/permissions"
 }
 
 workspace {

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -130,6 +130,63 @@ paths:
           description: Method Repository configuration detail
         500:
           description: Internal Server Error
+  /methods/{namespace}/{name}/{snapshotId}/permissions
+    get:
+      tags:
+        - Method Repository
+      operationId: get ACL permissions on a Method Repository method
+      summary: get ACL permissions on a Method Repository method
+      produces:
+        - application/json
+      parameters:
+        - name: namespace
+          description: Method namespace
+          required: true
+          type: string
+          in: path
+        - name: name
+          description: Method name
+          required: true
+          type: string
+          in: path
+        - name: snapshotId
+          description: Method snapshot ID
+          required: true
+          type: string
+          in: path
+      responses:
+        200:
+          description: the indicated method ACL
+        500:
+          description: Internal Server Error
+    post:
+      tags:
+        - Method Repository
+      operationId: get ACL permissions on a Method Repository method
+      summary: get ACL permissions on a Method Repository method
+      produces:
+        - application/json
+      parameters:
+        - name: namespace
+          description: Method namespace
+          required: true
+          type: string
+          in: path
+        - name: name
+          description: Method name
+          required: true
+          type: string
+          in: path
+        - name: snapshotId
+          description: Method snapshot ID
+          required: true
+          type: string
+          in: path
+      responses:
+        200:
+          description: the indicated method ACL once the posted changes have been applied
+        500:
+          description: Internal Server Error
   /configurations/{namespace}/{name}/{snapshotId}/permissions
     get:
       tags:

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -154,6 +154,8 @@ paths:
           required: true
           type: string
           in: path
+        schema:
+          $ref: '#/definitions/MethodConfigACL'
       responses:
         200:
           description: the indicated method ACL
@@ -182,9 +184,13 @@ paths:
           required: true
           type: string
           in: path
+        schema:
+          $ref: '#/definitions/MethodConfigACL'
       responses:
         200:
           description: the indicated method ACL once the posted changes have been applied
+          schema:
+            $ref: '#/definitions/MethodConfigACL'
         500:
           description: Internal Server Error
   /configurations/{namespace}/{name}/{snapshotId}/permissions
@@ -214,6 +220,8 @@ paths:
       responses:
         200:
           description: the indicated configuration ACL
+          schema:
+            $ref: '#/definitions/MethodConfigACL'
         500:
           description: Internal Server Error
     post:
@@ -1305,6 +1313,17 @@ definitions:
         additionalProperties:
           type: string
         description: Map of attributes
+  MethodConfigACL:
+    properties:
+      userId:
+        type: string
+        description: a user's ID or "public"
+      accessLevel:
+        type: string
+        description: one of "NO ACCESS", "READER", or "OWNER"
+    required:
+      - userId
+      - accessLevel
   SubmissionIngest:
     properties:
       methodConfigurationNamespace:

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -130,6 +130,63 @@ paths:
           description: Method Repository configuration detail
         500:
           description: Internal Server Error
+  /configurations/{namespace}/{name}/{snapshotId}/permissions
+    get:
+      tags:
+        - Method Repository
+      operationId: get ACL permissions on a Method Repository configuration
+      summary: get ACL permissions on a Method Repository configuration
+      produces:
+        - application/json
+      parameters:
+        - name: namespace
+          description: Method Configuration namespace
+          required: true
+          type: string
+          in: path
+        - name: name
+          description: Method Configuration name
+          required: true
+          type: string
+          in: path
+        - name: snapshotId
+          description: Method Configuration snapshot ID
+          required: true
+          type: string
+          in: path
+      responses:
+        200:
+          description: the indicated configuration ACL
+        500:
+          description: Internal Server Error
+    post:
+      tags:
+        - Method Repository
+      operationId: get ACL permissions on a Method Repository configuration
+      summary: get ACL permissions on a Method Repository configuration
+      produces:
+        - application/json
+      parameters:
+        - name: namespace
+          description: Method Configuration namespace
+          required: true
+          type: string
+          in: path
+        - name: name
+          description: Method Configuration name
+          required: true
+          type: string
+          in: path
+        - name: snapshotId
+          description: Method Configuration snapshot ID
+          required: true
+          type: string
+          in: path
+      responses:
+        200:
+          description: the indicated configuration ACL once the posted changes have been applied
+        500:
+          description: Internal Server Error
   /workspaces/{workspaceNamespace}/{workspaceName}:
     get:
       tags:

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
@@ -23,6 +23,12 @@ object FireCloudConfig {
     lazy val methodsBaseUrl = baseUrl + methodsPath
     lazy val configurationsPath = methods.getString("configurationsPath")
     lazy val configurationsBaseUrl = baseUrl + configurationsPath
+
+    def methodsPermissionsFromMethod(namespace:String, name:String, snapshotId:Int) = baseUrl +
+      methods.getString("methodsPermissionsPath").format(namespace, name, snapshotId)
+
+    def configurationsPermissionsFromConfig(namespace:String, name:String, snapshotId:Int) = baseUrl +
+      methods.getString("configurationsPermissionsPath").format(namespace, name, snapshotId)
   }
 
   object Rawls {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/core/AgoraPermissionHandler.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/core/AgoraPermissionHandler.scala
@@ -18,10 +18,8 @@ import scala.concurrent.Future
 import scala.util.{Failure, Success}
 
 object AgoraPermissionHandler {
-  case class Delete(url: String, user: String)
   case class Get(url: String)
   case class Post(url: String, agoraPermissions: List[AgoraPermission])
-  case class Put(url: String, agoraPermission: AgoraPermission)
   def props(requestContext: RequestContext): Props = Props(new GetEntitiesWithTypeActor(requestContext))
 
   // TODO: add tests for all of the following methods!

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/core/AgoraPermissionHandler.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/core/AgoraPermissionHandler.scala
@@ -108,9 +108,11 @@ class AgoraPermissionActor (requestContext: RequestContext) extends Actor with F
     case AgoraPermissionHandler.Post(url: String, agoraPermissions: List[AgoraPermission]) =>
       val pipeline = authHeaders(requestContext) ~> sendReceive
       // TODO: allow AGORA to see empty values?
-      //or should such things bie dropped here?  What if only one of the requests in  batch is bad?
+      //or should such things be dropped here?  What if only one of the requests in  batch is bad?
       //should all be dropped?
       //For now, forward to Agora  and let it catch any error?
+      //if the permissions are untranslateable then catch the error and return it to user
+
       val permissionListFuture: Future[HttpResponse] = pipeline { Post(url.toString,
         HttpClient.createJsonHttpEntity(agoraPermissions.toString()))
       }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/core/AgoraPermissionHandler.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/core/AgoraPermissionHandler.scala
@@ -46,7 +46,15 @@ object AgoraPermissionHandler {
     }
   }
 
-  def determineIfASingleFCPermissionIsValidForTranslationByUser(fireCloudPermission: FireCloudPermission):Boolean = {
+
+  def hasValidUserAndRole(fireCloudPermission: FireCloudPermission):Boolean = {
+    val vRole=this.hasValidRole(fireCloudPermission)
+    val vUser=this.hasValidUser(fireCloudPermission)
+    return (vRole && vUser)
+  }
+
+
+  def hasValidUser(fireCloudPermission: FireCloudPermission):Boolean = {
     fireCloudPermission.user match {
       case Some("") => false
       case None => false
@@ -56,7 +64,7 @@ object AgoraPermissionHandler {
   }
 
 
-  def determineIfASingleFCPermissionIsValidForTranslationByAccessLevel(fireCloudPermission: FireCloudPermission):Boolean = {
+  def hasValidRole(fireCloudPermission: FireCloudPermission):Boolean = {
     fireCloudPermission.role match {
       case Some("NO ACCESS") => true
       case Some("OWNER") => true

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/core/AgoraPermissionHandler.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/core/AgoraPermissionHandler.scala
@@ -128,12 +128,6 @@ class AgoraPermissionActor (requestContext: RequestContext) extends Actor with F
 
     case AgoraPermissionHandler.Post(url: String, agoraPermissions: List[AgoraPermission]) =>
       val pipeline = authHeaders(requestContext) ~> sendReceive
-      // TODO: allow AGORA to see empty values?
-      //or should such things be dropped here?  What if only one of the requests in  batch is bad?
-      //should all be dropped?
-      //For now, forward to Agora  and let it catch any error?
-      //if the permissions are untranslateable then catch the error and return it to user
-
       val permissionListFuture: Future[HttpResponse] = pipeline { Post(url.toString,
         HttpClient.createJsonHttpEntity(agoraPermissions.toString()))
       }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/core/AgoraPermissionHandler.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/core/AgoraPermissionHandler.scala
@@ -63,8 +63,10 @@ object AgoraPermissionHandler {
       case None => "NO ACCESS"
       case Some(r) => {
         r.sorted match {
+          case List("All") => "OWNER"
           case List("Create","Manage","Read","Redact","Write") => "OWNER"
           case List("Read") => "READER"
+          case List("Nothing") => "NO ACCESS"
           case _ => "NO ACCESS" // TODO: throw an exception instead? Log something?
         }
       }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/core/AgoraPermissionHandler.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/core/AgoraPermissionHandler.scala
@@ -46,6 +46,27 @@ object AgoraPermissionHandler {
     }
   }
 
+  def determineIfASingleFCPermissionIsValidForTranslationByUser(fireCloudPermission: FireCloudPermission):Boolean = {
+    fireCloudPermission.user match {
+      case Some("") => false
+      case None => false
+      //any non-empty user is okay!
+      case _ => true
+    }
+  }
+
+
+  def determineIfASingleFCPermissionIsValidForTranslationByAccessLevel(fireCloudPermission: FireCloudPermission):Boolean = {
+    fireCloudPermission.role match {
+      case Some("NO ACCESS") => true
+      case Some("OWNER") => true
+      case Some("READER") => true
+      //anything that's one of the above-3 is good, anything else is bad
+      case _ => false
+    }
+  }
+
+
   // translation between a FireCloud role and a list of Agora roles
   def toAgoraRoles(fireCloudRole:Option[String]) = {
     fireCloudRole match {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/core/AgoraPermissionHandler.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/core/AgoraPermissionHandler.scala
@@ -1,0 +1,144 @@
+package org.broadinstitute.dsde.firecloud.core
+
+import akka.actor.{Actor, Props}
+import akka.event.Logging
+import org.broadinstitute.dsde.firecloud.model.MethodRepository.{AgoraPermission, FireCloudPermission}
+import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
+import org.broadinstitute.dsde.firecloud.service.FireCloudRequestBuilding
+import org.broadinstitute.dsde.firecloud.service.PerRequest.RequestComplete
+import org.broadinstitute.dsde.firecloud.HttpClient
+import spray.client.pipelining._
+import spray.http.StatusCodes._
+import spray.http.{Uri, HttpResponse, StatusCodes}
+import spray.httpx.SprayJsonSupport._
+import spray.json.DefaultJsonProtocol._
+import spray.routing.RequestContext
+
+import scala.concurrent.Future
+import scala.util.{Failure, Success}
+
+object AgoraPermissionHandler {
+  case class Delete(url: String, user: String)
+  case class Get(url: String)
+  case class Post(url: String, agoraPermissions: List[AgoraPermission])
+  case class Put(url: String, agoraPermission: AgoraPermission)
+  def props(requestContext: RequestContext): Props = Props(new GetEntitiesWithTypeActor(requestContext))
+
+  // TODO: add tests for all of the following methods!
+
+  // convenience method to translate a FireCloudPermission object to an AgoraPermission object
+  def toAgoraPermission(fireCloudPermission: FireCloudPermission):AgoraPermission = {
+    fireCloudPermission.user match {
+      case None => {
+        // TODO: should throw an error if user is not specified
+        AgoraPermission(None, Some(List.empty))
+      }
+      case Some(u) => AgoraPermission(Some(u), Some(toAgoraRoles(fireCloudPermission.role)))
+    }
+  }
+
+  // convenience method to translate an AgoraPermission to a FireCloudPermission object
+  def toFireCloudPermission(agoraPermission: AgoraPermission):FireCloudPermission = {
+    agoraPermission.user match {
+      case None => {
+        // TODO: should throw an error if user is not specified
+        FireCloudPermission(None, Some("NO ACCESS"))
+      }
+      case Some(u) => FireCloudPermission(Some(u), Some(toFireCloudRole(agoraPermission.roles)))
+    }
+  }
+
+  // translation between a FireCloud role and a list of Agora roles
+  def toAgoraRoles(fireCloudRole:Option[String]) = {
+    fireCloudRole match {
+      case None => List("Nothing")
+      case Some("OWNER") => List("Read","Write","Create","Redact","Manage") // Could use "All" instead but this is more precise
+      case Some("READER") => List("Read")
+      case Some("NO ACCESS") => List("Nothing")
+      case _ => List("Nothing") // TODO: throw an exception instead? Log something?
+    }
+  }
+
+  // translation between a list of Agora roles and a FireCloud role
+  def toFireCloudRole(agoraRoles:Option[List[String]]) = {
+    agoraRoles match {
+      case None => "NO ACCESS"
+      case Some(r) => {
+        r.sorted match {
+          case List("Create","Manage","Read","Redact","Write") => "OWNER"
+          case List("Read") => "READER"
+          case _ => "NO ACCESS" // TODO: throw an exception instead? Log something?
+        }
+      }
+    }
+  }
+}
+
+class AgoraPermissionActor (requestContext: RequestContext) extends Actor with FireCloudRequestBuilding {
+
+  implicit val system = context.system
+  import system.dispatcher
+
+  val log = Logging(system, getClass)
+
+  // TODO: tests
+
+  def receive = {
+    // GET requests
+    case AgoraPermissionHandler.Get(url: String) =>
+      val pipeline = authHeaders(requestContext) ~> sendReceive
+      val permissionListFuture: Future[HttpResponse] = pipeline { Get(url) }
+      permissionListFuture onComplete {
+        case Success(response) =>
+          response.status match {
+            case StatusCodes.OK =>
+              val agoraPermissions = unmarshal[List[AgoraPermission]].apply(response)
+              val fireCloudPermissions = agoraPermissions.map(x => x.toFireCloudPermission)
+              context.parent ! RequestComplete(OK, fireCloudPermissions)
+              context stop self
+            case x =>
+              context.parent ! RequestComplete(x, response.entity)
+              context stop self
+          }
+        case Failure(e) =>
+          context.parent ! RequestComplete(StatusCodes.InternalServerError, e.getMessage)
+          context stop self
+      }
+
+    case AgoraPermissionHandler.Post(url: String, agoraPermissions: List[AgoraPermission]) =>
+      val pipeline = authHeaders(requestContext) ~> sendReceive
+      // TODO: allow AGORA to see empty values?
+      //or should such things bie dropped here?  What if only one of the requests in  batch is bad?
+      //should all be dropped?
+      //For now, forward to Agora  and let it catch any error?
+      val permissionListFuture: Future[HttpResponse] = pipeline { Post(url.toString,
+        HttpClient.createJsonHttpEntity(agoraPermissions.toString()))
+      }
+      permissionListFuture onComplete {
+        case Success(response) =>
+          response.status match {
+            case StatusCodes.OK =>
+              val agoraPermission = unmarshal[AgoraPermission].apply(response)
+              val fireCloudPermission = agoraPermission.toFireCloudPermission
+              context.parent ! RequestComplete(OK, fireCloudPermission)
+              context stop self
+            case x =>
+              context.parent ! RequestComplete(x, response.entity)
+              context stop self
+          }
+        case Failure(e) =>
+          context.parent ! RequestComplete(StatusCodes.InternalServerError, e.getMessage)
+          context stop self
+      }
+
+
+
+    case _ =>
+      context.parent ! RequestComplete(StatusCodes.BadRequest)
+      context stop self
+  }
+
+
+}
+
+

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/MethodRepository.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/MethodRepository.scala
@@ -32,8 +32,7 @@ object MethodRepository {
     user: Option[String] = None,
     role: Option[String] = None
   ) {
-    def verifyValidUser = AgoraPermissionHandler.determineIfASingleFCPermissionIsValidForTranslationByUser(this)
-    def verifyValidRole = AgoraPermissionHandler.determineIfASingleFCPermissionIsValidForTranslationByAccessLevel(this)
+    def verifyValidUserAndRole = AgoraPermissionHandler.hasValidUserAndRole(this)
     def toAgoraPermission = AgoraPermissionHandler.toAgoraPermission(this)
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/MethodRepository.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/MethodRepository.scala
@@ -1,49 +1,46 @@
 package org.broadinstitute.dsde.firecloud.model
 
-import com.wordnik.swagger.annotations.{ApiModelProperty, ApiModel}
-
-import scala.annotation.meta.field
+import org.broadinstitute.dsde.firecloud.core.AgoraPermissionHandler
 
 object MethodRepository {
 
-  @ApiModel(value = "Configuration")
   case class Configuration(
-                            @(ApiModelProperty@field)(dataType = "string", value = "Namespace")
-                            namespace: Option[String] = None,
-                            @(ApiModelProperty@field)(dataType = "string", value = "Name ")
-                            name: Option[String] = None,
-                            @(ApiModelProperty@field)(dataType = "string", value = "Snapshot Id")
-                            snapshotId: Option[Int] = None,
-                            @(ApiModelProperty@field)(dataType = "string", value = "Synopsis")
-                            synopsis: Option[String] = None,
-                            @(ApiModelProperty@field)(dataType = "string", value = "Documentation")
-                            documentation: Option[String] = None,
-                            @(ApiModelProperty@field)(dataType = "string", value = "Owner")
-                            owner: Option[String] = None,
-                            @(ApiModelProperty@field)(dataType = "string", value = "Payload")
-                            payload: Option[String] = None,
-                            @(ApiModelProperty@field)(dataType = "string", value = "Excluded Field")
-                            excludedField: Option[String] = None,
-                            @(ApiModelProperty@field)(dataType = "string", value = "Included Field")
-                            includedField: Option[String] = None)
+    namespace: Option[String] = None,
+    name: Option[String] = None,
+    snapshotId: Option[Int] = None,
+    synopsis: Option[String] = None,
+    documentation: Option[String] = None,
+    owner: Option[String] = None,
+    payload: Option[String] = None,
+    excludedField: Option[String] = None,
+    includedField: Option[String] = None
+  )
 
-  @ApiModel(value = "Method")
   case class Method(
-                     @(ApiModelProperty@field)(dataType = "string", value = "Namespace")
-                     namespace: Option[String] = None,
-                     @(ApiModelProperty@field)(dataType = "string", value = "Name")
-                     name: Option[String] = None,
-                     @(ApiModelProperty@field)(dataType = "string", value = "Snapshot Id")
-                     snapshotId: Option[Int] = None,
-                     @(ApiModelProperty@field)(dataType = "string", value = "Synopsis")
-                     synopsis: Option[String] = None,
-                     @(ApiModelProperty@field)(dataType = "string", value = "Owner")
-                     owner: Option[String] = None,
-                     @(ApiModelProperty@field)(dataType = "string", value = "Creation Date")
-                     createDate: Option[String] = None,
-                     @(ApiModelProperty@field)(dataType = "string", value = "Payload")
-                     url: Option[String] = None,
-                     @(ApiModelProperty@field)(dataType = "string", value = "The type of the entity (Task, Workflow, Configuration)")
-                     entityType: Option[String] = None)
+    namespace: Option[String] = None,
+    name: Option[String] = None,
+    snapshotId: Option[Int] = None,
+    synopsis: Option[String] = None,
+    owner: Option[String] = None,
+    createDate: Option[String] = None,
+    url: Option[String] = None,
+    entityType: Option[String] = None
+  )
+
+  // represents a method/config permission as exposed to the user from the orchestration layer
+  case class FireCloudPermission(
+    user: Option[String] = None,
+    role: Option[String] = None
+  ) {
+    def toAgoraPermission = AgoraPermissionHandler.toAgoraPermission(this)
+  }
+
+  // represents a method/config permission as exposed by Agora
+  case class AgoraPermission(
+    user: Option[String] = None,
+    roles: Option[List[String]] = None
+  ) {
+    def toFireCloudPermission = AgoraPermissionHandler.toFireCloudPermission(this)
+  }
 
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/MethodRepository.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/MethodRepository.scala
@@ -32,6 +32,8 @@ object MethodRepository {
     user: Option[String] = None,
     role: Option[String] = None
   ) {
+    def verifyValidUser = AgoraPermissionHandler.determineIfASingleFCPermissionIsValidForTranslationByUser(this)
+    def verifyValidRole = AgoraPermissionHandler.determineIfASingleFCPermissionIsValidForTranslationByAccessLevel(this)
     def toAgoraPermission = AgoraPermissionHandler.toAgoraPermission(this)
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.dsde.firecloud.model
 
 import org.broadinstitute.dsde.firecloud.core.GetEntitiesWithType.EntityWithType
 import spray.http.StatusCode
+import org.broadinstitute.dsde.firecloud.model.MethodRepository.{AgoraPermission, FireCloudPermission}
 import spray.json._
 import spray.json.DefaultJsonProtocol._
 
@@ -27,6 +28,9 @@ object ModelJsonProtocol {
   implicit val impConfigurationCopyIngest = jsonFormat5(CopyConfigurationIngest)
   implicit val impMethodConfigurationPublish = jsonFormat3(MethodConfigurationPublish)
   implicit val impPublishConfigurationIngest = jsonFormat4(PublishConfigurationIngest)
+
+  implicit val impFireCloudPermission = jsonFormat2(FireCloudPermission)
+  implicit val impAgoraPermission = jsonFormat2(AgoraPermission)
 
   implicit val impEntityMetadata = jsonFormat4(EntityMetadata)
   implicit val impModelSchema = jsonFormat1(EntityModel)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/MethodsService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/MethodsService.scala
@@ -30,10 +30,6 @@ trait MethodsService extends HttpService with PerRequestCreator with FireCloudDi
       // generate the Agora url we'll call
       val url = FireCloudConfig.Agora.methodsPermissionsFromMethod(namespace, name, snapshotId)
 
-      delete {
-        //this functionality is achieve via "NO ACCESS" in the Post
-        requestContext => requestContext.complete(BadRequest)
-      } ~
         get { requestContext =>
           // pass to AgoraPermissionHandler
           perRequest(requestContext,
@@ -52,10 +48,6 @@ trait MethodsService extends HttpService with PerRequestCreator with FireCloudDi
                 Props(new AgoraPermissionActor(requestContext)),
                 AgoraPermissionHandler.Post(url, agoraPermissions))
           }
-        } ~
-        put {
-          //use POST for all functionality
-          requestContext => requestContext.complete(BadRequest)
         }}
 
 
@@ -66,10 +58,6 @@ trait MethodsService extends HttpService with PerRequestCreator with FireCloudDi
       // generate the Agora url we'll call
       val url = FireCloudConfig.Agora.configurationsPermissionsFromConfig(namespace, name, snapshotId)
 
-      delete {
-        //this functionality is achieve via "NO ACCESS" in the Post
-        requestContext => requestContext.complete(BadRequest)
-      } ~
       get { requestContext =>
         // pass to AgoraPermissionHandler
         perRequest(requestContext,
@@ -88,10 +76,6 @@ trait MethodsService extends HttpService with PerRequestCreator with FireCloudDi
               Props(new AgoraPermissionActor(requestContext)),
               AgoraPermissionHandler.Post(url, agoraPermissions))
           }
-        } ~
-        put {
-          //use POST for all functionality
-          requestContext => requestContext.complete(BadRequest)
         }}
 
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/MethodsService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/MethodsService.scala
@@ -4,7 +4,7 @@ import org.broadinstitute.dsde.firecloud.model.MethodRepository._
 import spray.routing.{HttpService, Route}
 import akka.actor.{Actor, Props}
 import org.broadinstitute.dsde.firecloud.core.{AgoraPermissionActor, AgoraPermissionHandler}
-//import org.broadinstitute.dsde.firecloud.core.AgoraPermissionHandler.determineIfASingleFCPermissionIsValidForTranslationByUser
+import org.broadinstitute.dsde.firecloud.model.{HttpResponseWithErrorReport, ErrorReport}
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
 import org.broadinstitute.dsde.firecloud.{FireCloudConfig}
 import org.slf4j.{ LoggerFactory}
@@ -45,7 +45,7 @@ trait MethodsService extends HttpService with PerRequestCreator with FireCloudDi
               val andAllByRoles=okayByRoles.foldLeft(true)(_ && _)
               if(!(andAllByUsers && andAllByRoles))
                 {
-                requestContext.complete(BadRequest)
+                requestContext.complete(HttpResponseWithErrorReport(BadRequest, "Invalid user or access setting detected! Each permission posted must have a non-empty user and a permission of READER, OWNER, or NO ACCESS!"))
                 }
 
               // translate the FireCloudPermissions into  AgoraPermissions

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/MethodsService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/MethodsService.scala
@@ -38,12 +38,16 @@ trait MethodsService extends HttpService with PerRequestCreator with FireCloudDi
           entity(as[List[FireCloudPermission]]) {
             fireCloudPermissions => requestContext =>
               //scan user and roles of each input to make sure they're valid
+              //this validityFlag represents a list of booleans where each item
+              //is true if an individual input is valid and okay to send to Agora
               val validityFlags=fireCloudPermissions.map(x => x.verifyValidUserAndRole)
               //see http://stackoverflow.com/questions/22518773/applying-logical-and-to-list-of-boolean-values
               val andAllByUsersAndRoles=validityFlags.foldLeft(true)(_ && _)
               if(!(andAllByUsersAndRoles))
                 {
-                requestContext.complete(HttpResponseWithErrorReport(BadRequest, "Invalid user or access setting detected! Each permission posted must have a non-empty user and a permission of READER, OWNER, or NO ACCESS!"))
+                requestContext.complete(HttpResponseWithErrorReport(BadRequest,
+                  "Invalid user or access setting detected! Each permission posted"+
+                    " must have a non-empty user and a permission of READER, OWNER, or NO ACCESS!"))
                 }
 
               // translate the FireCloudPermissions into  AgoraPermissions

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/MethodsService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/MethodsService.scala
@@ -64,7 +64,7 @@ trait MethodsService extends HttpService with PerRequestCreator with FireCloudDi
     path("configurations" / Segment / Segment / IntNumber / "permissions") { (namespace, name, snapshotId) =>
 
       // generate the Agora url we'll call
-      val url = FireCloudConfig.Agora.methodsPermissionsFromMethod(namespace, name, snapshotId)
+      val url = FireCloudConfig.Agora.configurationsPermissionsFromConfig(namespace, name, snapshotId)
 
       delete {
         //this functionality is achieve via "NO ACCESS" in the Post

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/MethodsService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/MethodsService.scala
@@ -38,12 +38,10 @@ trait MethodsService extends HttpService with PerRequestCreator with FireCloudDi
           entity(as[List[FireCloudPermission]]) {
             fireCloudPermissions => requestContext =>
               //scan user and roles of each input to make sure they're valid
-              val okayByUsers=fireCloudPermissions.map(x => x.verifyValidUser)
-              val okayByRoles=fireCloudPermissions.map(x => x.verifyValidRole)
+              val validityFlags=fireCloudPermissions.map(x => x.verifyValidUserAndRole)
               //see http://stackoverflow.com/questions/22518773/applying-logical-and-to-list-of-boolean-values
-              val andAllByUsers = okayByUsers.foldLeft(true)(_ && _)
-              val andAllByRoles=okayByRoles.foldLeft(true)(_ && _)
-              if(!(andAllByUsers && andAllByRoles))
+              val andAllByUsersAndRoles=validityFlags.foldLeft(true)(_ && _)
+              if(!(andAllByUsersAndRoles))
                 {
                 requestContext.complete(HttpResponseWithErrorReport(BadRequest, "Invalid user or access setting detected! Each permission posted must have a non-empty user and a permission of READER, OWNER, or NO ACCESS!"))
                 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/MethodsService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/MethodsService.scala
@@ -18,24 +18,23 @@ class MethodsServiceActor extends Actor with MethodsService {
 
 
 
+
+
 trait MethodsService extends HttpService with PerRequestCreator with FireCloudDirectives {
 
   lazy val log = LoggerFactory.getLogger(getClass)
 
-  // Agora routes that require special handling
+  // Agora permissions that require special handling
 
-  val methodsACLOverrideRoute: Route =
-    path("methods" / Segment / Segment / IntNumber / "permissions") { (namespace, name, snapshotId) =>
-
-      // generate the Agora url we'll call
-      val url = FireCloudConfig.Agora.methodsPermissionsFromMethod(namespace, name, snapshotId)
-
-        get { requestContext =>
-          // pass to AgoraPermissionHandler
-          perRequest(requestContext,
-            Props(new AgoraPermissionActor(requestContext)),
-            AgoraPermissionHandler.Get(url))
-        } ~
+  val methodsAndConfigsACLOverrideRoute: Route =
+    path( "configurations|methods".r / Segment / Segment / IntNumber / "permissions") { ( agora_ent, namespace, name, snapshotId) =>
+      val url = getUrlFromBasePath(agora_ent, namespace, name, snapshotId)
+      get { requestContext =>
+        // pass to AgoraPermissionHandler
+        perRequest(requestContext,
+          Props(new AgoraPermissionActor(requestContext)),
+          AgoraPermissionHandler.Get(url))
+      } ~
         post {
           // take the body of the HTTP POST and construct a FireCloudPermission from it
           entity(as[List[FireCloudPermission]]) {
@@ -52,32 +51,6 @@ trait MethodsService extends HttpService with PerRequestCreator with FireCloudDi
 
 
 
-  val configurationsACLOverrideRoute: Route =
-    path("configurations" / Segment / Segment / IntNumber / "permissions") { (namespace, name, snapshotId) =>
-
-      // generate the Agora url we'll call
-      val url = FireCloudConfig.Agora.configurationsPermissionsFromConfig(namespace, name, snapshotId)
-
-      get { requestContext =>
-        // pass to AgoraPermissionHandler
-        perRequest(requestContext,
-          Props(new AgoraPermissionActor(requestContext)),
-          AgoraPermissionHandler.Get(url))
-        } ~
-      post {
-        // take the body of the HTTP POST and construct a FireCloudPermission from it
-        entity(as[List[FireCloudPermission]]) {
-          fireCloudPermissions => requestContext =>
-            // translate the FireCloudPermissions into  AgoraPermissions
-            val agoraPermissions = fireCloudPermissions.map(x => x.toAgoraPermission)
-            // pass to AgoraPermissionHandler
-            perRequest(
-              requestContext,
-              Props(new AgoraPermissionActor(requestContext)),
-              AgoraPermissionHandler.Post(url, agoraPermissions))
-          }
-        }}
-
 
       // Agora routes that can be passthroughs. Because these routes conflict with the override routes, make sure
       // they are processed second!
@@ -86,7 +59,17 @@ trait MethodsService extends HttpService with PerRequestCreator with FireCloudDi
           passthroughAllPaths("configurations", FireCloudConfig.Agora.configurationsBaseUrl)
 
       // combine all of the above route definitions, keeping overrides first.
-      val routes =  methodsACLOverrideRoute ~ configurationsACLOverrideRoute ~ passthroughRoutes
+      val routes =  methodsAndConfigsACLOverrideRoute ~ passthroughRoutes
 
 
+
+  private def getUrlFromBasePath(agoraEntity: String, namespace: String, name: String, snapshotId: Int): String = {
+    agoraEntity match {
+      case "methods" =>
+        FireCloudConfig.Agora.methodsPermissionsFromMethod(namespace, name, snapshotId)
+      case "configurations" =>
+        FireCloudConfig.Agora.configurationsPermissionsFromConfig(namespace, name, snapshotId)
+    }
+
+  }
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/MethodsService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/MethodsService.scala
@@ -1,21 +1,108 @@
 package org.broadinstitute.dsde.firecloud.service
 
-import akka.actor.Actor
-import org.broadinstitute.dsde.firecloud.FireCloudConfig
-import org.slf4j.LoggerFactory
+import org.broadinstitute.dsde.firecloud.model.MethodRepository._
 import spray.routing.{HttpService, Route}
+import akka.actor.{Actor, Props}
+import org.broadinstitute.dsde.firecloud.core.{AgoraPermissionActor, AgoraPermissionHandler}
+import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
+import org.broadinstitute.dsde.firecloud.{FireCloudConfig}
+import org.slf4j.{ LoggerFactory}
+import spray.http.StatusCodes._
+import spray.httpx.SprayJsonSupport._
+import spray.json.DefaultJsonProtocol._
 
 class MethodsServiceActor extends Actor with MethodsService {
   def actorRefFactory = context
   def receive = runRoute(routes)
 }
 
-trait MethodsService extends HttpService with FireCloudDirectives {
+
+
+trait MethodsService extends HttpService with PerRequestCreator with FireCloudDirectives {
 
   lazy val log = LoggerFactory.getLogger(getClass)
 
-  val routes: Route =
-    passthroughAllPaths("methods", FireCloudConfig.Agora.methodsBaseUrl) ~
-    passthroughAllPaths("configurations", FireCloudConfig.Agora.configurationsBaseUrl)
+  // Agora routes that require special handling
+
+  val methodsACLOverrideRoute: Route =
+    path("methods" / Segment / Segment / IntNumber / "permissions") { (namespace, name, snapshotId) =>
+
+      // generate the Agora url we'll call
+      val url = FireCloudConfig.Agora.methodsPermissionsFromMethod(namespace, name, snapshotId)
+
+      delete {
+        //this functionality is achieve via "NO ACCESS" in the Post
+        requestContext => requestContext.complete(BadRequest)
+      } ~
+        get { requestContext =>
+          // pass to AgoraPermissionHandler
+          perRequest(requestContext,
+            Props(new AgoraPermissionActor(requestContext)),
+            AgoraPermissionHandler.Get(url))
+        } ~
+        post {
+          // take the body of the HTTP POST and construct a FireCloudPermission from it
+          entity(as[List[FireCloudPermission]]) {
+            fireCloudPermissions => requestContext =>
+              // translate the FireCloudPermissions into  AgoraPermissions
+              val agoraPermissions = fireCloudPermissions.map(x => x.toAgoraPermission)
+              // pass to AgoraPermissionHandler
+              perRequest(
+                requestContext,
+                Props(new AgoraPermissionActor(requestContext)),
+                AgoraPermissionHandler.Post(url, agoraPermissions))
+          }
+        } ~
+        put {
+          //use POST for all functionality
+          requestContext => requestContext.complete(BadRequest)
+        }}
+
+
+
+  val configurationsACLOverrideRoute: Route =
+    path("configurations" / Segment / Segment / IntNumber / "permissions") { (namespace, name, snapshotId) =>
+
+      // generate the Agora url we'll call
+      val url = FireCloudConfig.Agora.methodsPermissionsFromMethod(namespace, name, snapshotId)
+
+      delete {
+        //this functionality is achieve via "NO ACCESS" in the Post
+        requestContext => requestContext.complete(BadRequest)
+      } ~
+      get { requestContext =>
+        // pass to AgoraPermissionHandler
+        perRequest(requestContext,
+          Props(new AgoraPermissionActor(requestContext)),
+          AgoraPermissionHandler.Get(url))
+        } ~
+      post {
+        // take the body of the HTTP POST and construct a FireCloudPermission from it
+        entity(as[List[FireCloudPermission]]) {
+          fireCloudPermissions => requestContext =>
+            // translate the FireCloudPermissions into  AgoraPermissions
+            val agoraPermissions = fireCloudPermissions.map(x => x.toAgoraPermission)
+            // pass to AgoraPermissionHandler
+            perRequest(
+              requestContext,
+              Props(new AgoraPermissionActor(requestContext)),
+              AgoraPermissionHandler.Post(url, agoraPermissions))
+          }
+        } ~
+        put {
+          //use POST for all functionality
+          requestContext => requestContext.complete(BadRequest)
+        }}
+
+
+      // Agora routes that can be passthroughs. Because these routes conflict with the override routes, make sure
+      // they are processed second!
+      val passthroughRoutes: Route =
+        passthroughAllPaths("methods", FireCloudConfig.Agora.methodsBaseUrl) ~
+          passthroughAllPaths("configurations", FireCloudConfig.Agora.configurationsBaseUrl)
+
+      // combine all of the above route definitions, keeping overrides first.
+      val routes =  methodsACLOverrideRoute ~ configurationsACLOverrideRoute ~ passthroughRoutes
+
 
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockMethodsServer.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockMethodsServer.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.firecloud.mock
 
 import org.broadinstitute.dsde.firecloud.mock.MockUtils._
 import org.broadinstitute.dsde.firecloud.model.ErrorReport
-import org.broadinstitute.dsde.firecloud.model.MethodRepository.{Configuration, Method}
+import org.broadinstitute.dsde.firecloud.model.MethodRepository.{AgoraPermission, Configuration, Method}
 import org.mockserver.integration.ClientAndServer
 import org.mockserver.integration.ClientAndServer._
 import org.mockserver.model.HttpRequest._
@@ -15,9 +15,51 @@ import DefaultJsonProtocol._
 
 object MockMethodsServer {
 
+
+
+
   val methodsServerPort = 8989
 
   /****** Mock Data ******/
+
+  def generateRandomRoles():List[String] ={
+    val randomNum=scala.util.Random.nextInt(2)
+    val aList=List[String]()
+    if(randomNum %2==0) {
+      aList :+ "Read"
+    }
+    val randomNum2=scala.util.Random.nextInt(2)
+    if(randomNum2 %2==0 )
+    {
+      aList :+ "Write"
+    }
+    val randomNum3=scala.util.Random.nextInt(2)
+    if(randomNum3 %2==0)
+    {
+      aList :+ "Create"
+    }
+    val randomNum4=scala.util.Random.nextInt(2)
+    if(randomNum4 %2==0)
+    {
+      aList :+ "Redact"
+    }
+    val randomNum5=scala.util.Random.nextInt(2)
+    if(randomNum5 %2==0)
+    {
+      aList :+ "Manage"
+    }
+    return aList
+  }
+
+ val mockPermissions: List[AgoraPermission] = {
+    List.tabulate(randomPositiveInt()-1)(
+    n=>
+      AgoraPermission(
+        user=Some(randomAlpha()),
+        roles=Some(generateRandomRoles())
+      )
+    )
+  }
 
   val mockMethods: List[Method] = {
     List.tabulate(randomPositiveInt())(

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockMethodsServer.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockMethodsServer.scala
@@ -22,7 +22,10 @@ object MockMethodsServer {
 
   /****** Mock Data ******/
 
-  def generateRandomRoles():List[String] ={
+  def generateRandomRoles():List[String] =
+  {
+    //each of the 5 individual roles
+    //has a 1/2 probability of showing up
     val randomNum=scala.util.Random.nextInt(2)
     val aList=List[String]()
     if(randomNum %2==0) {
@@ -158,6 +161,55 @@ object MockMethodsServer {
         .withHeader(header)
         .withBody(agoraErrorReport(MethodNotAllowed).toJson.compactPrint)
     )
+
+    MockMethodsServer.methodsServer
+    .when(
+      request()
+        .withMethod("GET")
+        .withPath("/configurations/%s/%s/%s/permissions"))
+      .respond(
+        response()
+          .withStatusCode(200)
+          .withHeader(header)
+          .withBody(mockPermissions.toJson.compactPrint))
+
+    MockMethodsServer.methodsServer
+      .when(
+        request()
+          .withMethod("GET")
+          .withPath("/methods/%s/%s/%s/permissions"))
+      .respond(
+        response()
+          .withStatusCode(200)
+          .withHeader(header)
+          .withBody(mockPermissions.toJson.compactPrint))
+
+    //POST returns the same as GET, but the data returned
+    //in the POST in real Agora is essentially an echo
+    //of what was sent which
+    MockMethodsServer.methodsServer
+      .when(
+        request()
+          .withMethod("POST")
+          .withPath("/configurations/%s/%s/%s/permissions"))
+      .respond(
+        response()
+          .withStatusCode(200)
+          .withHeader(header)
+          .withBody(mockPermissions.toJson.compactPrint))
+
+    MockMethodsServer.methodsServer
+      .when(
+        request()
+          .withMethod("POST")
+          .withPath("/methods/%s/%s/%s/permissions"))
+      .respond(
+        response()
+          .withStatusCode(200)
+          .withHeader(header)
+          .withBody(mockPermissions.toJson.compactPrint))
+
+
 
     MockMethodsServer.methodsServer
       .when(

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/MethodsServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/MethodsServiceSpec.scala
@@ -105,6 +105,12 @@ class MethodsServiceSpec extends ServiceSpec with MethodsService {
       }
     }
 
-  }
+  /*"when calling GET on a given configuration" - {
+    "A list of FireCloud permissions is returned" in {
+      Get("/configurations/") ~> dummyAuthHeaders ~> sealRoute(routes) ~> check {
+      }
+    }
 
-}
+  }*/
+
+}}

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/MethodsServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/MethodsServiceSpec.scala
@@ -104,19 +104,23 @@ class MethodsServiceSpec extends ServiceSpec with MethodsService {
       }
     }
 
-  "when calling GET on a given configuration" - {
-    "A list of (translated agora-to) FireCloud permissions is returned" in {
-      Get("/configurations/broad-dsde-dev/EddieFastaCounter/1/permissions") ~> dummyAuthHeaders ~> sealRoute(routes) ~> check {
-        status should equal(OK)
-        val perms = responseAs[List[FireCloudPermission]]
-        perms foreach {
-          p: FireCloudPermission =>
-            p.user shouldNot be(empty)
-            p.role shouldBe Some(List)
+    "when calling GET on a given method" - {
+      "A list of (translated agora-to) FireCloud permissions is returned" in {
+        Get("/configurations/broad-dsde-dev/EddieFastaCounter/1/permissions") ~> dummyAuthHeaders ~> sealRoute(routes) ~> check {
+          status should equal(OK)
+          val perms = responseAs[List[FireCloudPermission]]
+          perms foreach {
+            p: FireCloudPermission =>
+              p.user shouldNot be(empty)
+              p.role shouldBe Some(List)
+              val pCount=p.role.##
+              val pCountGoodFlag=(0<=pCount && pCount<=5)
+              pCountGoodFlag shouldBe true
+
+          }
         }
       }
     }
-  }
 
     "when calling GET on a given method" - {
       "A list of (translated agora-to) FireCloud permissions is returned" in {
@@ -125,8 +129,12 @@ class MethodsServiceSpec extends ServiceSpec with MethodsService {
           val perms = responseAs[List[FireCloudPermission]]
           perms foreach {
             p: FireCloudPermission =>
-              p.user shouldNot be(empty)
-              p.role shouldBe Some(List)
+             p.user shouldNot be(empty)
+             p.role shouldBe Some(List)
+             val pCount=p.role.##
+             val pCountGoodFlag=(0<=pCount && pCount<=5)
+             pCountGoodFlag shouldBe true
+
           }
         }
       }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/MethodsServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/MethodsServiceSpec.scala
@@ -1,9 +1,8 @@
 package org.broadinstitute.dsde.firecloud.service
 
 import org.broadinstitute.dsde.firecloud.mock.MockMethodsServer
-import org.broadinstitute.dsde.firecloud.model.MethodRepository.{Configuration, Method}
+import org.broadinstitute.dsde.firecloud.model.MethodRepository._
 import spray.http.StatusCodes._
-
 import spray.httpx.SprayJsonSupport._
 import spray.json.DefaultJsonProtocol._
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
@@ -105,12 +104,32 @@ class MethodsServiceSpec extends ServiceSpec with MethodsService {
       }
     }
 
-  /*"when calling GET on a given configuration" - {
-    "A list of FireCloud permissions is returned" in {
-      Get("/configurations/") ~> dummyAuthHeaders ~> sealRoute(routes) ~> check {
+  "when calling GET on a given configuration" - {
+    "A list of (translated agora-to) FireCloud permissions is returned" in {
+      Get("/configurations/broad-dsde-dev/EddieFastaCounter/1/permissions") ~> dummyAuthHeaders ~> sealRoute(routes) ~> check {
+        status should equal(OK)
+        val perms = responseAs[List[FireCloudPermission]]
+        perms foreach {
+          p: FireCloudPermission =>
+            p.user shouldNot be(empty)
+            p.role shouldBe Some(List)
+        }
       }
     }
+  }
 
-  }*/
+    "when calling GET on a given method" - {
+      "A list of (translated agora-to) FireCloud permissions is returned" in {
+        Get("/methods/broad-dsde-dev/EddieFastaCounter/1/permissions") ~> dummyAuthHeaders ~> sealRoute(routes) ~> check {
+          status should equal(OK)
+          val perms = responseAs[List[FireCloudPermission]]
+          perms foreach {
+            p: FireCloudPermission =>
+              p.user shouldNot be(empty)
+              p.role shouldBe Some(List)
+          }
+        }
+      }
+    }
 
 }}


### PR DESCRIPTION
wip - agora permissions endpoints and translations to FireCloud roles

hadle put, delete requests by responding with BadRequest

prepare for fanning

pass both URL and permissions object to handler

cleanup

fix errors for mapping and post passthru

fix declarion to match implementaiton

rearrange and comment

rearrange close brace

it compiles

compiles

cleanup

more cleanup

methods ACL override route

remove unused delete from handler