### PR TITLE
Un-publish on Workspace Delete

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -1645,6 +1645,8 @@ paths:
       responses:
         202:
           description: Request Accepted
+        403:
+          description: User does not have correct permissions to delete a published workspace
         404:
           description: Workspace does not exist
         500:

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpRawlsDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpRawlsDAO.scala
@@ -194,4 +194,8 @@ class HttpRawlsDAO( implicit val system: ActorSystem, implicit val executionCont
     }
   }
 
+  def deleteWorkspace(workspaceNamespace: String, workspaceName: String)(implicit userToken: WithAccessToken): Future[String] = {
+    authedRequestToObject[String]( Delete(s"${FireCloudConfig.Rawls.authUrl}/workspaces/$workspaceNamespace/$workspaceName") )
+  }
+
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpRawlsDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpRawlsDAO.scala
@@ -194,8 +194,8 @@ class HttpRawlsDAO( implicit val system: ActorSystem, implicit val executionCont
     }
   }
 
-  def deleteWorkspace(workspaceNamespace: String, workspaceName: String)(implicit userToken: WithAccessToken): Future[String] = {
-    authedRequestToObject[String]( Delete(s"${FireCloudConfig.Rawls.authUrl}/workspaces/$workspaceNamespace/$workspaceName") )
+  def deleteWorkspace(workspaceNamespace: String, workspaceName: String)(implicit userToken: WithAccessToken): Future[WorkspaceDeleteResponse] = {
+    authedRequestToObject[WorkspaceDeleteResponse]( Delete(s"${FireCloudConfig.Rawls.authUrl}/workspaces/$workspaceNamespace/$workspaceName") )
   }
 
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/RawlsDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/RawlsDAO.scala
@@ -90,6 +90,8 @@ trait RawlsDAO extends LazyLogging with ReportsSubsystemStatus {
 
   def getMethodConfigs(workspaceNamespace: String, workspaceName: String)(implicit userToken: WithAccessToken): Future[Seq[MethodConfigurationShort]]
 
+  def deleteWorkspace(workspaceNamespace: String, workspaceName: String)(implicit userToken: WithAccessToken): Future[String]
+
   override def serviceName:String = RawlsDAO.serviceName
 
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/RawlsDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/RawlsDAO.scala
@@ -90,7 +90,7 @@ trait RawlsDAO extends LazyLogging with ReportsSubsystemStatus {
 
   def getMethodConfigs(workspaceNamespace: String, workspaceName: String)(implicit userToken: WithAccessToken): Future[Seq[MethodConfigurationShort]]
 
-  def deleteWorkspace(workspaceNamespace: String, workspaceName: String)(implicit userToken: WithAccessToken): Future[String]
+  def deleteWorkspace(workspaceNamespace: String, workspaceName: String)(implicit userToken: WithAccessToken): Future[WorkspaceDeleteResponse]
 
   override def serviceName:String = RawlsDAO.serviceName
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
@@ -145,6 +145,7 @@ object ModelJsonProtocol extends WorkspaceJsonSupport {
   implicit val impMethod = jsonFormat10(MethodRepository.Method.apply)
   implicit val impConfiguration = jsonFormat9(MethodRepository.Configuration)
 
+  implicit val impWorkspaceDeleteResponse = jsonFormat1(WorkspaceDeleteResponse)
   implicit val impWorkspaceCreate = jsonFormat4(WorkspaceCreate.apply)
 
   implicit val impUIWorkspaceResponse = jsonFormat6(UIWorkspaceResponse)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/Workspace.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/Workspace.scala
@@ -5,6 +5,8 @@ import org.broadinstitute.dsde.rawls.model.Attributable.AttributeMap
 import org.broadinstitute.dsde.rawls.model.WorkspaceAccessLevels.WorkspaceAccessLevel
 import org.broadinstitute.dsde.rawls.model._
 
+case class WorkspaceDeleteResponse(message: Option[String] = None)
+
 case class WorkspaceCreate(
   namespace: String,
   name: String,

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/LibraryService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/LibraryService.scala
@@ -186,11 +186,7 @@ class LibraryService (protected val argUserInfo: UserInfo,
         Future(RequestCompleteWithErrorReport(BadRequest, errorMessage.getOrElse(BadRequest.defaultMessage)))
       else {
         // user requested a change in published flag, and metadata is valid; make the change.
-        rawlsDAO.updateLibraryAttributes(ns, name, updatePublishAttribute(publishArg)) map { ws =>
-          if (publishArg)
-            publishDocument(ws, ontologyDAO, searchDAO)
-          else
-            removeDocument(ws, searchDAO)
+        setWorkspacePublishedStatus(workspaceResponse.workspace, publishArg, rawlsDAO, ontologyDAO, searchDAO) map { ws =>
           RequestComplete(ws)
         }
       }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/WorkspacePublishingSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/WorkspacePublishingSupport.scala
@@ -53,7 +53,7 @@ trait WorkspacePublishingSupport extends LibraryServiceSupport {
       else {
         val message = s"Unable to update this workspace, ${ws.namespace}:${ws.name}, to $publishArg in elastic search."
         logger.error(message)
-        throw new FireCloudException(s"Unable to update this workspace, ${ws.namespace}:${ws.name}, to $publishArg in elastic search.")
+        throw new FireCloudException(message)
       }
     }
   }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceService.scala
@@ -44,6 +44,7 @@ object WorkspaceService {
   case class PutTags(workspaceNamespace: String, workspaceName: String, tags: List[String]) extends WorkspaceServiceMessage
   case class PatchTags(workspaceNamespace: String, workspaceName: String, tags: List[String]) extends WorkspaceServiceMessage
   case class DeleteTags(workspaceNamespace: String, workspaceName: String, tags: List[String]) extends WorkspaceServiceMessage
+  case class DeleteWorkspace(workspaceNamespace: String, workspaceName: String) extends WorkspaceServiceMessage
 
   def props(workspaceServiceConstructor: WithAccessToken => WorkspaceService, userToken: WithAccessToken): Props = {
     Props(workspaceServiceConstructor(userToken))
@@ -92,6 +93,8 @@ class WorkspaceService(protected val argUserToken: WithAccessToken, val rawlsDAO
       patchTags(workspaceNamespace, workspaceName, tags) pipeTo sender
     case DeleteTags(workspaceNamespace: String, workspaceName: String,tags:List[String]) =>
       deleteTags(workspaceNamespace, workspaceName, tags) pipeTo sender
+    case DeleteWorkspace(workspaceNamespace: String, workspaceName: String) =>
+      deleteWorkspace(workspaceNamespace, workspaceName) pipeTo sender
 
   }
 
@@ -220,6 +223,10 @@ class WorkspaceService(protected val argUserToken: WithAccessToken, val rawlsDAO
       Future(RequestComplete(StatusCodes.OK, formatTags(tags)))
     }
 
+  }
+
+  def deleteWorkspace(workspaceNamespace: String, workspaceName: String): Future[PerRequestMessage] = {
+    ???
   }
 
   private def getTagsFromWorkspace(ws:Workspace): Seq[String] = {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceService.scala
@@ -239,14 +239,13 @@ class WorkspaceService(protected val argUserToken: WithAccessToken, val rawlsDAO
       }
       rawlsDAO.deleteWorkspace(ws.workspace.namespace, ws.workspace.name) map { response =>
         (wsPublished, wsRemoved) match {
-          case (false, _) =>
-            RequestComplete(response)
-          case (true, false) =>
-            val message = unPublishErrorMessage(workspaceNamespace, workspaceName)
-            RequestComplete(response.copy(message = Some(response.message.getOrElse("") + message)))
           case (true, true) =>
             val message = unPublishSuccessMessage(workspaceNamespace, workspaceName)
             RequestComplete(response.copy(message = Some(response.message.getOrElse("") + message)))
+          case (true, false) =>
+            val message = unPublishErrorMessage(workspaceNamespace, workspaceName)
+            RequestComplete(response.copy(message = Some(response.message.getOrElse("") + message)))
+          case _ => RequestComplete(response)
         }
       }
     }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceService.scala
@@ -232,7 +232,7 @@ class WorkspaceService(protected val argUserToken: WithAccessToken, val rawlsDAO
           }
         } recover {
           case e: FireCloudExceptionWithErrorReport => RequestComplete(e.errorReport.statusCode.getOrElse(InternalServerError), e.errorReport)
-          case e => RequestComplete(InternalServerError, e.getMessage)
+          case e => RequestComplete(InternalServerError, ErrorReport(message = e.getMessage))
         }
       } else {
         rawlsDAO.deleteWorkspace(ws.workspace.namespace, ws.workspace.name) map { response =>

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceService.scala
@@ -228,14 +228,11 @@ class WorkspaceService(protected val argUserToken: WithAccessToken, val rawlsDAO
           Future(removeDocument(ws.workspace, searchDAO)).flatMap { f2 =>
             rawlsDAO.deleteWorkspace(ns, name) map { f3 =>
               RequestComplete(f3.copy(message = Some(f3.message.getOrElse("") + unPublishSuccessMessage(ns, name))))
-            } recover {
-              case e: FireCloudExceptionWithErrorReport => RequestCompleteWithErrorReport(e.errorReport.statusCode.getOrElse(InternalServerError), e.getMessage)
-              case e => RequestCompleteWithErrorReport(InternalServerError, e.getMessage)
             }
           }
         } recover {
-          case e: FireCloudExceptionWithErrorReport => RequestCompleteWithErrorReport(e.errorReport.statusCode.getOrElse(InternalServerError), e.getMessage)
-          case e => RequestCompleteWithErrorReport(InternalServerError, e.getMessage)
+          case e: FireCloudExceptionWithErrorReport => RequestComplete(e.errorReport.statusCode.getOrElse(InternalServerError), e.errorReport)
+          case e => RequestComplete(InternalServerError, e.getMessage)
         }
       } else {
         rawlsDAO.deleteWorkspace(ws.workspace.namespace, ws.workspace.name) map { response =>

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceService.scala
@@ -231,8 +231,8 @@ class WorkspaceService(protected val argUserToken: WithAccessToken, val rawlsDAO
             }
           }
         } recover {
-          case e: FireCloudExceptionWithErrorReport => RequestComplete(e.errorReport.statusCode.getOrElse(InternalServerError), e.errorReport)
-          case e => RequestComplete(InternalServerError, ErrorReport(message = e.getMessage))
+          case e: FireCloudExceptionWithErrorReport => RequestComplete(e.errorReport.statusCode.getOrElse(InternalServerError), ErrorReport(message = s"You cannot delete this workspace: ${e.errorReport.message}")
+          case e => RequestComplete(InternalServerError, ErrorReport(message = s"You cannot delete this workspace: ${e.getMessage}"))
         }
       } else {
         rawlsDAO.deleteWorkspace(ws.workspace.namespace, ws.workspace.name) map { response =>

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceService.scala
@@ -234,6 +234,7 @@ class WorkspaceService(protected val argUserToken: WithAccessToken, val rawlsDAO
             }
           }
         } recover {
+          case e: FireCloudExceptionWithErrorReport => RequestCompleteWithErrorReport(e.errorReport.statusCode.getOrElse(InternalServerError), e.getMessage)
           case e => RequestCompleteWithErrorReport(InternalServerError, e.getMessage)
         }
       } else {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceService.scala
@@ -226,7 +226,17 @@ class WorkspaceService(protected val argUserToken: WithAccessToken, val rawlsDAO
   }
 
   def deleteWorkspace(workspaceNamespace: String, workspaceName: String): Future[PerRequestMessage] = {
-    ???
+    // Is there any reason to wait for unpublish to complete before deleting?
+    rawlsDAO.getWorkspace(workspaceNamespace, workspaceName) flatMap { ws =>
+      if (isPublished(ws)) {
+        removeDocument(ws.workspace, searchDAO)
+      }
+      Future(())
+    }
+
+    rawlsDAO.deleteWorkspace(workspaceNamespace, workspaceName) flatMap { response =>
+      Future(RequestComplete(response))
+    }
   }
 
   private def getTagsFromWorkspace(ws:Workspace): Seq[String] = {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiService.scala
@@ -74,8 +74,18 @@ trait WorkspaceApiService extends HttpService with FireCloudRequestBuilding
         pathPrefix(Segment / Segment) { (workspaceNamespace, workspaceName) =>
           val workspacePath = rawlsWorkspacesRoot + "/%s/%s".format(workspaceNamespace, workspaceName)
           pathEnd {
-            requireUserInfo() { _ =>
-              passthrough(workspacePath, HttpMethods.GET, HttpMethods.DELETE)
+            get {
+              requireUserInfo() { _ =>
+                passthrough(workspacePath, HttpMethods.GET)
+              }
+            } ~
+            delete {
+              requireUserInfo() { userInfo => requestContext =>
+                perRequest(requestContext,
+                  WorkspaceService.props(workspaceServiceConstructor, userInfo),
+                  WorkspaceService.DeleteWorkspace(workspaceNamespace, workspaceName)
+                )
+              }
             }
           } ~
           path("methodconfigs") {

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockRawlsDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockRawlsDAO.scala
@@ -145,6 +145,9 @@ class MockRawlsDAO  extends RawlsDAO {
     false
   )
 
+  private val publishedRawlsWorkspaceWithAttributesThatFailsIndexDeletion =
+    publishedRawlsWorkspaceWithAttributes.copy(workspaceId = "unpublishfailure")
+
   val unpublishedRawlsWorkspaceLibraryValid = Workspace(
     "attributes",
     "att",
@@ -248,6 +251,7 @@ class MockRawlsDAO  extends RawlsDAO {
       case "publishedwriter" => Future(WorkspaceResponse(WorkspaceAccessLevels.Write, canShare = false, catalog=false, publishedRawlsWorkspaceWithAttributes, WorkspaceSubmissionStats(None, None, runningSubmissionsCount = 0), List.empty))
       case "unpublishedwriter" => Future(WorkspaceResponse(WorkspaceAccessLevels.Write, canShare = false, catalog=false, rawlsWorkspaceWithAttributes, WorkspaceSubmissionStats(None, None, runningSubmissionsCount = 0), List.empty))
       case "publishedowner" => Future.successful(WorkspaceResponse(WorkspaceAccessLevels.Owner, canShare = true, catalog=false, publishedRawlsWorkspaceWithAttributes, WorkspaceSubmissionStats(None, None, runningSubmissionsCount = 0), List.empty))
+      case "publishedownerfailindexdelete" => Future.successful(WorkspaceResponse(WorkspaceAccessLevels.Owner, canShare = true, catalog=false, publishedRawlsWorkspaceWithAttributesThatFailsIndexDeletion, WorkspaceSubmissionStats(None, None, runningSubmissionsCount = 0), List.empty))
       case "libraryValid" => Future.successful(WorkspaceResponse(WorkspaceAccessLevels.Owner, canShare = true, catalog=false, unpublishedRawlsWorkspaceLibraryValid, WorkspaceSubmissionStats(None, None, runningSubmissionsCount = 0), List.empty))
       case _ => Future.successful(WorkspaceResponse(WorkspaceAccessLevels.Owner, canShare = true, catalog=false, newWorkspace, WorkspaceSubmissionStats(None, None, runningSubmissionsCount = 0), List.empty))
     }
@@ -360,7 +364,7 @@ class MockRawlsDAO  extends RawlsDAO {
 
   def status: Future[SubsystemStatus] = Future(SubsystemStatus(true))
 
-  def deleteWorkspace(workspaceNamespace: String, workspaceName: String)(implicit userToken: WithAccessToken): Future[Any] = {
-    ???
+  def deleteWorkspace(workspaceNamespace: String, workspaceName: String)(implicit userToken: WithAccessToken): Future[WorkspaceDeleteResponse] = {
+    Future.successful(WorkspaceDeleteResponse(Some("Your Google bucket 'bucketId' will be deleted within 24h.")))
   }
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockRawlsDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockRawlsDAO.scala
@@ -119,7 +119,7 @@ class MockRawlsDAO  extends RawlsDAO {
     false
   )
 
-  private val publishedRawlsWorkspaceWithAttributes = Workspace(
+  val publishedRawlsWorkspaceWithAttributes = Workspace(
     "attributes",
     "att",
     Set.empty, //authdomain
@@ -144,9 +144,6 @@ class MockRawlsDAO  extends RawlsDAO {
     Map(), //authdomain acls,
     false
   )
-
-  private val publishedRawlsWorkspaceWithAttributesThatFailsIndexDeletion =
-    publishedRawlsWorkspaceWithAttributes.copy(workspaceId = "unpublishfailure")
 
   val unpublishedRawlsWorkspaceLibraryValid = Workspace(
     "attributes",
@@ -188,7 +185,7 @@ class MockRawlsDAO  extends RawlsDAO {
   val rawlsWorkspaceResponseWithAttributes = WorkspaceResponse(WorkspaceAccessLevels.Owner, canShare=false, catalog=false, rawlsWorkspaceWithAttributes, WorkspaceSubmissionStats(None, None, runningSubmissionsCount = 0), List.empty)
   val publishedRawlsWorkspaceResponseWithAttributes = WorkspaceResponse(WorkspaceAccessLevels.Owner, canShare=false, catalog=false, publishedRawlsWorkspaceWithAttributes, WorkspaceSubmissionStats(None, None, runningSubmissionsCount = 0), List.empty)
 
-  private def newWorkspace: Workspace = {
+  def newWorkspace: Workspace = {
     Workspace(
       namespace = "namespace",
       name = "name",
@@ -251,7 +248,6 @@ class MockRawlsDAO  extends RawlsDAO {
       case "publishedwriter" => Future(WorkspaceResponse(WorkspaceAccessLevels.Write, canShare = false, catalog=false, publishedRawlsWorkspaceWithAttributes, WorkspaceSubmissionStats(None, None, runningSubmissionsCount = 0), List.empty))
       case "unpublishedwriter" => Future(WorkspaceResponse(WorkspaceAccessLevels.Write, canShare = false, catalog=false, rawlsWorkspaceWithAttributes, WorkspaceSubmissionStats(None, None, runningSubmissionsCount = 0), List.empty))
       case "publishedowner" => Future.successful(WorkspaceResponse(WorkspaceAccessLevels.Owner, canShare = true, catalog=false, publishedRawlsWorkspaceWithAttributes, WorkspaceSubmissionStats(None, None, runningSubmissionsCount = 0), List.empty))
-      case "publishedownerfailindexdelete" => Future.successful(WorkspaceResponse(WorkspaceAccessLevels.Owner, canShare = true, catalog=false, publishedRawlsWorkspaceWithAttributesThatFailsIndexDeletion, WorkspaceSubmissionStats(None, None, runningSubmissionsCount = 0), List.empty))
       case "libraryValid" => Future.successful(WorkspaceResponse(WorkspaceAccessLevels.Owner, canShare = true, catalog=false, unpublishedRawlsWorkspaceLibraryValid, WorkspaceSubmissionStats(None, None, runningSubmissionsCount = 0), List.empty))
       case _ => Future.successful(WorkspaceResponse(WorkspaceAccessLevels.Owner, canShare = true, catalog=false, newWorkspace, WorkspaceSubmissionStats(None, None, runningSubmissionsCount = 0), List.empty))
     }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockRawlsDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockRawlsDAO.scala
@@ -359,4 +359,8 @@ class MockRawlsDAO  extends RawlsDAO {
     Future.successful(Seq.empty[MethodConfigurationShort])
 
   def status: Future[SubsystemStatus] = Future(SubsystemStatus(true))
+
+  def deleteWorkspace(workspaceNamespace: String, workspaceName: String)(implicit userToken: WithAccessToken): Future[Any] = {
+    ???
+  }
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockSearchDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockSearchDAO.scala
@@ -30,6 +30,12 @@ class MockSearchDAO extends SearchDAO {
   }
 
   override def deleteDocument(id: String) = {
+    id match {
+      case x if x == "unpublishfailure" =>
+        deleteDocumentInvoked = false
+        throw new Exception("Exception deleting document")
+      case _ => deleteDocumentInvoked = true
+    }
     deleteDocumentInvoked = true
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockSearchDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockSearchDAO.scala
@@ -30,12 +30,6 @@ class MockSearchDAO extends SearchDAO {
   }
 
   override def deleteDocument(id: String) = {
-    id match {
-      case x if x == "unpublishfailure" =>
-        deleteDocumentInvoked = false
-        throw new Exception("Exception deleting document")
-      case _ => deleteDocumentInvoked = true
-    }
     deleteDocumentInvoked = true
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceServiceSpec.scala
@@ -1,19 +1,23 @@
 package org.broadinstitute.dsde.firecloud.service
 import akka.testkit.TestActorRef
-import org.broadinstitute.dsde.firecloud.{FireCloudException, FireCloudExceptionWithErrorReport}
+import org.broadinstitute.dsde.firecloud.dataaccess.{MockRawlsDAO, MockSearchDAO}
+import org.broadinstitute.dsde.firecloud.{Application, FireCloudException}
 import org.broadinstitute.dsde.firecloud.model.{AccessToken, WithAccessToken, WorkspaceDeleteResponse}
 import org.broadinstitute.dsde.firecloud.service.PerRequest.{RequestComplete, RequestCompleteWithHeaders}
+import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.AttributeUpdateOperation
 import org.broadinstitute.dsde.rawls.model.{AttributeBoolean, AttributeName, AttributeString, Workspace, _}
 import org.scalatest.BeforeAndAfterEach
 import spray.http.{OAuth2BearerToken, StatusCode, StatusCodes}
 
-import scala.concurrent.Await
+import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.concurrent.duration._
 
 
 class WorkspaceServiceSpec extends BaseServiceSpec with BeforeAndAfterEach {
 
-  val workspaceServiceConstructor: (WithAccessToken) => WorkspaceService = WorkspaceService.constructor(app)
+  val customApp = Application(agoraDao, googleServicesDao, ontologyDao, consentDao, new MockRawlsDeleteWSDAO(), new MockSearchDeleteWSDAO(), thurloeDao)
+
+  val workspaceServiceConstructor: (WithAccessToken) => WorkspaceService = WorkspaceService.constructor(customApp)
 
   lazy val ws: WorkspaceService = TestActorRef(WorkspaceService.props(workspaceServiceConstructor, AccessToken(OAuth2BearerToken("")))).underlyingActor
 
@@ -60,7 +64,7 @@ class WorkspaceServiceSpec extends BaseServiceSpec with BeforeAndAfterEach {
     }
 
     "should delete a published workspace successfully" in {
-      val workspaceNamespace = "publishedowner"
+      val workspaceNamespace = "unpublishsuccess"
       val rqComplete = Await.
         result(ws.deleteWorkspace(workspaceNamespace, workspaceName), Duration.Inf).
         asInstanceOf[RequestComplete[WorkspaceDeleteResponse]]
@@ -70,7 +74,7 @@ class WorkspaceServiceSpec extends BaseServiceSpec with BeforeAndAfterEach {
     }
 
     "should not delete a published workspace if un-publish fails" in {
-      val workspaceNamespace = "publishedownerfailindexdelete"
+      val workspaceNamespace = "unpublishfailure"
       val rqComplete = Await.
         result(ws.deleteWorkspace(workspaceNamespace, workspaceName), Duration.Inf).
         asInstanceOf[RequestComplete[(StatusCode, ErrorReport)]]
@@ -78,6 +82,62 @@ class WorkspaceServiceSpec extends BaseServiceSpec with BeforeAndAfterEach {
       status should be (StatusCodes.InternalServerError)
     }
 
+  }
+
+}
+
+/*
+ * Mock out DAO classes specific to this test class.
+ * Override the chain of methods that are called within these service tests to isolate functionality.
+ */
+class MockRawlsDeleteWSDAO(implicit val executionContext: ExecutionContext) extends MockRawlsDAO {
+
+  override def deleteWorkspace(workspaceNamespace: String, workspaceName: String)(implicit userToken: WithAccessToken): Future[WorkspaceDeleteResponse] = {
+    Future.successful(WorkspaceDeleteResponse(Some("Your Google bucket 'bucketId' will be deleted within 24h.")))
+  }
+
+  private val unpublishsuccess = publishedRawlsWorkspaceWithAttributes.copy(
+    namespace = "unpublishsuccess",
+    name = "name",
+    workspaceId = "unpublishsuccess"
+  )
+
+  private val unpublishfailure = publishedRawlsWorkspaceWithAttributes.copy(
+    namespace = "unpublishfailure",
+    name = "name",
+    workspaceId = "unpublishfailure"
+  )
+
+  override def getWorkspace(ns: String, name: String)(implicit userToken: WithAccessToken): Future[WorkspaceResponse] = {
+    ns match {
+      case "attributes" => Future(rawlsWorkspaceResponseWithAttributes)
+      case "projectowner" => Future(WorkspaceResponse(WorkspaceAccessLevels.ProjectOwner, canShare = true, catalog=false, newWorkspace, WorkspaceSubmissionStats(None, None, runningSubmissionsCount = 0), List.empty))
+      case "unpublishsuccess" => Future(WorkspaceResponse(WorkspaceAccessLevels.Owner, canShare = true, catalog=false, unpublishsuccess, WorkspaceSubmissionStats(None, None, runningSubmissionsCount = 0), List.empty))
+      case "unpublishfailure" => Future(WorkspaceResponse(WorkspaceAccessLevels.Owner, canShare = true, catalog=false, unpublishfailure, WorkspaceSubmissionStats(None, None, runningSubmissionsCount = 0), List.empty))
+      case _ => Future(WorkspaceResponse(WorkspaceAccessLevels.Owner, canShare = true, catalog=false, newWorkspace, WorkspaceSubmissionStats(None, None, runningSubmissionsCount = 0), List.empty))
+    }
+  }
+
+  override def updateLibraryAttributes(ns: String, name: String, attributeOperations: Seq[AttributeUpdateOperation])(implicit userToken: WithAccessToken): Future[Workspace] = {
+    ns match {
+      case "projectowner" => Future(newWorkspace)
+      case "unpublishsuccess" => Future(publishedRawlsWorkspaceWithAttributes)
+      case "unpublishfailure" => Future(unpublishfailure)
+      case _ => Future(newWorkspace)
+    }
+  }
+
+}
+
+class MockSearchDeleteWSDAO extends MockSearchDAO {
+
+  override def deleteDocument(id: String): Unit = {
+    id match {
+      case "unpublishfailure" =>
+        deleteDocumentInvoked = false
+        throw new FireCloudException(s"Failed to remove document with id $id from elastic search")
+      case _ => deleteDocumentInvoked = true
+    }
   }
 
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceServiceSpec.scala
@@ -1,22 +1,28 @@
 package org.broadinstitute.dsde.firecloud.service
-import akka.actor.ActorRefFactory
 import akka.testkit.TestActorRef
-
-import scala.concurrent.duration._
-import org.broadinstitute.dsde.firecloud.model.{AccessToken, WithAccessToken}
-import org.broadinstitute.dsde.firecloud.service.PerRequest.{PerRequestMessage, RequestCompleteWithHeaders}
-import spray.http.{HttpHeader, OAuth2BearerToken, StatusCode, StatusCodes}
+import org.broadinstitute.dsde.firecloud.model.{AccessToken, WithAccessToken, WorkspaceDeleteResponse}
+import org.broadinstitute.dsde.firecloud.service.PerRequest.{RequestComplete, RequestCompleteWithHeaders}
+import org.broadinstitute.dsde.rawls.model.{AttributeBoolean, AttributeName, AttributeString, Workspace, _}
+import org.scalatest.BeforeAndAfterEach
+import spray.http.{OAuth2BearerToken, StatusCode, StatusCodes}
 
 import scala.concurrent.Await
+import scala.concurrent.duration._
 
 
-class WorkspaceServiceSpec extends BaseServiceSpec {
- //val ws = new WorkspaceService(new AccessToken(OAuth2BearerToken("")), app.rawlsDAO, app.thurloeDAO)
+class WorkspaceServiceSpec extends BaseServiceSpec with BeforeAndAfterEach {
 
   val workspaceServiceConstructor: (WithAccessToken) => WorkspaceService = WorkspaceService.constructor(app)
 
-  lazy val ws: WorkspaceService = TestActorRef(WorkspaceService.props(workspaceServiceConstructor, new AccessToken(OAuth2BearerToken("")))).underlyingActor
+  lazy val ws: WorkspaceService = TestActorRef(WorkspaceService.props(workspaceServiceConstructor, AccessToken(OAuth2BearerToken("")))).underlyingActor
 
+  override def beforeEach(): Unit = {
+    searchDao.reset
+  }
+
+  override def afterEach(): Unit = {
+    searchDao.reset
+  }
 
   "export workspace attributes as TSV " - {
     "export valid tsv" in {
@@ -39,7 +45,40 @@ class WorkspaceServiceSpec extends BaseServiceSpec {
 
   }
 
+  "delete workspace" - {
 
+    val workspaceName = "name"
+
+    "should delete an unpublished workspace successfully" in {
+      val workspaceNamespace = "projectowner"
+      val rqComplete = Await.
+        result(ws.deleteWorkspace(workspaceNamespace, workspaceName), Duration.Inf).
+        asInstanceOf[RequestComplete[WorkspaceDeleteResponse]]
+      val workspaceDeleteResponse = rqComplete.response
+      workspaceDeleteResponse.message.isDefined should be (true)
+    }
+
+    "should delete a published workspace successfully" in {
+      val workspaceNamespace = "publishedowner"
+      val rqComplete = Await.
+        result(ws.deleteWorkspace(workspaceNamespace, workspaceName), Duration.Inf).
+        asInstanceOf[RequestComplete[WorkspaceDeleteResponse]]
+      val workspaceDeleteResponse = rqComplete.response
+      workspaceDeleteResponse.message.isDefined should be (true)
+      workspaceDeleteResponse.message.get should include (ws.unPublishSuccessMessage(workspaceNamespace, workspaceName))
+    }
+
+    "should delete a published workspace successfully even if un-publish fails" in {
+      val workspaceNamespace = "publishedownerfailindexdelete"
+      val rqComplete = Await.
+        result(ws.deleteWorkspace(workspaceNamespace, workspaceName), Duration.Inf).
+        asInstanceOf[RequestComplete[WorkspaceDeleteResponse]]
+      val workspaceDeleteResponse = rqComplete.response
+      workspaceDeleteResponse.message.isDefined should be (true)
+      workspaceDeleteResponse.message.get should include (ws.unPublishErrorMessage(workspaceNamespace, workspaceName))
+    }
+
+  }
 
 }
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceServiceSpec.scala
@@ -75,7 +75,7 @@ class WorkspaceServiceSpec extends BaseServiceSpec with BeforeAndAfterEach {
         asInstanceOf[RequestComplete[WorkspaceDeleteResponse]]
       val workspaceDeleteResponse = rqComplete.response
       workspaceDeleteResponse.message.isDefined should be (true)
-      workspaceDeleteResponse.message.get should include (ws.unPublishErrorMessage(workspaceNamespace, workspaceName))
+      status shouldNot be (200)
     }
 
   }


### PR DESCRIPTION
## Addresses 
https://broadinstitute.atlassian.net/browse/GAWB-2352
Requires corresponding UI PR: https://github.com/broadinstitute/firecloud-ui/pull/931

## Changes:
Update the delete workspace logic to include un-publishing from Library if necessary.

## Testing:
* Delete a normal, un-published workspace and ensure no regressions
* Delete a published workspace and ensure that it does not show up in Library.
* Try to delete a published workspace with users that are not allowed.
  * Workspace "READER"
  * Workspace "OWNER" but not "CATALOG" permissions
  * "CATALOG" user, but not "OWNER"

---

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](../CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](../CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [x] Get two thumbsworth of review and PO signoff if necessary
- [x] Verify all tests go green
- [x] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [x] Test this change deployed correctly and works on dev environment after deployment
