### PR TITLE
GAWB-1231: project-owner vs owner

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/LibraryService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/LibraryService.scala
@@ -89,7 +89,7 @@ class LibraryService (protected val argUserInfo: UserInfo, val rawlsDAO: RawlsDA
   def setWorkspaceIsPublished(ns: String, name: String, value: Boolean): Future[PerRequestMessage] = {
     rawlsDAO.getWorkspace(ns, name) flatMap { workspaceResponse =>
       // verify owner on workspace
-      if (!workspaceResponse.accessLevel.contains("OWNER")) {
+      if (!workspaceResponse.accessLevel.contains("OWNER") && !workspaceResponse.accessLevel.contains("PROJECT_OWNER")) {
         Future(RequestCompleteWithErrorReport(Forbidden, "must be an owner"))
       } else {
         val operations = updatePublishAttribute(value)

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockRawlsDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockRawlsDAO.scala
@@ -20,7 +20,12 @@ class MockRawlsDAO  extends RawlsDAO {
   override def isLibraryCurator(userInfo: UserInfo): Future[Boolean] = Future(true)
 
   override def getWorkspace(ns: String, name: String)(implicit userInfo: UserInfo): Future[RawlsWorkspaceResponse] = {
-    Future(RawlsWorkspaceResponse(Some("OWNER")))
+    ns match {
+      case "projectowner" => Future(RawlsWorkspaceResponse(Some("PROJECT_OWNER")))
+      case "reader" => Future(RawlsWorkspaceResponse(Some("READER")))
+      case _ => Future(RawlsWorkspaceResponse(Some("OWNER")))
+    }
+
   }
 
   override def patchWorkspaceAttributes(ns: String, name: String, attributes: Seq[AttributeUpdateOperation])(implicit userInfo: UserInfo): Future[RawlsWorkspace] = {


### PR DESCRIPTION
- [x] **Submitter**: Include the JIRA issue number in the PR description
- [x] **Submitter**: Make sure Swagger is updated if API changes
- [x] **Submitter**: If updating admin endpoints, also update [firecloud-admin-cli](https://github.com/broadinstitute/firecloud-admin-cli)
- [x] **Submitter**: Check documentation and code comments. Add explanatory PR comments if helpful.
- [x] **Submitter**: JIRA ticket checks:
  * Acceptance criteria exists and is met
  * Note any changes to implementation from the description
  * Add notes on what you've tested
- [x] **Submitter**: Update RC_XXX release ticket with any config or environment changes necessary
- [x] **Submitter**: Update FISMA documentation if changes to:
  * Authentication
  * Authorization
  * Encryption
  * Audit trails
- [x] **Submitter**: If you're adding new libraries, sign us up to security updates for them
- [x] Tell the tech lead (TL) that the PR exists if they wants to look at it
- [x] Anoint a lead reviewer (LR). **Assign PR to LR**
* Review cycle:
  * LR reviews
  * Rest of team may comment on PR at will
  * **LR assigns to submitter** for feedback fixes
  * Submitter rebases to develop again if necessary
  * Submitter makes further commits. DO NOT SQUASH
  * Submitter updates documentation as needed
  * Submitter **reassigns to LR** for further feedback
- [x] **TL** sign off
- [x] **LR** sign off
- [x] **Assign to submitter** to finalize
- [x] **Submitter**: Verify all tests go green, including CI tests
- [x] **Submitter**: Squash commits and merge to develop
- [ ] **Submitter**: Delete branch after merge
- [ ] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [ ] **Submitter**: Verify swagger UI on dev environment still works after deployment
- [ ] **Submitter**: Inform other teams of any API changes via hipchat and/or email
- [ ] **Submitter**: Mark JIRA issue as resolved once this checklist is completed

