### PR TITLE
DSDEEPB-2248: use version number for Thurloe profile instead of true/false

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/core/ProfileClient.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/core/ProfileClient.scala
@@ -47,7 +47,7 @@ class ProfileClientActor(requestContext: RequestContext) extends Actor with Fire
         val allSucceeded = responses.forall { _.status.isSuccess }
         allSucceeded match {
           case true =>
-            val kv2 = FireCloudKeyValue(Some("isRegistrationComplete"), Some("true"))
+            val kv2 = FireCloudKeyValue(Some("isRegistrationComplete"), Some(Profile.currentVersion.toString))
             val completionUpdate = pipeline {
               Post(UserService.remoteSetKeyURL, ThurloeKeyValue(Some(userInfo.getUniqueId), Some(kv2)))
             }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/Profile.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/Profile.scala
@@ -42,6 +42,10 @@ case class Profile (
 }
 
 object Profile {
+
+  // increment this number every time you make a change to the user-provided profile fields
+  val currentVersion:Int = 1
+
   def apply(wrapper: ProfileWrapper) = {
 
     val mappedKVPs:Map[String,String] = (wrapper.keyValuePairs map {


### PR DESCRIPTION
now, when we save a profile to Thurloe, we store a version number instead of a true/false indicator. This allows us to change the profile fields over time.

