### PR TITLE
Minor refactoring

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/core/ProfileClient.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/core/ProfileClient.scala
@@ -93,7 +93,7 @@ class ProfileClientActor(requestContext: RequestContext) extends Actor with Fire
   def checkUserInRawls(
     pipeline: WithTransformerConcatenation[HttpRequest, Future[HttpResponse]],
     requestContext: RequestContext): Future[PerRequestMessage] = {
-    pipeline { Get(UserService.rawlsGetUserURL) } flatMap { response =>
+    pipeline { Get(UserService.rawlsRegisterUserURL) } flatMap { response =>
         response.status match {
           case x if x == OK =>
             Future(RequestComplete(OK))

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/UserService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/UserService.scala
@@ -30,9 +30,6 @@ object UserService {
   val billingPath = FireCloudConfig.Rawls.authPrefix + "/user/billing"
   val billingUrl = FireCloudConfig.Rawls.baseUrl + billingPath
 
-  val rawlsGetUserPath = "/register/user"
-  val rawlsGetUserURL = FireCloudConfig.Rawls.baseUrl + rawlsGetUserPath
-
   val rawlsRegisterUserPath = "/register/user"
   val rawlsRegisterUserURL = FireCloudConfig.Rawls.baseUrl + rawlsRegisterUserPath
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/UserServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/UserServiceSpec.scala
@@ -43,7 +43,7 @@ class UserServiceSpec extends ServiceSpec with UserService {
       )
 
     workspaceServer
-      .when(request.withMethod("GET").withPath(UserService.rawlsGetUserPath))
+      .when(request.withMethod("GET").withPath(UserService.rawlsRegisterUserPath))
       .respond(
         org.mockserver.model.HttpResponse.response()
           .withHeaders(MockUtils.header).withStatusCode(OK.intValue)
@@ -147,9 +147,9 @@ class UserServiceSpec extends ServiceSpec with UserService {
 
     "When testing profile update for a brand new user in Rawls" - {
       "OK response is returned" in {
-        workspaceServer.clear(request.withMethod("GET").withPath(UserService.rawlsGetUserPath))
+        workspaceServer.clear(request.withMethod("GET").withPath(UserService.rawlsRegisterUserPath))
         workspaceServer
-          .when(request.withMethod("GET").withPath(UserService.rawlsGetUserPath))
+          .when(request.withMethod("GET").withPath(UserService.rawlsRegisterUserPath))
           .respond(
             org.mockserver.model.HttpResponse.response()
               .withHeaders(MockUtils.header).withStatusCode(NotFound.intValue)
@@ -163,10 +163,10 @@ class UserServiceSpec extends ServiceSpec with UserService {
 
     "When testing profile update for a pre-existing but non-enabled user in Rawls" - {
       "OK response is returned" in {
-        workspaceServer.clear(request.withMethod("GET").withPath(UserService.rawlsGetUserPath))
+        workspaceServer.clear(request.withMethod("GET").withPath(UserService.rawlsRegisterUserPath))
         workspaceServer.clear(request.withMethod("POST").withPath(UserService.rawlsRegisterUserPath))
         workspaceServer
-          .when(request.withMethod("GET").withPath(UserService.rawlsGetUserPath))
+          .when(request.withMethod("GET").withPath(UserService.rawlsRegisterUserPath))
           .respond(
             org.mockserver.model.HttpResponse.response()
               .withHeaders(MockUtils.header).withStatusCode(NotFound.intValue)


### PR DESCRIPTION
* Trimmed down the TSV Formatter so that it doesn't need to use a mutable seq any longer
* Consolidate the use of the Rawls `/register/user' path since it is the same for get and post.