### PR TITLE
Tweaks to run orch locally for development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,14 +29,13 @@ WORKDIR /app
 
 # Grab dependencies.
 COPY build.sbt build.sbt
-COPY project project
+COPY project/plugins.sbt project/plugins.sbt
 RUN sbt compile
 
 # Compile first to cache it.
-COPY src src
+COPY src/main src/main
+COPY src/test src/test
 RUN sbt compile
-
-# RUN AGORA_URL_ROOT='http://localhost:8989' RAWLS_URL_ROOT='http://localhost:8990' sbt test
 
 RUN sbt assembly
 

--- a/script/create-configs.sh
+++ b/script/create-configs.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -euox pipefail
+IFS=$'\n\t'
+
+
+run_with_ui=${1:-'false'}
+
+docker run --rm -it -v "$PWD":/working broadinstitute/dsde-toolbox \
+  render-templates.sh local "$(<~/.vault-token)"
+
+if [ "$run_with_ui" = 'false' ]; then
+  sed -i '' 's/"20080:80"/"80:80"/1' target/config/proxy-compose.yaml
+  sed -i '' 's/"20443:443"/"443:443"/1' target/config/proxy-compose.yaml
+  sed -i '' 's/basePath: \/service/basePath: \//1' src/main/resources/swagger/api-docs.yaml
+fi

--- a/src/docker/run.sh
+++ b/src/docker/run.sh
@@ -1,3 +1,11 @@
-#!/bin/sh
+#!/bin/bash
+set -euox pipefail
+IFS=$'\n\t'
 
-exec java -jar /app/target/scala-2.11/FireCloud-Orchestration-assembly-*.jar
+
+if [ -e /app/target/scala-2.11/FireCloud-Orchestration-assembly-*.jar ]; then
+  exec java -jar /app/target/scala-2.11/FireCloud-Orchestration-assembly-*.jar
+else
+  cd /app
+  exec sbt '~ reStart'
+fi


### PR DESCRIPTION
Minor Dockerfile cleanups.

run.sh now attempts to find the .jar file. If it does not find one, it runs sbt '~ reStart' so incremental building works on every file save.

./script/create-configs.sh creates the config files from vault and, without arguments, modifies the resulting configs so that local.broadinstitute.org points to the orchestration containers.

Tested both sbt reStart and .jar modes locally.