### PR TITLE
Bugfix: TSV parser should replace missing fields with the empty strin…

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/utils/TSVParser.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/utils/TSVParser.scala
@@ -11,7 +11,6 @@ case class TSVLoadFile(
 )
 
 object TSVParser {
-
   private lazy val parser: CsvParser = {
     // Note we're using a CsvParser with a tab delimiter rather a TsvParser.
     // This is because the CSV formatter handles quotations correctly while the TSV formatter doesn't.
@@ -31,7 +30,11 @@ object TSVParser {
   }
 
   def parse(tsvString: String): TSVLoadFile = {
-    val allRows = parser.parseAll(new StringReader(tsvString)).asScala.toList
+    val allRows = parser.parseAll(new StringReader(tsvString)).asScala
+      // The CsvParser returns null for missing fields, however the application expects the
+      // empty string. This replaces all nulls with the empty string.
+      .map(_.map(s => Option(s).getOrElse("")))
+      .toList
     allRows match {
       case h :: t =>
         val tsvData = t.zipWithIndex.map { case (line, idx) => parseLine(line, idx, h.length) }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockTSV.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockTSV.scala
@@ -207,6 +207,17 @@ object MockTSVStrings {
     List("baz", "biz").tabbed
   ).windowsNewlineSeparated
 
+  val missingFields1 = List(
+    List("foo", "bar", "baz").tabbed,
+    List("biz", "", "buz").tabbed
+  ).newlineSeparated
+
+  val missingFields2 = List(
+    List("foo", "bar", "baz").tabbed,
+    List("", "", "buz").tabbed,
+    List("abc", "123", "").tabbed
+  ).newlineSeparated
+
 }
 
 object MockTSVLoadFiles {
@@ -229,6 +240,8 @@ object MockTSVLoadFiles {
   val validRemoveAddAttribute = TSVLoadFile("workspace", Seq("a1", "a2"), Seq(Seq("__DELETE__", "v2")))
   val validQuotedValues = TSVLoadFile("foo", Seq("foo", "bar"), Seq(Seq("baz", "biz")))
   val validQuotedValuesWithTabs = TSVLoadFile("foo", Seq("foo", "bar"), Seq(Seq("baz", "this\thas\ttabs")))
+  val missingFields1 = TSVLoadFile("foo", Seq("foo", "bar", "baz"), Seq(Seq("biz", "", "buz")))
+  val missingFields2 = TSVLoadFile("foo", Seq("foo", "bar", "baz"), Seq(Seq("", "", "buz"), Seq("abc", "123", "")))
 }
 
 object MockTSVFormData {

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/utils/TSVParserSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/utils/TSVParserSpec.scala
@@ -56,6 +56,36 @@ class TSVParserSpec extends FlatSpec {
     }
   }
 
+  it should "handle quoted values" in {
+    val expected = MockTSVLoadFiles.validQuotedValues
+    assertResult(expected) {
+      TSVParser.parse(MockTSVStrings.quotedValues)
+    }
+  }
+
+  it should "handle quoted values containing tabs" in {
+    val expected = MockTSVLoadFiles.validQuotedValuesWithTabs
+    assertResult(expected) {
+      TSVParser.parse(MockTSVStrings.quotedValuesWithTabs)
+    }
+  }
+
+  it should "handle windows newline separators" in {
+    val expected = MockTSVLoadFiles.validQuotedValues
+    assertResult(expected) {
+      TSVParser.parse(MockTSVStrings.windowsNewline)
+    }
+  }
+
+  it should "replace missing fields with empty strings" in {
+    assertResult(MockTSVLoadFiles.missingFields1) {
+      TSVParser.parse(MockTSVStrings.missingFields1)
+    }
+    assertResult(MockTSVLoadFiles.missingFields2) {
+      TSVParser.parse(MockTSVStrings.missingFields2)
+    }
+  }
+
   "EntityClient.backwardsCompatStripIdSuffixes" should "fix up the names of attributes for certain reference types for pairs" in {
     val entityType: String = "pair"
     val requiredAttributes: Map[String, String] = Map("case_sample_id" -> "sample",
@@ -126,27 +156,6 @@ class TSVParserSpec extends FlatSpec {
 
     assertResult(TSVLoadFile(input.head, expect, Seq.empty), entityType) {
       EntityClient.backwardsCompatStripIdSuffixes(TSVLoadFile(input.head, input, Seq.empty), entityType)
-    }
-  }
-
-  it should "handle quoted values" in {
-    val expected = MockTSVLoadFiles.validQuotedValues
-    assertResult(expected) {
-      TSVParser.parse(MockTSVStrings.quotedValues)
-    }
-  }
-
-  it should "handle quoted values containing tabs" in {
-    val expected = MockTSVLoadFiles.validQuotedValuesWithTabs
-    assertResult(expected) {
-      TSVParser.parse(MockTSVStrings.quotedValuesWithTabs)
-    }
-  }
-
-  it should "handle windows newline separators" in {
-    val expected = MockTSVLoadFiles.validQuotedValues
-    assertResult(expected) {
-      TSVParser.parse(MockTSVStrings.windowsNewline)
     }
   }
 }


### PR DESCRIPTION
…g instead of null

- [x] **Submitter**: Include the JIRA issue number in the PR description
- [x] **Submitter**: Make sure Swagger is updated if API changes
- [x] **Submitter**: If updating admin endpoints, also update [firecloud-admin-cli](https://github.com/broadinstitute/firecloud-admin-cli)
- [x] **Submitter**: Check documentation and code comments. Add explanatory PR comments if helpful.
- [x] **Submitter**: JIRA ticket checks:
  * Acceptance criteria exists and is met
  * Note any changes to implementation from the description
  * Add notes on what you've tested
- [x] **Submitter**: Update RC_XXX release ticket with any config or environment changes necessary
- [x] **Submitter**: Update FISMA documentation if changes to:
  * Authentication
  * Authorization
  * Encryption
  * Audit trails
- [x] Tell the tech lead (TL) that the PR exists if they wants to look at it
- [x] Anoint a lead reviewer (LR). **Assign PR to LR**
* Review cycle:
  * LR reviews
  * Rest of team may comment on PR at will
  * **LR assigns to submitter** for feedback fixes
  * Submitter rebases to develop again if necessary
  * Submitter makes further commits. DO NOT SQUASH
  * Submitter updates documentation as needed
  * Submitter **reassigns to LR** for further feedback
- [ ] **TL** sign off
- [ ] **LR** sign off
- [ ] **Product Owner** sign off
- [ ] **Assign to submitter** to finalize
- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Squash commits and merge to develop
- [ ] **Submitter**: Delete branch after merge
- [ ] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [ ] **Submitter**: Verify swagger UI on dev environment still works after deployment
- [ ] **Submitter**: Inform other teams of any API changes via hipchat and/or email
- [ ] **Submitter**: Mark JIRA issue as resolved once this checklist is completed
