### PR TITLE
GAWB-2682: Remove testNihService

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudServiceActor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudServiceActor.scala
@@ -111,7 +111,6 @@ class FireCloudServiceActor extends HttpServiceActor with FireCloudDirectives
         storageRoutes ~
         swaggerUiService ~
         syncRoute ~
-        testNihService ~
         userService.routes ~
         workspaceRoutes ~
         notificationsRoutes ~
@@ -154,21 +153,6 @@ class FireCloudServiceActor extends HttpServiceActor with FireCloudDirectives
         | pathPrefixTest("lang" /) | pathPrefixTest("lib" /)) {
       get {
         getFromResourceDirectory(swaggerUiPath)
-      }
-    }
-  }
-
-  // Placeholder endpoint for testing an authenticated request from NIH. The user will hit this
-  // only after successful authentication. Right now, it just echos the request so we can see what
-  // we get. TODO(dmohs): Remove or turn into an echo endpoint after testing.
-  val testNihService = {
-    path("link-nih-account") {
-      extract(_.request) { request =>
-        complete(
-          "Received:\n" + request.method + " " + request.uri + "\n\n"
-            + request.headers.mkString("\n") + "\n\n"
-            + request.entity + "\n"
-        )
       }
     }
   }


### PR DESCRIPTION
1. Ran locally and verified that https://local.broadinstitute.org:10443/link-nih-account returned `404`.
2. Ran `sbt test` and `sbt it:test`.
3. Looked for any related documentation on `api-docs.yaml` to be removed but couldn't find one.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [x] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
