### PR TITLE
DSDEEPB-1723: OAuth implementation in orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ Run the container:
 ```
 docker run --rm --name orch \
   -p 8080:8080 \
-  -e GOOGLE_CLIENT_ID=GOOGLE_CLIENT_ID \
-  -e GOOGLE_SECRET_JSON=GOOGLE_SECRET_JSON \
+  -e GOOGLE_CLIENT_ID=$GOOGLE_CLIENT_ID \
+  -e GOOGLE_SECRET_JSON=$GOOGLE_SECRET_JSON \
   -e RAWLS_URL_ROOT='https://rawls.dsde-dev.broadinstitute.org' \
   -e AGORA_URL_ROOT='https://agora.dsde-dev.broadinstitute.org' \
   -e THURLOE_URL_ROOT='https://thurloe.dsde-dev.broadinstitute.org' \

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ sbt
 > assembly
 ```
 
-Ensure that `GOOGLE_CLIENT_ID` (with origins set to `http://localhost:8080` and `https://localhost:8080` - see below), 
-`AGORA_URL_ROOT`, `RAWLS_URL_ROOT`, and `THURLOE_URL_ROOT` are defined in your environment, and execute the jar with the path to the jar and path of the desired config file:
+Ensure that `GOOGLE_CLIENT_ID` and `GOOGLE_SECRET_JSON` (with origin set to `https://local.broadinstitute.org` - see below), 
+`AGORA_URL_ROOT`, `RAWLS_URL_ROOT`, `THURLOE_URL_ROOT`, and `FIRECLOUD_URL_ROOT` are defined in your environment, and execute the jar with the path to the jar and path of the desired config file:
 
 ```
 java -Dconfig.file=src/main/resources/application.conf \
@@ -56,7 +56,8 @@ sbt
 ## Testing
 
 ```
-AGORA_URL_ROOT='http://localhost:8989' RAWLS_URL_ROOT='http://localhost:8990' THURLOE_URL_ROOT='http://localhost:8991' sbt test
+AGORA_URL_ROOT='http://localhost:8989' RAWLS_URL_ROOT='http://localhost:8990' \
+    THURLOE_URL_ROOT='http://localhost:8991' FIRECLOUD_URL_ROOT='https://local.broadinstitute.org' sbt test
 ```
 
 ## Debugging
@@ -80,16 +81,20 @@ Add your docker host as an authorized JavaScript origin, one entry per line.  Na
 Set your client ID in your environment:
 ```
 export GOOGLE_CLIENT_ID='...'
+export GOOGLE_SECRET_JSON='...'
+
 ```
 
 Run the container:
 ```
 docker run --rm --name orch \
   -p 8080:8080 \
-  -e GOOGLE_CLIENT_ID=$GOOGLE_CLIENT_ID \
+  -e GOOGLE_CLIENT_ID=GOOGLE_CLIENT_ID \
+  -e GOOGLE_SECRET_JSON=GOOGLE_SECRET_JSON \
   -e RAWLS_URL_ROOT='https://rawls.dsde-dev.broadinstitute.org' \
   -e AGORA_URL_ROOT='https://agora.dsde-dev.broadinstitute.org' \
   -e THURLOE_URL_ROOT='https://thurloe.dsde-dev.broadinstitute.org' \
+  -e FIRECLOUD_URL_ROOT='https://local.broadinstitute.org' \
   broadinstitute/firecloud-orchestration
 ```
 

--- a/build.sbt
+++ b/build.sbt
@@ -55,6 +55,7 @@ libraryDependencies ++= {
     "com.typesafe.akka"   %%  "akka-contrib"  % akkaV,
     "com.typesafe.akka"   %%  "akka-testkit"  % akkaV     % "test",
     "com.typesafe.akka"   %%  "akka-slf4j"    % akkaV,
+    "com.google.api-client" % "google-api-client" % "1.20.0",
     "org.specs2"          %%  "specs2-core"   % "2.3.11"  % "test",
     "org.scalatest"       %%  "scalatest"     % "2.2.1"   % "test",
     "org.mock-server"      %  "mockserver-netty" % "3.9.2" % "test"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,5 +3,6 @@ addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.12.0")
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.7.2")
 
 addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.0.0")
+
 // latest coveralls (1.0.0) is *only* compatible with scoverage 1.0.4 or less: https://github.com/scoverage/sbt-coveralls/issues/49
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.0.4")

--- a/src/main/config/docker-compose.yaml.ctmpl
+++ b/src/main/config/docker-compose.yaml.ctmpl
@@ -8,10 +8,12 @@ app:
   {{.Data.app_ports}}
   {{.Data.app_volumes}}
   environment:
-    GOOGLE_CLIENT_ID: {{.Data.env_client_id}}
-    AGORA_URL_ROOT: {{.Data.env_agora_url}}
-    RAWLS_URL_ROOT: {{.Data.env_rawls_url}}
-    THURLOE_URL_ROOT: {{.Data.env_thurloe_url}}
+    - GOOGLE_CLIENT_ID={{.Data.env_client_id}}
+    - AGORA_URL_ROOT={{.Data.env_agora_url}}
+    - RAWLS_URL_ROOT={{.Data.env_rawls_url}}
+    - THURLOE_URL_ROOT={{.Data.env_thurloe_url}}
+    - FIRECLOUD_URL_ROOT={{.Data.env_firecloud_url}}
+    - GOOGLE_SECRET_JSON={{.Data.env_google_json}}
 proxy:
   extends:
     file: proxy-compose.yaml

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
@@ -7,7 +7,7 @@ object FireCloudConfig {
 
   object Auth {
     lazy val googleClientId = sys.env.get("GOOGLE_CLIENT_ID").get
-    lazy val googleClientSecret = sys.env.get("GOOGLE_CLIENT_SECRET").get
+    lazy val googleSecretJson = sys.env.get("GOOGLE_SECRET_JSON").get
   }
 
   object HttpConfig {
@@ -53,6 +53,10 @@ object FireCloudConfig {
     lazy val getAll = profile.getString("getAll")
     lazy val get = profile.getString("get")
     lazy val delete = profile.getString("delete")
+  }
+
+  object FireCloud {
+    lazy val baseUrl = sys.env.get("FIRECLOUD_URL_ROOT").get
   }
 
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
@@ -7,6 +7,7 @@ object FireCloudConfig {
 
   object Auth {
     lazy val googleClientId = sys.env.get("GOOGLE_CLIENT_ID").get
+    lazy val googleClientSecret = sys.env.get("GOOGLE_CLIENT_SECRET").get
   }
 
   object HttpConfig {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudServiceActor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudServiceActor.scala
@@ -26,6 +26,8 @@ class FireCloudServiceActor extends HttpServiceActor {
   val routes = statusService.routes ~ methodsService.routes ~ workspaceService.routes ~ entityService.routes ~
     methodConfigurationService.routes ~ submissionsService.routes ~ userService.routes ~ storageService.routes
 
+  val oAuthService = new OAuthService with ActorRefFactoryContext
+
   lazy val log = LoggerFactory.getLogger(getClass)
   val logRequests = mapInnerRoute { route => requestContext =>
     log.debug(requestContext.request.toString)
@@ -43,12 +45,14 @@ class FireCloudServiceActor extends HttpServiceActor {
       pathPrefix("service") {
         swaggerUiService ~
           testNihService ~
+          oAuthService.routes ~
           pathPrefix("api") {
             routes
           }
       } ~
         swaggerUiService ~
         testNihService ~
+        oAuthService.routes ~
         pathPrefix("api") {
           routes
         }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
@@ -15,7 +15,7 @@ object HttpGoogleServicesDAO {
 
   val secretContent = FireCloudConfig.Auth.googleSecretJson
   val baseUrl = FireCloudConfig.FireCloud.baseUrl
-  val callbackPath = "/service/oauth2callback"
+  val callbackPath = "/service/callback"
 
   // this needs to match a value in the "Authorized redirect URIs" section of the Google credential in use
   val callbackUri = Uri(s"${baseUrl}${callbackPath}")

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
@@ -1,0 +1,85 @@
+package org.broadinstitute.dsde.firecloud.dataaccess
+
+import java.io.StringReader
+
+import com.google.api.client.googleapis.auth.oauth2.{GoogleAuthorizationCodeFlow, GoogleClientSecrets, GoogleTokenResponse}
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport
+import com.google.api.client.json.jackson2.JacksonFactory
+import org.broadinstitute.dsde.firecloud.FireCloudConfig
+import org.broadinstitute.dsde.firecloud.model.{OAuthException, OAuthTokens}
+import spray.http.Uri
+
+import scala.collection.JavaConversions._
+
+object HttpGoogleServicesDAO {
+
+  val secretContent = FireCloudConfig.Auth.googleSecretJson
+  val baseUrl = FireCloudConfig.FireCloud.baseUrl
+  val callbackPath = "/service/oauth2callback"
+
+  // this needs to match a value in the "Authorized redirect URIs" section of the Google credential in use
+  val callbackUri = Uri(s"${baseUrl}${callbackPath}")
+
+  // modify these if we need more granular access in the future
+  val gcsFullControl = "https://www.googleapis.com/auth/devstorage.full_control"
+  val computeFullControl = "https://www.googleapis.com/auth/compute"
+  // TODO: remove compute?
+  val scopes = Seq(gcsFullControl,computeFullControl,"profile","email")
+
+  val httpTransport = GoogleNetHttpTransport.newTrustedTransport
+  val jsonFactory = JacksonFactory.getDefaultInstance
+
+  val clientSecrets = GoogleClientSecrets.load(jsonFactory, new StringReader(secretContent))
+
+  val flow = new GoogleAuthorizationCodeFlow.Builder(httpTransport,
+    jsonFactory, clientSecrets, scopes).build()
+
+
+  /**
+   * first step of OAuth dance: redirect the browser to Google's login page
+   */
+  def getGoogleRedirectURI(state: String, approvalPrompt: String = "auto"): String = {
+    flow.newAuthorizationUrl()
+        .setRedirectUri(callbackUri.toString)
+        .setState(state)
+        .setAccessType("offline")   // enables refresh token
+        .setApprovalPrompt(approvalPrompt) // "force" to get a new refresh token
+        .build()
+        // TODO: login hint?
+  }
+
+  /**
+   * third step of OAuth dance: exchange an auth code for access/refresh tokens
+   */
+  def getTokens(actualState: String,  expectedState: String, authCode: String): OAuthTokens = {
+
+    if ( actualState != expectedState ) throw new OAuthException(
+      "State mismatch: this authentication request cannot be completed.")
+
+    val gcsTokenResponse: GoogleTokenResponse = flow.newTokenRequest(authCode)
+      .setRedirectUri(callbackUri.toString)
+      .execute()
+
+    val refreshToken = gcsTokenResponse.getRefreshToken match {
+      case null => None
+      case x => Some(x)
+    }
+    val idToken = gcsTokenResponse.getIdToken match {
+      case null => None
+      case x => Some(x)
+    }
+
+    new OAuthTokens(
+      gcsTokenResponse.getAccessToken,
+      gcsTokenResponse.getTokenType,
+      gcsTokenResponse.getExpiresInSeconds,
+      refreshToken,
+      idToken
+    )
+  }
+
+  def randomStateString = randomString(24)
+
+  def randomString(length: Int) = scala.util.Random.alphanumeric.take(length).mkString
+
+}

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
@@ -95,7 +95,7 @@ object ModelJsonProtocol {
   implicit val impThurloeKeyValue = jsonFormat2(ThurloeKeyValue)
   implicit val impRegistration = jsonFormat4(Profile)
 
-  implicit val impTokenResponse = jsonFormat5(TokenResponse)
+  implicit val impTokenResponse = jsonFormat5(OAuthTokens)
 
   // don't make this implicit! It would be pulled in by anything including ModelJsonProtocol._
   val entityExtractionRejectionHandler = RejectionHandler {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
@@ -95,6 +95,7 @@ object ModelJsonProtocol {
   implicit val impThurloeKeyValue = jsonFormat2(ThurloeKeyValue)
   implicit val impRegistration = jsonFormat4(Profile)
 
+  implicit val impTokenResponse = jsonFormat5(TokenResponse)
 
   // don't make this implicit! It would be pulled in by anything including ModelJsonProtocol._
   val entityExtractionRejectionHandler = RejectionHandler {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/OAuth.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/OAuth.scala
@@ -1,10 +1,16 @@
 package org.broadinstitute.dsde.firecloud.model
 
-
-case class TokenResponse(
+/* NB: field names here are not Scala conventional. These are the field names returned in the raw
+    response from Google, and if we ever need to, that response could be unmarshalled into this
+    case class. If we used Scala-standard names the unmarshalling would break.
+  */
+case class OAuthTokens(
   access_token: String,
   token_type: String,
-  expires_in: Int,
+  expires_in: Long,
   refresh_token: Option[String],
   id_token: Option[String]
 )
+
+case class OAuthException(message: String = null, cause: Throwable = null) extends RuntimeException(message, cause)
+

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/OAuth.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/OAuth.scala
@@ -1,0 +1,10 @@
+package org.broadinstitute.dsde.firecloud.model
+
+
+case class TokenResponse(
+  access_token: String,
+  token_type: String,
+  expires_in: Int,
+  refresh_token: Option[String],
+  id_token: Option[String]
+)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/OAuthService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/OAuthService.scala
@@ -37,7 +37,6 @@ trait OAuthService extends HttpService with PerRequestCreator with FireCloudDire
              */
             case e: Exception => {
               log.error("problem during OAuth redirect", e)
-              // TODO: here and elsewhere, redirect to a UI error page instead of issuing a 401?
               complete(StatusCodes.Unauthorized, e.getMessage)
             }
           }
@@ -63,7 +62,7 @@ trait OAuthService extends HttpService with PerRequestCreator with FireCloudDire
 
             val uiRedirect = Uri(FireCloudConfig.FireCloud.baseUrl)
               .withFragment(actualState)
-              .withQuery(("token", accessToken))
+              .withQuery(("access_token", accessToken))
             redirect(uiRedirect, StatusCodes.TemporaryRedirect)
           } catch {
             case e:OAuthException => complete(StatusCodes.Unauthorized, e.getMessage) // these can be shown to the user

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/OAuthService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/OAuthService.scala
@@ -1,0 +1,112 @@
+package org.broadinstitute.dsde.firecloud.service
+
+import org.broadinstitute.dsde.firecloud.FireCloudConfig
+import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
+import org.broadinstitute.dsde.firecloud.model.TokenResponse
+import org.slf4j.LoggerFactory
+import spray.client.pipelining._
+import spray.http.StatusCodes._
+import spray.http.Uri.{Authority, Host, Path, Query}
+import spray.http.{FormData, StatusCodes, Uri}
+import spray.httpx.SprayJsonSupport._
+import spray.routing._
+
+import scala.concurrent.Future
+import scala.util.{Failure, Success}
+
+
+// see https://developers.google.com/identity/protocols/OAuth2WebServer
+
+trait OAuthService extends HttpService with PerRequestCreator with FireCloudDirectives {
+
+  private implicit val executionContext = actorRefFactory.dispatcher
+
+  lazy val log = LoggerFactory.getLogger(getClass)
+
+  val routes: Route =
+    path("login") {
+      get {
+        headerValueByName("X-Forwarded-Host") { fHost => requestContext =>
+
+          // create the callback url
+          // TODO: make scheme dynamic based on request
+          val redirectUri = Uri(scheme = "https", Authority(Host(fHost)), Path("/service/oauth2callback"))
+
+          /* configure the login request with:
+            - client ID
+            - client secret
+            - scopes that your app needs to request
+
+            optional:
+            - approval_prompt=auto ("force" to get a new refresh token)
+            - login_hint=email or sub
+            - include_granted_scopes=false ("true" to include previously-granted scopes)
+         */
+          // TODO: generate and validate unique state param
+          // TODO: extract scopes into a constant enum somewhere
+          // TODO: login hint, if possible
+          // TODO: approval_prompt should not be hardcoded to force
+          val authUrl = Uri("https://accounts.google.com/o/oauth2/auth")
+            .withQuery(("response_type", "code"),
+              ("client_id", FireCloudConfig.Auth.googleClientId),
+              ("redirect_uri", redirectUri.toString),
+              ("scope", "profile email https://www.googleapis.com/auth/devstorage.full_control https://www.googleapis.com/auth/compute"),
+              ("state", "TODO"),
+              ("access_type", "offline"))
+          requestContext.redirect(authUrl, StatusCodes.TemporaryRedirect)
+        }
+      }
+    } ~
+    path("oauth2callback") {
+      get {
+        /*
+      interpret auth server's response
+        An error response:
+        https://oauth2-login-demo.appspot.com/auth?error=access_denied
+      An authorization code response:
+        https://oauth2-login-demo.appspot.com/auth?code=4/P7q7W91a-oMsCeLvIaQm6bTrgtp7
+      */
+        parameters("code", "state") { (code, state) =>
+          headerValueByName("X-Forwarded-Host") { fHost => requestContext =>
+
+            // create the callback url
+            // TODO: this doesn't seem to be used, but is required?
+            val redirectUri = Uri(scheme = "https", Authority(Host(fHost)), Uri.Path("/service/oauth2callback"))
+
+            // create the token exchange url
+            val tokenExchangeUrl = Uri("https://www.googleapis.com/oauth2/v3/token")
+
+            // create the post payload for token exchange
+            val postData = Map(("code", code),
+              ("client_id", FireCloudConfig.Auth.googleClientId),
+              ("client_secret", FireCloudConfig.Auth.googleClientSecret),
+              ("redirect_uri", redirectUri.toString),
+              ("grant_type", "authorization_code"))
+
+            val tokenExchangeRequest = Post(tokenExchangeUrl, FormData(postData))
+            val pipeline = sendReceive ~> unmarshal[TokenResponse]
+            val futureToken: Future[TokenResponse] = pipeline(tokenExchangeRequest)
+
+            // exchange for a token, then send the access token to the UI
+            futureToken onComplete {
+              case Success(tr: TokenResponse) => {
+                // TODO: make scheme dynamic based on request
+                // TODO: what url does the UI want to be redirected to?
+                // TODO: drop a cookie instead of sending token in url
+                val uiRedirect = Uri(scheme = "https", Authority(Host(fHost)), Path("/login"), Query(("token", tr.access_token)), fragment = None)
+                requestContext.redirect(uiRedirect, StatusCodes.TemporaryRedirect)
+              }
+              // TODO: much, much better error handling
+              case Failure(error) => requestContext.complete(InternalServerError, error.toString)
+              case _ => requestContext.complete(InternalServerError, "unknown")
+            }
+          }
+        } ~
+          parameter("error") { errorMsg =>
+            // TODO: much, much better error handling
+            complete(StatusCodes.Unauthorized, errorMsg)
+          }
+      }
+    }
+
+}


### PR DESCRIPTION
ready-for-review implementation of OAuth in orchestration layer.

You will need to set up new env vars for this:
* FIRECLOUD_URL_ROOT: what's the base url for the UI? (https://firecloud.dsde-dev.broadinstitute.org or https://local.broadinstitute.org). We need this to cleanly redirect the browser.
* GOOGLE_SECRET_JSON: the json, as downloaded from Google Developers Console, representing the client id/secret in use.

These are set up for the dev environment, but will need to be configured in staging/alpha/etc before this code goes out there.

You'll also need to make sure your credentials as set up in Google have the FIRECLOUD_URL_ROOT as an allowed origin, and have FIRECLOUD_URL_ROOT/service/oauth2callback as an authorized redirect URI.

To test, go to https://local.broadinstitute.org/service/login?path=foo in your browser to start the OAuth process. Your browser will be redirected a few times and you should end up at https://local.broadinstitute.org/?token={yourtokenhere}#foo.

