### PR TITLE
GAWB-849: point to updated agora url

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -3358,7 +3358,7 @@ paths:
         200:
           description: OK
 
-  /ga4gh/tools/{id}/versions/{version-id}/{type}/descriptor:
+  /ga4gh/v1/tools/{id}/versions/{version-id}/{type}/descriptor:
     get:
       summary: Get the tool descriptor (CWL/WDL) for the specified tool.
       description: Returns the CWL or WDL descriptor for the specified tool.

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/Ga4ghApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/Ga4ghApiService.scala
@@ -15,11 +15,13 @@ trait Ga4ghApiService extends HttpService with FireCloudDirectives {
 
   val ga4ghRoutes: Route =
     pathPrefix("ga4gh") {
-      pathPrefix("tools") {
-        path (Segment / "versions" / Segment / Segment / "descriptor") { (id, versionId, descriptorType) =>
-          get {
-            val targetUri = Uri(s"$agora/ga4gh/v1/tools/$id/versions/$versionId/$descriptorType/descriptor")
-            passthrough(targetUri, HttpMethods.GET)
+      pathPrefix("v1") {
+        pathPrefix("tools") {
+          path(Segment / "versions" / Segment / Segment / "descriptor") { (id, versionId, descriptorType) =>
+            get {
+              val targetUri = Uri(s"$agora/ga4gh/v1/tools/$id/versions/$versionId/$descriptorType/descriptor")
+              passthrough(targetUri, HttpMethods.GET)
+            }
           }
         }
       }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/Ga4ghApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/Ga4ghApiService.scala
@@ -18,7 +18,7 @@ trait Ga4ghApiService extends HttpService with FireCloudDirectives {
       pathPrefix("tools") {
         path (Segment / "versions" / Segment / Segment / "descriptor") { (id, versionId, descriptorType) =>
           get {
-            val targetUri = Uri(s"$agora/ga4gh/tools/$id/versions/$versionId/$descriptorType/descriptor")
+            val targetUri = Uri(s"$agora/ga4gh/v1/tools/$id/versions/$versionId/$descriptorType/descriptor")
             passthrough(targetUri, HttpMethods.GET)
           }
         }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/Ga4ghApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/Ga4ghApiServiceSpec.scala
@@ -14,12 +14,13 @@ class Ga4ghApiServiceSpec extends BaseServiceSpec with Ga4ghApiService with Befo
   def actorRefFactory = system
 
   var toolRegistryServer: ClientAndServer = _
+  val toolRegistryDummyAgoraPath = "/ga4gh/v1/tools/namespace:name/versions/1/WDL/descriptor"
   val toolRegistryDummyUrlPath = "/ga4gh/tools/namespace:name/versions/1/WDL/descriptor"
 
   override def beforeAll(): Unit = {
     toolRegistryServer = startClientAndServer(MockUtils.methodsServerPort)
 
-    toolRegistryServer.when(request().withMethod(HttpMethods.GET.name).withPath(toolRegistryDummyUrlPath))
+    toolRegistryServer.when(request().withMethod(HttpMethods.GET.name).withPath(toolRegistryDummyAgoraPath))
       .respond(
         org.mockserver.model.HttpResponse.response()
           .withStatusCode(OK.intValue)

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/Ga4ghApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/Ga4ghApiServiceSpec.scala
@@ -14,13 +14,12 @@ class Ga4ghApiServiceSpec extends BaseServiceSpec with Ga4ghApiService with Befo
   def actorRefFactory = system
 
   var toolRegistryServer: ClientAndServer = _
-  val toolRegistryDummyAgoraPath = "/ga4gh/v1/tools/namespace:name/versions/1/WDL/descriptor"
-  val toolRegistryDummyUrlPath = "/ga4gh/tools/namespace:name/versions/1/WDL/descriptor"
+  val toolRegistryDummyUrlPath = "/ga4gh/v1/tools/namespace:name/versions/1/WDL/descriptor"
 
   override def beforeAll(): Unit = {
     toolRegistryServer = startClientAndServer(MockUtils.methodsServerPort)
 
-    toolRegistryServer.when(request().withMethod(HttpMethods.GET.name).withPath(toolRegistryDummyAgoraPath))
+    toolRegistryServer.when(request().withMethod(HttpMethods.GET.name).withPath(toolRegistryDummyUrlPath))
       .respond(
         org.mockserver.model.HttpResponse.response()
           .withStatusCode(OK.intValue)


### PR DESCRIPTION
Partially addresses https://broadinstitute.atlassian.net/browse/GAWB-849 
Required for https://github.com/broadinstitute/agora/pull/218

Changes the public-facing API to point to the same version that exists in the agora PR.

---

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [x] Get two thumbsworth of review and PO signoff if necessary
- [x] Verify all tests go green
- [x] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [x] Test this change deployed correctly and works on dev environment after deployment
