### PR TITLE
GAWB-1811: enable gzip by default for calls to external services

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/FireCloudDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/FireCloudDirectives.scala
@@ -25,14 +25,14 @@ trait FireCloudDirectives extends spray.routing.Directives with PerRequestCreato
   def respondWithJSON = respondWithMediaType(`application/json`)
 
   def passthrough(unencodedPath: String, methods: HttpMethod*) = methods map { inMethod =>
-    generateExternalHttpPerRequestForMethod(requestCompression = false, unencodedPath, inMethod)
+    generateExternalHttpPerRequestForMethod(requestCompression = true, unencodedPath, inMethod)
   } reduce (_ ~ _)
 
   def passthrough(requestCompression: Boolean, unencodedPath: String, methods: HttpMethod*) = methods map { inMethod =>
     generateExternalHttpPerRequestForMethod(requestCompression, unencodedPath, inMethod)
   } reduce (_ ~ _)
 
-  def passthroughAllPaths(ourEndpointPath: String, targetEndpointUrl: String, requestCompression: Boolean = false) = pathPrefix( separateOnSlashes(ourEndpointPath) ) {
+  def passthroughAllPaths(ourEndpointPath: String, targetEndpointUrl: String, requestCompression: Boolean = true) = pathPrefix( separateOnSlashes(ourEndpointPath) ) {
     extract(_.request.method) { httpMethod =>
       unmatchedPath { remaining =>
         parameterMap { params =>

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/PerRequest.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/PerRequest.scala
@@ -143,7 +143,7 @@ trait PerRequestCreator {
 
   /** convenience for HttpClient */
   def externalHttpPerRequest(r: RequestContext, request: HttpRequest) =
-    perRequest(r, Props(new HttpClient(r)), HttpClient.PerformExternalRequest(requestCompression = false, request))
+    perRequest(r, Props(new HttpClient(r)), HttpClient.PerformExternalRequest(requestCompression = true, request))
 
   /** overloaded convenience method for HttpClient */
   def externalHttpPerRequest(requestCompression: Boolean, r: RequestContext, request: HttpRequest) =


### PR DESCRIPTION
if a service under orchestration (e.g. rawls) supports gzip, orch can take advantage of it. This PR requests gzip by default from the external services. This enables gzip for the workspace listing - as well as most other calls.

I could have satisfied GAWB-1811 by enabling gzip for the workspaces list only, but it felt good to enable it by default everywhere - everything still seems to work!

## Debugging/testing notes
It's pretty difficult to verify that gzip is working between orch and another service. I verified it in two ways:

1. I modified `logback.xml` and set the log level for `org.broadinstitute.dsde` to debug. By tweaking the code, I toggled back and forth between enabling/disabling gzip via the `requestCompression` argument. I saw that, for the same request, the response's `Content-Length` header value would change - in my test, gzipped had a value of 906, and uncompressed had a value of 2847. I double-checked these values by calling rawls directly from curl.

2. I again modified the code and added the following in `HttpClient.scala`:
```
trait LogResponseEncoding extends spray.httpx.ResponseTransformation {
  def logResponseEncoding(log: Logger): ResponseTransformer = { response =>
    log.warn(s"response.encoding is: ${response.encoding}")
    response
  }
}
```
and then tweaked the pipeline to include:
```
sendReceive ~> logResponseEncoding(log) ~> decode(Gzip)
```
And made some requests through swagger. I saw that it logged as expected:
```
response.encoding is: gzip
```

Note that this is necessary, instead of relying on our existing debug logging of the response, because the `decode(Gzip)` directive actually REMOVES the content-encoding header! See https://github.com/spray/spray/blob/master/spray-httpx/src/main/scala/spray/httpx/encoding/Decoder.scala#L27 for that.



- [x] **Submitter**: Include the JIRA issue number in the PR description
- [x] **Submitter**: Make sure Swagger is updated if API changes
- [x] **Submitter**: If updating admin endpoints, also update [firecloud-admin-cli](https://github.com/broadinstitute/firecloud-admin-cli)
- [x] **Submitter**: Check documentation and code comments. Add explanatory PR comments if helpful.
- [x] **Submitter**: JIRA ticket checks:
  * Acceptance criteria exists and is met
  * Note any changes to implementation from the description
  * Add notes on what you've tested
- [x] **Submitter**: Update RC_XXX release ticket with any config or environment changes necessary
- [x] **Submitter**: Update FISMA documentation if changes to:
  * Authentication
  * Authorization
  * Encryption
  * Audit trails
- [x] **Submitter**: If you're adding new libraries, sign us up to security updates for them
- [x] Tell the tech lead (TL) that the PR exists if they wants to look at it
- [x] Anoint a lead reviewer (LR). **Assign PR to LR**
* Review cycle:
  * LR reviews
  * Rest of team may comment on PR at will
  * **LR assigns to submitter** for feedback fixes
  * Submitter rebases to develop again if necessary
  * Submitter makes further commits. DO NOT SQUASH
  * Submitter updates documentation as needed
  * Submitter **reassigns to LR** for further feedback
- [x] **TL** sign off
- [x] **LR** sign off
- [ ] **Product Owner** sign off
- [ ] **Assign to submitter** to finalize
- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Squash commits and merge to develop
- [ ] **Submitter**: Delete branch after merge
- [ ] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [ ] **Submitter**: Verify swagger UI on dev environment still works after deployment
- [ ] **Submitter**: Inform other teams of any API changes via hipchat and/or email
- [ ] **Submitter**: Mark JIRA issue as resolved once this checklist is completed
