### PR TITLE
Eliminate URL boilerplate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,22 +2,18 @@ FROM phusion/baseimage
 
 # How to install OpenJDK 8 from:
 # http://ubuntuhandbook.org/index.php/2015/01/install-openjdk-8-ubuntu-14-04-12-04-lts/
-RUN add-apt-repository ppa:openjdk-r/ppa
-
 # How to install sbt on Linux from:
 # http://www.scala-sbt.org/release/tutorial/Installing-sbt-on-Linux.html
-RUN echo "deb https://dl.bintray.com/sbt/debian /" | tee -a /etc/apt/sources.list.d/sbt.list
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 642AC823
 
-RUN apt-get update
-RUN apt-get install -qy openjdk-8-jdk sbt
-
-# Standard apt-get cleanup.
-RUN apt-get -yq autoremove && \
-    apt-get -yq clean && \
-    rm -rf /var/lib/apt/lists/* && \
-    rm -rf /tmp/* && \
-    rm -rf /var/tmp/*
+# Add repos, update, cleanup all in one command to minimize layer size.
+RUN true \
+  && add-apt-repository ppa:openjdk-r/ppa \
+  && echo "deb https://dl.bintray.com/sbt/debian /" | tee -a /etc/apt/sources.list.d/sbt.list \
+  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 642AC823 \
+  && apt-get update \
+  && apt-get install -qy openjdk-8-jdk sbt \
+  && apt-get -yq autoremove && apt-get -yq clean && rm -rf /var/lib/apt/lists/* \
+    && rm -rf /tmp/* && rm -rf /var/tmp/*
 
 # Actually download sbt
 RUN sbt version

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -24,6 +24,10 @@ spray.can.server {
   request-timeout = infinite
 }
 
+spray.can.parsing {
+  max-content-length = 50m
+}
+
 http {
   interface="0.0.0.0"
   port=8080

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -56,8 +56,6 @@ workspace {
   template="/methodconfigs/template"
   importEntitiesPath="/workspaces/%s/%s/importEntities"
   workspacesEntitiesCopyPath="/workspaces/entities/copy"
-  submissionsPath="/workspaces/%s/%s/submissions"
-  submissionsIdPath="/workspaces/%s/%s/submissions/%s"
 }
 
 userprofile {

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -31,6 +31,7 @@ http {
 }
 
 methods {
+  authPrefix="/api/v1"
   methodsPath="/methods"
   configurationsPath="/configurations"
 }

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -1044,6 +1044,35 @@ paths:
           description: Success
         500:
           description: Internal Error
+  /storage/{bucket}/{object}:
+    get:
+      tags:
+      - Storage
+      operationId: getMetadata
+      summary: |
+        Get metadata about an object stored in GCS.
+      description: |
+        Mirror of Google's Cloud Storage json API. See https://cloud.google.com/storage/docs/json_api/v1/objects/get
+      produces:
+      - application/json
+      parameters:
+        - name: bucket
+          description: Name of the bucket in which the object resides.
+          required: true
+          type: string
+          in: path
+        - name: object
+          description: Name of the object. (be sure to urlencode)
+          required: true
+          type: string
+          in: path
+      responses:
+        200:
+          description: Success
+        404:
+          description: Not Found
+        500:
+          description: Internal Error
   /profile:
     get:
       tags:

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
@@ -55,9 +55,6 @@ object FireCloudConfig {
     lazy val importEntitiesPath = workspace.getString("importEntitiesPath")
     lazy val workspacesEntitiesCopyPath = workspace.getString("workspacesEntitiesCopyPath")
     lazy val workspacesEntitiesCopyUrl = authUrl + workspacesEntitiesCopyPath
-    lazy val submissionsPath = workspace.getString("submissionsPath")
-    lazy val submissionsUrl = authUrl + submissionsPath
-    lazy val submissionsIdPath = workspace.getString("submissionsIdPath")
 
     def entityPathFromWorkspace(namespace: String, name: String) = authUrl + entitiesPath.format(namespace, name)
     def methodConfigPathFromWorkspace(namespace: String, name: String) = authUrl + methodConfigsListPath.format(namespace, name)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
@@ -19,10 +19,12 @@ object FireCloudConfig {
   object Agora {
     private val methods = config.getConfig("methods")
     lazy val baseUrl = sys.env.get("AGORA_URL_ROOT").get
+    lazy val authPrefix = methods.getString("authPrefix")
+    lazy val authUrl = baseUrl + authPrefix
     lazy val methodsPath = methods.getString("methodsPath")
-    lazy val methodsBaseUrl = baseUrl + methodsPath
+    lazy val methodsBaseUrl = authUrl + methodsPath
     lazy val configurationsPath = methods.getString("configurationsPath")
-    lazy val configurationsBaseUrl = baseUrl + configurationsPath
+    lazy val configurationsBaseUrl = authUrl + configurationsPath
   }
 
   object Rawls {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudServiceActor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudServiceActor.scala
@@ -20,10 +20,11 @@ class FireCloudServiceActor extends HttpServiceActor {
   val entityService = new EntityService with ActorRefFactoryContext
   val methodConfigurationService = new MethodConfigurationService with ActorRefFactoryContext
   val submissionsService = new SubmissionService with ActorRefFactoryContext
+  val storageService = new StorageService with ActorRefFactoryContext
   val statusService = new StatusService with ActorRefFactoryContext
   val userService = new UserService with ActorRefFactoryContext
   val routes = statusService.routes ~ methodsService.routes ~ workspaceService.routes ~ entityService.routes ~
-    methodConfigurationService.routes ~ submissionsService.routes ~ userService.routes
+    methodConfigurationService.routes ~ submissionsService.routes ~ userService.routes ~ storageService.routes
 
   lazy val log = LoggerFactory.getLogger(getClass)
   val logRequests = mapInnerRoute { route => requestContext =>

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/EntityService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/EntityService.scala
@@ -28,7 +28,7 @@ trait EntityService extends HttpService with PerRequestCreator with FireCloudDir
       path("entities_with_type") {
         get { requestContext =>
           perRequest(requestContext, Props(new GetEntitiesWithTypeActor(requestContext)),
-            GetEntitiesWithType.ProcessUrl(baseRawlsEntitiesUrl))
+            GetEntitiesWithType.ProcessUrl(encodeUri(baseRawlsEntitiesUrl)))
         }
       } ~
       pathPrefix("entities") {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/FireCloudDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/FireCloudDirectives.scala
@@ -5,6 +5,19 @@ import spray.http.MediaTypes._
 
 import scala.util.Try
 
+object FireCloudDirectiveUtils {
+  def encodeUri(path: String): String = {
+    val pattern = """(https|http)://([^/\r\n]+?)(:\d+)?(/[^\r\n]*)?""".r
+
+    def toUri(url: String) = url match {
+      case pattern(theScheme, theHost, thePort, thePath) =>
+        val p: Int = Try(thePort.replace(":","").toInt).toOption.getOrElse(0)
+        Uri.from(scheme = theScheme, port = p, host = theHost, path = thePath)
+    }
+    toUri(path).toString
+  }
+}
+
 trait FireCloudDirectives extends spray.routing.Directives with PerRequestCreator with spray.httpx.RequestBuilding {
   def respondWithJSON = respondWithMediaType(`application/json`)
 
@@ -40,15 +53,6 @@ trait FireCloudDirectives extends spray.routing.Directives with PerRequestCreato
     }
   }
 
-  def encodeUri(path: String): String = {
-    val pattern = """(https|http)://([^/\r\n]+?)(:\d+)?(/[^\r\n]*)?""".r
+  def encodeUri(path: String): String = FireCloudDirectiveUtils.encodeUri(path)
 
-    def toUri(url: String) = url match {
-      case pattern(theScheme, theHost, thePort, thePath) =>
-        val p: Int = Try(thePort.replace(":","").toInt).toOption.getOrElse(0)
-        Uri.from(scheme = theScheme, port = p, host = theHost, path = thePath)
-    }
-
-    toUri(path).toString
-  }
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/PerRequest.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/PerRequest.scala
@@ -63,6 +63,7 @@ trait PerRequest extends Actor {
     case _:HttpHeaders.Server => true
     case _:HttpHeaders.`Content-Type` => true
     case _:HttpHeaders.`Content-Length` => true
+    case _:HttpHeaders.`Transfer-Encoding` => true
     case _ => false
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/StorageService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/StorageService.scala
@@ -1,0 +1,26 @@
+package org.broadinstitute.dsde.firecloud.service
+
+import akka.actor.Actor
+import spray.routing._
+
+class StorageServiceActor extends Actor with StorageService {
+  def actorRefFactory = context
+  def receive = runRoute(routes)
+}
+
+trait StorageService extends HttpService with PerRequestCreator with FireCloudDirectives {
+
+  private final val ApiPrefix = "storage"
+  private implicit val executionContext = actorRefFactory.dispatcher
+
+  val gcsStatUrl = "https://www.googleapis.com/storage/v1/b/%s/o/%s"
+
+  val routes: Route =
+    pathPrefix(ApiPrefix) {
+      // call Google's storage REST API for info about this object
+      path(Segment / Segment) { (bucket,obj) => requestContext =>
+        val extReq = Get(gcsStatUrl.format(bucket,obj))
+        externalHttpPerRequest(requestContext, extReq)
+      }
+    }
+}

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/SubmissionService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/SubmissionService.scala
@@ -14,6 +14,8 @@ abstract class SubmissionServiceActor extends Actor with SubmissionService {
 
 trait SubmissionService extends HttpService with PerRequestCreator with FireCloudDirectives {
 
+  val submissionsPath = "/workspaces/%s/%s/submissions"
+
   val routes = postAndGetRoutes
   lazy val log = LoggerFactory.getLogger(getClass)
 
@@ -21,7 +23,8 @@ trait SubmissionService extends HttpService with PerRequestCreator with FireClou
     pathPrefix("workspaces" / Segment / Segment) {
       (workspaceNamespace, workspaceName) =>
         pathPrefixTest("submissions") {
-          val path = FireCloudConfig.Rawls.submissionsUrl.format(workspaceNamespace, workspaceName)
+          val path = FireCloudConfig.Rawls.authUrl +
+            submissionsPath.format(workspaceNamespace, workspaceName)
           passthroughAllPaths("submissions", path)
         }
     }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockMethodsServer.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockMethodsServer.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.firecloud.mock
 
+import org.broadinstitute.dsde.firecloud.FireCloudConfig
 import org.broadinstitute.dsde.firecloud.mock.MockUtils._
 import org.broadinstitute.dsde.firecloud.model.ErrorReport
 import org.broadinstitute.dsde.firecloud.model.MethodRepository.{Configuration, Method}
@@ -16,6 +17,9 @@ import DefaultJsonProtocol._
 object MockMethodsServer {
 
   val methodsServerPort = 8989
+
+  val methodsUrl = FireCloudConfig.Agora.authPrefix + FireCloudConfig.Agora.methodsPath
+  val configsUrl = FireCloudConfig.Agora.authPrefix + FireCloudConfig.Agora.configurationsPath
 
   /****** Mock Data ******/
 
@@ -70,7 +74,7 @@ object MockMethodsServer {
       .when(
         request()
           .withMethod("GET")
-          .withPath("/methods")
+          .withPath(methodsUrl)
           .withHeader(authHeader)
       ).respond(
         response()
@@ -85,7 +89,7 @@ object MockMethodsServer {
       .when(
         request()
           .withMethod("GET")
-          .withPath("/methods")
+          .withPath(methodsUrl)
       ).respond(
         response()
           .withHeaders(header)
@@ -97,7 +101,7 @@ object MockMethodsServer {
       .when(
         request()
           .withMethod("POST")
-          .withPath("/methods")
+          .withPath(methodsUrl)
       ).respond(
       response()
         .withStatusCode(MethodNotAllowed.intValue)
@@ -109,7 +113,7 @@ object MockMethodsServer {
       .when(
         request()
           .withMethod("PUT")
-          .withPath("/methods")
+          .withPath(methodsUrl)
       ).respond(
       response()
         .withStatusCode(MethodNotAllowed.intValue)
@@ -121,7 +125,7 @@ object MockMethodsServer {
       .when(
         request()
           .withMethod("GET")
-          .withPath("/configurations")
+          .withPath(configsUrl)
           .withHeader(authHeader)
       ).respond(
         response()
@@ -136,7 +140,7 @@ object MockMethodsServer {
       .when(
         request()
           .withMethod("GET")
-          .withPath("/configurations")
+          .withPath(configsUrl)
       ).respond(
         response()
           .withHeaders(header)
@@ -148,7 +152,7 @@ object MockMethodsServer {
       .when(
         request()
           .withMethod("POST")
-          .withPath("/configurations")
+          .withPath(configsUrl)
       ).respond(
       response()
         .withStatusCode(MethodNotAllowed.intValue)
@@ -160,7 +164,7 @@ object MockMethodsServer {
       .when(
         request()
           .withMethod("PUT")
-          .withPath("/configurations")
+          .withPath(configsUrl)
       ).respond(
       response()
         .withStatusCode(MethodNotAllowed.intValue)

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/SubmissionServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/SubmissionServiceSpec.scala
@@ -1,6 +1,5 @@
 package org.broadinstitute.dsde.firecloud.service
 
-import org.broadinstitute.dsde.firecloud.FireCloudConfig
 import org.broadinstitute.dsde.firecloud.mock.{MockUtils, MockWorkspaceServer}
 import org.broadinstitute.dsde.firecloud.model.SubmissionIngest
 import spray.http.StatusCodes._
@@ -20,18 +19,13 @@ class SubmissionServiceSpec extends ServiceSpec with SubmissionService {
     MockWorkspaceServer.stopWorkspaceServer()
   }
 
-  val localSubmissionsPath = FireCloudConfig.Rawls.submissionsPath.format(
+  val localSubmissionsPath = submissionsPath.format(
     MockWorkspaceServer.mockValidWorkspace.namespace.get,
     MockWorkspaceServer.mockValidWorkspace.name.get)
 
-  val localSubmissionIdPath = FireCloudConfig.Rawls.submissionsIdPath.format(
-    MockWorkspaceServer.mockValidWorkspace.namespace.get,
-    MockWorkspaceServer.mockValidWorkspace.name.get,
-    MockWorkspaceServer.mockValidId)
+  val localSubmissionIdPath = localSubmissionsPath + "/%s".format(MockWorkspaceServer.mockValidId)
 
-  val localInvalidSubmissionIdPath = FireCloudConfig.Rawls.submissionsIdPath.format(
-    MockWorkspaceServer.mockValidWorkspace.namespace.get,
-    MockWorkspaceServer.mockValidWorkspace.name.get,
+  val localInvalidSubmissionIdPath = localSubmissionsPath + "/%s".format(
     MockWorkspaceServer.mockInvalidId)
 
   "SubmissionService" - {


### PR DESCRIPTION
- unrelated Dockerfile tweak
- removes requirement to duplicate URLs in FireCloudConfig.scala
- URLs are defined closer to use
- a side-benefit to this change is that it is more obvious that the "submission ID" URL is only used in tests

As far as I can tell, the only drawback to this change is that URLs can no longer be changed without recompiling code, but I'm not sure that is a use case we want to support.

If we agree that this is better, I will update the other URLs either as part of this PR or in a follow-up.