### PR TITLE
GAWB-1174 Added passthrough for rawls bucket usage service

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceService.scala
@@ -101,6 +101,9 @@ trait WorkspaceService extends HttpService with PerRequestCreator with FireCloud
         } ~
         path ("unlock") {
           passthrough(workspacePath + "/unlock", HttpMethods.PUT)
+        } ~
+        path ("bucketUsage") {
+          passthrough(workspacePath + "/bucketUsage", HttpMethods.GET)
         }
       }
     }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceServiceSpec.scala
@@ -34,6 +34,7 @@ class WorkspaceServiceSpec extends ServiceSpec with WorkspaceService with Before
   private final val lockPath = workspacesRoot + "/%s/%s/lock".format(workspace.namespace.get, workspace.name.get)
   private final val unlockPath = workspacesRoot + "/%s/%s/unlock".format(workspace.namespace.get, workspace.name.get)
   private final val bucketPath = workspacesRoot + "/%s/%s/checkBucketReadAccess".format(workspace.namespace.get, workspace.name.get)
+  private final val bucketUsagePath = workspacesRoot + "/%s/%s/bucketUsage".format(workspace.namespace.get, workspace.name.get)
 
   private final val workspaceBasePath = FireCloudConfig.Rawls.authPrefix + FireCloudConfig.Rawls.workspacesPath
   private final val tsvImportPath = "/" + workspacesRoot + "/%s/%s/importEntities".format(workspace.namespace.get, workspace.name.get)
@@ -116,6 +117,13 @@ class WorkspaceServiceSpec extends ServiceSpec with WorkspaceService with Before
     // workspaces/%s/%s/checkBucketReadAccess
     workspaceServer
       .when(request().withMethod("GET").withPath(bucketPath))
+      .respond(
+        org.mockserver.model.HttpResponse.response()
+          .withHeaders(MockUtils.header).withStatusCode(OK.intValue)
+      )
+    // workspaces/%s/%s/bucketUsage
+    workspaceServer
+      .when(request().withMethod("GET").withPath(bucketUsagePath))
       .respond(
         org.mockserver.model.HttpResponse.response()
           .withHeaders(MockUtils.header).withStatusCode(OK.intValue)
@@ -255,6 +263,17 @@ class WorkspaceServiceSpec extends ServiceSpec with WorkspaceService with Before
       }
     }
 
+    "Passthrough tests on the /workspaces/segment/segment/bucketUsage path" - {
+      "MethodNotAllowed error is returned for HTTP POST, PATCH, PUT, DELETE methods" in {
+        List(HttpMethods.POST, HttpMethods.PATCH, HttpMethods.PUT, HttpMethods.DELETE) map {
+          method =>
+            new RequestBuilder(method)("/workspaces/namespace/name/bucketUsage") ~> sealRoute(routes) ~> check {
+              status should equal(MethodNotAllowed)
+            }
+        }
+      }
+    }
+
   }
 
   "WorkspaceService Passthrough Tests" - {
@@ -346,6 +365,15 @@ class WorkspaceServiceSpec extends ServiceSpec with WorkspaceService with Before
     "Passthrough tests on the /workspaces/%s/%s/checkBucketReadAccess path" - {
       "MethodNotAllowed error is not returned for GET method" in {
         Get(bucketPath) ~> sealRoute(routes) ~> check {
+          status shouldNot equal(MethodNotAllowed)
+        }
+      }
+    }
+
+
+    "Passthrough tests on the /workspaces/%s/%s/bucketUsage path" - {
+      "MethodNotAllowed error is not returned for GET method" in {
+        Get(bucketUsagePath) ~> sealRoute(routes) ~> check {
           status shouldNot equal(MethodNotAllowed)
         }
       }


### PR DESCRIPTION
- [x] **Submitter**: Include the JIRA issue number in the PR description
- [ ] **Submitter**: Make sure Swagger is updated if API changes
- [ ] **Submitter**: If updating admin endpoints, also update [firecloud-admin-cli](https://github.com/broadinstitute/firecloud-admin-cli)
- [ ] **Submitter**: Check documentation and code comments. Add explanatory PR comments if helpful.
- [ ] **Submitter**: JIRA ticket checks:
  * Acceptance criteria exists and is met
  * Note any changes to implementation from the description
  * Add notes on what you've tested
- [ ] **Submitter**: Update RC_XXX release ticket with any config or environment changes necessary
- [ ] **Submitter**: Update FISMA documentation if changes to:
  * Authentication
  * Authorization
  * Encryption
  * Audit trails
- [ ] **Submitter**: If you're adding new libraries, sign us up to security updates for them
- [ ] Tell the tech lead (TL) that the PR exists if they wants to look at it
- [ ] Anoint a lead reviewer (LR). **Assign PR to LR**
* Review cycle:
  * LR reviews
  * Rest of team may comment on PR at will
  * **LR assigns to submitter** for feedback fixes
  * Submitter rebases to develop again if necessary
  * Submitter makes further commits. DO NOT SQUASH
  * Submitter updates documentation as needed
  * Submitter **reassigns to LR** for further feedback
- [ ] **TL** sign off
- [ ] **LR** sign off
- [ ] **Assign to submitter** to finalize
- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Squash commits and merge to develop
- [ ] **Submitter**: Delete branch after merge
- [ ] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [ ] **Submitter**: Verify swagger UI on dev environment still works after deployment
- [ ] **Submitter**: Inform other teams of any API changes via hipchat and/or email
- [ ] **Submitter**: Mark JIRA issue as resolved once this checklist is completed

