### PR TITLE
Fix Profile definition in api-docs.yaml

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,9 +4,9 @@ Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that firs
 
 I, the developer opening this PR, do solemnly pinky swear that:
 
-- [ ] I've followed [the instructions](../CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
+- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
 - [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
-- [ ] I've updated the [FISMA documentation](../CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
+- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing
 
 In all cases:
 

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -4517,7 +4517,7 @@ definitions:
         description: User's title
       contactEmail:
         type: string
-        description: User's title
+        description: User's contact email (if different from account email)
       institute:
         type: string
         description: User's home institution
@@ -4535,7 +4535,7 @@ definitions:
         description: User's program location country
       pi:
         type: string
-        description: Principle Investigator
+        description: Principal Investigator
       nonProfitStatus:
         type: string
         description: User's program non-profit status

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -4506,18 +4506,50 @@ definitions:
   Profile:
     type: object
     properties:
-      name:
+      firstName:
         type: string
-        description: User's full name
-      email:
+        description: User's first name
+      lastName:
         type: string
-        description: User's email address
-      institution:
+        description: User's last name
+      title:
+        type: string
+        description: User's title
+      contactEmail:
+        type: string
+        description: User's title
+      institute:
         type: string
         description: User's home institution
+      institutionalProgram:
+        type: string
+        description: User's institutional program
+      programLocationCity:
+        type: string
+        description: User's program location city
+      programLocationState:
+        type: string
+        description: User's program location state
+      programLocationCountry:
+        type: string
+        description: User's program location country
       pi:
         type: string
-        description: Primary Investigator
+        description: Principle Investigator
+      nonProfitStatus:
+        type: string
+        description: User's program non-profit status
+    required:
+      - firstName
+      - lastName
+      - title
+      - institute
+      - institutionalProgram
+      - programLocationCity
+      - programLocationState
+      - programLocationCountry
+      - pi
+      - nonProfitStatus
 
   PublishConfigurationIngest:
     type: object


### PR DESCRIPTION
The definition was badly out-of-date.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](../CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](../CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [x] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
