### PR TITLE
increase route test timeouts from 1 to 5 seconds to pass Travis.

### DIFF
--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/ServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/ServiceSpec.scala
@@ -8,8 +8,12 @@ import spray.http.StatusCode
 import spray.httpx.SprayJsonSupport._
 import spray.testkit.ScalatestRouteTest
 
+import scala.concurrent.duration._
+
 // common Service Spec to be inherited by service tests
 trait ServiceSpec extends FreeSpec with ScalaFutures with ScalatestRouteTest with Matchers with FireCloudRequestBuilding {
+
+  implicit val routeTestTimeout = RouteTestTimeout(5.seconds)
 
   // is the response an ErrorReport with the given Source and StatusCode
   def errorReportCheck(source: String, statusCode: StatusCode) = {


### PR DESCRIPTION
We have a test in Travis that fails most of the time but not all the time, and I have a gut feeling Travis is just being slow.