### PR TITLE
DSDEEPB-1592: Move all rawls endpoints under /api

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -37,15 +37,20 @@ methods {
 
 workspace {
   model="model.json"
+  authPrefix="/api"
+  workspacesPath="/workspaces"
   entitiesPath="/workspaces/%s/%s/entities"
   methodConfigsListPath="/workspaces/%s/%s/methodconfigs"
   getMethodConfigPath="/workspaces/%s/%s/methodconfigs/%s/%s"
   getMethodConfigValidationPath="/workspaces/%s/%s/methodconfigs/%s/%s/validate"
   methodConfigUpdatePath="/workspaces/%s/%s/methodconfigs/%s/%s"
   methodConfigRenamePath="/workspaces/%s/%s/methodconfigs/%s/%s/rename"
+  methodConfigPath="/methodconfigs"
   copyFromMethodRepoConfig="/methodconfigs/copyFromMethodRepo"
   copyToMethodRepoConfig="/methodconfigs/copyToMethodRepo"
   template="/methodconfigs/template"
   importEntitiesPath="/workspaces/%s/%s/importEntities"
   workspacesEntitiesCopyPath="/workspaces/entities/copy"
+  submissionsPath="/workspaces/%s/%s/submissions"
+  submissionsIdPath="/workspaces/%s/%s/submissions/%s"
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
@@ -29,29 +29,37 @@ object FireCloudConfig {
     private val workspace = config.getConfig("workspace")
     lazy val model = "/" + workspace.getString("model")
     lazy val baseUrl = sys.env.get("RAWLS_URL_ROOT").get
+    lazy val authPrefix = workspace.getString("authPrefix")
+    lazy val authUrl = baseUrl + authPrefix
+    lazy val workspacesPath = workspace.getString("workspacesPath")
+    lazy val workspacesUrl = authUrl + workspacesPath
     lazy val entitiesPath = workspace.getString("entitiesPath")
     lazy val methodConfigsListPath = workspace.getString("methodConfigsListPath")
-    lazy val getMethodConfigUrl = baseUrl + workspace.getString("getMethodConfigPath")
-    lazy val getMethodConfigValidationUrl = baseUrl + workspace.getString("getMethodConfigValidationPath")
+    lazy val getMethodConfigUrl = authUrl + workspace.getString("getMethodConfigPath")
+    lazy val getMethodConfigValidationUrl = authUrl + workspace.getString("getMethodConfigValidationPath")
     lazy val methodConfigUpdatePath = workspace.getString("methodConfigUpdatePath")
     lazy val methodConfigRenamePath = workspace.getString("methodConfigRenamePath")
-    lazy val listMethodConfigurationsUrl = baseUrl + methodConfigsListPath
-    lazy val updateMethodConfigurationUrl = baseUrl + methodConfigUpdatePath
-    lazy val renameMethodConfigurationUrl = baseUrl + methodConfigRenamePath
+    lazy val listMethodConfigurationsUrl = authUrl + methodConfigsListPath
+    lazy val updateMethodConfigurationUrl = authUrl + methodConfigUpdatePath
+    lazy val renameMethodConfigurationUrl = authUrl + methodConfigRenamePath
+    lazy val methodConfigPath = workspace.getString("methodConfigPath")
+    lazy val methodConfigUrl = authUrl + workspace.getString("methodConfigPath")
     lazy val copyFromMethodRepoConfigPath = workspace.getString("copyFromMethodRepoConfig")
-    lazy val copyFromMethodRepoConfigUrl = baseUrl + copyFromMethodRepoConfigPath
+    lazy val copyFromMethodRepoConfigUrl = authUrl + copyFromMethodRepoConfigPath
     lazy val copyToMethodRepoConfigPath = workspace.getString("copyToMethodRepoConfig")
-    lazy val copyToMethodRepoConfigUrl = baseUrl + copyToMethodRepoConfigPath
+    lazy val copyToMethodRepoConfigUrl = authUrl + copyToMethodRepoConfigPath
     lazy val templatePath = workspace.getString("template")
-    lazy val templateUrl = baseUrl + templatePath
+    lazy val templateUrl = authUrl + templatePath
     lazy val importEntitiesPath = workspace.getString("importEntitiesPath")
-    lazy val importEntitiesUrl = baseUrl + importEntitiesPath
     lazy val workspacesEntitiesCopyPath = workspace.getString("workspacesEntitiesCopyPath")
-    lazy val workspacesEntitiesCopyUrl = baseUrl + workspacesEntitiesCopyPath
+    lazy val workspacesEntitiesCopyUrl = authUrl + workspacesEntitiesCopyPath
+    lazy val submissionsPath = workspace.getString("submissionsPath")
+    lazy val submissionsUrl = authUrl + submissionsPath
+    lazy val submissionsIdPath = workspace.getString("submissionsIdPath")
 
-    def entityPathFromWorkspace(namespace: String, name: String) = baseUrl + workspace.getString("entitiesPath").format(namespace, name)
-    def methodConfigPathFromWorkspace(namespace: String, name: String) = baseUrl + methodConfigsListPath.format(namespace, name)
-    def importEntitiesPathFromWorkspace(namespace: String, name: String) = importEntitiesUrl.format(namespace, name)
+    def entityPathFromWorkspace(namespace: String, name: String) = authUrl + entitiesPath.format(namespace, name)
+    def methodConfigPathFromWorkspace(namespace: String, name: String) = authUrl + methodConfigsListPath.format(namespace, name)
+    def importEntitiesPathFromWorkspace(namespace: String, name: String) = authUrl + importEntitiesPath.format(namespace, name)
   }
 
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/SubmissionService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/SubmissionService.scala
@@ -21,8 +21,8 @@ trait SubmissionService extends HttpService with PerRequestCreator with FireClou
     pathPrefix("workspaces" / Segment / Segment) {
       (workspaceNamespace, workspaceName) =>
         pathPrefixTest("submissions") {
-          val path = "workspaces/" + workspaceNamespace + "/" + workspaceName + "/submissions"
-          passthroughAllPaths("submissions", FireCloudConfig.Rawls.baseUrl + "/" + path)
+          val path = FireCloudConfig.Rawls.submissionsUrl.format(workspaceNamespace, workspaceName)
+          passthroughAllPaths("submissions", path)
         }
     }
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceService.scala
@@ -24,8 +24,7 @@ trait WorkspaceService extends HttpService with PerRequestCreator with FireCloud
   private implicit val executionContext = actorRefFactory.dispatcher
 
   lazy val log = LoggerFactory.getLogger(getClass)
-  lazy val rawlsUrlRoot = FireCloudConfig.Rawls.baseUrl
-  lazy val rawlsWorkspacesRoot = rawlsUrlRoot + "/workspaces"
+  lazy val rawlsWorkspacesRoot = FireCloudConfig.Rawls.workspacesUrl
 
   val routes: Route =
     pathPrefix("workspaces") {

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockWorkspaceServer.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockWorkspaceServer.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.firecloud.mock
 
+import org.broadinstitute.dsde.firecloud.FireCloudConfig
 import org.broadinstitute.dsde.firecloud.mock.MockUtils._
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
 import org.broadinstitute.dsde.firecloud.model._
@@ -141,7 +142,10 @@ object MockWorkspaceServer {
     expression = Option.empty
   )
 
-  val entitiesWithTypeBasePath = "/workspaces/broad-dsde-dev/alexb_test_submission/"
+  val workspaceBasePath = FireCloudConfig.Rawls.authPrefix + FireCloudConfig.Rawls.workspacesPath
+  val entitiesWithTypeBasePath = workspaceBasePath + "/broad-dsde-dev/alexb_test_submission/"
+
+  val methodConfigBasePath = FireCloudConfig.Rawls.authPrefix + FireCloudConfig.Rawls.methodConfigPath
 
   var workspaceServer: ClientAndServer = _
 
@@ -158,7 +162,7 @@ object MockWorkspaceServer {
       .when(
         request()
           .withMethod("POST")
-          .withPath(s"/workspaces/%s/%s/submissions"
+          .withPath(s"${workspaceBasePath}/%s/%s/submissions"
             .format(mockValidWorkspace.namespace.get, mockValidWorkspace.name.get))
           .withHeader(authHeader))
       .callback(
@@ -170,7 +174,7 @@ object MockWorkspaceServer {
       .when(
         request()
           .withMethod("POST")
-          .withPath(s"/workspaces/%s/%s/submissions"
+          .withPath(s"${workspaceBasePath}/%s/%s/submissions"
           .format(mockValidWorkspace.namespace.get, mockValidWorkspace.name.get)))
       .respond(
         response()
@@ -182,7 +186,7 @@ object MockWorkspaceServer {
       .when(
         request()
           .withMethod("GET")
-          .withPath(s"/workspaces/%s/%s/submissions"
+          .withPath(s"${workspaceBasePath}/%s/%s/submissions"
           .format(mockValidWorkspace.namespace.get, mockValidWorkspace.name.get))
           .withHeader(authHeader))
       .respond(
@@ -195,7 +199,7 @@ object MockWorkspaceServer {
       .when(
         request()
           .withMethod("GET")
-          .withPath(s"/workspaces/%s/%s/submissions/%s"
+          .withPath(s"${workspaceBasePath}/%s/%s/submissions/%s"
             .format(mockValidWorkspace.namespace.get, mockValidWorkspace.name.get, mockValidId))
           .withHeader(authHeader))
       .respond(
@@ -209,7 +213,7 @@ object MockWorkspaceServer {
       .when(
         request()
           .withMethod("DELETE")
-          .withPath(s"/workspaces/%s/%s/submissions/%s"
+          .withPath(s"${workspaceBasePath}/%s/%s/submissions/%s"
           .format(mockValidWorkspace.namespace.get, mockValidWorkspace.name.get, mockValidId))
           .withHeader(authHeader))
       .respond(
@@ -225,7 +229,7 @@ object MockWorkspaceServer {
       .when(
         request()
           .withMethod("POST")
-          .withPath("/workspaces")
+          .withPath(workspaceBasePath)
           .withHeader(authHeader))
       .callback(
         callback().
@@ -236,7 +240,7 @@ object MockWorkspaceServer {
       .when(
         request()
           .withMethod("POST")
-          .withPath("/workspaces")
+          .withPath(workspaceBasePath)
       ).respond(
         response()
           .withHeaders(header)
@@ -248,7 +252,7 @@ object MockWorkspaceServer {
       .when(
         request()
           .withMethod("GET")
-          .withPath("/workspaces")
+          .withPath(workspaceBasePath)
           .withHeader(authHeader))
       .respond(
         response()
@@ -261,7 +265,7 @@ object MockWorkspaceServer {
       .when(
         request()
           .withMethod("GET")
-          .withPath(s"/workspaces/%s/%s"
+          .withPath(s"${workspaceBasePath}/%s/%s"
             .format(mockValidWorkspace.namespace.get, mockValidWorkspace.name.get))
           .withHeader(authHeader))
       .respond(
@@ -275,7 +279,7 @@ object MockWorkspaceServer {
       when(
         request()
           .withMethod("GET")
-          .withPath(s"/workspaces/%s/%s"
+          .withPath(s"${workspaceBasePath}/%s/%s"
             .format(mockInvalidWorkspace.namespace.get, mockInvalidWorkspace.name.get))
           .withHeader(authHeader))
       .respond(
@@ -287,7 +291,7 @@ object MockWorkspaceServer {
       .when(
         request()
           .withMethod("DELETE")
-          .withPath(s"/workspaces/%s/%s"
+          .withPath(s"${workspaceBasePath}/%s/%s"
           .format(mockValidWorkspace.namespace.get, mockValidWorkspace.name.get))
           .withHeader(authHeader))
       .respond(
@@ -300,7 +304,7 @@ object MockWorkspaceServer {
       when(
         request()
           .withMethod("DELETE")
-          .withPath(s"/workspaces/%s/%s"
+          .withPath(s"${workspaceBasePath}/%s/%s"
             .format(mockInvalidWorkspace.namespace.get, mockInvalidWorkspace.name.get))
           .withHeader(authHeader))
       .respond(
@@ -312,7 +316,7 @@ object MockWorkspaceServer {
       .when(
         request()
           .withMethod("GET")
-          .withPath(s"/workspaces/%s/%s/acl"
+          .withPath(s"${workspaceBasePath}/%s/%s/acl"
             .format(mockValidWorkspace.namespace.get, mockValidWorkspace.name.get))
           .withHeader(authHeader))
       .respond(
@@ -326,7 +330,7 @@ object MockWorkspaceServer {
       .when(
         request()
           .withMethod("PATCH")
-          .withPath(s"/workspaces/%s/%s/acl"
+          .withPath(s"${workspaceBasePath}/%s/%s/acl"
             .format(mockValidWorkspace.namespace.get, mockValidWorkspace.name.get))
           .withBody(mockWorkspaceACL.toJson.prettyPrint)
           .withHeader(authHeader))
@@ -342,7 +346,7 @@ object MockWorkspaceServer {
       when(
         request()
           .withMethod("GET")
-          .withPath(s"/workspaces/%s/%s/methodconfigs"
+          .withPath(s"${workspaceBasePath}/%s/%s/methodconfigs"
             .format(mockInvalidWorkspace.namespace.get, mockInvalidWorkspace.name.get))
           .withHeader(authHeader))
       .respond(
@@ -354,7 +358,7 @@ object MockWorkspaceServer {
       when(
         request()
           .withMethod("GET")
-          .withPath(s"/workspaces/%s/%s/methodconfigs".
+          .withPath(s"${workspaceBasePath}/%s/%s/methodconfigs".
             format(mockValidWorkspace.namespace.get, mockValidWorkspace.name.get))
           .withHeader(authHeader))
       .respond(
@@ -367,7 +371,7 @@ object MockWorkspaceServer {
       when(
         request()
           .withMethod("PATCH")
-          .withPath(s"/workspaces/%s/%s"
+          .withPath(s"${workspaceBasePath}/%s/%s"
           .format(mockValidWorkspace.namespace.get, mockValidWorkspace.name.get))
           .withBody(mockUpdateAttributeOperation.toJson.prettyPrint)
           .withHeader(authHeader))
@@ -382,7 +386,7 @@ object MockWorkspaceServer {
       when(
         request()
           .withMethod("PUT")
-          .withPath(s"/workspaces/%s/%s/methodconfigs/%s/%s".
+          .withPath(s"${workspaceBasePath}/%s/%s/methodconfigs/%s/%s".
           format(
             mockValidWorkspace.namespace.get,
             mockValidWorkspace.name.get,
@@ -399,7 +403,7 @@ object MockWorkspaceServer {
       when(
         request()
           .withMethod("GET")
-          .withPath(s"/workspaces/%s/%s/methodconfigs/%s/%s".
+          .withPath(s"${workspaceBasePath}/%s/%s/methodconfigs/%s/%s".
           format(
             mockValidWorkspace.namespace.get,
             mockValidWorkspace.name.get,
@@ -416,7 +420,7 @@ object MockWorkspaceServer {
       when(
         request()
           .withMethod("PUT")
-          .withPath(s"/workspaces/%s/%s/methodconfigs/%s/%s".
+          .withPath(s"${workspaceBasePath}/%s/%s/methodconfigs/%s/%s".
           format(
             mockValidWorkspace.namespace.get,
             mockValidWorkspace.name.get,
@@ -432,7 +436,7 @@ object MockWorkspaceServer {
       when(
         request()
           .withMethod("DELETE")
-          .withPath(s"/workspaces/%s/%s/methodconfigs/%s/%s".
+          .withPath(s"${workspaceBasePath}/%s/%s/methodconfigs/%s/%s".
           format(
             mockValidWorkspace.namespace.get,
             mockValidWorkspace.name.get,
@@ -447,7 +451,7 @@ object MockWorkspaceServer {
       when(
         request()
           .withMethod("DELETE")
-          .withPath(s"/workspaces/%s/%s/methodconfigs/%s/%s".
+          .withPath(s"${workspaceBasePath}/%s/%s/methodconfigs/%s/%s".
           format(
             mockInvalidWorkspace.namespace.get,
             mockInvalidWorkspace.name.get,
@@ -462,7 +466,7 @@ object MockWorkspaceServer {
       when(
         request()
           .withMethod("GET")
-          .withPath(s"/workspaces/%s/%s/methodconfigs/%s/%s/validate".
+          .withPath(s"${workspaceBasePath}/%s/%s/methodconfigs/%s/%s/validate".
           format(
             mockValidWorkspace.namespace.get,
             mockValidWorkspace.name.get,
@@ -479,7 +483,7 @@ object MockWorkspaceServer {
       .when(
         request()
           .withMethod("PUT")
-          .withPath(s"/workspaces/${mockValidWorkspace.namespace.get}/${mockValidWorkspace.name.get}/methodconfigs")
+          .withPath(s"${workspaceBasePath}/${mockValidWorkspace.namespace.get}/${mockValidWorkspace.name.get}/methodconfigs")
           .withBody("")
           .withHeader(authHeader))
       .respond(
@@ -494,7 +498,7 @@ object MockWorkspaceServer {
       .when(
         request()
           .withMethod("POST")
-          .withPath(s"/workspaces/${mockSampleValid.wsNamespace.get}/${mockSampleValid.wsName.get}/entities")
+          .withPath(s"${workspaceBasePath}/${mockSampleValid.wsNamespace.get}/${mockSampleValid.wsName.get}/entities")
           .withBody(mockSampleValid.toJson.compactPrint)
           .withHeader(authHeader))
       .respond(
@@ -520,7 +524,7 @@ object MockWorkspaceServer {
       .when(
         request()
           .withMethod("POST")
-          .withPath(s"/workspaces/${mockPairValid.wsNamespace.get}/${mockPairValid.wsName.get}/entities")
+          .withPath(s"${workspaceBasePath}/${mockPairValid.wsNamespace.get}/${mockPairValid.wsName.get}/entities")
           .withBody(mockPairValid.toJson.compactPrint)
           .withHeader(authHeader))
       .respond(
@@ -533,7 +537,7 @@ object MockWorkspaceServer {
       .when(
         request()
           .withMethod("POST")
-          .withPath(s"/workspaces/${mockSampleConflict.wsNamespace.get}/${mockSampleConflict.wsName.get}/entities")
+          .withPath(s"${workspaceBasePath}/${mockSampleConflict.wsNamespace.get}/${mockSampleConflict.wsName.get}/entities")
           .withBody(mockSampleConflict.toJson.compactPrint)
           .withHeader(authHeader))
       .respond(
@@ -546,7 +550,7 @@ object MockWorkspaceServer {
       when(
         request()
           .withMethod("POST")
-          .withPath("/methodconfigs/copyFromMethodRepo")
+          .withPath(s"${methodConfigBasePath}/copyFromMethodRepo")
           .withHeader(authHeader))
       .callback(
         callback().
@@ -557,7 +561,7 @@ object MockWorkspaceServer {
       .when(
         request()
           .withMethod("POST")
-          .withPath("/methodconfigs/copyFromMethodRepo")
+          .withPath(s"${methodConfigBasePath}/copyFromMethodRepo")
       ).respond(
         response()
           .withHeaders(header)
@@ -569,7 +573,7 @@ object MockWorkspaceServer {
       .when(
         request()
           .withMethod("POST")
-          .withPath(s"/workspaces/${mockValidWorkspace.namespace.get}/${mockValidWorkspace.name.get}/entities/batchUpsert")
+          .withPath(s"${workspaceBasePath}/${mockValidWorkspace.namespace.get}/${mockValidWorkspace.name.get}/entities/batchUpsert")
           .withHeader(authHeader))
       .respond(
         response()
@@ -581,7 +585,7 @@ object MockWorkspaceServer {
       .when(
         request()
           .withMethod("POST")
-          .withPath(s"/workspaces/${mockValidWorkspace.namespace.get}/${mockValidWorkspace.name.get}/entities/batchUpdate")
+          .withPath(s"${workspaceBasePath}/${mockValidWorkspace.namespace.get}/${mockValidWorkspace.name.get}/entities/batchUpdate")
           .withHeader(authHeader))
       .respond(
         response()

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/EntitiesWithTypeServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/EntitiesWithTypeServiceSpec.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.firecloud.service
 
+import org.broadinstitute.dsde.firecloud.FireCloudConfig
 import org.broadinstitute.dsde.firecloud.core.GetEntitiesWithType.EntityWithType
 import org.broadinstitute.dsde.firecloud.mock.{MockUtils, MockWorkspaceServer}
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
@@ -22,8 +23,9 @@ with Matchers with EntityService with FireCloudRequestBuilding {
   // Due to the large volume of service specific test cases, generate them here to prevent the
   // extra clutter
   var workspaceServer: ClientAndServer = _
-  val validFireCloudPath = "/workspaces/broad-dsde-dev/valid/"
-  val invalidFireCloudPath = "/workspaces/broad-dsde-dev/invalid/"
+  val workspacesBase = FireCloudConfig.Rawls.workspacesPath
+  val validFireCloudPath = workspacesBase + "/broad-dsde-dev/valid/"
+  val invalidFireCloudPath = workspacesBase + "/broad-dsde-dev/invalid/"
   val sampleAtts = Map(
     "sample_type" -> "Blood".toJson,
     "ref_fasta" -> "gs://cancer-exome-pipeline-demo-data/Homo_sapiens_assembly19.fasta".toJson,
@@ -45,21 +47,21 @@ with Matchers with EntityService with FireCloudRequestBuilding {
     // Valid cases
     workspaceServer
       .when(
-        request().withMethod("GET").withPath(validFireCloudPath + "entities").withHeader(MockUtils.authHeader))
+        request().withMethod("GET").withPath(FireCloudConfig.Rawls.authPrefix + validFireCloudPath + "entities").withHeader(MockUtils.authHeader))
       .respond(
         org.mockserver.model.HttpResponse.response()
           .withHeaders(MockUtils.header).withBody(List("participant", "sample").toJson.compactPrint).withStatusCode(OK.intValue)
       )
     workspaceServer
       .when(
-        request().withMethod("GET").withPath(validFireCloudPath + "entities/sample").withHeader(MockUtils.authHeader))
+        request().withMethod("GET").withPath(FireCloudConfig.Rawls.authPrefix + validFireCloudPath + "entities/sample").withHeader(MockUtils.authHeader))
       .respond(
         org.mockserver.model.HttpResponse.response()
           .withHeaders(MockUtils.header).withBody(validSampleEntities.toJson.compactPrint).withStatusCode(OK.intValue)
       )
     workspaceServer
       .when(
-        request().withMethod("GET").withPath(validFireCloudPath + "entities/participant").withHeader(MockUtils.authHeader))
+        request().withMethod("GET").withPath(FireCloudConfig.Rawls.authPrefix + validFireCloudPath + "entities/participant").withHeader(MockUtils.authHeader))
       .respond(
         org.mockserver.model.HttpResponse.response()
           .withHeaders(MockUtils.header).withBody(validParticipants.toJson.compactPrint).withStatusCode(OK.intValue)
@@ -68,21 +70,21 @@ with Matchers with EntityService with FireCloudRequestBuilding {
     // Invalid cases:
     workspaceServer
       .when(
-        request().withMethod("GET").withPath(invalidFireCloudPath + "entities").withHeader(MockUtils.authHeader))
+        request().withMethod("GET").withPath(FireCloudConfig.Rawls.authPrefix + invalidFireCloudPath + "entities").withHeader(MockUtils.authHeader))
       .respond(
         org.mockserver.model.HttpResponse.response()
           .withHeaders(MockUtils.header).withBody(List("participant", "sample").toJson.compactPrint).withStatusCode(OK.intValue)
       )
     workspaceServer
       .when(
-        request().withMethod("GET").withPath(invalidFireCloudPath + "entities/sample").withHeader(MockUtils.authHeader))
+        request().withMethod("GET").withPath(FireCloudConfig.Rawls.authPrefix + invalidFireCloudPath + "entities/sample").withHeader(MockUtils.authHeader))
       .respond(
         org.mockserver.model.HttpResponse.response()
           .withHeaders(MockUtils.header).withBody("Error").withStatusCode(InternalServerError.intValue)
       )
     workspaceServer
       .when(
-        request().withMethod("GET").withPath(invalidFireCloudPath + "entities/participant").withHeader(MockUtils.authHeader))
+        request().withMethod("GET").withPath(FireCloudConfig.Rawls.authPrefix + invalidFireCloudPath + "entities/participant").withHeader(MockUtils.authHeader))
       .respond(
         org.mockserver.model.HttpResponse.response()
           .withHeaders(MockUtils.header).withBody("Error").withStatusCode(InternalServerError.intValue)

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/EntityServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/EntityServiceSpec.scala
@@ -44,7 +44,7 @@ class EntityServiceSpec extends FreeSpec with ScalaFutures with ScalatestRouteTe
       .when(
         request()
           .withMethod("GET")
-          .withPath(FireCloudConfig.Rawls.entitiesPath.format("broad-dsde-dev", "valid") + "/sample")
+          .withPath(FireCloudConfig.Rawls.authPrefix + FireCloudConfig.Rawls.entitiesPath.format("broad-dsde-dev", "valid") + "/sample")
           .withHeader(MockUtils.authHeader))
       .respond(
         org.mockserver.model.HttpResponse.response()
@@ -57,7 +57,7 @@ class EntityServiceSpec extends FreeSpec with ScalaFutures with ScalatestRouteTe
       .when(
         request()
           .withMethod("GET")
-          .withPath(FireCloudConfig.Rawls.entitiesPath.format("broad-dsde-dev", "valid"))
+          .withPath(FireCloudConfig.Rawls.authPrefix + FireCloudConfig.Rawls.entitiesPath.format("broad-dsde-dev", "valid"))
           .withHeader(MockUtils.authHeader))
       .respond(
         org.mockserver.model.HttpResponse.response()
@@ -68,7 +68,7 @@ class EntityServiceSpec extends FreeSpec with ScalaFutures with ScalatestRouteTe
       .when(
         request()
           .withMethod("POST")
-          .withPath(FireCloudConfig.Rawls.workspacesEntitiesCopyPath)
+          .withPath(FireCloudConfig.Rawls.authPrefix + FireCloudConfig.Rawls.workspacesEntitiesCopyPath)
           .withHeader(MockUtils.authHeader))
       .respond(
         org.mockserver.model.HttpResponse.response()

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/SubmissionServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/SubmissionServiceSpec.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.firecloud.service
 
+import org.broadinstitute.dsde.firecloud.FireCloudConfig
 import org.broadinstitute.dsde.firecloud.mock.{MockUtils, MockWorkspaceServer}
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
 import org.broadinstitute.dsde.firecloud.model.SubmissionIngest
@@ -23,16 +24,16 @@ class SubmissionServiceSpec extends FreeSpec with ScalaFutures with ScalatestRou
     MockWorkspaceServer.stopWorkspaceServer()
   }
 
-  val localSubmissionsPath = s"/workspaces/%s/%s/submissions".format(
+  val localSubmissionsPath = FireCloudConfig.Rawls.submissionsPath.format(
     MockWorkspaceServer.mockValidWorkspace.namespace.get,
     MockWorkspaceServer.mockValidWorkspace.name.get)
 
-  val localSubmissionIdPath = s"/workspaces/%s/%s/submissions/%s".format(
+  val localSubmissionIdPath = FireCloudConfig.Rawls.submissionsIdPath.format(
     MockWorkspaceServer.mockValidWorkspace.namespace.get,
     MockWorkspaceServer.mockValidWorkspace.name.get,
     MockWorkspaceServer.mockValidId)
 
-  val localInvalidSubmissionIdPath = s"/workspaces/%s/%s/submissions/%s".format(
+  val localInvalidSubmissionIdPath = FireCloudConfig.Rawls.submissionsIdPath.format(
     MockWorkspaceServer.mockValidWorkspace.namespace.get,
     MockWorkspaceServer.mockValidWorkspace.name.get,
     MockWorkspaceServer.mockValidId + MockUtils.randomPositiveInt())


### PR DESCRIPTION
All rawls endpoints move under /api for protection. This involved some cleanup and consolidation of hardcoded endpoints into application.conf.