### PR TITLE
fix misconfiguration in application.conf timeouts

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -27,45 +27,43 @@ spray.can {
       max-content-length = 50m
     }
   }
-  spray.can {
-    client {
-      # The max time period that a client connection will be waiting for a response
-      # before triggering a request timeout. The timer for this logic is not started
-      # until the connection is actually in a state to receive the response, which
-      # may be quite some time after the request has been received from the
-      # application!
-      # There are two main reasons to delay the start of the request timeout timer:
-      # 1. On the host-level API with pipelining disabled:
-      #    If the request cannot be sent immediately because all connections are
-      #    currently busy with earlier requests it has to be queued until a
-      #    connection becomes available.
-      # 2. With pipelining enabled:
-      #    The request timeout timer starts only once the response for the
-      #    preceding request on the connection has arrived.
-      # Set to `infinite` to completely disable request timeouts.
-      request-timeout = 300 s
+  client {
+    # The max time period that a client connection will be waiting for a response
+    # before triggering a request timeout. The timer for this logic is not started
+    # until the connection is actually in a state to receive the response, which
+    # may be quite some time after the request has been received from the
+    # application!
+    # There are two main reasons to delay the start of the request timeout timer:
+    # 1. On the host-level API with pipelining disabled:
+    #    If the request cannot be sent immediately because all connections are
+    #    currently busy with earlier requests it has to be queued until a
+    #    connection becomes available.
+    # 2. With pipelining enabled:
+    #    The request timeout timer starts only once the response for the
+    #    preceding request on the connection has arrived.
+    # Set to `infinite` to completely disable request timeouts.
+    request-timeout = 300 s
 
-      # The time period within which the TCP connecting process must be completed.
-      # Set to `infinite` to disable.
-      connecting-timeout = 20 s
-    }
+    # The time period within which the TCP connecting process must be completed.
+    # Set to `infinite` to disable.
+    connecting-timeout = 20 s
+  }
 
-    host-connector {
-      # The maximum number of parallel connections that an `HttpHostConnector`
-      # is allowed to establish to a host. Must be greater than zero.
-      max-connections = 8
+  host-connector {
+    # The maximum number of parallel connections that an `HttpHostConnector`
+    # is allowed to establish to a host. Must be greater than zero.
+    max-connections = 8
 
-      # The maximum number of times an `HttpHostConnector` attempts to repeat
-      # failed requests (if the request can be safely retried) before
-      # giving up and returning an error.
-      max-retries = 5
+    # The maximum number of times an `HttpHostConnector` attempts to repeat
+    # failed requests (if the request can be safely retried) before
+    # giving up and returning an error.
+    max-retries = 5
 
-      # If this setting is enabled, the `HttpHostConnector` pipelines requests
-      # across connections, otherwise only one single request can be "open"
-      # on a particular HTTP connection.
-      pipelining = on
+    # If this setting is enabled, the `HttpHostConnector` pipelines requests
+    # across connections, otherwise only one single request can be "open"
+    # on a particular HTTP connection.
+    pipelining = on
 
-    }
   }
 }
 


### PR DESCRIPTION
this does not fully fix the issue for the end user.

There was a simple misconfiguration in our application.conf - previously, I was trying to set spray.can.spray.can.client timeouts, not spray.can.client.

After this change is in place, the bug in question now gets 504 timeouts after 60 seconds. This is probably a timeout from the Apache proxy and needs to be fixed by devops - but this PR is a prerequisite.