### PR TITLE
Fix payloadOnly, payloadAsObject parameters going missing on their way to Agora [GAWB-2468]

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -1085,7 +1085,6 @@ paths:
           in: query
           description: Boolean to return only the payload of the method.
           required: false
-          type: string
           type: boolean
           default: false
       responses:

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -307,6 +307,12 @@ paths:
         - $ref: '#/parameters/configNamespaceParam'
         - $ref: '#/parameters/configNameParam'
         - $ref: '#/parameters/configSnapshotId'
+        - name: payloadAsObject
+          in: query
+          description: Instead of returning a string under key payload, return a JSON object under key payloadObject
+          required: false
+          type: boolean
+          default: false
       responses:
         200:
           description: Method Repository configuration detail

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -1086,6 +1086,8 @@ paths:
           description: Boolean to return only the payload of the method.
           required: false
           type: string
+          type: boolean
+          default: false
       responses:
         200:
           description: A single method.

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/MethodsApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/MethodsApiService.scala
@@ -47,7 +47,9 @@ trait MethodsApiService extends HttpService
         pathEnd {
           (get | delete) {
             extract(_.request.method) { method =>
-              passthrough(s"$passthroughBase/${urlify(namespace,name)}/$snapshotId", method)
+              extract(_.request.uri.query) { query =>
+                passthrough(Uri(s"$passthroughBase/${urlify(namespace, name)}/$snapshotId").withQuery(query), method)
+              }
             }
           }
         } ~


### PR DESCRIPTION
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](../CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](../CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [x] Get two thumbsworth of review and PO signoff if necessary
- [x] Verify all tests go green
- [x] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [x] Test this change deployed correctly and works on dev environment after deployment
