### PR TITLE
move shibboleth signing secret in vault

### DIFF
--- a/src/main/config/firecloud-orchestration-compose.yaml.ctmpl
+++ b/src/main/config/firecloud-orchestration-compose.yaml.ctmpl
@@ -14,7 +14,7 @@ app:
     - THURLOE_URL_ROOT={{.Data.env_thurloe_url_root}}
     - FIRECLOUD_URL_ROOT={{.Data.env_firecloud_url_root}}
     - GOOGLE_SECRET_JSON={{.Data.env_google_secret_json}}
-    {{$signingkey := printf "secret/dsde/%s/shibboleth/signing-secret" $environment}}
+    {{$signingkey := printf "secret/dsde/%s/common/signing-secret" $environment}}
     {{with vault $signingkey}}
     - JWT_SIGNING_KEY={{.Data.value}}
     {{end}}


### PR DESCRIPTION
In Vault, I've added the signing key to the new common location for local and dev. I've also removed it from local, but NOT from dev (need to coordinate with the shib service before removing it there)