### PR TITLE
Synchronize maps when modifying groups in MockRawlsDAO

### DIFF
--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockRawlsDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockRawlsDAO.scala
@@ -144,7 +144,7 @@ class MockRawlsDAO  extends RawlsDAO {
   override def adminAddMemberToGroup(groupName: String, memberList: RawlsGroupMemberList): Future[Boolean] = {
     val userEmailsToAdd = memberList.userSubjectIds.getOrElse(Seq[String]()).toSet
     val groupWithNewMembers = (groupName -> ((groups(groupName).filterNot(userEmailsToAdd.contains)) ++ userEmailsToAdd))
-    groups = groups.synchronized { groups + groupWithNewMembers }
+    this.synchronized { groups = groups + groupWithNewMembers }
 
     Future.successful(true)
   }
@@ -152,7 +152,7 @@ class MockRawlsDAO  extends RawlsDAO {
   override def adminOverwriteGroupMembership(groupName: String, memberList: RawlsGroupMemberList): Future[Boolean] = {
     val userEmailsToAdd = memberList.userSubjectIds.getOrElse(Set[String]()).toSet
     val groupWithNewMembers = (groupName -> userEmailsToAdd)
-    groups = groups.synchronized { groups + groupWithNewMembers }
+    this.synchronized { groups = groups + groupWithNewMembers }
 
     Future.successful(true)
   }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockRawlsDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockRawlsDAO.scala
@@ -144,7 +144,7 @@ class MockRawlsDAO  extends RawlsDAO {
   override def adminAddMemberToGroup(groupName: String, memberList: RawlsGroupMemberList): Future[Boolean] = {
     val userEmailsToAdd = memberList.userSubjectIds.getOrElse(Seq[String]()).toSet
     val groupWithNewMembers = (groupName -> ((groups(groupName).filterNot(userEmailsToAdd.contains)) ++ userEmailsToAdd))
-    groups = groups + groupWithNewMembers
+    groups = groups.synchronized { groups + groupWithNewMembers }
 
     Future.successful(true)
   }
@@ -152,7 +152,7 @@ class MockRawlsDAO  extends RawlsDAO {
   override def adminOverwriteGroupMembership(groupName: String, memberList: RawlsGroupMemberList): Future[Boolean] = {
     val userEmailsToAdd = memberList.userSubjectIds.getOrElse(Set[String]()).toSet
     val groupWithNewMembers = (groupName -> userEmailsToAdd)
-    groups = groups + groupWithNewMembers
+    groups = groups.synchronized { groups + groupWithNewMembers }
 
     Future.successful(true)
   }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/NihApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/NihApiServiceSpec.scala
@@ -141,8 +141,8 @@ class NihApiServiceSpec extends ApiServiceSpec {
   it should "return NoContent and properly sync the whitelist for users of different link statuses across whitelists" in withDefaultApiServices { services =>
     Post("/sync_whitelist") ~> sealRoute(services.syncRoute) ~> check {
       status should equal(NoContent)
+      assertSameElements(Set(services.thurloeDao.TCGA_AND_TARGET_LINKED, services.thurloeDao.TCGA_LINKED), services.rawlsDao.groups(tcgaDbGaPAuthorized))
+      assertSameElements(Set(services.thurloeDao.TCGA_AND_TARGET_LINKED, services.thurloeDao.TARGET_LINKED), services.rawlsDao.groups(targetDbGaPAuthorized))
     }
-    assertSameElements(Set(services.thurloeDao.TCGA_AND_TARGET_LINKED, services.thurloeDao.TCGA_LINKED), services.rawlsDao.groups(tcgaDbGaPAuthorized))
-    assertSameElements(Set(services.thurloeDao.TCGA_AND_TARGET_LINKED, services.thurloeDao.TARGET_LINKED), services.rawlsDao.groups(targetDbGaPAuthorized))
   }
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/NihApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/NihApiServiceSpec.scala
@@ -52,9 +52,9 @@ class NihApiServiceSpec extends ApiServiceSpec {
 
     Post("/nih/callback", JWTWrapper("bad-token")) ~> dummyUserIdHeaders(toLink) ~> sealRoute(services.nihRoutes) ~> check {
       status should equal(BadRequest)
+      assert(!services.rawlsDao.groups(tcgaDbGaPAuthorized).contains(toLink))
+      assert(!services.rawlsDao.groups(targetDbGaPAuthorized).contains(toLink))
     }
-    assert(!services.rawlsDao.groups(tcgaDbGaPAuthorized).contains(toLink))
-    assert(!services.rawlsDao.groups(targetDbGaPAuthorized).contains(toLink))
   }
 
   it should "link and sync when user is on TCGA whitelist but not TARGET" in withDefaultApiServices { services =>
@@ -64,9 +64,9 @@ class NihApiServiceSpec extends ApiServiceSpec {
     assert(!services.rawlsDao.groups(tcgaDbGaPAuthorized).contains(toLink))
     Post("/nih/callback", tcgaUserJwt) ~> dummyUserIdHeaders(toLink) ~> sealRoute(services.nihRoutes) ~> check {
       status should equal(OK)
+      assert(!services.rawlsDao.groups(targetDbGaPAuthorized).contains(toLink))
+      assert(services.rawlsDao.groups(tcgaDbGaPAuthorized).contains(toLink))
     }
-    assert(!services.rawlsDao.groups(targetDbGaPAuthorized).contains(toLink))
-    assert(services.rawlsDao.groups(tcgaDbGaPAuthorized).contains(toLink))
   }
 
   it should "link and sync when user is on TARGET whitelist but not TCGA" in withDefaultApiServices { services =>
@@ -76,9 +76,9 @@ class NihApiServiceSpec extends ApiServiceSpec {
     assert(!services.rawlsDao.groups(tcgaDbGaPAuthorized).contains(toLink))
     Post("/nih/callback", targetUserJwt) ~> dummyUserIdHeaders(toLink) ~> sealRoute(services.nihRoutes) ~> check {
       status should equal(OK)
+      assert(services.rawlsDao.groups(targetDbGaPAuthorized).contains(toLink))
+      assert(!services.rawlsDao.groups(tcgaDbGaPAuthorized).contains(toLink))
     }
-    assert(services.rawlsDao.groups(targetDbGaPAuthorized).contains(toLink))
-    assert(!services.rawlsDao.groups(tcgaDbGaPAuthorized).contains(toLink))
   }
 
   it should "link and sync when user is on both the TARGET and TCGA whitelists" in withDefaultApiServices { services =>
@@ -88,9 +88,9 @@ class NihApiServiceSpec extends ApiServiceSpec {
     assert(!services.rawlsDao.groups(tcgaDbGaPAuthorized).contains(toLink))
     Post("/nih/callback", firecloudDevJwt) ~> dummyUserIdHeaders(toLink) ~> sealRoute(services.nihRoutes) ~> check {
       status should equal(OK)
+      assert(services.rawlsDao.groups(targetDbGaPAuthorized).contains(toLink))
+      assert(services.rawlsDao.groups(tcgaDbGaPAuthorized).contains(toLink))
     }
-    assert(services.rawlsDao.groups(targetDbGaPAuthorized).contains(toLink))
-    assert(services.rawlsDao.groups(tcgaDbGaPAuthorized).contains(toLink))
   }
 
   it should "link but not sync when user is on neither the TARGET nor the TCGA whitelist" in withDefaultApiServices { services =>
@@ -98,9 +98,9 @@ class NihApiServiceSpec extends ApiServiceSpec {
 
     Post("/nih/callback", validJwtNotOnWhitelist) ~> dummyUserIdHeaders(toLink) ~> sealRoute(services.nihRoutes) ~> check {
       status should equal(OK)
+      assert(!services.rawlsDao.groups(tcgaDbGaPAuthorized).contains(toLink))
+      assert(!services.rawlsDao.groups(targetDbGaPAuthorized).contains(toLink))
     }
-    assert(!services.rawlsDao.groups(tcgaDbGaPAuthorized).contains(toLink))
-    assert(!services.rawlsDao.groups(targetDbGaPAuthorized).contains(toLink))
   }
 
   it should "return OK when an expired user re-links. their new link time should be 30 days in the future" in withDefaultApiServices { services =>
@@ -124,9 +124,9 @@ class NihApiServiceSpec extends ApiServiceSpec {
 
       assert(linkExpireTime >= DateUtils.nowMinus1Hour) //link expire time is fresh
       assert(linkExpireTime <= DateUtils.nowPlus30Days) //link expire time is approx 30 days in the future
+      assert(services.rawlsDao.groups(tcgaDbGaPAuthorized).contains(toLink))
+      assert(services.rawlsDao.groups(targetDbGaPAuthorized).contains(toLink))
     }
-    assert(services.rawlsDao.groups(tcgaDbGaPAuthorized).contains(toLink))
-    assert(services.rawlsDao.groups(targetDbGaPAuthorized).contains(toLink))
   }
 
   /* Test scenario:


### PR DESCRIPTION
- [ ] **Submitter**: Include the JIRA issue number in the PR description
- [x] **Submitter**: Make sure Swagger is updated if API changes
- [x] **Submitter**: If updating admin endpoints, also update [firecloud-admin-cli](https://github.com/broadinstitute/firecloud-admin-cli)
- [x] **Submitter**: Check documentation and code comments. Add explanatory PR comments if helpful.
- [ ] **Submitter**: JIRA ticket checks:
  * Acceptance criteria exists and is met
  * Note any changes to implementation from the description
  * To Demo flag is set
  * Release Summary is filled out, if applicable
  * Add notes on how to QA
- [x] **Submitter**: Update RC_XXX release ticket with any config or environment changes necessary
- [x] **Submitter**: Update FISMA documentation if changes to:
  * Authentication
  * Authorization
  * Encryption
  * Audit trails
- [ ] Tell the tech lead (TL) that the PR exists if they wants to look at it
- [ ] Anoint a lead reviewer (LR). **Assign PR to LR**
* Review cycle:
  * LR reviews
  * Rest of team may comment on PR at will
  * **LR assigns to submitter** for feedback fixes
  * Submitter rebases to develop again if necessary
  * Submitter makes further commits. DO NOT SQUASH
  * Submitter updates documentation as needed
  * Submitter **reassigns to LR** for further feedback
- [ ] **TL** sign off
- [ ] **LR** sign off
- [ ] **Product Owner** sign off
- [ ] **Assign to submitter** to finalize
- [ ] **Submitter**: Verify all tests go green, including CI tests
- [ ] **Submitter**: Squash commits and merge to develop
- [ ] **Submitter**: Delete branch after merge
- [ ] **Submitter**: **Test this change works on dev environment after deployment**. YOU own getting it fixed if dev isn't working for ANY reason!
- [ ] **Submitter**: Verify swagger UI on dev environment still works after deployment
- [ ] **Submitter**: Inform other teams of any API changes via Slack and/or email
- [ ] **Submitter**: Mark JIRA issue as resolved once this checklist is completed
