### PR TITLE
Add authenticated LDAP to proxy config

### DIFF
--- a/src/main/config/proxy-compose.yaml.ctmpl
+++ b/src/main/config/proxy-compose.yaml.ctmpl
@@ -7,6 +7,8 @@
 {{$commonkey := printf "secret/dsde/%s/common/proxy-ldap" $environment}}{{with vault $commonkey}}
 {{$proxy_ldap_group := .Data.proxy_ldap_group}}
 {{$proxy_ldap_url := .Data.proxy_ldap_url}}
+{{$proxy_ldap_bind_dn := .Data.proxy_ldap_bind_dn}}
+{{$proxy_ldap_bind_password := .Data.proxy_ldap_bind_password}}
 proxy:
   image: broadinstitute/openidc-proxy:latest
   {{ $proxy_ports }}
@@ -24,5 +26,7 @@ proxy:
     AUTH_REQUIRE2: Require ldap-group {{ $proxy_ldap_group }}
     AUTH_LDAP_URL2: 'AuthLDAPURL "{{ $proxy_ldap_url }}"'
     AUTH_LDAP_GROUP_ATTR2: 'AuthLDAPGroupAttribute member'
+    AUTH_LDAP_BIND_DN2: 'AuthLDAPBindDN "{{ $proxy_ldap_bind_dn }}"'
+    AUTH_LDAP_BIND_PASSWORD2: 'AuthLDAPBindPassword {{ $proxy_ldap_bind_password }}'
     REMOTE_USER_CLAIM: sub
 {{end}}{{end}}{{end}}

--- a/src/main/config/proxy-compose.yaml.ctmpl
+++ b/src/main/config/proxy-compose.yaml.ctmpl
@@ -14,12 +14,8 @@ proxy:
   {{ $proxy_ports }}
   {{ $proxy_volumes }}
   environment:
-    AUTH_TYPE: AuthType None
-    AUTH_TYPE2: AuthType oauth20
     CALLBACK_URI: {{ $env_callback_uri }}
     LOG_LEVEL: {{ $proxy_log_level }}
-    AUTH_REQUIRE: Require all granted
-    AUTH_REQUIRE2: Require valid-user
     PROXY_PATH: /
     PROXY_PATH2: /api
     SERVER_NAME: {{ $env_server_name }}

--- a/src/main/config/proxy-compose.yaml.ctmpl
+++ b/src/main/config/proxy-compose.yaml.ctmpl
@@ -1,18 +1,28 @@
-{{with $environment := env "ENVIRONMENT"}}
-{{$keyname := printf "secret/dsde/%s/firecloud-orchestration/firecloud-orchestration-compose.yaml" $environment}}
-{{with vault $keyname}}
-
+{{with $environment := env "ENVIRONMENT"}}{{$fcokey := printf "secret/dsde/%s/firecloud-orchestration/firecloud-orchestration-compose.yaml" $environment}}{{with vault $fcokey}}
+{{$proxy_ports := .Data.proxy_ports}}
+{{$proxy_volumes := .Data.proxy_volumes}}
+{{$env_callback_uri := .Data.env_callback_uri}}
+{{$env_server_name := .Data.env_server_name}}
+{{$proxy_log_level := .Data.proxy_log_level}}
+{{$commonkey := printf "secret/dsde/%s/common/proxy-ldap" $environment}}{{with vault $commonkey}}
+{{$proxy_ldap_group := .Data.proxy_ldap_group}}
+{{$proxy_ldap_url := .Data.proxy_ldap_url}}
 proxy:
   image: broadinstitute/openidc-proxy:latest
-  {{.Data.proxy_ports}}
-  {{.Data.proxy_volumes}}
+  {{ $proxy_ports }}
+  {{ $proxy_volumes }}
   environment:
-    CALLBACK_URI: {{.Data.env_callback_uri}}
-    LOG_LEVEL: {{.Data.proxy_log_level}}
-    SERVER_NAME: {{.Data.env_server_name}}
-    AUTH_REQUIRE2: Require ldap-group {{.Data.proxy_ldap_group}}
-    AUTH_LDAP_URL2: 'AuthLDAPURL "{{.Data.proxy_ldap_url}}"'
+    AUTH_TYPE: AuthType None
+    AUTH_TYPE2: AuthType oauth20
+    CALLBACK_URI: {{ $env_callback_uri }}
+    LOG_LEVEL: {{ $proxy_log_level }}
+    AUTH_REQUIRE: Require all granted
+    AUTH_REQUIRE2: Require valid-user
+    PROXY_PATH: /
+    PROXY_PATH2: /api
+    SERVER_NAME: {{ $env_server_name }}
+    AUTH_REQUIRE2: Require ldap-group {{ $proxy_ldap_group }}
+    AUTH_LDAP_URL2: 'AuthLDAPURL "{{ $proxy_ldap_url }}"'
     AUTH_LDAP_GROUP_ATTR2: 'AuthLDAPGroupAttribute member'
     REMOTE_USER_CLAIM: sub
-{{end}}
-{{end}}
+{{end}}{{end}}{{end}}


### PR DESCRIPTION
This is required for 1/20 FireCloud launch, based on security scans of the FC system.

Previously, the proxy used an anonymous connection to the LDAP server for authorization. We need to use a credential to talk to LDAP instead; this PR makes that happen.