### PR TITLE
Apply column/attribute mapping in the reverse order for TSV output

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelSchema.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelSchema.scala
@@ -39,8 +39,13 @@ object ModelSchema {
     getTypeSchema(entityType).map(_.requiredAttributes)
   }
 
-  def getAttributeRenamingMap(entityType: String): Try[Map[String,String]] = {
+  def getAttributeImportRenamingMap(entityType: String): Try[Map[String,String]] = {
     getTypeSchema(entityType).map(_.attributeRenaming.getOrElse(Map.empty))
+  }
+
+  def getAttributeExportRenamingMap(entityType: String): Try[Map[String,String]] = {
+    // the inverse of the import mapping
+    getAttributeImportRenamingMap(entityType).map(_.map(_.swap))
   }
 }
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/utils/TSVFormatter.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/utils/TSVFormatter.scala
@@ -30,7 +30,7 @@ object TSVFormatter {
   }
 
   def makeEntityTsvString(entities: List[EntityWithType], entityType: String): String = {
-    val headerRenamingMap: Map[String, String] = ModelSchema.getAttributeRenamingMap(entityType).getOrElse(Map.empty[String, String])
+    val headerRenamingMap: Map[String, String] = ModelSchema.getAttributeExportRenamingMap(entityType).getOrElse(Map.empty[String, String])
     val entityHeader = "entity:" + entityType + "_id"
     val headers: immutable.IndexedSeq[String] = entityHeader +: entities.
       filter { _.entityType == entityType }.

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/utils/TSVParserSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/utils/TSVParserSpec.scala
@@ -62,7 +62,7 @@ class TSVParserSpec extends FlatSpec {
       TSVParser.parse(MockTSVStrings.validMultiline)
     }
   }
-  "EntityClient.improveAttributeNames" should "fix up the names of attributes for certain reference types for pairs" in {
+  "EntityClient.colNamesToAttributeNames" should "fix up the names of attributes for certain reference types for pairs" in {
     val entityType: String = "pair"
     val requiredAttributes: Map[String, String] = Map("case_sample_id" -> "sample",
       "control_sample_id" -> "sample",
@@ -86,7 +86,7 @@ class TSVParserSpec extends FlatSpec {
       "ref_fasta" -> None)
 
     assertResult(expect) {
-      EntityClient.improveAttributeNames(entityType, input, requiredAttributes)
+      EntityClient.colNamesToAttributeNames(entityType, input, requiredAttributes)
     }
   }
 
@@ -109,7 +109,7 @@ class TSVParserSpec extends FlatSpec {
       "ref_fasta" -> None)
 
     assertResult(expect) {
-      EntityClient.improveAttributeNames(entityType, input, requiredAttributes)
+      EntityClient.colNamesToAttributeNames(entityType, input, requiredAttributes)
     }
   }
 
@@ -128,7 +128,7 @@ class TSVParserSpec extends FlatSpec {
       "some_other_id" -> None)
     
     assertResult(expect) {
-      EntityClient.improveAttributeNames(entityType, input, requiredAttributes)
+      EntityClient.colNamesToAttributeNames(entityType, input, requiredAttributes)
     }
   }
 }


### PR DESCRIPTION
Attempt at GAWB-2 but not yet tested on a running Orchestration instance
