### PR TITLE
DSDEEPB-1757: store OAuth refresh tokens via rawls

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
@@ -96,6 +96,7 @@ object ModelJsonProtocol {
   implicit val impRegistration = jsonFormat4(Profile)
 
   implicit val impTokenResponse = jsonFormat5(OAuthTokens)
+  implicit val impRawlsToken = jsonFormat1(RawlsToken)
 
   // don't make this implicit! It would be pulled in by anything including ModelJsonProtocol._
   val entityExtractionRejectionHandler = RejectionHandler {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/OAuth.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/OAuth.scala
@@ -12,5 +12,7 @@ case class OAuthTokens(
   id_token: Option[String]
 )
 
+case class RawlsToken(refreshToken: String)
+
 case class OAuthException(message: String = null, cause: Throwable = null) extends RuntimeException(message, cause)
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/OAuthService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/OAuthService.scala
@@ -2,13 +2,28 @@ package org.broadinstitute.dsde.firecloud.service
 
 import org.broadinstitute.dsde.firecloud.FireCloudConfig
 import org.broadinstitute.dsde.firecloud.dataaccess.HttpGoogleServicesDAO
-import org.broadinstitute.dsde.firecloud.model.OAuthException
+import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
+import org.broadinstitute.dsde.firecloud.model.{RawlsToken, OAuthException}
 import org.slf4j.LoggerFactory
 import spray.http.Uri._
-import spray.http.{StatusCodes, Uri}
+import spray.http.{HttpResponse, OAuth2BearerToken, StatusCodes, Uri}
 import spray.routing._
+import spray.client.pipelining._
+import spray.httpx.SprayJsonSupport._
+
+import scala.concurrent.Future
+import scala.util.{Failure, Success}
 
 // see https://developers.google.com/identity/protocols/OAuth2WebServer
+
+object OAuthService {
+  val remoteTokenPutPath = FireCloudConfig.Rawls.authPrefix + "/user/refreshToken"
+  val remoteTokenPutUrl = FireCloudConfig.Rawls.baseUrl + remoteTokenPutPath
+
+  val remoteTokenDatePath = FireCloudConfig.Rawls.authPrefix + "/user/rereshTokenDate"
+  val remoteTokenDateUrl = FireCloudConfig.Rawls.baseUrl + remoteTokenDatePath
+
+}
 
 trait OAuthService extends HttpService with PerRequestCreator with FireCloudDirectives {
 
@@ -24,7 +39,7 @@ trait OAuthService extends HttpService with PerRequestCreator with FireCloudDire
 
           // approval prompt - "force" to force a refresh token
           // TODO: future story: make dynamic based on whether or not the user has a refresh token stored already
-          val approvalPrompt = "auto"
+          val approvalPrompt = "force"
 
           try {
             // create the authentication url and redirect the browser
@@ -59,6 +74,30 @@ trait OAuthService extends HttpService with PerRequestCreator with FireCloudDire
             // not sure what the google library does under the covers - is it blocking?
             val gcsTokenResponse = HttpGoogleServicesDAO.getTokens(actualState, expectedState, code)
             val accessToken = gcsTokenResponse.access_token
+            val refreshToken = gcsTokenResponse.refresh_token
+
+            // if we have a refresh token, store it in rawls
+            refreshToken map {rt =>
+              val tokenReq = Put(OAuthService.remoteTokenPutUrl, RawlsToken(accessToken))
+              // we can't use the standard externalHttpPerRequest here, because the requestContext doesn't have the
+              // access token yet; we have to add the token manually
+              val pipeline = addCredentials(OAuth2BearerToken(accessToken)) ~> sendReceive
+              val tokenStoreFuture: Future[HttpResponse] = pipeline { tokenReq }
+
+              // we intentionally don't gate the login process on storage of the refresh token. Token storage
+              // will happen async. If token storage fails, we rely on underlying services to notice the
+              // missing token and re-initiate the oauth grants.
+              tokenStoreFuture onComplete {
+                case Success(response) => {
+                  response.status match {
+                    case StatusCodes.Created => log.debug("successfully stored refresh token")
+                    case x => log.warn(s"failed to store refresh token (status code ${x}): " + response.entity)
+                  }
+                }
+                case Failure(error) => log.warn("failed to store refresh token: " + error.getMessage)
+                case _ => log.warn("failed to store refresh token due to unknown error")
+              }
+            }
 
             // redirect to the root url ("/"), with a fragment containing the user's original path and
             // the access token. The access token part LOOKS like a query param, but the entire string including "?"


### PR DESCRIPTION
with this PR:
* we *always* request a refresh token during login. This means that you'll *always* see the Google screen asking your permission. We have DSDEEPB-1759 as a follow-on story to make this more graceful.
* once we have a refresh token, we PUT it to rawls.