### PR TITLE
Change fields to match Rawls

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ErrorReport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ErrorReport.scala
@@ -21,11 +21,11 @@ case class ErrorReport (
                      @(ApiModelProperty@field)(required = true, value = "The error message / exception text")
                      message: String,
                      @(ApiModelProperty@field)(required = true, value = "The HTTP status code of the response, if applicable")
-                     httpStatusCode: Option[StatusCode] = None,
+                     statusCode: Option[StatusCode] = None,
                      @(ApiModelProperty@field)(required = true, value = "Root causes of the error, if applicable")
                      causes: Seq[ErrorReport] = Seq(),
                      @(ApiModelProperty@field)(required = true, value = "Stack traces associated with the error, if applicable")
-                     stackTraces: Seq[StackTraceElement] = Seq())
+                     stackTrace: Seq[StackTraceElement] = Seq())
 
 object ErrorReport extends ((String,String,Option[StatusCode],Seq[ErrorReport],Seq[StackTraceElement]) => ErrorReport) {
   private val SOURCE = "FireCloud"

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/ServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/ServiceSpec.scala
@@ -15,7 +15,7 @@ trait ServiceSpec extends FreeSpec with ScalaFutures with ScalatestRouteTest wit
   def errorReportCheck(source: String, statusCode: StatusCode) = {
     val report = responseAs[ErrorReport]
     report.source should be(source)
-    report.httpStatusCode.get should be(statusCode)
+    report.statusCode.get should be(statusCode)
   }
 
 }


### PR DESCRIPTION
I find it a tad suspicious that this isn't causing unmarshalling errors, but it seems to work.