### PR TITLE
add a stable 'me' endpoint for checking user status

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -1618,6 +1618,34 @@ paths:
             - email
             - profile
             - https://www.googleapis.com/auth/devstorage.full_control
+  /me:
+    get:
+      tags:
+        - Profile
+      operationId: me
+      summary: Returns registration and activation status for the current user
+      responses:
+        200:
+          description: OK
+          produces:
+          - application/json
+          schema:
+            $ref: '#/definitions/Me'
+        401:
+          description: Unauthorized. User is not allowed in FireCloud or has not signed in.
+        403:
+          description: Forbidden. User is registered in FireCloud, but not activated.
+        404:
+          description: Not Found. User is authenticated to Google but not a FireCloud member.
+        500:
+          description: Internal Server Error determining user status.
+      security:
+        - bearer:
+        - googleoauth:
+            - openid
+            - email
+            - profile
+            - https://www.googleapis.com/auth/devstorage.full_control
   /register/profile:
     get:
       tags:
@@ -2188,3 +2216,25 @@ definitions:
         default: 0
       descriptionSinceLastLink:
         type: string
+  Enabled:
+    properties:
+      google:
+        type: boolean
+        description: User enabled via Google?
+      ldap:
+        type: boolean
+        description: User enabled in LDAP?
+  UserInfo:
+    properties:
+      userSubjectId:
+        type: string
+        description: Subject ID (from Google)
+      userEmail:
+        type: string
+        description: User's email
+  Me:
+    properties:
+      userInfo:
+        $ref: '#/definitions/UserInfo'
+      enabled:
+        $ref: '#/definitions/Enabled'

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
@@ -105,6 +105,11 @@ object ModelJsonProtocol {
   implicit val impJWTWrapper = jsonFormat1(JWTWrapper)
   implicit val impNihStatus = jsonFormat7(NIHStatus)
 
+  implicit val impRawlsUserInfo = jsonFormat2(RawlsUserInfo)
+  implicit val impRawlsEnabled = jsonFormat2(RawlsEnabled)
+  implicit val impRegistrationInfo = jsonFormat2(RegistrationInfo)
+
+
   // don't make this implicit! It would be pulled in by anything including ModelJsonProtocol._
   val entityExtractionRejectionHandler = RejectionHandler {
     case MalformedRequestContentRejection(errorMsg, _) :: _ =>

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/UserInfo.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/UserInfo.scala
@@ -16,3 +16,9 @@ import spray.http.OAuth2BearerToken
 case class UserInfo(userEmail: String, accessToken: OAuth2BearerToken, accessTokenExpiresIn: Long, id: String) {
   def getUniqueId = id
 }
+
+case class RegistrationInfo(userInfo: RawlsUserInfo, enabled: RawlsEnabled)
+
+case class RawlsUserInfo(userSubjectId: String, userEmail: String)
+case class RawlsEnabled(google: Boolean, ldap: Boolean)
+

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/UserService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/UserService.scala
@@ -8,11 +8,10 @@ import org.broadinstitute.dsde.firecloud.model._
 import org.broadinstitute.dsde.firecloud.utils.StandardUserInfoDirectives
 import org.slf4j.LoggerFactory
 import spray.client.pipelining._
-import spray.http.{StatusCode, HttpRequest, HttpCredentials}
+import spray.http.{StatusCode, HttpCredentials}
 import spray.http.HttpHeaders.Authorization
 import spray.http.StatusCodes._
 import spray.httpx.SprayJsonSupport._
-import spray.json.DefaultJsonProtocol._
 import spray.httpx.unmarshalling._
 import spray.routing._
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/UserService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/UserService.scala
@@ -7,8 +7,16 @@ import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
 import org.broadinstitute.dsde.firecloud.model._
 import org.broadinstitute.dsde.firecloud.utils.StandardUserInfoDirectives
 import org.slf4j.LoggerFactory
+import spray.client.pipelining._
+import spray.http.{StatusCode, HttpRequest, HttpCredentials}
+import spray.http.HttpHeaders.Authorization
+import spray.http.StatusCodes._
 import spray.httpx.SprayJsonSupport._
+import spray.json.DefaultJsonProtocol._
+import spray.httpx.unmarshalling._
 import spray.routing._
+
+import scala.util.{Failure, Success}
 
 class UserServiceActor extends Actor with UserService {
   def actorRefFactory = context
@@ -37,13 +45,66 @@ object UserService {
 
 // TODO: this should use UserInfoDirectives, not StandardUserInfoDirectives. That would require a refactoring
 // of how we create service actors, so I'm pushing that work out to later.
-trait UserService extends HttpService with PerRequestCreator with FireCloudDirectives with StandardUserInfoDirectives {
+trait UserService extends HttpService with PerRequestCreator with FireCloudRequestBuilding with FireCloudDirectives with StandardUserInfoDirectives {
 
   private implicit val executionContext = actorRefFactory.dispatcher
 
   lazy val log = LoggerFactory.getLogger(getClass)
 
-  val routes = requireUserInfo() { userInfo =>
+  val routes =
+    path("me") {
+      get { requestContext =>
+
+        // inspect headers for a pre-existing Authorization: header
+        val authorizationHeader: Option[HttpCredentials] = (requestContext.request.headers collect {
+          case Authorization(h) => h
+        }).headOption
+
+        authorizationHeader match {
+          // no Authorization header; the user must be unauthorized
+          case None =>
+            respondWithUserInfo(Unauthorized, Unauthorized.defaultMessage, requestContext)
+          // browser sent Authorization header; try to query rawls for user status
+          case Some(c) =>
+            val pipeline = authHeaders(requestContext) ~> sendReceive
+            val extReq = Get(UserService.rawlsRegisterUserURL)
+            pipeline(extReq) onComplete {
+              case Success(response) =>
+                response.status match {
+                  // rawls rejected our request. User is either invalid or their token timed out; this is truly unauthorized
+                  case Unauthorized => respondWithUserInfo(Unauthorized, Unauthorized.defaultMessage, requestContext)
+                  // rawls 404 means the user is not registered with FireCloud
+                  case NotFound => respondWithUserInfo(NotFound, "FireCloud user registration not found", requestContext)
+                  // rawls error? boo. All we can do is respond with an error.
+                  case InternalServerError => respondWithUserInfo(InternalServerError, InternalServerError.defaultMessage, requestContext)
+                  // rawls found the user; we'll try to parse the response and inspect it
+                  case OK =>
+                    val respJson = response.entity.as[RegistrationInfo]
+                    respJson match {
+                      case Right(regInfo) =>
+                        if (regInfo.enabled.google && regInfo.enabled.ldap) {
+                          // rawls says the user is fully registered and activated!
+                          requestContext.complete(OK, regInfo)
+                        } else {
+                          // rawls knows about the user, but the user isn't activated
+                          respondWithUserInfo(Forbidden, "FireCloud user not activated", requestContext)
+                        }
+                      // we couldn't parse the rawls response. Respond with an error.
+                      case Left(error) =>
+                        respondWithUserInfo(InternalServerError, InternalServerError.defaultMessage, requestContext)
+                    }
+                  case x =>
+                    // we got an unexpected error code from rawls; pass it on
+                    respondWithUserInfo(InternalServerError, "Unexpected response validating registration: " + x.toString, requestContext)
+                }
+              // we couldn't reach rawls (within timeout period). Respond with an error.
+              case Failure(error) =>
+                respondWithUserInfo(InternalServerError, InternalServerError.defaultMessage, requestContext)
+            }
+        }
+      }
+    } ~
+    requireUserInfo() { userInfo =>
     pathPrefix("api") {
       path("profile" / "billing") { requestContext =>
         val extReq = Get(UserService.billingUrl)
@@ -78,4 +139,9 @@ trait UserService extends HttpService with PerRequestCreator with FireCloudDirec
       }
     }
   }
+
+  private def respondWithUserInfo(statusCode: StatusCode, message: String, requestContext: RequestContext) = {
+    requestContext.complete(statusCode, ErrorReport(statusCode=statusCode, message=message))
+  }
+
 }


### PR DESCRIPTION
In support of the UI's checking/handling of user auth/registration status, this adds an endpoint at /me (i.e. /service/me) that:
* always returns json
* always returns 200, 401, 403, 404, or 500

Hopefully this helps keep the UI implementation simpler.

This is a proof-of-concept PR and I'm expecting folks might have feedback!