### PR TITLE
remove _id from all column keys in imported TSV

### DIFF
--- a/src/main/resources/model.json
+++ b/src/main/resources/model.json
@@ -27,16 +27,25 @@
     },
     "participant_set": {
         "requiredAttributes": {},
+        "attributeRenaming": {
+            "participant_id": "participant"
+        },
         "plural": "participant_sets",
         "memberType": "participant"
     },
     "sample_set": {
         "requiredAttributes": {},
+        "attributeRenaming": {
+            "sample_id": "sample"
+        },
         "plural": "sample_sets",
         "memberType": "sample"
     },
     "pair_set": {
         "requiredAttributes": {},
+        "attributeRenaming": {
+            "pair_id": "pair"
+        },
         "plural": "pair_sets",
         "memberType": "pair"
     }

--- a/src/main/resources/model.json
+++ b/src/main/resources/model.json
@@ -7,6 +7,9 @@
         "requiredAttributes": {
             "participant_id": "participant"
         },
+        "attributeRenaming": {
+            "participant_id": "participant"
+        },
         "plural": "samples"
     },
     "pair": {
@@ -17,7 +20,8 @@
         },
         "attributeRenaming": {
             "case_sample_id": "case_sample",
-            "control_sample_id": "control_sample"
+            "control_sample_id": "control_sample",
+            "participant_id": "participant"
         },
         "plural": "pairs"
     },

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/utils/TSVParserSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/utils/TSVParserSpec.scala
@@ -58,7 +58,6 @@ class TSVParserSpec extends FlatSpec {
 
   it should "load a multi-line file" in {
     val parseResult = MockTSVLoadFiles.validMultiLine
-
     assertResult(parseResult) {
       TSVParser.parse(MockTSVStrings.validMultiline)
     }
@@ -81,7 +80,30 @@ class TSVParserSpec extends FlatSpec {
     val expect = Seq(
       "case_sample" -> Some("sample"),
       "control_sample" -> Some("sample"),
-      "participant_id" -> Some("participant"),
+      "participant" -> Some("participant"),
+      "some_other_id" -> None,
+      "ref_dict" -> None,
+      "ref_fasta" -> None)
+
+    assertResult(expect) {
+      EntityClient.improveAttributeNames(entityType, input, requiredAttributes)
+    }
+  }
+
+  it should "fix up the names of attributes for samples" in {
+    val entityType: String = "sample"
+    val requiredAttributes: Map[String, String] = Map(
+      "participant_id" -> "participant")
+
+    val input = Seq(
+      "entity:sample_id", // first column stripped off when parsing attributes
+      "participant_id",
+      "some_other_id",
+      "ref_dict",
+      "ref_fasta")
+
+    val expect = Seq(
+      "participant" -> Some("participant"),
       "some_other_id" -> None,
       "ref_dict" -> None,
       "ref_fasta" -> None)

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/utils/TSVParserSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/utils/TSVParserSpec.scala
@@ -62,7 +62,7 @@ class TSVParserSpec extends FlatSpec {
       TSVParser.parse(MockTSVStrings.validMultiline)
     }
   }
-  "EntityClient.improveAttributeNames" should "fix up the names of attributes for certain reference types" in {
+  "EntityClient.improveAttributeNames" should "fix up the names of attributes for certain reference types for pairs" in {
     val entityType: String = "pair"
     val requiredAttributes: Map[String, String] = Map("case_sample_id" -> "sample",
       "control_sample_id" -> "sample",
@@ -90,7 +90,7 @@ class TSVParserSpec extends FlatSpec {
     }
   }
 
-  it should "fix up the names of attributes for samples" in {
+  it should "fix up the names of attributes for certain reference types for samples" in {
     val entityType: String = "sample"
     val requiredAttributes: Map[String, String] = Map(
       "participant_id" -> "participant")
@@ -108,6 +108,25 @@ class TSVParserSpec extends FlatSpec {
       "ref_dict" -> None,
       "ref_fasta" -> None)
 
+    assertResult(expect) {
+      EntityClient.improveAttributeNames(entityType, input, requiredAttributes)
+    }
+  }
+
+
+  it should "fix up the names of attributes for certain reference types for participant sets" in {
+    val entityType: String = "participant_set"
+    val requiredAttributes: Map[String, String] = Map.empty
+
+    val input = Seq(
+      "entity:participant_set_id", // first column stripped off when parsing attributes
+      "participant_id",
+      "some_other_id")
+
+    val expect = Seq(
+      "participant" -> None,
+      "some_other_id" -> None)
+    
     assertResult(expect) {
       EntityClient.improveAttributeNames(entityType, input, requiredAttributes)
     }


### PR DESCRIPTION
For https://broadinstitute.atlassian.net/browse/DSDEEPB-1457.

Remove _id from the end of all column keys, which are specified in the TSV spec: https://docs.google.com/document/d/1iBhW0LwrJYBihQw0qa0c-6hc3kd_mnOqlUlvghlxVMs