### PR TITLE
DSDEEPB-2395: grant access to NIH users immediately upon link

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -99,7 +99,7 @@ userprofile {
   setKey="/thurloe"
   get="/thurloe/%s/%s"
   getAll="/thurloe/%s"
-  getQuery="/thurloe?"
+  getQuery="/thurloe"
   delete="/thurloe/%s/%s"
 }
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/NIHService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/NIHService.scala
@@ -54,7 +54,7 @@ trait NIHService extends HttpService with PerRequestCreator with FireCloudDirect
                 val groupUpdate = perRequest(requestContext, Props(new ProfileClientActor(requestContext)),
                   ProfileClient.SyncSelf(userInfo))
 
-                // TODO: isDbgapAuthorized should be removed entirely, since /api/nih/status reads it from rawls
+                // TODO: DSDEEPB-2512 isDbgapAuthorized should be removed entirely, since /api/nih/status reads it from rawls
                 val isDbgapAuthorized = false
                 val nihLink = NIHLink(linkedNihUsername, lastLinkTime, linkExpireTime, isDbgapAuthorized)
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/NIHSyncService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/NIHSyncService.scala
@@ -12,8 +12,10 @@ trait NIHSyncService extends HttpService with PerRequestCreator with FireCloudDi
   lazy val log = LoggerFactory.getLogger(getClass)
 
   val routes: Route =
-    path("sync_whitelist") { requestContext =>
-      perRequest(requestContext, Props(new ProfileClientActor(requestContext)),
-        ProfileClient.SyncWhitelist)
+    post {
+      path("sync_whitelist") { requestContext =>
+        perRequest(requestContext, Props(new ProfileClientActor(requestContext)),
+          ProfileClient.SyncWhitelist)
+      }
     }
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/NIHSyncEndpointsSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/NIHSyncEndpointsSpec.scala
@@ -15,7 +15,6 @@ class NIHSyncEndpointsSpec extends ServiceSpec with NIHSyncService {
 
 
   val syncWhitelistPath = "/sync_whitelist"
-  val syncSelfPath = "/api/sync_self"
 
   "NIHSyncEndpointsSpec" - {
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/NIHSyncEndpointsSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/NIHSyncEndpointsSpec.scala
@@ -1,0 +1,45 @@
+package org.broadinstitute.dsde.firecloud.service
+
+import org.broadinstitute.dsde.firecloud.core.NIHWhitelistUtils
+import org.broadinstitute.dsde.firecloud.utils.DateUtils
+import spray.http.HttpMethods
+import spray.http.StatusCodes._
+
+import scala.concurrent.duration._
+import scala.concurrent.{Await, Future}
+
+
+class NIHSyncEndpointsSpec extends ServiceSpec with NIHSyncService {
+
+  def actorRefFactory = system
+
+
+  val syncWhitelistPath = "/sync_whitelist"
+  val syncSelfPath = "/api/sync_self"
+
+  "NIHSyncEndpointsSpec" - {
+
+    "when calling the sync whitelist service" - {
+
+        s"POST on $syncWhitelistPath" - {
+          "should not receive a MethodNotAllowed" in {
+            Post(syncWhitelistPath) ~> sealRoute(routes) ~> check {
+              status shouldNot equal(MethodNotAllowed)
+            }
+          }
+        }
+
+        s"GET, PUT, DELETE on $syncWhitelistPath" - {
+          "should receive a MethodNotAllowed" in {
+            List(HttpMethods.GET, HttpMethods.PUT, HttpMethods.DELETE) map {
+              method =>
+                new RequestBuilder(method)(syncWhitelistPath) ~> sealRoute(routes) ~> check {
+                  status should equal(MethodNotAllowed)
+                }
+            }
+          }
+        }
+      }
+    }
+
+}


### PR DESCRIPTION
I have now tested functionality locally, and this is ready for review. This PR adds a feature such that when a user successfully links an account to NIH, if the user exists on the current version of the whitelist, the user is immediately granted TCGA access.

This is purely additive. This does NOT remove the user from TCGA access in the corner case where the user previously had access, re-links an account, but is no longer on the current whitelist. In that case, the user will be removed the next time the scheduled sync-the-entire-whitelist process runs.

Testing this is somewhat difficult, especially if you do not have admin access directly to rawls. You will have to:
* manually update the whitelist file (see the fully-rendered firecloud-orchestration-compose for the location of that) to control whether or not your linked user is in the whitelist
* manually re-link your NIH account multiple times - I modded the UI code to always show the link-expiration warning banner to make this easy
* manually (e.g. via swagger) call the /api/nih/status endpoint to see the state of your isDbgapAuthorized key
* manually call the /sync_whitelist endpoint if you want to see the interaction with the full sync process

I can help with any of these!

