### PR TITLE
Update workspace service

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -26,6 +26,32 @@ paths:
       responses:
         200:
           description: List of workspaces.
+    post:
+      tags:
+        - Workspaces
+      operationId: createWorkspace
+      summary: Create workspace
+      produces:
+        - application/json
+      parameters:
+        - name: workspace
+          description: New workspace information
+          required: true
+          type: string
+          in: body
+          schema:
+            $ref: WorkspaceIngest
+      responses:
+        200:
+          description: No response was specified
+        201:
+          description: Successful Request
+        403:
+          description: Unable to create bucket for workspace
+        409:
+          description: Workspace by that name already exists
+        500:
+          description: Internal Server Error
   /methods:
     get:
       tags:
@@ -1020,6 +1046,19 @@ paths:
           description: Internal Error
 
 definitions:
+  WorkspaceIngest:
+    properties:
+      namespace:
+        type: string
+        description: New workspace namespace
+      name:
+        type: string
+        description: New workspace name
+      attributes:
+        type: object
+        additionalProperties:
+          type: string
+        description: Map of attributes
   SubmissionIngest:
     properties:
       methodConfigurationNamespace:

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceService.scala
@@ -1,17 +1,12 @@
 package org.broadinstitute.dsde.firecloud.service
 
 import java.text.SimpleDateFormat
-import java.util.Date
 
 import akka.actor.{Actor, Props}
+import org.broadinstitute.dsde.firecloud.{EntityClient, FireCloudConfig}
 import org.slf4j.LoggerFactory
 import spray.http.HttpMethods
-import spray.http.StatusCodes._
-import spray.json.DefaultJsonProtocol._
-import spray.json._
 import spray.routing._
-
-import org.broadinstitute.dsde.firecloud.{EntityClient, FireCloudConfig, HttpClient}
 
 class WorkspaceServiceActor extends Actor with WorkspaceService {
   def actorRefFactory = context
@@ -30,33 +25,7 @@ trait WorkspaceService extends HttpService with PerRequestCreator with FireCloud
   val routes: Route =
     pathPrefix("workspaces") {
       pathEnd {
-        passthrough(rawlsWorkspacesRoot, HttpMethods.GET) ~
-        post {
-          entity(as[String]) { ingest =>
-            // TODO: replace with a directive that pulls the username from the Google info!
-            // TODO: rawls should populate createdBy/createdDate/attributes on its own!
-            // commonNameFromOptionalCookie() { username => requestContext =>
-            requestContext =>
-              val username = Option("FIXME!")
-
-              username match {
-                case Some(x) =>
-                  val params = ingest.parseJson.convertTo[Map[String, JsValue]]
-                    .updated("createdBy", username.get.toJson)
-                    .updated("createdDate", dateFormat.format(new Date()).toJson)
-                    .updated("attributes", JsObject())
-                  val extReq = Post(
-                    rawlsWorkspacesRoot,
-                    HttpClient.createJsonHttpEntity(params.toJson.compactPrint)
-                  )
-                  externalHttpPerRequest(requestContext, extReq)
-                case None =>
-                  log.error("No authenticated username provided.")
-                  requestContext.complete(Unauthorized)
-              }
-            // }
-          }
-        }
+        passthrough(rawlsWorkspacesRoot, HttpMethods.GET, HttpMethods.POST)
       } ~
       pathPrefix(Segment / Segment) { (workspaceNamespace, workspaceName) =>
         val workspacePath = rawlsWorkspacesRoot + "/%s/%s".format(workspaceNamespace, workspaceName)


### PR DESCRIPTION
* Add swagger api doc for missing create call.
* Remove the custom handling of create workspace in favor or using a passthrough request. It was doing unnecessary things that Rawls is now handling correctly.