### PR TITLE
DSDEEPB-2403: FireCloud OAuth login updates NIH link expiration time

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
@@ -69,9 +69,10 @@ object HttpGoogleServicesDAO {
       case null => None
       case x => Some(x)
     }
-    val idToken = gcsTokenResponse.getIdToken match {
-      case null => None
-      case x => Some(x)
+    val List(idToken:Option[String], subjectId:Option[String]) = gcsTokenResponse.getIdToken match {
+      case null => List(None, None)
+      case x =>
+        List( Some(x), Some(gcsTokenResponse.parseIdToken().getPayload.getSubject) )
     }
 
     new OAuthTokens(
@@ -79,7 +80,8 @@ object HttpGoogleServicesDAO {
       gcsTokenResponse.getTokenType,
       gcsTokenResponse.getExpiresInSeconds,
       refreshToken,
-      idToken
+      idToken,
+      subjectId
     )
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
@@ -98,7 +98,7 @@ object ModelJsonProtocol {
   implicit val impProfileWrapper = jsonFormat2(ProfileWrapper)
 
 
-  implicit val impTokenResponse = jsonFormat5(OAuthTokens)
+  implicit val impTokenResponse = jsonFormat6(OAuthTokens)
   implicit val impRawlsToken = jsonFormat1(RawlsToken)
   implicit val impRawlsTokenDate = jsonFormat1(RawlsTokenDate)
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/OAuth.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/OAuth.scala
@@ -9,7 +9,8 @@ case class OAuthTokens(
   token_type: String,
   expires_in: Long,
   refresh_token: Option[String],
-  id_token: Option[String]
+  id_token: Option[String],
+  subject_id: Option[String]
 )
 
 case class RawlsToken(refreshToken: String)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/Profile.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/Profile.scala
@@ -79,8 +79,8 @@ case class NIHStatus(
     isDbgapAuthorized: Option[Boolean] = None,
     lastLinkTime: Option[Long] = None,
     linkExpireTime: Option[Long] = None,
-    secondsSinceLastLink: Option[Long] = None,
-    descriptionSinceLastLink: Option[String] = None
+    descriptionSinceLastLink: Option[String] = None,
+    descriptionUntilExpires: Option[String] = None
 )
 
 object ProfileValidator {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/utils/DateUtils.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/utils/DateUtils.scala
@@ -26,6 +26,10 @@ object DateUtils {
     Hours.hoursBetween(dtFromSeconds(seconds), nowDateTime).getHours
   }
 
+  def hoursUntil(seconds: Long): Int = {
+    Hours.hoursBetween(nowDateTime, dtFromSeconds(seconds)).getHours
+  }
+
   def secondsSince(seconds: Long): Int = {
     Seconds.secondsBetween(dtFromSeconds(seconds), nowDateTime).getSeconds
   }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/NIHServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/NIHServiceSpec.scala
@@ -66,19 +66,6 @@ class NIHServiceSpec extends ServiceSpec with NIHService {
       }
     }
 
-    "when GET-ting a profile with missing isDbgapAuthorized" - {
-      "NoContent response is returned" in {
-        respondWith(
-          linkedNihUsername = Some("nihuser"),
-          lastLinkTime = Some(222),
-          linkExpireTime = Some(333)
-        )
-        Get(targetUri) ~> dummyUserIdHeaders(uniqueId) ~> sealRoute(routes) ~> check {
-          status should equal(NoContent)
-        }
-      }
-    }
-
     "when GET-ting a profile with missing lastLinkTime" - {
       "loginRequired is true" in {
         respondWith(
@@ -149,25 +136,6 @@ class NIHServiceSpec extends ServiceSpec with NIHService {
       }
     }
 
-    "when GET-ting a profile with expired lastLinkTime and future linkExpireTime" - {
-      "loginRequired is true" in {
-
-        val lastLinkTime = DateUtils.nowMinus24Hours
-        val linkExpireTime = DateUtils.nowPlus30Days
-
-        respondWith(
-          linkedNihUsername = Some("nihuser"),
-          lastLinkTime = Some(lastLinkTime),
-          linkExpireTime = Some(linkExpireTime),
-          isDbgapAuthorized = Some(true)
-        )
-        Get(targetUri) ~> dummyUserIdHeaders(uniqueId) ~> sealRoute(routes) ~> check {
-          status should equal(OK)
-          val nihStatus = responseAs[NIHStatus]
-          nihStatus.loginRequired shouldBe(true)
-        }
-      }
-    }
   }
 
   def respondWith(


### PR DESCRIPTION
When logging in to FireCloud, if the current user:
* has a linked NIH account
* has not re-linked with NIH within the last 24 hours
* has a NIH link expiration of more than 24 hours
then set the user's NIH link expiration to be 24 hours.

The implementation of this PR is, at first glance (and maybe the fifth glance), unconventional. The OAuth login would need to query Thurloe for NIH link keys, then inspect those keys and act appropriately. We already had an endpoint that queried and inspected those keys ... so I added the check-for-expiration feature into that code path. I like this approach also because it makes it trivially easy to enable the check-for-expiration feature in the /api/nih/status endpoint; in turn this may make it easy to call the check more often.

ProfileClient.scala has a bunch of code that moved around, so the diff shows bigger than it really is. I'll try to comment inline with details.
