### PR TITLE
encode uris to allow for spaces and other special characters in path

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -427,7 +427,7 @@ paths:
           description: Workspace or entity type does not exist
         500:
           description: Internal Server Error
-  /workspaces/{workspaceNamespace}/{workspaceName}/method_configs:
+  /workspaces/{workspaceNamespace}/{workspaceName}/methodconfigs:
     get:
       tags:
         - Method Configurations

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/FireCloudDirectivesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/FireCloudDirectivesSpec.scala
@@ -1,0 +1,33 @@
+package org.broadinstitute.dsde.firecloud.service
+
+import org.scalatest.FreeSpec
+import spray.testkit.ScalatestRouteTest
+
+class FireCloudDirectivesSpec extends FreeSpec with ScalatestRouteTest with FireCloudDirectives {
+
+  def actorRefFactory = system
+
+  "FireCloudDirectives" - {
+    "Unencoded passthrough URLs" - {
+      "should be encoded" in {
+        val unencoded = "http://abc.com/path with spaces/"
+        val encoded = encodeUri(unencoded)
+        assert(encoded.equals("http://abc.com/path%20with%20spaces/"))
+      }
+    }
+    "Encoded passthrough URLs" - {
+      "should not be re-encoded" in {
+        val unencoded = "https://abc.com/path%20with%20spaces/"
+        val encoded = encodeUri(unencoded)
+        assert(encoded.equals("https://abc.com/path%20with%20spaces/"))
+      }
+    }
+    "Passthrough URLs with no parameters" - {
+      "should not break during encoding" in {
+        val unencoded = "http://abc.com/"
+        val encoded = encodeUri(unencoded)
+        assert(encoded.equals("http://abc.com/"))
+      }
+    }
+  }
+}


### PR DESCRIPTION
This addresses a bug that would cause an exception to be thrown if there were special characters in a resource name (i.e. a space in a workspace name). I'm not a regex expert so if somebody who is could double check my pattern, that would be great!

Also fixed a little thing in swagger that I noticed was inconsistent with the actual orchestration code.

Jira ticket: https://broadinstitute.atlassian.net/browse/DSDEEPB-1479