### PR TITLE
DSDEEPB-1911: allow GCS object names containing slashes

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/StorageService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/StorageService.scala
@@ -18,8 +18,8 @@ trait StorageService extends HttpService with PerRequestCreator with FireCloudDi
   val routes: Route =
     pathPrefix(ApiPrefix) {
       // call Google's storage REST API for info about this object
-      path(Segment / Segment) { (bucket,obj) => requestContext =>
-        val extReq = Get(gcsStatUrl.format(bucket,obj))
+      path(Segment / Rest) { (bucket,obj) => requestContext =>
+        val extReq = Get(gcsStatUrl.format(bucket, java.net.URLEncoder.encode(obj,"UTF-8")))
         externalHttpPerRequest(requestContext, extReq)
       }
     }


### PR DESCRIPTION
quick change to support GCS objects with slashes - i.e. "subdirectories" of buckets.

Note: this fixes a problem in orch. In UI testing, I saw this working with my own test cases, but NOT with the test case mentioned in DSDEEPB-1911. That may be a UI bug.