### PR TITLE
pin orch to sbt version 0.13 because it fails with sbt 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,4 +72,3 @@ crashlytics-build.properties
 *.pid
 .DS_Store
 
-project/build.properties

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.16

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,2 @@
+# build was failing on sbt 1.0.2, so pin to sbt 0.13.
 sbt.version=0.13.16


### PR DESCRIPTION
no jira ticket. Orch doesn't specify an sbt version, and I was getting failures using sbt 1.0.2, so I pinned it to sbt 0.13.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
