### PR TITLE
GAWB-2601: passthrough for ga4gh tool descriptor api in agora

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -3315,6 +3315,57 @@ paths:
         200:
           description: OK
 
+  /ga4gh/tools/{id}/versions/{version-id}/{type}/descriptor:
+    get:
+      summary: Get the tool descriptor (CWL/WDL) for the specified tool.
+      description: Returns the CWL or WDL descriptor for the specified tool.
+      tags:
+        - GA4GH Tool Registry
+      parameters:
+        - name: type
+          required: true
+          in: path
+          description: >
+            The output type of the descriptor. If not specified it is up to the underlying
+            implementation to determine which output type to return. Plain types return the
+            bare descriptor while the "non-plain" types return a descriptor wrapped
+            with metadata.
+
+              *In FireCloud, only WDL and plain-WDL are supported.*
+          type: string
+          enum:
+            - CWL
+            - WDL
+            - plain-CWL
+            - plain-WDL
+        - name: id
+          in: path
+          description: >
+            A unique identifier of the tool, scoped to this registry, for example `123456`.
+
+              *In FireCloud, this must be a namespace + ":" + name. For instance, if your namespace
+              is 'foo' and name is 'bar', this must be 'foo:bar'.*
+          required: true
+          type: string
+        - name: version-id
+          in: path
+          required: true
+          type: string
+          description: >
+            An identifier of the tool version for this particular tool registry, for example `v1`.
+
+              *In FireCloud, this must be an integer representing the FireCloud snapshot id.*
+      responses:
+        '200':
+          description: The tool descriptor.
+          schema:
+            $ref: '#/definitions/ToolDescriptor'
+        '404':
+          description: The tool can not be output in the specified type.
+          schema:
+            $ref: '#/definitions/Error'
+      security: []
+
 ##########################################################################################
 ## PARAMETERS
 ##########################################################################################
@@ -4863,6 +4914,24 @@ definitions:
       inputName:
         type: string
         description: name of input
+
+  ToolDescriptor:
+    description: A tool descriptor is a metadata document that describes one or more tools.
+    required:
+      - type
+      - descriptor
+    properties:
+      type:
+        type: string
+        enum:
+          - CWL
+          - WDL
+      descriptor:
+        type: string
+        description: The descriptor that represents this version of the tool. (CWL or WDL)
+      url:
+        type: string
+        description: 'Optional url to the tool descriptor used to build this image, should include version information, and can include a git hash (e.g. https://raw.githubusercontent.com/ICGC-TCGA-PanCancer/pcawg_delly_workflow/ea2a5db69bd20a42976838790bc29294df3af02b/delly_docker/Delly.cwl )'
 
   UserInfo:
     type: object

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudServiceActor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudServiceActor.scala
@@ -28,6 +28,7 @@ class FireCloudServiceActor extends HttpServiceActor with FireCloudDirectives
   with NotificationsApiService
   with StatusApiService
   with MethodsApiService
+  with Ga4ghApiService
   {
 
   implicit val system = context.system
@@ -114,6 +115,7 @@ class FireCloudServiceActor extends HttpServiceActor with FireCloudDirectives
         workspaceRoutes ~
         notificationsRoutes ~
         statusRoutes ~
+        ga4ghRoutes ~
         pathPrefix("api") {
           apiRoutes
         } ~

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/Ga4ghApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/Ga4ghApiService.scala
@@ -1,0 +1,28 @@
+package org.broadinstitute.dsde.firecloud.webservice
+
+import org.broadinstitute.dsde.firecloud.FireCloudConfig
+import org.broadinstitute.dsde.firecloud.service.FireCloudDirectives
+import spray.http.{HttpMethods, Uri}
+import spray.routing._
+
+import scala.concurrent.ExecutionContext
+
+trait Ga4ghApiService extends HttpService with FireCloudDirectives {
+
+  private implicit val ec: ExecutionContext = actorRefFactory.dispatcher
+
+  private val agora = FireCloudConfig.Agora.baseUrl
+
+  val ga4ghRoutes: Route =
+    pathPrefix("ga4gh") {
+      pathPrefix("tools") {
+        path (Segment / "versions" / Segment / Segment / "descriptor") { (id, versionId, descriptorType) =>
+          get {
+            val targetUri = Uri(s"$agora/ga4gh/tools/$id/versions/$versionId/$descriptorType/descriptor")
+            passthrough(targetUri, HttpMethods.GET)
+          }
+        }
+      }
+    }
+
+}

--- a/src/test/resources/reference.conf
+++ b/src/test/resources/reference.conf
@@ -70,7 +70,7 @@ duos {
 # these are the settings currently used at runtime; copy them here
 # so we're testing under similar conditions.
 spray.can.host-connector {
-  max-connections = 8
+  max-connections = 4
   max-retries = 5
-  pipelining = true
+  pipelining = off
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/Ga4ghApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/Ga4ghApiServiceSpec.scala
@@ -1,0 +1,54 @@
+package org.broadinstitute.dsde.firecloud.webservice
+
+import org.broadinstitute.dsde.firecloud.mock.MockUtils
+import org.broadinstitute.dsde.firecloud.service.BaseServiceSpec
+import org.mockserver.integration.ClientAndServer
+import org.mockserver.integration.ClientAndServer.startClientAndServer
+import org.mockserver.model.HttpRequest.request
+import org.scalatest.BeforeAndAfterEach
+import spray.http.HttpMethods
+import spray.http.StatusCodes._
+
+class Ga4ghApiServiceSpec extends BaseServiceSpec with Ga4ghApiService with BeforeAndAfterEach {
+
+  def actorRefFactory = system
+
+  var toolRegistryServer: ClientAndServer = _
+  val toolRegistryDummyUrlPath = "/ga4gh/tools/namespace:name/versions/1/WDL/descriptor"
+
+  override def beforeAll(): Unit = {
+    toolRegistryServer = startClientAndServer(MockUtils.methodsServerPort)
+
+    toolRegistryServer.when(request().withMethod(HttpMethods.GET.name).withPath(toolRegistryDummyUrlPath))
+      .respond(
+        org.mockserver.model.HttpResponse.response()
+          .withStatusCode(OK.intValue)
+      )
+  }
+
+  override def afterAll(): Unit = {
+    toolRegistryServer.stop()
+  }
+
+  "GA4GH API service" - {
+    "Tool Registry" - {
+      "get-descriptor passthrough API" - {
+
+        "should reject all but GET" in {
+          List(HttpMethods.POST, HttpMethods.PUT, HttpMethods.PATCH, HttpMethods.DELETE, HttpMethods.HEAD) foreach {
+            method =>
+              new RequestBuilder(method)(toolRegistryDummyUrlPath) ~> ga4ghRoutes ~> check {
+                assert(!handled)
+              }
+          }
+        }
+        "should accept GET" in {
+          Get(toolRegistryDummyUrlPath) ~> ga4ghRoutes ~> check {
+           assert(handled)
+          }
+        }
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
see broadinstitute/agora#212 - this just adds the required passthrough to orchestration.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
