### PR TITLE
DSDEEPB-1730: increase spray's content-length limit to 50m

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -24,6 +24,10 @@ spray.can.server {
   request-timeout = infinite
 }
 
+spray.can.parsing {
+  max-content-length = 50m
+}
+
 http {
   interface="0.0.0.0"
   port=8080


### PR DESCRIPTION
**This will not fix the bug for the end user** because we need a similar change in rawls. Once both changes are in, I _think_ this will fix it; we'll have to test empirically.