### PR TITLE
DSDEEPB-2111: Unable to load workspaces with space in name

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/FireCloudDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/FireCloudDirectives.scala
@@ -47,7 +47,7 @@ trait FireCloudDirectives extends spray.routing.Directives with PerRequestCreato
     extract(_.request.method) { httpMethod =>
       unmatchedPath { remaining =>
         parameterMap { params =>
-          passthrough(Uri(targetEndpointUrl + remaining).withQuery(params).toString, httpMethod)
+          passthrough(Uri(encodeUri(targetEndpointUrl + remaining)).withQuery(params).toString, httpMethod)
         }
       }
     }


### PR DESCRIPTION
I'm not 100% solid on how the `passthroughAllPaths` directive works, but this seems to fix it and doesn't break the other usages.