### PR TITLE
encode uris in GET entities_with_type

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/EntityService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/EntityService.scala
@@ -28,7 +28,7 @@ trait EntityService extends HttpService with PerRequestCreator with FireCloudDir
       path("entities_with_type") {
         get { requestContext =>
           perRequest(requestContext, Props(new GetEntitiesWithTypeActor(requestContext)),
-            GetEntitiesWithType.ProcessUrl(baseRawlsEntitiesUrl))
+            GetEntitiesWithType.ProcessUrl(encodeUri(baseRawlsEntitiesUrl)))
         }
       } ~
       pathPrefix("entities") {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/FireCloudDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/FireCloudDirectives.scala
@@ -5,6 +5,19 @@ import spray.http.MediaTypes._
 
 import scala.util.Try
 
+object FireCloudDirectiveUtils {
+  def encodeUri(path: String): String = {
+    val pattern = """(https|http)://([^/\r\n]+?)(:\d+)?(/[^\r\n]*)?""".r
+
+    def toUri(url: String) = url match {
+      case pattern(theScheme, theHost, thePort, thePath) =>
+        val p: Int = Try(thePort.replace(":","").toInt).toOption.getOrElse(0)
+        Uri.from(scheme = theScheme, port = p, host = theHost, path = thePath)
+    }
+    toUri(path).toString
+  }
+}
+
 trait FireCloudDirectives extends spray.routing.Directives with PerRequestCreator with spray.httpx.RequestBuilding {
   def respondWithJSON = respondWithMediaType(`application/json`)
 
@@ -40,15 +53,6 @@ trait FireCloudDirectives extends spray.routing.Directives with PerRequestCreato
     }
   }
 
-  def encodeUri(path: String): String = {
-    val pattern = """(https|http)://([^/\r\n]+?)(:\d+)?(/[^\r\n]*)?""".r
+  def encodeUri(path: String): String = FireCloudDirectiveUtils.encodeUri(path)
 
-    def toUri(url: String) = url match {
-      case pattern(theScheme, theHost, thePort, thePath) =>
-        val p: Int = Try(thePort.replace(":","").toInt).toOption.getOrElse(0)
-        Uri.from(scheme = theScheme, port = p, host = theHost, path = thePath)
-    }
-
-    toUri(path).toString
-  }
 }


### PR DESCRIPTION
Now you can load entities in workspaces that have fancy characters in their names