### PR TITLE
tweak spray client timeout/connection params

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -27,6 +27,46 @@ spray.can {
       max-content-length = 50m
     }
   }
+  spray.can {
+    client {
+      # The max time period that a client connection will be waiting for a response
+      # before triggering a request timeout. The timer for this logic is not started
+      # until the connection is actually in a state to receive the response, which
+      # may be quite some time after the request has been received from the
+      # application!
+      # There are two main reasons to delay the start of the request timeout timer:
+      # 1. On the host-level API with pipelining disabled:
+      #    If the request cannot be sent immediately because all connections are
+      #    currently busy with earlier requests it has to be queued until a
+      #    connection becomes available.
+      # 2. With pipelining enabled:
+      #    The request timeout timer starts only once the response for the
+      #    preceding request on the connection has arrived.
+      # Set to `infinite` to completely disable request timeouts.
+      request-timeout = 300 s
+
+      # The time period within which the TCP connecting process must be completed.
+      # Set to `infinite` to disable.
+      connecting-timeout = 20 s
+    }
+
+    host-connector {
+      # The maximum number of parallel connections that an `HttpHostConnector`
+      # is allowed to establish to a host. Must be greater than zero.
+      max-connections = 8
+
+      # The maximum number of times an `HttpHostConnector` attempts to repeat
+      # failed requests (if the request can be safely retried) before
+      # giving up and returning an error.
+      max-retries = 5
+
+      # If this setting is enabled, the `HttpHostConnector` pipelines requests
+      # across connections, otherwise only one single request can be "open"
+      # on a particular HTTP connection.
+      pipelining = on
+
+    }
+  }
 }
 
 http {


### PR DESCRIPTION
See http://kamon.io/teamblog/2014/11/02/understanding-spray-client-timeout-settings/ and http://spray.io/documentation/1.2.3/spray-can/configuration/ for explanations. Goal of this is twofold:

1) increase timeouts for things like TSV uploads (DSDEEPB-1747). I don't think the timeouts will be completely addressed by this change, because we also need changes to Apache proxy timeouts.

2) increase performance under simultaneous load a bit, by allowing more simultaneous connections to rawls.