### PR TITLE
GAWB-2579: passthrough query params for redacting methods while editing

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/MethodsApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/MethodsApiService.scala
@@ -38,7 +38,12 @@ trait MethodsApiService extends HttpService
         (get | post) {
           extract(_.request.method) { method =>
             extract(_.request.uri.query) { query =>
-              passthrough(Uri(passthroughBase).withQuery(query), method)
+              // only pass query params for GETs
+              val targetUri = if (method == HttpMethods.GET)
+                Uri(passthroughBase).withQuery(query)
+              else
+                Uri(passthroughBase)
+              passthrough(targetUri, method)
             }
           }
         }
@@ -48,7 +53,13 @@ trait MethodsApiService extends HttpService
           (get | delete) {
             extract(_.request.method) { method =>
               extract(_.request.uri.query) { query =>
-                passthrough(Uri(s"$passthroughBase/${urlify(namespace, name)}/$snapshotId").withQuery(query), method)
+                // only pass query params for GETs
+                val baseUri = Uri(s"$passthroughBase/${urlify(namespace, name)}/$snapshotId")
+                val targetUri = if (method == HttpMethods.GET)
+                  baseUri.withQuery(query)
+                else
+                  baseUri
+                passthrough(targetUri, method)
               }
             }
           }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/MethodsApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/MethodsApiService.scala
@@ -110,7 +110,9 @@ trait MethodsApiService extends HttpService
         pathPrefix( IntNumber ) { snapshotId =>
           pathEnd {
             post {
-              passthrough(s"$passthroughBase/${urlify(namespace,name)}/$snapshotId", HttpMethods.POST)
+              extract(_.request.uri.query) { query =>
+                passthrough(Uri(s"$passthroughBase/${urlify(namespace, name)}/$snapshotId").withQuery(query), HttpMethods.POST)
+              }
             }
           } ~
           path( "configurations" ) {

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/MethodsApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/MethodsApiServiceSpec.scala
@@ -1,39 +1,84 @@
 package org.broadinstitute.dsde.firecloud.service
 
+import akka.actor.ActorSystem
+import com.typesafe.scalalogging.slf4j.LazyLogging
 import org.broadinstitute.dsde.firecloud.mock.MockUtils
 import org.broadinstitute.dsde.firecloud.webservice.MethodsApiService
 import org.mockserver.integration.ClientAndServer
 import org.mockserver.integration.ClientAndServer._
+import org.mockserver.mock.action.ExpectationCallback
+import org.mockserver.model.HttpCallback.callback
+import org.mockserver.model.{HttpRequest, HttpResponse}
 import org.mockserver.model.HttpRequest._
-import spray.http.HttpMethods
+import org.mockserver.model.HttpResponse.response
+import org.scalatest.Matchers
+import spray.http.HttpMethod
+import spray.http.HttpMethods._
 import spray.http.StatusCodes._
 
 class MethodsApiServiceSpec extends ServiceSpec with MethodsApiService {
 
-  val methodsPermPath="/methods/namespace/name/1/permissions"
-  val configsPermPath="/configurations/namespace/name/1/permissions"
+  def actorRefFactory:ActorSystem = system
 
-  def actorRefFactory = system
   var methodsServer: ClientAndServer = _
-  val httpMethods = List(HttpMethods.GET, HttpMethods.POST, HttpMethods.PUT,
-    HttpMethods.DELETE, HttpMethods.PATCH, HttpMethods.OPTIONS, HttpMethods.HEAD)
+
+  case class Api(localPath: String, verb: HttpMethod, remotePath: String, allowQueryParams: Boolean)
+
+  // we don't include OPTIONS here because we accept all OPTIONS requests to all endpoints for CORS.
+  // we also don't include TRACE or CONNECT or any of the more obscure verbs.
+  val allHttpMethods = Seq(GET, POST, PUT, PATCH, DELETE, HEAD)
+
+  /*
+    list all the passthrough routes in MethodsApiService.
+
+    orchestration routes as seen by the end user are /api/methods/etc.... But, the MethodsApiService
+    defines them as /methods/etc... and they are later wrapped by FireCloudServiceActor in "/api".
+    So, our unit tests here use the values defined in MethodsApiService, without the "/api".
+
+    NB: we don't test the permissions endpoints here, because they are not passthroughs;
+    those are tested elsewhere
+  */
+  val testCases = Seq(
+    Api("/configurations", GET, "/api/v1/configurations", allowQueryParams=true),
+    Api("/configurations", POST, "/api/v1/configurations", allowQueryParams=false),
+    Api("/configurations/namespace/name/1", GET, "/api/v1/configurations/namespace/name/1", allowQueryParams=true),
+    Api("/configurations/namespace/name/1", DELETE, "/api/v1/configurations/namespace/name/1", allowQueryParams=false),
+    Api("/methods", GET, "/api/v1/methods", allowQueryParams=true),
+    Api("/methods", POST, "/api/v1/methods", allowQueryParams=false),
+    Api("/methods/namespace/name/1", GET, "/api/v1/methods/namespace/name/1", allowQueryParams=true),
+    Api("/methods/namespace/name/1", DELETE, "/api/v1/methods/namespace/name/1", allowQueryParams=false),
+    Api("/methods/namespace/name/1", POST, "/api/v1/methods/namespace/name/1", allowQueryParams=true),
+    Api("/methods/namespace/name/1/configurations", GET, "/api/v1/methods/namespace/name/1/configurations", allowQueryParams=false),
+    Api("/methods/definitions", GET, "/api/v1/methods/definitions", allowQueryParams=false),
+    Api("/methods/namespace/name/configurations", GET, "/api/v1/methods/namespace/name/configurations", allowQueryParams=false)
+  )
+
+  /*
+    given the above test cases, find all the remaining HTTP methods that we should NOT support - we'll
+    use these for negative test cases.
+
+    NB: this negative-test determination will fail if/when we define some paths to have both passthrough and
+    non-passthrough routes for different http verbs. As of this writing, each path is either all passthrough
+    or all non-passthrough.
+   */
+  val negativeCases:Map[String,Seq[HttpMethod]] = testCases
+    .groupBy(_.localPath)
+    .map(api => api._1 -> api._2.map(_.verb))
+    .map(neg => neg._1 -> allHttpMethods.diff(neg._2))
+
+  // pick a status code to represent success in our mocks that we don't use elsewhere.
+  // this guarantees the code is coming from our mock, not from some other route.
+  val mockSuccessResponseCode = NonAuthoritativeInformation
 
   override def beforeAll(): Unit = {
     methodsServer = startClientAndServer(MockUtils.methodsServerPort)
-    httpMethods foreach {
-      method =>
-        methodsServer
-          .when(request().withMethod(method.name).withPath(remoteMethodsPath))
-          .respond(
-            org.mockserver.model.HttpResponse.response()
-              .withHeaders(MockUtils.header).withStatusCode(OK.intValue)
-          )
-        methodsServer
-          .when(request().withMethod(method.name).withPath(remoteConfigurationsPath))
-          .respond(
-            org.mockserver.model.HttpResponse.response()
-              .withHeaders(MockUtils.header).withStatusCode(OK.intValue)
-          )
+
+    // for each test case, set up an agora mock that echoes back to us the method, path, and presence/absence of
+    // query params that were actually used in the passthrough request.
+    testCases foreach { api =>
+      methodsServer
+        .when(request().withMethod(api.verb.name).withPath(api.remotePath))
+          .callback(callback().withCallbackClass("org.broadinstitute.dsde.firecloud.service.MethodsApiServiceSpecCallback"))
     }
   }
 
@@ -41,38 +86,57 @@ class MethodsApiServiceSpec extends ServiceSpec with MethodsApiService {
     methodsServer.stop()
   }
 
-  "MethodsService" - {
-    "when testing all HTTP methods on the methods and configuratins paths" - {
+  // tests
+  "MethodsApiService uses of passthrough directive" - {
+    testCases foreach { api =>
+      s"should succeed on ${api.verb.toString} to ${api.localPath}" in {
+        // always send query params to the orch endpoint, to simulate an end user manually adding them.
+        // we'll check inside the test whether or not the query params are sent through to agora.
+        new RequestBuilder(api.verb)(api.localPath + "?foo=bar&baz=qux") ~> methodsApiServiceRoutes ~> check {
+          assertResult(mockSuccessResponseCode) {
+            status
+          }
+          val passthroughResult = responseAs[String].split(" ")
 
-      val allowedMethods = List(HttpMethods.GET, HttpMethods.POST)
-      val disallowedMethods = httpMethods diff allowedMethods
+          val queryParamMsg = if (api.allowQueryParams) "allow" else "omit"
 
-      "MethodNotAllowed error is not returned for allowed methods" in {
-        allowedMethods foreach {
-          method =>
-            new RequestBuilder(method)("/" + localMethodsPath) ~> sealRoute(methodsApiServiceRoutes) ~> check {
-              status shouldNot equal(MethodNotAllowed)
-            }
-            new RequestBuilder(method)("/" + localConfigsPath) ~> sealRoute(methodsApiServiceRoutes) ~> check {
-              status shouldNot equal(MethodNotAllowed)
-            }
+          assertResult(api.verb.toString, "unexpected http verb in passthrough") {
+            passthroughResult(0)
+          }
+          assertResult(api.remotePath, "unexpected uri path in passthrough") {
+            passthroughResult(1)
+          }
+          assertResult(api.allowQueryParams, s"passthrough should $queryParamMsg query params") {
+            passthroughResult(2).toBoolean
+          }
         }
       }
-
-      "MethodNotAllowed error is returned for disallowed methods" in {
-        disallowedMethods foreach {
-          method =>
-            new RequestBuilder(method)("/" + localMethodsPath) ~> sealRoute(methodsApiServiceRoutes) ~> check {
-              status should equal(MethodNotAllowed)
-            }
-            new RequestBuilder(method)("/" + localConfigsPath) ~> sealRoute(methodsApiServiceRoutes) ~> check {
-              status should equal(MethodNotAllowed)
-            }
+    }
+    // negative tests
+    negativeCases foreach { neg =>
+      neg._2 foreach { verb =>
+        s"should reject a ${verb.toString} to ${neg._1}" in {
+          new RequestBuilder(verb)(neg._1) ~> methodsApiServiceRoutes ~> check {
+            assert(!handled)
+          }
         }
       }
-
-
     }
   }
 
+}
+
+class MethodsApiServiceSpecCallback extends ExpectationCallback with Matchers with LazyLogging {
+
+
+  override def handle(httpRequest: HttpRequest): HttpResponse = {
+    val method:String = httpRequest.getMethod.getValue
+    val path:String = httpRequest.getPath.getValue
+    val hasParams:Boolean = !httpRequest.getQueryStringParameters.isEmpty
+
+    val content = s"$method $path $hasParams"
+
+    val resp = response().withHeaders(MockUtils.header).withStatusCode(NonAuthoritativeInformation.intValue).withBody(content)
+    resp
+  }
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/MethodsApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/MethodsApiServiceSpec.scala
@@ -1,16 +1,16 @@
-package org.broadinstitute.dsde.firecloud.service
+package org.broadinstitute.dsde.firecloud.webservice
 
 import akka.actor.ActorSystem
 import com.typesafe.scalalogging.slf4j.LazyLogging
 import org.broadinstitute.dsde.firecloud.mock.MockUtils
-import org.broadinstitute.dsde.firecloud.webservice.MethodsApiService
+import org.broadinstitute.dsde.firecloud.service.ServiceSpec
 import org.mockserver.integration.ClientAndServer
 import org.mockserver.integration.ClientAndServer._
 import org.mockserver.mock.action.ExpectationCallback
 import org.mockserver.model.HttpCallback.callback
-import org.mockserver.model.{HttpRequest, HttpResponse}
 import org.mockserver.model.HttpRequest._
 import org.mockserver.model.HttpResponse.response
+import org.mockserver.model.{HttpRequest, HttpResponse}
 import org.scalatest.Matchers
 import spray.http.HttpMethod
 import spray.http.HttpMethods._
@@ -78,7 +78,7 @@ class MethodsApiServiceSpec extends ServiceSpec with MethodsApiService {
     testCases foreach { api =>
       methodsServer
         .when(request().withMethod(api.verb.name).withPath(api.remotePath))
-          .callback(callback().withCallbackClass("org.broadinstitute.dsde.firecloud.service.MethodsApiServiceSpecCallback"))
+          .callback(callback().withCallbackClass("org.broadinstitute.dsde.firecloud.webservice.MethodsApiServiceSpecCallback"))
     }
   }
 


### PR DESCRIPTION
Three commits in this PR:
1. The actual bug: make sure to pass query params to agora for the edit endpoint
2. Total rewrite of the MethodsApiServiceSpec unit tests, which were woefully inadequate. This includes a fix to the runtime routes for issues found in testing
3. Move MethodsApiServiceSpec from the service package to the webservice package

Note: I am currently unable to verify this locally due to problems with sam.

I chose to go down the implementation route of only passing query params where absolutely necessary, with the principle of exposing the smallest surface area possible for security. The other option would have been to rewrite `passthrough` or provide another `passthrough` option to always pass query params; I didn't like that because it has implications elsewhere.

**Please see my comment on the Jira ticket for testing locally!!!**

----

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
