### PR TITLE
GAWB-553: orchestration cookies (and logging optimization)

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/HttpClient.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/HttpClient.scala
@@ -73,7 +73,7 @@ class HttpClient (requestContext: RequestContext) extends Actor
 
 trait LogRequestBuilding extends spray.httpx.RequestBuilding {
   def logRequest(log: Logger): RequestTransformer = { request =>
-    log.debug("Sending request: " + request)
+    if (log.isDebugEnabled) {log.debug("Sending request: " + request)}
     request
   }
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/HttpClient.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/HttpClient.scala
@@ -55,11 +55,9 @@ class HttpClient (requestContext: RequestContext) extends Actor
     val pipeline: HttpRequest => Future[HttpResponse] =
       requestCompression match {
         case true =>
-          authHeaders(requestContext) ~> addHeaders(Cookie(requestContext.request.cookies), `Accept-Encoding`(gzip)) ~>
-            logRequest(log) ~> sendReceive ~> decode(Gzip)
+          authHeaders(requestContext) ~> addHeaders(`Accept-Encoding`(gzip)) ~> logRequest(log) ~> sendReceive ~> decode(Gzip)
         case _ =>
-          authHeaders(requestContext) ~> addHeader(Cookie(requestContext.request.cookies)) ~>
-            logRequest(log) ~> sendReceive
+          authHeaders(requestContext) ~> logRequest(log) ~> sendReceive
       }
     pipeline(externalRequest) onComplete {
       case Success(response) =>


### PR DESCRIPTION
(no this isn't in our sprint. It really bugged me and I went to investigate it and found out afterwards Joel filed a ticket for it.)

Two changes in here, in separate commits:

1) Orchestration's HttpClient, used for passthroughs and elsewhere, no longer forwards cookies on to underlying services. I cannot think of a reason that we need to send cookies. Most importantly, the particular code formation that was in use ALWAYS added a Cookie: header, even if it had an empty value ... which it did most/all the time. This resulted in an invalid cookie, which in turn caused rawls (and probably agora, thurloe, etc) to spew messages like:

```
rawls [WARN] [04/26/2016 21:30:52.401] [rawls-akka.actor.default-dispatcher-8] [akka://rawls/user/IO-HTTP/listener-0/0] Illegal request header: Illegal 'Cookie' header: Unexpected end of input, expected $timesCookie (line 1, pos 1):
```

over and over and over. I tried to dig through history to find out why we added cookies. It appears to have been added as part of #74, which ... had no reviewers???? This was ~7 months ago.

2) While I was in this class, I made a slight tweak to the logRequest RequestTransformer. Previously, we would ALWAYS call `request.toString`, then perform string concat for `"Sending request: " + request`, and send the resultant string into the logger. The logger would then perform a level check, and since we don't run at debug level except in local-dev cases, the logger would then toss out the string; all the string concatenation and manipulation was wasted. Now, we perform the logger level check up front, and short-circuit, avoiding all the string manipulation. I would not normally worry about this level of micro-optimization, but (I was in the code anyway and) the request object is a pretty big object to serialize to string, and we were doing this for EVERY http request.
- [x] **Submitter**: Rebase to develop. DO NOT SQUASH
- [x] **Submitter**: Make sure Swagger is updated if API changes
- [x] **Submitter**: Make sure documentation for code is complete
- [x] **Submitter**: Review code comments; remove done TODOs, create stories for remaining TODOs
- [x] **Submitter**: Include the JIRA issue number in the PR description
- [x] **Submitter**: Add description or comments on the PR explaining the hows/whys (if not obvious)
- [x] **Submitter**: Tell tech lead that the PR exists if s/he wants to look at it
- [x] **Submitter**: Anoint a lead reviewer (LR). **Assign PR to LR**
- [x] **LR**: Initial review by LR and others.
- [ ] Comment / review / update cycle:
  - Rest of team may comments on PR at will
  - **LR assigns to submitter** for feedback fixes
  - Submitter updates documentation as needed
  - Submitter rebases to develop again if necessary
  - Submitter makes further commits. DO NOT SQUASH. **Reassign to LR** for further feedback
- [x] **Tech lead**:  sign off
- [x] **LR**: sign off
- [x] **Assign to submitter** to finalize
- [x] **Submitter**: Squash commits, rebase if necessary
- [x] **Submitter**: Verify all tests go green, including CI tests
- [x] **Submitter**: Merge to develop 
- [x] **Submitter**: Delete branch after merge
- [x] **Submitter**: Check configuration files in Jenkins in case they need changes
- [x] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [x] **Submitter**: Verify swagger UI on dev server still works after deployment
- [x] **Submitter**: Inform other teams of any API changes via hipchat and/or email
- [x] **Submitter**: Mark JIRA issue as resolved once this checklist is completed
