### PR TITLE
GAWB-970: Library: index workspace in ES onPublish, delete from ES onUnpublish/onDelete

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchDAO.scala
@@ -59,14 +59,14 @@ class ElasticSearchDAO(servers:Seq[Authority], indexName: String) extends Search
   }
 
   override def indexDocument(doc: Document) = {
-    //println("invoking indexDocument in ES")
+    logger.info("invoking indexDocument in ES")
     executeESRequest[IndexRequest, IndexResponse, IndexRequestBuilder] (
       client.prepareIndex(indexName, datatype, doc.id).setSource(doc.content.compactPrint)
     )
   }
 
   override def deleteDocument(id: String) = {
-    //println("invoking deleteDocument in ES")
+    logger.info("invoking deleteDocument in ES")
     executeESRequest[DeleteRequest, DeleteResponse, DeleteRequestBuilder] (
       client.prepareDelete(indexName, datatype, id)
     )

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchDAO.scala
@@ -59,14 +59,12 @@ class ElasticSearchDAO(servers:Seq[Authority], indexName: String) extends Search
   }
 
   override def indexDocument(doc: Document) = {
-    logger.info("invoking indexDocument in ES")
     executeESRequest[IndexRequest, IndexResponse, IndexRequestBuilder] (
       client.prepareIndex(indexName, datatype, doc.id).setSource(doc.content.compactPrint)
     )
   }
 
   override def deleteDocument(id: String) = {
-    logger.info("invoking deleteDocument in ES")
     executeESRequest[DeleteRequest, DeleteResponse, DeleteRequestBuilder] (
       client.prepareDelete(indexName, datatype, id)
     )

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchDAO.scala
@@ -58,15 +58,15 @@ class ElasticSearchDAO(servers:Seq[Authority], indexName: String) extends Search
     bulkResponse.buildFailureMessage
   }
 
-  // TODO: untested and unused; remove this comment once you see this works
   override def indexDocument(doc: Document) = {
+    //println("invoking indexDocument in ES")
     executeESRequest[IndexRequest, IndexResponse, IndexRequestBuilder] (
       client.prepareIndex(indexName, datatype, doc.id).setSource(doc.content.compactPrint)
     )
   }
 
-  // TODO: untested and unused; remove this comment once you see this works
   override def deleteDocument(id: String) = {
+    //println("invoking deleteDocument in ES")
     executeESRequest[DeleteRequest, DeleteResponse, DeleteRequestBuilder] (
       client.prepareDelete(indexName, datatype, id)
     )

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/LibraryService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/LibraryService.scala
@@ -84,33 +84,21 @@ class LibraryService (protected val argUserInfo: UserInfo, val rawlsDAO: RawlsDA
         }
     }
   }
-
+  
   def setWorkspaceIsPublished(ns: String, name: String, value: Boolean): Future[PerRequestMessage] = {
-    println("in setWorkspaceIsPublished")
     rawlsDAO.getWorkspace(ns, name) flatMap { workspaceResponse =>
       // verify owner on workspace
       if (!workspaceResponse.accessLevel.contains("OWNER")) {
         Future(RequestCompleteWithErrorReport(Forbidden, "must be an owner"))
       } else {
         val operations = updatePublishAttribute(value)
-        val wsfuture = rawlsDAO.patchWorkspaceAttributes(ns, name, operations)
-        val response = if (value) {
-          wsfuture map { newws =>
-            searchDAO.indexDocument(indexableDocument(newws))
-          }
-          //wsfuture
-          true
+        rawlsDAO.patchWorkspaceAttributes(ns, name, operations) map { ws =>
+          if (value)
+            searchDAO.indexDocument(indexableDocument(ws))
+          else
+            searchDAO.deleteDocument(ws.workspaceId)
+          RequestComplete(ws)
         }
-        else {
-          wsfuture map { newws =>
-            searchDAO.deleteDocument(newws.workspaceId)
-          }
-          //wsfuture
-          true
-        }
-//        println(response)
-//        Future(RequestComplete(wsfuture))
-        wsfuture map (RequestComplete(_))
       }
     }
   }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/LibraryService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/LibraryService.scala
@@ -6,6 +6,7 @@ import com.typesafe.scalalogging.slf4j.LazyLogging
 import org.broadinstitute.dsde.firecloud.Application
 import org.broadinstitute.dsde.firecloud.dataaccess.{RawlsDAO, SearchDAO}
 import org.broadinstitute.dsde.firecloud.model.Attributable.AttributeMap
+import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
 import org.broadinstitute.dsde.firecloud.model.{AttributeName, Document, RequestCompleteWithErrorReport, UserInfo}
 import org.broadinstitute.dsde.firecloud.service.LibraryService._
 import org.broadinstitute.dsde.firecloud.service.PerRequest.{PerRequestMessage, RequestComplete}
@@ -13,10 +14,9 @@ import org.broadinstitute.dsde.firecloud.utils.RoleSupport
 import org.slf4j.LoggerFactory
 import spray.http.StatusCodes._
 import spray.httpx.SprayJsonSupport
+import spray.json.DefaultJsonProtocol._
 import spray.json.JsonParser.ParsingException
 import spray.json._
-import spray.json.DefaultJsonProtocol._
-import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
@@ -74,7 +74,7 @@ class LibraryService (protected val argUserInfo: UserInfo, val rawlsDAO: RawlsDA
         }
     }
   }
-  
+
   def setWorkspaceIsPublished(ns: String, name: String, value: Boolean): Future[PerRequestMessage] = {
     rawlsDAO.getWorkspace(ns, name) flatMap { workspaceResponse =>
       // verify owner on workspace

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/LibraryService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/LibraryService.scala
@@ -74,33 +74,21 @@ class LibraryService (protected val argUserInfo: UserInfo, val rawlsDAO: RawlsDA
         }
     }
   }
-
+  
   def setWorkspaceIsPublished(ns: String, name: String, value: Boolean): Future[PerRequestMessage] = {
-    println("in setWorkspaceIsPublished")
     rawlsDAO.getWorkspace(ns, name) flatMap { workspaceResponse =>
       // verify owner on workspace
       if (!workspaceResponse.accessLevel.contains("OWNER")) {
         Future(RequestCompleteWithErrorReport(Forbidden, "must be an owner"))
       } else {
         val operations = updatePublishAttribute(value)
-        val wsfuture = rawlsDAO.patchWorkspaceAttributes(ns, name, operations)
-        val response = if (value) {
-          wsfuture map { newws =>
-            searchDAO.indexDocument(indexableDocument(newws))
-          }
-          //wsfuture
-          true
+        rawlsDAO.patchWorkspaceAttributes(ns, name, operations) map { ws =>
+          if (value)
+            searchDAO.indexDocument(indexableDocument(ws))
+          else
+            searchDAO.deleteDocument(ws.workspaceId)
+          RequestComplete(ws)
         }
-        else {
-          wsfuture map { newws =>
-            searchDAO.deleteDocument(newws.workspaceId)
-          }
-          //wsfuture
-          true
-        }
-//        println(response)
-//        Future(RequestComplete(wsfuture))
-        wsfuture map (RequestComplete(_))
       }
     }
   }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/LibraryService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/LibraryService.scala
@@ -86,13 +86,31 @@ class LibraryService (protected val argUserInfo: UserInfo, val rawlsDAO: RawlsDA
   }
 
   def setWorkspaceIsPublished(ns: String, name: String, value: Boolean): Future[PerRequestMessage] = {
+    println("in setWorkspaceIsPublished")
     rawlsDAO.getWorkspace(ns, name) flatMap { workspaceResponse =>
       // verify owner on workspace
       if (!workspaceResponse.accessLevel.contains("OWNER")) {
         Future(RequestCompleteWithErrorReport(Forbidden, "must be an owner"))
       } else {
         val operations = updatePublishAttribute(value)
-        rawlsDAO.patchWorkspaceAttributes(ns, name, operations) map (RequestComplete(_))
+        val wsfuture = rawlsDAO.patchWorkspaceAttributes(ns, name, operations)
+        val response = if (value) {
+          wsfuture map { newws =>
+            searchDAO.indexDocument(indexableDocument(newws))
+          }
+          //wsfuture
+          true
+        }
+        else {
+          wsfuture map { newws =>
+            searchDAO.deleteDocument(newws.workspaceId)
+          }
+          //wsfuture
+          true
+        }
+//        println(response)
+//        Future(RequestComplete(wsfuture))
+        wsfuture map (RequestComplete(_))
       }
     }
   }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/LibraryService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/LibraryService.scala
@@ -9,8 +9,6 @@ import org.broadinstitute.dsde.firecloud.dataaccess.{RawlsDAO, SearchDAO}
 import org.broadinstitute.dsde.firecloud.model.Attributable.AttributeMap
 import org.broadinstitute.dsde.firecloud.model.{AttributeName, Document, ErrorReport, RequestCompleteWithErrorReport, UserInfo}
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol.impRawlsWorkspace
-import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
-import org.broadinstitute.dsde.firecloud.model.{AttributeName, Document, RequestCompleteWithErrorReport, UserInfo}
 import org.broadinstitute.dsde.firecloud.service.LibraryService._
 import org.broadinstitute.dsde.firecloud.service.PerRequest.{PerRequestMessage, RequestComplete}
 import org.broadinstitute.dsde.firecloud.utils.RoleSupport
@@ -18,9 +16,10 @@ import org.everit.json.schema.ValidationException
 import org.slf4j.LoggerFactory
 import spray.http.StatusCodes._
 import spray.httpx.SprayJsonSupport
-import spray.json.DefaultJsonProtocol._
 import spray.json.JsonParser.ParsingException
 import spray.json._
+import spray.json.DefaultJsonProtocol._
+import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
 
 import scala.collection.JavaConversions._
 import scala.concurrent.{ExecutionContext, Future}
@@ -85,7 +84,7 @@ class LibraryService (protected val argUserInfo: UserInfo, val rawlsDAO: RawlsDA
         }
     }
   }
-  
+
   def setWorkspaceIsPublished(ns: String, name: String, value: Boolean): Future[PerRequestMessage] = {
     rawlsDAO.getWorkspace(ns, name) flatMap { workspaceResponse =>
       // verify owner on workspace

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockRawlsDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockRawlsDAO.scala
@@ -20,7 +20,7 @@ class MockRawlsDAO  extends RawlsDAO {
   override def isLibraryCurator(userInfo: UserInfo): Future[Boolean] = Future(true)
 
   override def getWorkspace(ns: String, name: String)(implicit userInfo: UserInfo): Future[RawlsWorkspaceResponse] = {
-    Future(new RawlsWorkspaceResponse)
+    Future(RawlsWorkspaceResponse(Some("OWNER")))
   }
 
   override def patchWorkspaceAttributes(ns: String, name: String, attributes: Seq[AttributeUpdateOperation])(implicit userInfo: UserInfo): Future[RawlsWorkspace] = {

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockSearchDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockSearchDAO.scala
@@ -19,11 +19,9 @@ class MockSearchDAO extends SearchDAO {
 
   override def bulkIndex(docs: Seq[Document]) = Unit
   override def indexDocument(doc: Document) = {
-    println("called mock index document")
     indexDocumentInvoked = true
   }
   override def deleteDocument(id: String) = {
-    println("called mock delete document")
     deleteDocumentInvoked = true
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockSearchDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockSearchDAO.scala
@@ -14,8 +14,17 @@ class MockSearchDAO extends SearchDAO {
   override def createIndex = Unit
   override def deleteIndex = Unit
 
+  var indexDocumentInvoked = false
+  var deleteDocumentInvoked = false
+
   override def bulkIndex(docs: Seq[Document]) = Unit
-  override def indexDocument(doc: Document) = Unit
-  override def deleteDocument(id: String) = Unit
+  override def indexDocument(doc: Document) = {
+    println("called mock index document")
+    indexDocumentInvoked = true
+  }
+  override def deleteDocument(id: String) = {
+    println("called mock delete document")
+    deleteDocumentInvoked = true
+  }
 
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/LibraryApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/LibraryApiServiceSpec.scala
@@ -4,7 +4,7 @@ import org.broadinstitute.dsde.firecloud.Application
 import org.broadinstitute.dsde.firecloud.dataaccess._
 import org.broadinstitute.dsde.firecloud.mock.MockUtils
 import org.broadinstitute.dsde.firecloud.mock.MockUtils._
-import org.broadinstitute.dsde.firecloud.model.{RawlsWorkspace, UserInfo}
+import org.broadinstitute.dsde.firecloud.model.UserInfo
 import org.broadinstitute.dsde.firecloud.webservice.LibraryApiService
 import org.mockserver.integration.ClientAndServer
 import org.mockserver.integration.ClientAndServer._

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/LibraryApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/LibraryApiServiceSpec.scala
@@ -6,9 +6,6 @@ import org.broadinstitute.dsde.firecloud.mock.MockUtils
 import org.broadinstitute.dsde.firecloud.mock.MockUtils._
 import org.broadinstitute.dsde.firecloud.model.{RawlsWorkspace, UserInfo}
 import org.broadinstitute.dsde.firecloud.webservice.LibraryApiService
-import org.everit.json.schema.Schema
-import org.everit.json.schema.loader.SchemaLoader
-import org.json.{JSONObject, JSONTokener}
 import org.mockserver.integration.ClientAndServer
 import org.mockserver.integration.ClientAndServer._
 import org.mockserver.model.HttpRequest._
@@ -25,7 +22,6 @@ class LibraryApiServiceSpec extends BaseServiceSpec with LibraryApiService {
   private final val publishedPath = "/api/library/%s/%s/published".format("namespace", "name")
 
   val libraryServiceConstructor: (UserInfo) => LibraryService = LibraryService.constructor(app)
-
 
   override def beforeAll(): Unit = {
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/LibraryApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/LibraryApiServiceSpec.scala
@@ -19,7 +19,7 @@ class LibraryApiServiceSpec extends BaseServiceSpec with LibraryApiService {
   var workspaceServer: ClientAndServer = _
 
   lazy val isCuratorPath = "/api/library/user/role/curator"
-  private final val publishedPath = "/api/library/%s/%s/published".format("broad-dsde-dev", "andreatest")
+  private final val publishedPath = "/api/library/%s/%s/published".format("namespace", "name")
 
   val libraryServiceConstructor: (UserInfo) => LibraryService = LibraryService.constructor(app)
 
@@ -60,13 +60,9 @@ class LibraryApiServiceSpec extends BaseServiceSpec with LibraryApiService {
     "when calling publish" - {
       "POST on " + publishedPath - {
         "should invoke indexDocument" in {
-          println(searchDAO)
           this.searchDAO.asInstanceOf[MockSearchDAO].indexDocumentInvoked = false
           new RequestBuilder(HttpMethods.POST)(publishedPath) ~> dummyUserIdHeaders("1234") ~> sealRoute(libraryRoutes) ~> check {
             status should equal(OK)
-            println(response)
-            println("index:" + searchDAO.asInstanceOf[MockSearchDAO].indexDocumentInvoked)
-            println("delete:" + searchDAO.asInstanceOf[MockSearchDAO].deleteDocumentInvoked)
             assert(this.searchDAO.asInstanceOf[MockSearchDAO].indexDocumentInvoked, "indexDocument should have been invoked")
             assert(this.searchDAO.asInstanceOf[MockSearchDAO].deleteDocumentInvoked == false, "deleteDocument should not have been invoked")
             this.searchDAO.asInstanceOf[MockSearchDAO].indexDocumentInvoked = false
@@ -75,33 +71,14 @@ class LibraryApiServiceSpec extends BaseServiceSpec with LibraryApiService {
       }
       "DELETE on " + publishedPath - {
         "should invoke deleteDocument" in {
-          println(searchDAO)
           this.searchDAO.asInstanceOf[MockSearchDAO].deleteDocumentInvoked = false
           new RequestBuilder(HttpMethods.DELETE)(publishedPath) ~> dummyUserIdHeaders("1234") ~> sealRoute(libraryRoutes) ~> check {
             status should equal(OK)
-            println(response)
-            println("index:" + searchDAO.asInstanceOf[MockSearchDAO].indexDocumentInvoked)
-            println("delete:" + searchDAO.asInstanceOf[MockSearchDAO].deleteDocumentInvoked)
             assert(this.searchDAO.asInstanceOf[MockSearchDAO].deleteDocumentInvoked, "deleteDocument should have been invoked")
             assert(this.searchDAO.asInstanceOf[MockSearchDAO].indexDocumentInvoked ==  false, "indexDocument should not have been invoked")
             this.searchDAO.asInstanceOf[MockSearchDAO].deleteDocumentInvoked = false
           }
        }
-      }
-      "POST2 on " + publishedPath - {
-        "should invoke indexDocument" in {
-          println(searchDAO)
-          this.searchDAO.asInstanceOf[MockSearchDAO].indexDocumentInvoked = false
-          new RequestBuilder(HttpMethods.POST)(publishedPath) ~> dummyUserIdHeaders("1234") ~> sealRoute(libraryRoutes) ~> check {
-            status should equal(OK)
-            println(response)
-            println("index:" + searchDAO.asInstanceOf[MockSearchDAO].indexDocumentInvoked)
-            println("delete:" + searchDAO.asInstanceOf[MockSearchDAO].deleteDocumentInvoked)
-            assert(this.searchDAO.asInstanceOf[MockSearchDAO].indexDocumentInvoked, "indexDocument should have been invoked")
-            assert(this.searchDAO.asInstanceOf[MockSearchDAO].deleteDocumentInvoked == false, "deleteDocument should not have been invoked")
-            this.searchDAO.asInstanceOf[MockSearchDAO].indexDocumentInvoked = false
-          }
-        }
       }
     }
   }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/LibraryApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/LibraryApiServiceSpec.scala
@@ -4,7 +4,7 @@ import org.broadinstitute.dsde.firecloud.Application
 import org.broadinstitute.dsde.firecloud.dataaccess._
 import org.broadinstitute.dsde.firecloud.mock.MockUtils
 import org.broadinstitute.dsde.firecloud.mock.MockUtils._
-import org.broadinstitute.dsde.firecloud.model.UserInfo
+import org.broadinstitute.dsde.firecloud.model.{RawlsWorkspace, UserInfo}
 import org.broadinstitute.dsde.firecloud.webservice.LibraryApiService
 import org.mockserver.integration.ClientAndServer
 import org.mockserver.integration.ClientAndServer._
@@ -19,8 +19,10 @@ class LibraryApiServiceSpec extends BaseServiceSpec with LibraryApiService {
   var workspaceServer: ClientAndServer = _
 
   lazy val isCuratorPath = "/api/library/user/role/curator"
+  private final val publishedPath = "/api/library/%s/%s/published".format("broad-dsde-dev", "andreatest")
 
   val libraryServiceConstructor: (UserInfo) => LibraryService = LibraryService.constructor(app)
+
 
   override def beforeAll(): Unit = {
 
@@ -50,6 +52,54 @@ class LibraryApiServiceSpec extends BaseServiceSpec with LibraryApiService {
                 System.out.println(response)
                 status should equal(MethodNotAllowed)
               }
+          }
+        }
+      }
+    }
+
+    "when calling publish" - {
+      "POST on " + publishedPath - {
+        "should invoke indexDocument" in {
+          println(searchDAO)
+          this.searchDAO.asInstanceOf[MockSearchDAO].indexDocumentInvoked = false
+          new RequestBuilder(HttpMethods.POST)(publishedPath) ~> dummyUserIdHeaders("1234") ~> sealRoute(libraryRoutes) ~> check {
+            status should equal(OK)
+            println(response)
+            println("index:" + searchDAO.asInstanceOf[MockSearchDAO].indexDocumentInvoked)
+            println("delete:" + searchDAO.asInstanceOf[MockSearchDAO].deleteDocumentInvoked)
+            assert(this.searchDAO.asInstanceOf[MockSearchDAO].indexDocumentInvoked, "indexDocument should have been invoked")
+            assert(this.searchDAO.asInstanceOf[MockSearchDAO].deleteDocumentInvoked == false, "deleteDocument should not have been invoked")
+            this.searchDAO.asInstanceOf[MockSearchDAO].indexDocumentInvoked = false
+          }
+        }
+      }
+      "DELETE on " + publishedPath - {
+        "should invoke deleteDocument" in {
+          println(searchDAO)
+          this.searchDAO.asInstanceOf[MockSearchDAO].deleteDocumentInvoked = false
+          new RequestBuilder(HttpMethods.DELETE)(publishedPath) ~> dummyUserIdHeaders("1234") ~> sealRoute(libraryRoutes) ~> check {
+            status should equal(OK)
+            println(response)
+            println("index:" + searchDAO.asInstanceOf[MockSearchDAO].indexDocumentInvoked)
+            println("delete:" + searchDAO.asInstanceOf[MockSearchDAO].deleteDocumentInvoked)
+            assert(this.searchDAO.asInstanceOf[MockSearchDAO].deleteDocumentInvoked, "deleteDocument should have been invoked")
+            assert(this.searchDAO.asInstanceOf[MockSearchDAO].indexDocumentInvoked ==  false, "indexDocument should not have been invoked")
+            this.searchDAO.asInstanceOf[MockSearchDAO].deleteDocumentInvoked = false
+          }
+       }
+      }
+      "POST2 on " + publishedPath - {
+        "should invoke indexDocument" in {
+          println(searchDAO)
+          this.searchDAO.asInstanceOf[MockSearchDAO].indexDocumentInvoked = false
+          new RequestBuilder(HttpMethods.POST)(publishedPath) ~> dummyUserIdHeaders("1234") ~> sealRoute(libraryRoutes) ~> check {
+            status should equal(OK)
+            println(response)
+            println("index:" + searchDAO.asInstanceOf[MockSearchDAO].indexDocumentInvoked)
+            println("delete:" + searchDAO.asInstanceOf[MockSearchDAO].deleteDocumentInvoked)
+            assert(this.searchDAO.asInstanceOf[MockSearchDAO].indexDocumentInvoked, "indexDocument should have been invoked")
+            assert(this.searchDAO.asInstanceOf[MockSearchDAO].deleteDocumentInvoked == false, "deleteDocument should not have been invoked")
+            this.searchDAO.asInstanceOf[MockSearchDAO].indexDocumentInvoked = false
           }
         }
       }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/LibraryApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/LibraryApiServiceSpec.scala
@@ -29,7 +29,7 @@ class LibraryApiServiceSpec extends BaseServiceSpec with LibraryApiService {
   var workspaceServer: ClientAndServer = _
 
   lazy val isCuratorPath = "/api/library/user/role/curator"
-  private final val publishedPath = "/api/library/%s/%s/published".format("broad-dsde-dev", "andreatest")
+  private final val publishedPath = "/api/library/%s/%s/published".format("namespace", "name")
 
   val libraryServiceConstructor: (UserInfo) => LibraryService = LibraryService.constructor(app)
 
@@ -99,13 +99,9 @@ class LibraryApiServiceSpec extends BaseServiceSpec with LibraryApiService {
     "when calling publish" - {
       "POST on " + publishedPath - {
         "should invoke indexDocument" in {
-          println(searchDAO)
           this.searchDAO.asInstanceOf[MockSearchDAO].indexDocumentInvoked = false
           new RequestBuilder(HttpMethods.POST)(publishedPath) ~> dummyUserIdHeaders("1234") ~> sealRoute(libraryRoutes) ~> check {
             status should equal(OK)
-            println(response)
-            println("index:" + searchDAO.asInstanceOf[MockSearchDAO].indexDocumentInvoked)
-            println("delete:" + searchDAO.asInstanceOf[MockSearchDAO].deleteDocumentInvoked)
             assert(this.searchDAO.asInstanceOf[MockSearchDAO].indexDocumentInvoked, "indexDocument should have been invoked")
             assert(this.searchDAO.asInstanceOf[MockSearchDAO].deleteDocumentInvoked == false, "deleteDocument should not have been invoked")
             this.searchDAO.asInstanceOf[MockSearchDAO].indexDocumentInvoked = false
@@ -114,33 +110,14 @@ class LibraryApiServiceSpec extends BaseServiceSpec with LibraryApiService {
       }
       "DELETE on " + publishedPath - {
         "should invoke deleteDocument" in {
-          println(searchDAO)
           this.searchDAO.asInstanceOf[MockSearchDAO].deleteDocumentInvoked = false
           new RequestBuilder(HttpMethods.DELETE)(publishedPath) ~> dummyUserIdHeaders("1234") ~> sealRoute(libraryRoutes) ~> check {
             status should equal(OK)
-            println(response)
-            println("index:" + searchDAO.asInstanceOf[MockSearchDAO].indexDocumentInvoked)
-            println("delete:" + searchDAO.asInstanceOf[MockSearchDAO].deleteDocumentInvoked)
             assert(this.searchDAO.asInstanceOf[MockSearchDAO].deleteDocumentInvoked, "deleteDocument should have been invoked")
             assert(this.searchDAO.asInstanceOf[MockSearchDAO].indexDocumentInvoked ==  false, "indexDocument should not have been invoked")
             this.searchDAO.asInstanceOf[MockSearchDAO].deleteDocumentInvoked = false
           }
        }
-      }
-      "POST2 on " + publishedPath - {
-        "should invoke indexDocument" in {
-          println(searchDAO)
-          this.searchDAO.asInstanceOf[MockSearchDAO].indexDocumentInvoked = false
-          new RequestBuilder(HttpMethods.POST)(publishedPath) ~> dummyUserIdHeaders("1234") ~> sealRoute(libraryRoutes) ~> check {
-            status should equal(OK)
-            println(response)
-            println("index:" + searchDAO.asInstanceOf[MockSearchDAO].indexDocumentInvoked)
-            println("delete:" + searchDAO.asInstanceOf[MockSearchDAO].deleteDocumentInvoked)
-            assert(this.searchDAO.asInstanceOf[MockSearchDAO].indexDocumentInvoked, "indexDocument should have been invoked")
-            assert(this.searchDAO.asInstanceOf[MockSearchDAO].deleteDocumentInvoked == false, "deleteDocument should not have been invoked")
-            this.searchDAO.asInstanceOf[MockSearchDAO].indexDocumentInvoked = false
-          }
-        }
       }
     }
   }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/LibraryApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/LibraryApiServiceSpec.scala
@@ -2,26 +2,23 @@ package org.broadinstitute.dsde.firecloud.service
 
 import java.net.URL
 
-import org.broadinstitute.dsde.firecloud.Application
 import org.broadinstitute.dsde.firecloud.dataaccess._
 import org.broadinstitute.dsde.firecloud.mock.MockUtils
 import org.broadinstitute.dsde.firecloud.mock.MockUtils._
-import org.broadinstitute.dsde.firecloud.model.{RawlsWorkspace, UserInfo}
+import org.broadinstitute.dsde.firecloud.model.UserInfo
 import org.broadinstitute.dsde.firecloud.webservice.LibraryApiService
+import org.everit.json.schema.Schema
+import org.everit.json.schema.loader.SchemaLoader
+import org.json.{JSONObject, JSONTokener}
 import org.mockserver.integration.ClientAndServer
 import org.mockserver.integration.ClientAndServer._
 import org.mockserver.model.HttpRequest._
 import org.parboiled.common.FileUtils
-
-import scala.util.Try
 import spray.http.HttpMethods
 import spray.http.StatusCodes._
 import spray.json._
-import spray.util._
-import org.everit.json.schema.Schema
-import org.everit.json.schema.loader.SchemaLoader
-import org.json.JSONObject
-import org.json.JSONTokener
+
+import scala.util.Try
 
 class LibraryApiServiceSpec extends BaseServiceSpec with LibraryApiService {
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/LibraryApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/LibraryApiServiceSpec.scala
@@ -6,7 +6,7 @@ import org.broadinstitute.dsde.firecloud.Application
 import org.broadinstitute.dsde.firecloud.dataaccess._
 import org.broadinstitute.dsde.firecloud.mock.MockUtils
 import org.broadinstitute.dsde.firecloud.mock.MockUtils._
-import org.broadinstitute.dsde.firecloud.model.UserInfo
+import org.broadinstitute.dsde.firecloud.model.{RawlsWorkspace, UserInfo}
 import org.broadinstitute.dsde.firecloud.webservice.LibraryApiService
 import org.mockserver.integration.ClientAndServer
 import org.mockserver.integration.ClientAndServer._
@@ -29,8 +29,10 @@ class LibraryApiServiceSpec extends BaseServiceSpec with LibraryApiService {
   var workspaceServer: ClientAndServer = _
 
   lazy val isCuratorPath = "/api/library/user/role/curator"
+  private final val publishedPath = "/api/library/%s/%s/published".format("broad-dsde-dev", "andreatest")
 
   val libraryServiceConstructor: (UserInfo) => LibraryService = LibraryService.constructor(app)
+
 
   override def beforeAll(): Unit = {
 
@@ -94,5 +96,52 @@ class LibraryApiServiceSpec extends BaseServiceSpec with LibraryApiService {
       }
     }
 
+    "when calling publish" - {
+      "POST on " + publishedPath - {
+        "should invoke indexDocument" in {
+          println(searchDAO)
+          this.searchDAO.asInstanceOf[MockSearchDAO].indexDocumentInvoked = false
+          new RequestBuilder(HttpMethods.POST)(publishedPath) ~> dummyUserIdHeaders("1234") ~> sealRoute(libraryRoutes) ~> check {
+            status should equal(OK)
+            println(response)
+            println("index:" + searchDAO.asInstanceOf[MockSearchDAO].indexDocumentInvoked)
+            println("delete:" + searchDAO.asInstanceOf[MockSearchDAO].deleteDocumentInvoked)
+            assert(this.searchDAO.asInstanceOf[MockSearchDAO].indexDocumentInvoked, "indexDocument should have been invoked")
+            assert(this.searchDAO.asInstanceOf[MockSearchDAO].deleteDocumentInvoked == false, "deleteDocument should not have been invoked")
+            this.searchDAO.asInstanceOf[MockSearchDAO].indexDocumentInvoked = false
+          }
+        }
+      }
+      "DELETE on " + publishedPath - {
+        "should invoke deleteDocument" in {
+          println(searchDAO)
+          this.searchDAO.asInstanceOf[MockSearchDAO].deleteDocumentInvoked = false
+          new RequestBuilder(HttpMethods.DELETE)(publishedPath) ~> dummyUserIdHeaders("1234") ~> sealRoute(libraryRoutes) ~> check {
+            status should equal(OK)
+            println(response)
+            println("index:" + searchDAO.asInstanceOf[MockSearchDAO].indexDocumentInvoked)
+            println("delete:" + searchDAO.asInstanceOf[MockSearchDAO].deleteDocumentInvoked)
+            assert(this.searchDAO.asInstanceOf[MockSearchDAO].deleteDocumentInvoked, "deleteDocument should have been invoked")
+            assert(this.searchDAO.asInstanceOf[MockSearchDAO].indexDocumentInvoked ==  false, "indexDocument should not have been invoked")
+            this.searchDAO.asInstanceOf[MockSearchDAO].deleteDocumentInvoked = false
+          }
+       }
+      }
+      "POST2 on " + publishedPath - {
+        "should invoke indexDocument" in {
+          println(searchDAO)
+          this.searchDAO.asInstanceOf[MockSearchDAO].indexDocumentInvoked = false
+          new RequestBuilder(HttpMethods.POST)(publishedPath) ~> dummyUserIdHeaders("1234") ~> sealRoute(libraryRoutes) ~> check {
+            status should equal(OK)
+            println(response)
+            println("index:" + searchDAO.asInstanceOf[MockSearchDAO].indexDocumentInvoked)
+            println("delete:" + searchDAO.asInstanceOf[MockSearchDAO].deleteDocumentInvoked)
+            assert(this.searchDAO.asInstanceOf[MockSearchDAO].indexDocumentInvoked, "indexDocument should have been invoked")
+            assert(this.searchDAO.asInstanceOf[MockSearchDAO].deleteDocumentInvoked == false, "deleteDocument should not have been invoked")
+            this.searchDAO.asInstanceOf[MockSearchDAO].indexDocumentInvoked = false
+          }
+        }
+      }
+    }
   }
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/LibraryServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/LibraryServiceSpec.scala
@@ -2,9 +2,7 @@ package org.broadinstitute.dsde.firecloud.service
 
 import java.net.URL
 import java.util.UUID
-
-import org.broadinstitute.dsde.firecloud.Application
-import org.broadinstitute.dsde.firecloud.dataaccess._
+import org.broadinstitute.dsde.firecloud.dataaccess.RawlsDAO
 import org.broadinstitute.dsde.firecloud.model.Attributable.AttributeMap
 import org.broadinstitute.dsde.firecloud.model._
 import org.broadinstitute.dsde.firecloud.model.AttributeUpdateOperations.{AddListMember, AddUpdateAttribute, _}

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/LibraryServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/LibraryServiceSpec.scala
@@ -1,7 +1,9 @@
 package org.broadinstitute.dsde.firecloud.service
 
 import java.util.UUID
-import org.broadinstitute.dsde.firecloud.dataaccess.RawlsDAO
+
+import org.broadinstitute.dsde.firecloud.Application
+import org.broadinstitute.dsde.firecloud.dataaccess._
 import org.broadinstitute.dsde.firecloud.model.Attributable.AttributeMap
 import org.broadinstitute.dsde.firecloud.model._
 import org.broadinstitute.dsde.firecloud.model.AttributeUpdateOperations.{AddListMember, AddUpdateAttribute, _}
@@ -10,7 +12,7 @@ import org.scalatest.FreeSpec
 import spray.json._
 import spray.json.DefaultJsonProtocol._
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
-
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.ExecutionContext
 
 class LibraryServiceSpec extends FreeSpec with LibraryServiceSupport {
@@ -33,6 +35,7 @@ class LibraryServiceSpec extends FreeSpec with LibraryServiceSupport {
     bucketName="bucketName",
     accessLevels=Map.empty,
     realm=None)
+
 
   "LibraryService" - {
     "when new attrs are empty" - {
@@ -146,6 +149,32 @@ class LibraryServiceSpec extends FreeSpec with LibraryServiceSupport {
           updatePublishAttribute(true)
         }
       }
+//      "should invoke indexDocumemnt" in {
+//        val agoraDAO:AgoraDAO = new MockAgoraDAO
+//        val rawlsDAO:RawlsDAO = new MockRawlsDAO
+//        val searchDAO:SearchDAO = new MockSearchDAO
+//        val app:Application = new Application(agoraDAO, rawlsDAO, searchDAO)
+//        LibraryService.constructor(app)(null)
+//        //LibraryService.props(libraryServiceConstructor, null)
+//        //var libraryService = new LibraryService(null, rawlsDAO, searchDAO)
+//
+//        assertResult(false) {
+//          searchDAO.asInstanceOf[MockSearchDAO].indexDocumentInvoked
+//        }
+//        searchDAO.deleteDocument("id")
+//        assertResult(true) {
+//          searchDAO.asInstanceOf[MockSearchDAO].deleteDocumentInvoked
+//        }
+//        LibraryService.SetPublishAttribute(testWorkspace.namespace, testWorkspace.name, true)
+////        libraryService.setWorkspaceIsPublished(testWorkspace.namespace, testWorkspace.name, true)
+//        assertResult(true) {
+//          searchDAO.asInstanceOf[MockSearchDAO].indexDocumentInvoked
+//        }
+//        assertResult(false) {
+//          searchDAO.asInstanceOf[MockSearchDAO].deleteDocumentInvoked
+//        }
+//        LibraryService.searchDAO=new MockSearchDAO
+//      }
     }
     "when unpublishing a workspace" - {
       "should remove the library:published attribute" in {

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/LibraryServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/LibraryServiceSpec.scala
@@ -2,7 +2,9 @@ package org.broadinstitute.dsde.firecloud.service
 
 import java.net.URL
 import java.util.UUID
-import org.broadinstitute.dsde.firecloud.dataaccess.RawlsDAO
+
+import org.broadinstitute.dsde.firecloud.Application
+import org.broadinstitute.dsde.firecloud.dataaccess._
 import org.broadinstitute.dsde.firecloud.model.Attributable.AttributeMap
 import org.broadinstitute.dsde.firecloud.model._
 import org.broadinstitute.dsde.firecloud.model.AttributeUpdateOperations.{AddListMember, AddUpdateAttribute, _}
@@ -16,6 +18,8 @@ import spray.json.DefaultJsonProtocol._
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
 
 import scala.util.Try
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.ExecutionContext
 
 class LibraryServiceSpec extends FreeSpec with LibraryServiceSupport {
   def toName(s:String) = AttributeName.fromDelimitedName(s)
@@ -173,6 +177,32 @@ class LibraryServiceSpec extends FreeSpec with LibraryServiceSupport {
           updatePublishAttribute(true)
         }
       }
+//      "should invoke indexDocumemnt" in {
+//        val agoraDAO:AgoraDAO = new MockAgoraDAO
+//        val rawlsDAO:RawlsDAO = new MockRawlsDAO
+//        val searchDAO:SearchDAO = new MockSearchDAO
+//        val app:Application = new Application(agoraDAO, rawlsDAO, searchDAO)
+//        LibraryService.constructor(app)(null)
+//        //LibraryService.props(libraryServiceConstructor, null)
+//        //var libraryService = new LibraryService(null, rawlsDAO, searchDAO)
+//
+//        assertResult(false) {
+//          searchDAO.asInstanceOf[MockSearchDAO].indexDocumentInvoked
+//        }
+//        searchDAO.deleteDocument("id")
+//        assertResult(true) {
+//          searchDAO.asInstanceOf[MockSearchDAO].deleteDocumentInvoked
+//        }
+//        LibraryService.SetPublishAttribute(testWorkspace.namespace, testWorkspace.name, true)
+////        libraryService.setWorkspaceIsPublished(testWorkspace.namespace, testWorkspace.name, true)
+//        assertResult(true) {
+//          searchDAO.asInstanceOf[MockSearchDAO].indexDocumentInvoked
+//        }
+//        assertResult(false) {
+//          searchDAO.asInstanceOf[MockSearchDAO].deleteDocumentInvoked
+//        }
+//        LibraryService.searchDAO=new MockSearchDAO
+//      }
     }
     "when unpublishing a workspace" - {
       "should remove the library:published attribute" in {

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/LibraryServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/LibraryServiceSpec.scala
@@ -175,32 +175,6 @@ class LibraryServiceSpec extends FreeSpec with LibraryServiceSupport {
           updatePublishAttribute(true)
         }
       }
-//      "should invoke indexDocumemnt" in {
-//        val agoraDAO:AgoraDAO = new MockAgoraDAO
-//        val rawlsDAO:RawlsDAO = new MockRawlsDAO
-//        val searchDAO:SearchDAO = new MockSearchDAO
-//        val app:Application = new Application(agoraDAO, rawlsDAO, searchDAO)
-//        LibraryService.constructor(app)(null)
-//        //LibraryService.props(libraryServiceConstructor, null)
-//        //var libraryService = new LibraryService(null, rawlsDAO, searchDAO)
-//
-//        assertResult(false) {
-//          searchDAO.asInstanceOf[MockSearchDAO].indexDocumentInvoked
-//        }
-//        searchDAO.deleteDocument("id")
-//        assertResult(true) {
-//          searchDAO.asInstanceOf[MockSearchDAO].deleteDocumentInvoked
-//        }
-//        LibraryService.SetPublishAttribute(testWorkspace.namespace, testWorkspace.name, true)
-////        libraryService.setWorkspaceIsPublished(testWorkspace.namespace, testWorkspace.name, true)
-//        assertResult(true) {
-//          searchDAO.asInstanceOf[MockSearchDAO].indexDocumentInvoked
-//        }
-//        assertResult(false) {
-//          searchDAO.asInstanceOf[MockSearchDAO].deleteDocumentInvoked
-//        }
-//        LibraryService.searchDAO=new MockSearchDAO
-//      }
     }
     "when unpublishing a workspace" - {
       "should remove the library:published attribute" in {


### PR DESCRIPTION
- [x] **Submitter**: Include the JIRA issue number in the PR description
- [x] **Submitter**: Make sure Swagger is updated if API changes
- [x] **Submitter**: If updating admin endpoints, also update [firecloud-admin-cli](https://github.com/broadinstitute/firecloud-admin-cli)
- [x] **Submitter**: Check documentation and code comments. Add explanatory PR comments if helpful.
- [x] **Submitter**: JIRA ticket checks:
  - Acceptance criteria exists and is met
  - Note any changes to implementation from the description
  - Add notes on what you've tested
- [x] **Submitter**: Update RC_XXX release ticket with any config or environment changes necessary
- [x] **Submitter**: Update FISMA documentation if changes to:
  - Authentication
  - Authorization
  - Encryption
  - Audit trails
- [x] **Submitter**: If you're adding new libraries, sign us up to security updates for them
- [x] Tell the tech lead (TL) that the PR exists if they wants to look at it
- [x] Anoint a lead reviewer (LR). **Assign PR to LR**
- Review cycle:
  - LR reviews
  - Rest of team may comment on PR at will
  - **LR assigns to submitter** for feedback fixes
  - Submitter rebases to develop again if necessary
  - Submitter makes further commits. DO NOT SQUASH
  - Submitter updates documentation as needed
  - Submitter **reassigns to LR** for further feedback
- [x] **TL** sign off
- [x] **LR** sign off
- [x] **Assign to submitter** to finalize
- [x] **Submitter**: Verify all tests go green, including CI tests
- [x] **Submitter**: Squash commits and merge to develop
- [x] **Submitter**: Delete branch after merge
- [ ] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [ ] **Submitter**: Verify swagger UI on dev environment still works after deployment
- [ ] **Submitter**: Inform other teams of any API changes via hipchat and/or email
- [ ] **Submitter**: Mark JIRA issue as resolved once this checklist is completed
