### PR TITLE
Add travis and coveralls support

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,1 @@
+service_name: travis-ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+jdk:
+  - oraclejdk8
+
+language: scala
+
+scala:
+  - 2.11.7
+
+script: AGORA_URL_ROOT='http://localhost:8989' RAWLS_URL_ROOT='http://localhost:8990' THURLOE_URL_ROOT='http://localhost:8991' sbt coverage test coverageReport
+
+after_success: sbt coveralls
+
+notifications:
+  email: false

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Build Status](https://travis-ci.org/broadinstitute/firecloud-orchestration.svg?branch=develop)](https://travis-ci.org/broadinstitute/firecloud-orchestration?branch=develop)
+[![Coverage Status](https://coveralls.io/repos/broadinstitute/firecloud-orchestration/badge.svg?branch=develop&service=github)](https://coveralls.io/github/broadinstitute/firecloud-orchestration?branch=develop)
+
 # FireCloud-Orchestration
 FireCloud Orchestration Service
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,7 @@
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.12.0")
 
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.7.2")
+
+addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.0.0")
+// latest coveralls (1.0.0) is *only* compatible with scoverage 1.0.4 or less: https://github.com/scoverage/sbt-coveralls/issues/49
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.0.4")


### PR DESCRIPTION
This is ready for review. 
* I have found that there are sporadic timeout issues when travis runs tests, especially when there are simultaneous runs triggered from a PR and a push. We need to look into ways to try and minimize that noise. 
* Notifications is turned off by default. I think having the notification checks clear in the PR is enough for a reviewer to determine status.