### PR TITLE
Eliminate URL boilerplate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,22 +2,18 @@ FROM phusion/baseimage
 
 # How to install OpenJDK 8 from:
 # http://ubuntuhandbook.org/index.php/2015/01/install-openjdk-8-ubuntu-14-04-12-04-lts/
-RUN add-apt-repository ppa:openjdk-r/ppa
-
 # How to install sbt on Linux from:
 # http://www.scala-sbt.org/release/tutorial/Installing-sbt-on-Linux.html
-RUN echo "deb https://dl.bintray.com/sbt/debian /" | tee -a /etc/apt/sources.list.d/sbt.list
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 642AC823
 
-RUN apt-get update
-RUN apt-get install -qy openjdk-8-jdk sbt
-
-# Standard apt-get cleanup.
-RUN apt-get -yq autoremove && \
-    apt-get -yq clean && \
-    rm -rf /var/lib/apt/lists/* && \
-    rm -rf /tmp/* && \
-    rm -rf /var/tmp/*
+# Add repos, update, cleanup all in one command to minimize layer size.
+RUN true \
+  && add-apt-repository ppa:openjdk-r/ppa \
+  && echo "deb https://dl.bintray.com/sbt/debian /" | tee -a /etc/apt/sources.list.d/sbt.list \
+  && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 642AC823 \
+  && apt-get update \
+  && apt-get install -qy openjdk-8-jdk sbt \
+  && apt-get -yq autoremove && apt-get -yq clean && rm -rf /var/lib/apt/lists/* \
+    && rm -rf /tmp/* && rm -rf /var/tmp/*
 
 # Actually download sbt
 RUN sbt version

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,5 +3,6 @@ addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.12.0")
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.7.2")
 
 addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.0.0")
+
 // latest coveralls (1.0.0) is *only* compatible with scoverage 1.0.4 or less: https://github.com/scoverage/sbt-coveralls/issues/49
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.0.4")

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -44,7 +44,6 @@ workspace {
   model="model.json"
   authPrefix="/api"
   workspacesPath="/workspaces"
-  entitiesPath="/workspaces/%s/%s/entities"
   methodConfigsListPath="/workspaces/%s/%s/methodconfigs"
   getMethodConfigPath="/workspaces/%s/%s/methodconfigs/%s/%s"
   getMethodConfigValidationPath="/workspaces/%s/%s/methodconfigs/%s/%s/validate"
@@ -55,9 +54,6 @@ workspace {
   copyToMethodRepoConfig="/methodconfigs/copyToMethodRepo"
   template="/methodconfigs/template"
   importEntitiesPath="/workspaces/%s/%s/importEntities"
-  workspacesEntitiesCopyPath="/workspaces/entities/copy"
-  submissionsPath="/workspaces/%s/%s/submissions"
-  submissionsIdPath="/workspaces/%s/%s/submissions/%s"
 }
 
 userprofile {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/EntityClient.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/EntityClient.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.firecloud
 
 import java.text.SimpleDateFormat
 
-import org.broadinstitute.dsde.firecloud.service.FireCloudRequestBuilding
+import org.broadinstitute.dsde.firecloud.service.{EntityService, FireCloudRequestBuilding}
 
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, Future}
@@ -68,7 +68,8 @@ class EntityClient (requestContext: RequestContext) extends Actor with FireCloud
     val pipeline: HttpRequest => Future[HttpResponse] =
       authHeaders(requestContext) ~> sendReceive
     val responseFuture: Future[HttpResponse] = pipeline {
-      Get(s"${FireCloudConfig.Rawls.entityPathFromWorkspace(workspaceNamespace, workspaceName)}/$entityType")
+      Get(EntityService.entitiesPathFromWorkspace(workspaceNamespace, workspaceName) +
+        s"/$entityType")
     }
 
     responseFuture onComplete {
@@ -112,7 +113,7 @@ class EntityClient (requestContext: RequestContext) extends Actor with FireCloud
   }
 
   def createEntityOrReportError(workspaceNamespace: String, workspaceName: String, entityJson: JsValue, entityType: String, entityName: String) = {
-    val url = FireCloudConfig.Rawls.entityPathFromWorkspace(workspaceNamespace, workspaceName)
+    val url = EntityService.entitiesPathFromWorkspace(workspaceNamespace, workspaceName)
     val externalRequest = Post(url, HttpClient.createJsonHttpEntity(entityJson.compactPrint))
     val pipeline = authHeaders(requestContext) ~> sendReceive
     // TODO figure out how to get the response in a non-blocking way,
@@ -209,7 +210,7 @@ class EntityClient (requestContext: RequestContext) extends Actor with FireCloud
     val pipeline: HttpRequest => Future[HttpResponse] =
       authHeaders(requestContext) ~> sendReceive
     val responseFuture: Future[HttpResponse] = pipeline {
-      Post(FireCloudConfig.Rawls.entityPathFromWorkspace(workspaceNamespace, workspaceName)+"/"+endpoint,
+      Post(EntityService.entitiesPathFromWorkspace(workspaceNamespace, workspaceName)+"/"+endpoint,
             HttpEntity(MediaTypes.`application/json`,calls.toJson.toString))
     }
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
@@ -35,7 +35,6 @@ object FireCloudConfig {
     lazy val authUrl = baseUrl + authPrefix
     lazy val workspacesPath = workspace.getString("workspacesPath")
     lazy val workspacesUrl = authUrl + workspacesPath
-    lazy val entitiesPath = workspace.getString("entitiesPath")
     lazy val methodConfigsListPath = workspace.getString("methodConfigsListPath")
     lazy val getMethodConfigUrl = authUrl + workspace.getString("getMethodConfigPath")
     lazy val getMethodConfigValidationUrl = authUrl + workspace.getString("getMethodConfigValidationPath")
@@ -53,15 +52,6 @@ object FireCloudConfig {
     lazy val templatePath = workspace.getString("template")
     lazy val templateUrl = authUrl + templatePath
     lazy val importEntitiesPath = workspace.getString("importEntitiesPath")
-    lazy val workspacesEntitiesCopyPath = workspace.getString("workspacesEntitiesCopyPath")
-    lazy val workspacesEntitiesCopyUrl = authUrl + workspacesEntitiesCopyPath
-    lazy val submissionsPath = workspace.getString("submissionsPath")
-    lazy val submissionsUrl = authUrl + submissionsPath
-    lazy val submissionsIdPath = workspace.getString("submissionsIdPath")
-
-    def entityPathFromWorkspace(namespace: String, name: String) = authUrl + entitiesPath.format(namespace, name)
-    def methodConfigPathFromWorkspace(namespace: String, name: String) = authUrl + methodConfigsListPath.format(namespace, name)
-    def importEntitiesPathFromWorkspace(namespace: String, name: String) = authUrl + importEntitiesPath.format(namespace, name)
   }
 
   object Thurloe {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/SubmissionService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/SubmissionService.scala
@@ -14,6 +14,8 @@ abstract class SubmissionServiceActor extends Actor with SubmissionService {
 
 trait SubmissionService extends HttpService with PerRequestCreator with FireCloudDirectives {
 
+  val submissionsPath = "/workspaces/%s/%s/submissions"
+
   val routes = postAndGetRoutes
   lazy val log = LoggerFactory.getLogger(getClass)
 
@@ -21,7 +23,8 @@ trait SubmissionService extends HttpService with PerRequestCreator with FireClou
     pathPrefix("workspaces" / Segment / Segment) {
       (workspaceNamespace, workspaceName) =>
         pathPrefixTest("submissions") {
-          val path = FireCloudConfig.Rawls.submissionsUrl.format(workspaceNamespace, workspaceName)
+          val path = FireCloudConfig.Rawls.authUrl +
+            submissionsPath.format(workspaceNamespace, workspaceName)
           passthroughAllPaths("submissions", path)
         }
     }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/EntityServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/EntityServiceSpec.scala
@@ -55,7 +55,7 @@ class EntityServiceSpec extends ServiceSpec with EntityService {
       .when(
         request()
           .withMethod("GET")
-          .withPath(FireCloudConfig.Rawls.authPrefix + FireCloudConfig.Rawls.entitiesPath.format("broad-dsde-dev", "valid") + "/sample")
+          .withPath(EntityService.entitiesPathFromWorkspace("broad-dsde-dev", "valid") + "/sample")
           .withHeader(MockUtils.authHeader))
       .respond(
         org.mockserver.model.HttpResponse.response()
@@ -68,7 +68,7 @@ class EntityServiceSpec extends ServiceSpec with EntityService {
       .when(
         request()
           .withMethod("GET")
-          .withPath(FireCloudConfig.Rawls.authPrefix + FireCloudConfig.Rawls.entitiesPath.format("broad-dsde-dev", "valid"))
+          .withPath(EntityService.entitiesPathFromWorkspace("broad-dsde-dev", "valid"))
           .withHeader(MockUtils.authHeader))
       .respond(
         org.mockserver.model.HttpResponse.response()
@@ -79,7 +79,7 @@ class EntityServiceSpec extends ServiceSpec with EntityService {
       .when(
         request()
           .withMethod("POST")
-          .withPath(FireCloudConfig.Rawls.authPrefix + FireCloudConfig.Rawls.workspacesEntitiesCopyPath)
+          .withPath(FireCloudConfig.Rawls.authPrefix + EntityService.copyPath)
           .withHeader(MockUtils.authHeader))
       .callback(
         callback().
@@ -91,7 +91,7 @@ class EntityServiceSpec extends ServiceSpec with EntityService {
       .when(
         request()
           .withMethod("GET")
-          .withPath(FireCloudConfig.Rawls.authPrefix + FireCloudConfig.Rawls.entitiesPath.format("broad-dsde-dev", "invalid") + "/sample")
+          .withPath(EntityService.entitiesPathFromWorkspace("broad-dsde-dev", "invalid") + "/sample")
           .withHeader(MockUtils.authHeader))
       .respond(
         org.mockserver.model.HttpResponse.response()
@@ -104,7 +104,7 @@ class EntityServiceSpec extends ServiceSpec with EntityService {
       .when(
         request()
           .withMethod("GET")
-          .withPath(FireCloudConfig.Rawls.authPrefix + FireCloudConfig.Rawls.entitiesPath.format("broad-dsde-dev", "invalid"))
+          .withPath(EntityService.entitiesPathFromWorkspace("broad-dsde-dev", "invalid"))
           .withHeader(MockUtils.authHeader))
       .respond(
         org.mockserver.model.HttpResponse.response()

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/ExportEntitiesByTypeServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/ExportEntitiesByTypeServiceSpec.scala
@@ -42,7 +42,7 @@ class ExportEntitiesByTypeServiceSpec extends ServiceSpec with EntityService {
       .when(
         request()
           .withMethod("GET")
-          .withPath(FireCloudConfig.Rawls.authPrefix + FireCloudConfig.Rawls.entitiesPath.format("broad-dsde-dev", "valid") + "/sample")
+          .withPath(EntityService.entitiesPathFromWorkspace("broad-dsde-dev", "valid") + "/sample")
           .withHeader(MockUtils.authHeader))
       .respond(
         org.mockserver.model.HttpResponse.response()
@@ -56,7 +56,7 @@ class ExportEntitiesByTypeServiceSpec extends ServiceSpec with EntityService {
       .when(
         request()
           .withMethod("GET")
-          .withPath(FireCloudConfig.Rawls.authPrefix + FireCloudConfig.Rawls.entitiesPath.format("broad-dsde-dev", "invalid") + "/sample")
+          .withPath(EntityService.entitiesPathFromWorkspace("broad-dsde-dev", "invalid") + "/sample")
           .withHeader(MockUtils.authHeader))
       .respond(
         org.mockserver.model.HttpResponse.response()

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/SubmissionServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/SubmissionServiceSpec.scala
@@ -1,6 +1,5 @@
 package org.broadinstitute.dsde.firecloud.service
 
-import org.broadinstitute.dsde.firecloud.FireCloudConfig
 import org.broadinstitute.dsde.firecloud.mock.{MockUtils, MockWorkspaceServer}
 import org.broadinstitute.dsde.firecloud.model.SubmissionIngest
 import spray.http.StatusCodes._
@@ -20,18 +19,13 @@ class SubmissionServiceSpec extends ServiceSpec with SubmissionService {
     MockWorkspaceServer.stopWorkspaceServer()
   }
 
-  val localSubmissionsPath = FireCloudConfig.Rawls.submissionsPath.format(
+  val localSubmissionsPath = submissionsPath.format(
     MockWorkspaceServer.mockValidWorkspace.namespace.get,
     MockWorkspaceServer.mockValidWorkspace.name.get)
 
-  val localSubmissionIdPath = FireCloudConfig.Rawls.submissionsIdPath.format(
-    MockWorkspaceServer.mockValidWorkspace.namespace.get,
-    MockWorkspaceServer.mockValidWorkspace.name.get,
-    MockWorkspaceServer.mockValidId)
+  val localSubmissionIdPath = localSubmissionsPath + "/%s".format(MockWorkspaceServer.mockValidId)
 
-  val localInvalidSubmissionIdPath = FireCloudConfig.Rawls.submissionsIdPath.format(
-    MockWorkspaceServer.mockValidWorkspace.namespace.get,
-    MockWorkspaceServer.mockValidWorkspace.name.get,
+  val localInvalidSubmissionIdPath = localSubmissionsPath + "/%s".format(
     MockWorkspaceServer.mockInvalidId)
 
   "SubmissionService" - {


### PR DESCRIPTION
- unrelated Dockerfile tweak
- removes requirement to duplicate URLs in FireCloudConfig.scala
- URLs are defined closer to use
- a side-benefit to this change is that it is more obvious that the "submission ID" URL is only used in tests

As far as I can tell, the only drawback to this change is that URLs can no longer be changed without recompiling code, but I'm not sure that is a use case we want to support.