### PR TITLE
Make sure url is encoded for download entity feature

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/EntityService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/EntityService.scala
@@ -49,7 +49,7 @@ trait EntityService extends HttpService with PerRequestCreator with FireCloudDir
           }
         } ~
         pathPrefix(Segment) { entityType =>
-          val entityTypeUrl = baseRawlsEntitiesUrl + "/" + entityType
+          val entityTypeUrl = encodeUri(baseRawlsEntitiesUrl + "/" + entityType)
           pathEnd {
             passthrough(entityTypeUrl, HttpMethods.GET)
           } ~


### PR DESCRIPTION
Does not complete the story of DSDEEPB-1148, but implements the new `encodeUri` functionality.