### PR TITLE
GAWB-70: add a cookie-authed download proxy for GCS objects

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/CookieAuthedService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/CookieAuthedService.scala
@@ -14,6 +14,7 @@ trait CookieAuthedService extends HttpService with PerRequestCreator with FireCl
   lazy val log = LoggerFactory.getLogger(getClass)
 
   def routes: Route =
+    // download "proxy" for TSV files
     path("workspaces" / Segment / Segment/ "entities" / Segment/ "tsv") {
       (workspaceNamespace, workspaceName, entityType) =>
         cookie("FCtoken") { tokenCookie =>
@@ -22,6 +23,20 @@ trait CookieAuthedService extends HttpService with PerRequestCreator with FireCl
             val filename = entityType + ".txt"
             perRequest(requestContext, Props(new ExportEntitiesByTypeActor(requestContext)),
               ExportEntitiesByType.ProcessEntities(baseRawlsEntitiesUrl, filename, entityType))
+          }
+        }
+    } ~
+    // download "proxy" for GCS objects. When using a simple RESTful url to download from GCS, Chrome/GCS will look
+    // at all the currently-signed in Google identities for the browser, and pick the "most recent" one. This may
+    // not be the one we want to use for downloading the GCS object. To force the identity we want, we send the
+    // access token in the Authorization header when downloading the object.
+    path("download" / "b" / Segment / "o" / RestPath) { (bucket, obj) =>
+        cookie("FCtoken") { tokenCookie =>
+          mapRequest(r => addCredentials(OAuth2BearerToken(tokenCookie.content)).apply(r)) { requestContext =>
+            val gcsApiUrl = s"https://www.googleapis.com/storage/v1/b/%s/o/%s?alt=media".format(
+              bucket, java.net.URLEncoder.encode(obj.toString, "UTF-8"))
+            val extReq = Get(gcsApiUrl)
+            externalHttpPerRequest(requestContext, extReq)
           }
         }
     }


### PR DESCRIPTION
This requires a UI change as well to be fully functional for the end user. This PR adds a "proxy" for downloading GCS objects. Previously, we used a simple RESTful url into Google to download objects, relying on Google to choose an appropriate cookie. If the end user was logged in to multiple Google identities, that RESTful url might choose the wrong identity.

Now, we proxy these downloads through orchestration, and send an Authorization: header with the current user's access token. This forces Google to use the identity we want.

Please merge this PR first (which adds an as-of-yet unused endpoint). Once this is in place, merge the UI PR that uses this endpoint.

Note: work on this PR identified two other bugs: GAWB-280, GAWB-281. I am not fixing those bugs as part of this PR.

Also, I am intentionally not updating swagger for this endpoint. We chose to leave the cookie-authed endpoints undocumented. We can debate that policy, but the lack of swagger in this PR is intentional.
- [x] **Submitter**: Rebase to develop. DO NOT SQUASH
- [x] **Submitter**: Make sure Swagger is updated if API changes
- [x] **Submitter**: Make sure documentation for code is complete
- [x] **Submitter**: Review code comments; remove done TODOs, create stories for remaining TODOs
- [x] **Submitter**: Include the JIRA issue number in the PR description
- [x] **Submitter**: Add description or comments on the PR explaining the hows/whys (if not obvious)
- [x] **Submitter**: Tell tech lead that the PR exists if s/he wants to look at it
- [x] **Submitter**: Anoint a lead reviewer (LR). **Assign PR to LR**
- [x] **LR**: Initial review by LR and others.
- [ ] Comment / review / update cycle:
  - Rest of team may comments on PR at will
  - **LR assigns to submitter** for feedback fixes
  - Submitter updates documentation as needed
  - Submitter rebases to develop again if necessary
  - Submitter makes further commits. DO NOT SQUASH. **Reassign to LR** for further feedback
- [x] **Tech lead**:  sign off
- [x] **LR**: sign off
- [x] **Assign to submitter** to finalize
- [x] **Submitter**: Squash commits, rebase if necessary
- [x] **Submitter**: Verify all tests go green, including CI tests
- [x] **Submitter**: Merge to develop 
- [x] **Submitter**: Delete branch after merge
- [x] **Submitter**: Check configuration files in Jenkins in case they need changes
- [x] **Submitter**: Verify swagger UI on dev server still works after deployment
- [x] **Submitter**: Inform other teams of any API changes via hipchat and/or email
- [x] **Submitter**: Mark JIRA issue as resolved once this checklist is completed
