### PR TITLE
Mirror for GCS get-metadata call to help with downloads

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -1044,6 +1044,35 @@ paths:
           description: Success
         500:
           description: Internal Error
+  /storage/{bucket}/{object}:
+    get:
+      tags:
+      - Storage
+      operationId: getMetadata
+      summary: |
+        Get metadata about an object stored in GCS.
+      description: |
+        Mirror of Google's Cloud Storage json API. See https://cloud.google.com/storage/docs/json_api/v1/objects/get
+      produces:
+      - application/json
+      parameters:
+        - name: bucket
+          description: Name of the bucket in which the object resides.
+          required: true
+          type: string
+          in: path
+        - name: object
+          description: Name of the object. (be sure to urlencode)
+          required: true
+          type: string
+          in: path
+      responses:
+        200:
+          description: Success
+        404:
+          description: Not Found
+        500:
+          description: Internal Error
 
 definitions:
   WorkspaceIngest:

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudServiceActor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudServiceActor.scala
@@ -20,9 +20,10 @@ class FireCloudServiceActor extends HttpServiceActor {
   val entityService = new EntityService with ActorRefFactoryContext
   val methodConfigurationService = new MethodConfigurationService with ActorRefFactoryContext
   val submissionsService = new SubmissionService with ActorRefFactoryContext
+  val storageService = new StorageService with ActorRefFactoryContext
   val statusService = new StatusService with ActorRefFactoryContext
   val routes = statusService.routes ~ methodsService.routes ~ workspaceService.routes ~ entityService.routes ~
-    methodConfigurationService.routes ~ submissionsService.routes
+    methodConfigurationService.routes ~ submissionsService.routes ~ storageService.routes
 
   lazy val log = LoggerFactory.getLogger(getClass)
   val logRequests = mapInnerRoute { route => requestContext =>

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/PerRequest.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/PerRequest.scala
@@ -63,6 +63,7 @@ trait PerRequest extends Actor {
     case _:HttpHeaders.Server => true
     case _:HttpHeaders.`Content-Type` => true
     case _:HttpHeaders.`Content-Length` => true
+    case _:HttpHeaders.`Transfer-Encoding` => true
     case _ => false
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/StorageService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/StorageService.scala
@@ -1,0 +1,26 @@
+package org.broadinstitute.dsde.firecloud.service
+
+import akka.actor.Actor
+import spray.routing._
+
+class StorageServiceActor extends Actor with StorageService {
+  def actorRefFactory = context
+  def receive = runRoute(routes)
+}
+
+trait StorageService extends HttpService with PerRequestCreator with FireCloudDirectives {
+
+  private final val ApiPrefix = "storage"
+  private implicit val executionContext = actorRefFactory.dispatcher
+
+  val gcsStatUrl = "https://www.googleapis.com/storage/v1/b/%s/o/%s"
+
+  val routes: Route =
+    pathPrefix(ApiPrefix) {
+      // call Google's storage REST API for info about this object
+      path(Segment / Segment) { (bucket,obj) => requestContext =>
+        val extReq = Get(gcsStatUrl.format(bucket,obj))
+        externalHttpPerRequest(requestContext, extReq)
+      }
+    }
+}


### PR DESCRIPTION
Create an endpoint within orchestration that contacts GCS to get info about a file, in support of downloading that file (or checking its existence, etc).

See https://cloud.google.com/storage/docs/json_api/v1/objects/get for details of the API.

UI can safely call the orchestration mirror via ajax without any CORS issues.

Remember you can browse GCS via their console, here: https://console.developers.google.com/project/broad-dsde-dev/storage/browser.

A few safe files you can use for manual testing (please don't delete these from GCS):
https://console.developers.google.com/project/broad-dsde-dev/storage/browser/bossdev/vault/test/

Note that it looks like this call returns a **safer** download url than the one we're generating in the UI. Because Google generates the download url instead of us reverse-engineering their downloads, we might want to switch over to this.