### PR TITLE
Allow port in URI to enable unit tests

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/FireCloudDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/FireCloudDirectives.scala
@@ -3,6 +3,8 @@ package org.broadinstitute.dsde.firecloud.service
 import spray.http.{Uri, HttpMethod}
 import spray.http.MediaTypes._
 
+import scala.util.Try
+
 trait FireCloudDirectives extends spray.routing.Directives with PerRequestCreator with spray.httpx.RequestBuilding {
   def respondWithJSON = respondWithMediaType(`application/json`)
 
@@ -39,10 +41,12 @@ trait FireCloudDirectives extends spray.routing.Directives with PerRequestCreato
   }
 
   def encodeUri(path: String): String = {
-    val pattern = """(https|http)://([^/\r\n]+)(/[^\r\n]*)?""".r
+    val pattern = """(https|http)://([^/\r\n]+?)(:\d+)?(/[^\r\n]*)?""".r
 
     def toUri(url: String) = url match {
-      case pattern(theScheme, theHost, thePath) => Uri.from(scheme = theScheme, host = theHost, path = thePath)
+      case pattern(theScheme, theHost, thePort, thePath) =>
+        val p: Int = Try(thePort.replace(":","").toInt).toOption.getOrElse(0)
+        Uri.from(scheme = theScheme, port = p, host = theHost, path = thePath)
     }
 
     toUri(path).toString

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/FireCloudDirectivesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/FireCloudDirectivesSpec.scala
@@ -24,9 +24,16 @@ class FireCloudDirectivesSpec extends FreeSpec with ScalatestRouteTest with Fire
     }
     "Passthrough URLs with no parameters" - {
       "should not break during encoding" in {
-        val unencoded = "http://abc.com/"
+        val unencoded = "http://abc.com/path"
         val encoded = encodeUri(unencoded)
-        assert(encoded.equals("http://abc.com/"))
+        assert(encoded.equals("http://abc.com/path"))
+      }
+    }
+    "URL with port specified" - {
+      "should not break during encoding" in {
+        val unencoded = "http://abc.com:8080/"
+        val encoded = encodeUri(unencoded)
+        assert(encoded.equals("http://abc.com:8080/"))
       }
     }
   }


### PR DESCRIPTION
After #112 unit tests did not work, because they require local mock server URLs with ports in them, like `http://localhost:8989`