### PR TITLE
DSDEEPB-1730 (rev 2): increase spray's content-length limit to 50m

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -20,12 +20,13 @@ akka {
   }
 }
 
-spray.can.server {
-  request-timeout = infinite
-}
-
-spray.can.parsing {
-  max-content-length = 50m
+spray.can {
+  server {
+    request-timeout = infinite
+    parsing {
+      max-content-length = 50m
+    }
+  }
 }
 
 http {


### PR DESCRIPTION
change spray.can.server.parsing, not spray.can.parsing when setting max Content-Length; see spray/spray#346.