### PR TITLE
allow login process to cross environments with whitelist check

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -1469,6 +1469,41 @@ paths:
           description: Key not found
         500:
           description: Internal server error
+  /../login:
+    get:
+      tags:
+        - OAuth
+      operationId: login
+      summary: Starts the authentication flow for a user
+      description: This is an unauthenticated endpoint at /login (not /api/login) that initiates the OAuth flow.
+        Authentication cannot be initiated from within swagger, because auth requires the entire browser
+        to redirect, and swagger uses ajax. To test, fill in your desired query params, then copy and paste the
+        request url into your browser address bar.
+      parameters:
+      - name: path
+        in: query
+        description: The url fragment to use after finishing authentication
+        required: false
+        type: string
+      - name: prompt
+        in: query
+        description: use "force" to always request a new refresh token
+        required: false
+        type: string
+        enum: ["auto","force"]
+        default: "force"
+      - name: callback
+        in: query
+        description: The host to use after finishing authentication. Include the scheme, but no trailing slash, e.g. https://firecloud.broadinstitute.org
+        required: false
+        type: string
+      responses:
+        307:
+          description: Successful redirect after authentication
+        401:
+          description: Unauthorized
+        500:
+          description: Internal server error
 
 definitions:
   WorkspaceIngest:

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
@@ -97,6 +97,7 @@ object ModelJsonProtocol {
 
   implicit val impTokenResponse = jsonFormat5(OAuthTokens)
   implicit val impRawlsToken = jsonFormat1(RawlsToken)
+  implicit val impRawlsTokenDate = jsonFormat1(RawlsTokenDate)
 
   // don't make this implicit! It would be pulled in by anything including ModelJsonProtocol._
   val entityExtractionRejectionHandler = RejectionHandler {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/OAuth.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/OAuth.scala
@@ -14,5 +14,7 @@ case class OAuthTokens(
 
 case class RawlsToken(refreshToken: String)
 
+case class RawlsTokenDate(refreshTokenUpdatedDate: String)
+
 case class OAuthException(message: String = null, cause: Throwable = null) extends RuntimeException(message, cause)
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/OAuthService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/OAuthService.scala
@@ -3,7 +3,8 @@ package org.broadinstitute.dsde.firecloud.service
 import org.broadinstitute.dsde.firecloud.FireCloudConfig
 import org.broadinstitute.dsde.firecloud.dataaccess.HttpGoogleServicesDAO
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
-import org.broadinstitute.dsde.firecloud.model.{RawlsToken, OAuthException}
+import org.broadinstitute.dsde.firecloud.model.{RawlsTokenDate, RawlsToken, OAuthException}
+import org.joda.time.{Days, DateTime}
 import org.slf4j.LoggerFactory
 import spray.http.Uri._
 import spray.http.{HttpResponse, OAuth2BearerToken, StatusCodes, Uri}
@@ -20,7 +21,7 @@ object OAuthService {
   val remoteTokenPutPath = FireCloudConfig.Rawls.authPrefix + "/user/refreshToken"
   val remoteTokenPutUrl = FireCloudConfig.Rawls.baseUrl + remoteTokenPutPath
 
-  val remoteTokenDatePath = FireCloudConfig.Rawls.authPrefix + "/user/rereshTokenDate"
+  val remoteTokenDatePath = FireCloudConfig.Rawls.authPrefix + "/user/refreshTokenDate"
   val remoteTokenDateUrl = FireCloudConfig.Rawls.baseUrl + remoteTokenDatePath
 
 }
@@ -40,12 +41,12 @@ trait OAuthService extends HttpService with PerRequestCreator with FireCloudDire
           // TODO: future story: generate and persist unique security token along with the callback/path
           val state = callback.getOrElse("") + "#" + userpath.getOrElse("")
 
-          // if the user requested "auto" then "auto"; if the user specified something else, or nothing, use "force".
-          // this allows the end user/UI to control when we force-request a new refresh token. Default to asking
-          // for the refresh token.
+          // if the user requested "force" then "force"; if the user specified something else, or nothing, use "auto".
+          // this allows the end user/UI to control when we force-request a new refresh token. Default to auto,
+          // to allow Google to decide; we'll verify in our token store after this step completes.
           val approvalPrompt = prompt match {
-            case Some("auto") => "auto"
-            case _ => "force"
+            case Some("force") => "force"
+            case _ => "auto"
           }
 
           try {
@@ -81,60 +82,62 @@ trait OAuthService extends HttpService with PerRequestCreator with FireCloudDire
             val accessToken = gcsTokenResponse.access_token
             val refreshToken = gcsTokenResponse.refresh_token
 
+            // we can't use the standard externalHttpPerRequest here, because the requestContext doesn't have the
+            // access token yet; we have to add the token manually
+            val pipeline = addCredentials(OAuth2BearerToken(accessToken)) ~> sendReceive
+
             // if we have a refresh token, store it in rawls
-            refreshToken foreach {rt =>
-              val tokenReq = Put(OAuthService.remoteTokenPutUrl, RawlsToken(accessToken))
-              // we can't use the standard externalHttpPerRequest here, because the requestContext doesn't have the
-              // access token yet; we have to add the token manually
-              val pipeline = addCredentials(OAuth2BearerToken(accessToken)) ~> sendReceive
-              val tokenStoreFuture: Future[HttpResponse] = pipeline { tokenReq }
+            refreshToken match {
+              case Some(rt) =>
+                val tokenReq = Put(OAuthService.remoteTokenPutUrl, RawlsToken(accessToken))
+                val tokenStoreFuture: Future[HttpResponse] = pipeline { tokenReq }
 
-              // we intentionally don't gate the login process on storage of the refresh token. Token storage
-              // will happen async. If token storage fails, we rely on underlying services to notice the
-              // missing token and re-initiate the oauth grants.
-              tokenStoreFuture onComplete {
-                case Success(response) =>
-                  response.status match {
-                    case StatusCodes.Created => log.debug("successfully stored refresh token")
-                    case x => log.warn(s"failed to store refresh token (status code $x): " + response.entity)
-                  }
-                case Failure(error) => log.warn("failed to store refresh token: " + error.getMessage)
-                case _ => log.warn("failed to store refresh token due to unknown error")
-              }
+                // we intentionally don't gate the login process on storage of the refresh token. Token storage
+                // will happen async. If token storage fails, we rely on underlying services to notice the
+                // missing token and re-initiate the oauth grants.
+                tokenStoreFuture onComplete {
+                  case Success(response) =>
+                    response.status match {
+                      case StatusCodes.Created => log.info("successfully stored refresh token")
+                      case x => log.warn(s"failed to store refresh token (status code $x): " + response.entity)
+                    }
+                  case Failure(error) => log.warn("failed to store refresh token: " + error.getMessage)
+                }
+                completeAuthWithRedirect(actualState, accessToken)
+              case None =>
+                val tokenDateReq = Get(OAuthService.remoteTokenDateUrl)
+                val tokenDateFuture: Future[HttpResponse] = pipeline { tokenDateReq }
+
+                onComplete(tokenDateFuture) {
+                  case Success(response) =>
+                    response.status match {
+                      case StatusCodes.OK =>
+                        // rawls found a refresh token; check its date
+                        val tokenDate = unmarshal[RawlsTokenDate].apply(response)
+                        val howOld = Days.daysBetween(DateTime.parse(tokenDate.refreshTokenUpdatedDate), DateTime.now)
+                        howOld.getDays match {
+                          case x if x < 90 =>
+                            log.debug(s"User's refresh token is $x days old; all good!")
+                            completeAuthWithRedirect(actualState, accessToken) // fine; continue on
+                          case x =>
+                            log.info(s"User's refresh token is $x days old; requesting a new one.")
+                            initiateAuth(actualState, "force")
+                        }
+                      case StatusCodes.NotFound =>
+                        log.info(s"User does not already have a refresh token; requesting a new one.")
+                        // rawls does not have a refresh token for us. restart auth.
+                        // TODO: if the rawls put-token endpoint goes down, this will cause an infinite loop in login
+                        initiateAuth(actualState, "force")
+                      case x =>
+                        log.warn("Unexpected response code when querying rawls for existence of refresh token: "
+                          + x.value + " " + x.reason)
+                        completeAuthWithRedirect(actualState, accessToken)
+                    }
+                  case Failure(error) =>
+                    log.warn("Could not query rawls for existence of refresh token: " + error.getMessage)
+                    completeAuthWithRedirect(actualState, accessToken)
+                }
             }
-
-            // as created in the /login endpoint, the actual state contains the desired callback url
-            // and the desired callback fragment, separated by a hash. But, either value may be the empty string.
-
-            val redirectParts = actualState.split("#")
-            val List(redirectBase, redirectFragment) = redirectParts match {
-              // callback#fragment
-              case x if x.length == 2 => List(redirectParts(0), redirectParts(1))
-              // #fragment
-              case x if (x.length == 1 && actualState.startsWith("#")) => List("", redirectParts(0))
-              // callback#
-              case x if (x.length == 1 && actualState.endsWith("#")) => List(redirectParts(0), "")
-              // #
-              case x if x.length == 0 => List("", "")
-              // an unexpected case where we have too many parts. Do our best to handle this gracefully.
-              case _ =>
-                log.debug(s"Unexpected state parameter during login callback: [$actualState]")
-                List(redirectParts.head, redirectParts.tail.mkString("#"))
-            }
-
-            // validate the redirect base against our known whitelist.
-            // this will return the original value if it exists in the whitelist,
-            // or the empty string if it does not
-            val finalRedirectBase = HttpGoogleServicesDAO.whitelistRedirect(redirectBase)
-
-            // redirect to the root url ("/"), with a fragment containing the user's original path and
-            // the access token. The access token part LOOKS like a query param, but the entire string including "?"
-            // is actually the fragment and the UI will parse it out.
-            val uiRedirect = Uri(finalRedirectBase)
-              .withPath(Uri.Path./)
-              .withFragment(s"$redirectFragment?access_token=$accessToken")
-
-            redirect(Uri(uiRedirect.toString), StatusCodes.TemporaryRedirect)
           } catch {
             case e:OAuthException => complete(StatusCodes.Unauthorized, e.getMessage) // these can be shown to the user
             case e: Exception => {
@@ -151,9 +154,45 @@ trait OAuthService extends HttpService with PerRequestCreator with FireCloudDire
     }
 
 
-  def initiateAuth(state: String, approvalPrompt: String) =  {
+  private def initiateAuth(state: String, approvalPrompt: String) =  {
+    log.info(s"initiateAuth: $approvalPrompt")
     val gcsAuthUrl = HttpGoogleServicesDAO.getGoogleRedirectURI(state, approvalPrompt=approvalPrompt)
     redirect(gcsAuthUrl, StatusCodes.TemporaryRedirect)
+  }
+
+  private def completeAuthWithRedirect(actualState: String, accessToken: String) = {
+    // as created in the /login endpoint, the actual state contains the desired callback url
+    // and the desired callback fragment, separated by a hash. But, either value may be the empty string.
+
+    val redirectParts = actualState.split("#")
+    val List(redirectBase, redirectFragment) = redirectParts match {
+      // callback#fragment
+      case x if x.length == 2 => List(redirectParts(0), redirectParts(1))
+      // #fragment
+      case x if (x.length == 1 && actualState.startsWith("#")) => List("", redirectParts(0))
+      // callback#
+      case x if (x.length == 1 && actualState.endsWith("#")) => List(redirectParts(0), "")
+      // #
+      case x if x.length == 0 => List("", "")
+      // an unexpected case where we have too many parts. Do our best to handle this gracefully.
+      case _ =>
+        log.debug(s"Unexpected state parameter during login callback: [$actualState]")
+        List(redirectParts.head, redirectParts.tail.mkString("#"))
+    }
+
+    // validate the redirect base against our known whitelist.
+    // this will return the original value if it exists in the whitelist,
+    // or the empty string if it does not
+    val finalRedirectBase = HttpGoogleServicesDAO.whitelistRedirect(redirectBase)
+
+    // redirect to the root url ("/"), with a fragment containing the user's original path and
+    // the access token. The access token part LOOKS like a query param, but the entire string including "?"
+    // is actually the fragment and the UI will parse it out.
+    val uiRedirect = Uri(finalRedirectBase)
+      .withPath(Uri.Path./)
+      .withFragment(s"$redirectFragment?access_token=$accessToken")
+
+    redirect(Uri(uiRedirect.toString), StatusCodes.TemporaryRedirect)
   }
 
 


### PR DESCRIPTION
Changes in this PR:
* swagger doc (via hack) for login endpoint
* "path" param, representing the user's current nav state, is now optional
* add new "prompt" param, controlling whether or not to force-request a refresh token. This satisfies DSDEEPB-1760; typical usage should omit this param and allow orchestration to use its default value
* add new "callback" param, controlling where the OAuth process should redirect to after successful auth. This allows an orchestration instance running in dev to redirect back to local.broadinstitute.org after authn - in turn, this allows developers to run a local UI instance talking to a dev orchestration instance.
* during the login dance, check with rawls for a cached refresh token. If one does not exist, or if the cached token is too old, restart auth and force-request a token. The restart should be invisible to the user (unless the user watches the multiple browser redirects)

Note: the "callback" param checks against the whitelist of allowed JS origins defined in the Google credential used by the orchestration instance. To work, this will require:
* any host, such as http://local.broadinstitute.org, that we want to redirect to MUST be listed in the allowed JS origins for the Google credential
* the Google credential json MUST be redeployed to the relevant orchestration instance's secrets

I realize these conditions are a PITA. But, this redirect is not part of the OAuth flow itself, and is therefore not enforced by Google; we must have some enforcement on it.