### PR TITLE
GAWB-849: Agora supported GA4GH APIs

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -3426,8 +3426,7 @@ paths:
     get:
       summary: List all tools
       description: >
-        This endpoint returns all tools available or a filtered subset using
-        metadata query parameters.
+        This endpoint returns all tools available.
       tags:
         - GA4GH Tool Registry
       responses:

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -5130,13 +5130,27 @@ definitions:
       meta-version:
         type: string
         description: 'The version of this tool in the registry. Iterates when fields like the description, author, etc. are updated.'
+      contains:
+        description: An array of IDs for the applications that are stored inside this tool (for example `https://bio.tools/tool/mytum.de/SNAP2/1`). This always returns an empty array.
+        type: array
+        items:
+           type: string
+      verified:
+        type: boolean
+        description: Reports whether this tool has been verified by a specific organization or individual.  This always returns false.
+      verified-source:
+        type: string
+        description: Source of metadata that can support a verified tool, such as an email or URL
+      signed:
+        type: boolean
+        description: Reports whether this tool has been signed.  This always returns false.
       versions:
         description: A list of versions for this tool
         type: array
         items:
           $ref: '#/definitions/ToolVersion'
   ToolVersion:
-    description: A tool version describes a particular iteration of a tool.
+    description: A tool version describes a particular iteration of a tool as described by a reference to a specific image and dockerfile.
     required:
       - url
       - id
@@ -5151,6 +5165,9 @@ definitions:
       id:
         type: string
         description: An identifier of the version of this tool for this particular tool registry, for example `v1`
+      image:
+        type: string
+        description: The docker path to the image (and version) for this tool. (e.g. quay.io/seqware/seqware_full/1.1). This always returns an empty string.
       descriptor-type:
         type: array
         description: The type (or types) of descriptors available.
@@ -5158,6 +5175,9 @@ definitions:
           type: string
           enum:
             - WDL
+      dockerfile:
+        type: boolean
+        description: Reports if this tool has a dockerfile available. This always returns false.
       meta-version:
         type: string
         description: 'The version of this tool version in the registry. Iterates when fields like the description, author, etc. are updated.'

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -5191,19 +5191,27 @@ definitions:
         type: string
         description: 'The version of this tool in the registry. Iterates when fields like the description, author, etc. are updated.'
       contains:
-        description: An array of IDs for the applications that are stored inside this tool (for example `https://bio.tools/tool/mytum.de/SNAP2/1`)
+        description: >
+          An array of IDs for the applications that are stored inside this tool (for example `https://bio.tools/tool/mytum.de/SNAP2/1`).
+          The Broad Institute does not support this feature and returns an empty array.
         type: array
         items:
            type: string
       verified:
         type: boolean
-        description: Reports whether this tool has been verified by a specific organization or individual
+        description: >
+          Reports whether this tool has been verified by a specific organization or individual
+          The Broad Institute does not support this feature and returns false.
       verified-source:
         type: string
-        description: Source of metadata that can support a verified tool, such as an email or URL
+        description: >
+          Source of metadata that can support a verified tool, such as an email or URL
+          The Broad Institute does not support this feature and returns an empty string.
       signed:
         type: boolean
-        description: Reports whether this tool has been signed.
+        description: >
+          Reports whether this tool has been signed.
+          The Broad Institute does not support this feature and returns false.
       versions:
         description: A list of versions for this tool
         type: array
@@ -5244,10 +5252,14 @@ definitions:
         description: 'The version of this tool version in the registry. Iterates when fields like the description, author, etc. are updated.'
       verified:
         type: boolean
-        description: Reports whether this tool has been verified by a specific organization or individual
+        description: >
+          Reports whether this tool has been verified by a specific organization or individual
+          The Broad Institute does not support this feature and returns false.
       verified-source:
         type: string
-        description: Source of metadata that can support a verified tool, such as an email or URL
+        description: >
+          Source of metadata that can support a verified tool, such as an email or URL
+          The Broad Institute does not support this feature and returns an empty string.
   ToolDescriptor:
     description: A tool descriptor is a metadata document that describes one or more tools.
     required:

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -3358,6 +3358,131 @@ paths:
         200:
           description: OK
 
+  /ga4gh/v1/tools/{id}:
+    get:
+      summary: List one specific tool, acts as an anchor for self references
+      description: This endpoint returns one specific tool (which has ToolVersions nested inside it)
+      tags:
+        - GA4GH Tool Registry
+      parameters:
+        - name: id
+          in: path
+          required: true
+          type: string
+          description: A unique identifier of the tool, scoped to this registry, for example `123456`
+      responses:
+        '200':
+          description: A tool.
+          schema:
+              $ref: '#/definitions/Tool'
+      security: []
+
+  /ga4gh/v1/tools/{id}/versions:
+    get:
+      summary: List versions of a tool
+      description: Returns all versions of the specified tool
+      tags:
+        - GA4GH Tool Registry
+      parameters:
+        - name: id
+          in: path
+          required: true
+          type: string
+          description: A unique identifier of the tool, scoped to this registry, for example `123456`
+      responses:
+        '200':
+          description: An array of tool versions
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/ToolVersion'
+      security: []
+
+  /ga4gh/v1/tools/{id}/versions/{version-id}:
+    get:
+      summary: List one specific tool version, acts as an anchor for self references
+      description: This endpoint returns one specific tool version
+      tags:
+        - GA4GH Tool Registry
+      parameters:
+        - name: id
+          in: path
+          required: true
+          type: string
+          description: A unique identifier of the tool, scoped to this registry, for example `123456`
+        - name: version-id
+          in: path
+          required: true
+          type: string
+          description: An identifier of the tool version, scoped to this registry, for example `v1`
+      responses:
+        '200':
+          description: A tool version.
+          schema:
+              $ref: '#/definitions/ToolVersion'
+      security: []
+
+  /ga4gh/v1/tools:
+    get:
+      summary: List all tools
+      description: >
+        This endpoint returns all tools available or a filtered subset using
+        metadata query parameters.
+      tags:
+        - GA4GH Tool Registry
+      parameters:
+        - name: id
+          type: string
+          in: query
+          description: A unique identifier of the tool, scoped to this registry, for example `123456`
+        - name: registry
+          in: query
+          type: string
+          description: The image registry that contains the image.
+        - name: organization
+          in: query
+          type: string
+          description: The organization in the registry that published the image.
+        - name: name
+          in: query
+          type: string
+          description: The name of the image.
+        - name: toolname
+          in: query
+          type: string
+          description: The name of the tool.
+        - name: description
+          in: query
+          type: string
+          description: The description of the tool.
+        - name: author
+          in: query
+          type: string
+          description: 'The author of the tool (TODO a thought occurs, are we assuming that the author of the CWL and the image are the same?).'
+        - $ref: '#/parameters/offset'
+        - $ref: '#/parameters/limit'
+      responses:
+        '200':
+          description: An array of Tools that match the filter.
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Tool'
+          headers:
+            next-page:
+              description: A URL that can be used to reach the next page based on the current offset and page record limit
+              type: string
+            last-page:
+              description: A URL that can be used to reach the last page based on the current page record limit
+              type: string
+            current-offset:
+              description: The current start index of the paging used for this result
+              type: string
+            current-limit:
+              description: The current page record limit used for this result
+              type: integer
+      security: []
+
   /ga4gh/v1/tools/{id}/versions/{version-id}/{type}/descriptor:
     get:
       summary: Get the tool descriptor (CWL/WDL) for the specified tool.
@@ -3408,6 +3533,36 @@ paths:
           schema:
             $ref: '#/definitions/Error'
       security: []
+
+  /ga4gh/v1/metadata:
+    get:
+      summary: Return some metadata that is useful for describing this registry
+      description: Return some metadata that is useful for describing this registry
+      tags:
+        - GA4GH Tool Registry
+      responses:
+        '200':
+          description: A Metadata object describing this service.
+          schema:
+              $ref: '#/definitions/Metadata'
+      security: []
+
+  /ga4gh/v1/tool-classes:
+    get:
+      summary: List all tool types
+      description: >
+        This endpoint returns all tool-classes available
+      tags:
+        - GA4GH Tool Registry
+      responses:
+        '200':
+          description: An array of methods that match the filter.
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/ToolClass'
+      security: []
+
 
 ##########################################################################################
 ## PARAMETERS
@@ -3498,6 +3653,17 @@ parameters:
     required: true
     type: string
     in: path
+  limit:
+    name: limit
+    in: query
+    description: Amount of records to return in a given page.  By default it is 1000.
+    type: integer
+    format: int32
+  offset:
+    name: offset
+    in: query
+    description: Start index of paging. Pagination results can be based on numbers or other values chosen by the registry implementor (for example, SHA values). If this exceeds the current result set return an empty set.  If not specified in the request this will start at the beginning of the results.
+    type: string
 
 ##########################################################################################
 ## DEFINITIONS
@@ -4978,6 +5144,110 @@ definitions:
         type: string
         description: name of input
 
+  ToolClass:
+    description: Describes a class (type) of tool allowing us to categorize workflows, tools, and maybe even other entities (such as services) separately
+    properties:
+      id:
+        type: string
+        description: The unique identifier for the class
+      name:
+        type: string
+        description: A short friendly name for the class
+      description:
+        type: string
+        description: A longer explanation of what this class is and what it can accomplish
+  Tool:
+    description: A tool (or described tool) describes one pairing of a tool as described in a descriptor file (which potentially describes multiple tools) and a Docker image.
+    required:
+      - url
+      - id
+      - organization
+      - author
+      - meta-version
+      - toolclass
+      - versions
+    properties:
+      url:
+        type: string
+        description: The URL for this tool in this registry, for example `http://agora.broadinstitute.org/tools/123456`
+      id:
+        type: string
+        description: A unique identifier of the tool, scoped to this registry, for example `123456` or `123456_v1`
+      organization:
+        type: string
+        description: The organization that published the image.
+      toolname:
+        type: string
+        description: The name of the tool.
+      toolclass:
+        $ref: '#/definitions/ToolClass'
+      description:
+        type: string
+        description: The description of the tool.
+      author:
+        type: string
+        description: Contact information for the author of this tool entry in the registry. (More complex authorship information is handled by the descriptor)
+      meta-version:
+        type: string
+        description: 'The version of this tool in the registry. Iterates when fields like the description, author, etc. are updated.'
+      contains:
+        description: An array of IDs for the applications that are stored inside this tool (for example `https://bio.tools/tool/mytum.de/SNAP2/1`)
+        type: array
+        items:
+           type: string
+      verified:
+        type: boolean
+        description: Reports whether this tool has been verified by a specific organization or individual
+      verified-source:
+        type: string
+        description: Source of metadata that can support a verified tool, such as an email or URL
+      signed:
+        type: boolean
+        description: Reports whether this tool has been signed.
+      versions:
+        description: A list of versions for this tool
+        type: array
+        items:
+          $ref: '#/definitions/ToolVersion'
+  ToolVersion:
+    description: A tool version describes a particular iteration of a tool as described by a reference to a specific image and dockerfile.
+    required:
+      - url
+      - id
+      - meta-version
+    properties:
+      name:
+        type: string
+        description: The name of the version.
+      url:
+        type: string
+        description: The URL for this tool in this registry, for example `http://agora.broadinstitute.org/tools/123456/1`
+      id:
+        type: string
+        description: An identifier of the version of this tool for this particular tool registry, for example `v1`
+      image:
+        type: string
+        description: The docker path to the image (and version) for this tool. (e.g. quay.io/seqware/seqware_full/1.1)
+      descriptor-type:
+        type: array
+        description: The type (or types) of descriptors available.
+        items:
+          type: string
+          enum:
+            - CWL
+            - WDL
+      dockerfile:
+        type: boolean
+        description: Reports if this tool has a dockerfile available.
+      meta-version:
+        type: string
+        description: 'The version of this tool version in the registry. Iterates when fields like the description, author, etc. are updated.'
+      verified:
+        type: boolean
+        description: Reports whether this tool has been verified by a specific organization or individual
+      verified-source:
+        type: string
+        description: Source of metadata that can support a verified tool, such as an email or URL
   ToolDescriptor:
     description: A tool descriptor is a metadata document that describes one or more tools.
     required:
@@ -4995,7 +5265,24 @@ definitions:
       url:
         type: string
         description: 'Optional url to the tool descriptor used to build this image, should include version information, and can include a git hash (e.g. https://raw.githubusercontent.com/ICGC-TCGA-PanCancer/pcawg_delly_workflow/ea2a5db69bd20a42976838790bc29294df3af02b/delly_docker/Delly.cwl )'
-
+  Metadata:
+    description: Describes this registry to better allow for mirroring and indexing.
+    required:
+      - version
+      - api-version
+    properties:
+      version:
+        type: string
+        description: The version of this registry
+      api-version:
+        type: string
+        description: The version of the GA4GH tool-registry API supported by this registry
+      country:
+        type: string
+        description: A country code for the registry (ISO 3166-1 alpha-3)
+      friendly-name:
+        type: string
+        description: A friendly name that can be used in addition to the hostname to describe a registry
   UserInfo:
     type: object
     properties:

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -3430,37 +3430,6 @@ paths:
         metadata query parameters.
       tags:
         - GA4GH Tool Registry
-      parameters:
-        - name: id
-          type: string
-          in: query
-          description: A unique identifier of the tool, scoped to this registry, for example `123456`
-        - name: registry
-          in: query
-          type: string
-          description: The image registry that contains the image.
-        - name: organization
-          in: query
-          type: string
-          description: The organization in the registry that published the image.
-        - name: name
-          in: query
-          type: string
-          description: The name of the image.
-        - name: toolname
-          in: query
-          type: string
-          description: The name of the tool.
-        - name: description
-          in: query
-          type: string
-          description: The description of the tool.
-        - name: author
-          in: query
-          type: string
-          description: 'The author of the tool (TODO a thought occurs, are we assuming that the author of the CWL and the image are the same?).'
-        - $ref: '#/parameters/offset'
-        - $ref: '#/parameters/limit'
       responses:
         '200':
           description: An array of Tools that match the filter.
@@ -3468,25 +3437,12 @@ paths:
             type: array
             items:
               $ref: '#/definitions/Tool'
-          headers:
-            next-page:
-              description: A URL that can be used to reach the next page based on the current offset and page record limit
-              type: string
-            last-page:
-              description: A URL that can be used to reach the last page based on the current page record limit
-              type: string
-            current-offset:
-              description: The current start index of the paging used for this result
-              type: string
-            current-limit:
-              description: The current page record limit used for this result
-              type: integer
       security: []
 
   /ga4gh/v1/tools/{id}/versions/{version-id}/{type}/descriptor:
     get:
-      summary: Get the tool descriptor (CWL/WDL) for the specified tool.
-      description: Returns the CWL or WDL descriptor for the specified tool.
+      summary: Get the tool descriptor (WDL) for the specified tool.
+      description: Returns the WDL descriptor for the specified tool.
       tags:
         - GA4GH Tool Registry
       parameters:
@@ -3498,13 +3454,9 @@ paths:
             implementation to determine which output type to return. Plain types return the
             bare descriptor while the "non-plain" types return a descriptor wrapped
             with metadata.
-
-              *In FireCloud, only WDL and plain-WDL are supported.*
           type: string
           enum:
-            - CWL
             - WDL
-            - plain-CWL
             - plain-WDL
         - name: id
           in: path
@@ -3653,17 +3605,6 @@ parameters:
     required: true
     type: string
     in: path
-  limit:
-    name: limit
-    in: query
-    description: Amount of records to return in a given page.  By default it is 1000.
-    type: integer
-    format: int32
-  offset:
-    name: offset
-    in: query
-    description: Start index of paging. Pagination results can be based on numbers or other values chosen by the registry implementor (for example, SHA values). If this exceeds the current result set return an empty set.  If not specified in the request this will start at the beginning of the results.
-    type: string
 
 ##########################################################################################
 ## DEFINITIONS
@@ -5190,35 +5131,13 @@ definitions:
       meta-version:
         type: string
         description: 'The version of this tool in the registry. Iterates when fields like the description, author, etc. are updated.'
-      contains:
-        description: >
-          An array of IDs for the applications that are stored inside this tool (for example `https://bio.tools/tool/mytum.de/SNAP2/1`).
-          The Broad Institute does not support this feature and returns an empty array.
-        type: array
-        items:
-           type: string
-      verified:
-        type: boolean
-        description: >
-          Reports whether this tool has been verified by a specific organization or individual
-          The Broad Institute does not support this feature and returns false.
-      verified-source:
-        type: string
-        description: >
-          Source of metadata that can support a verified tool, such as an email or URL
-          The Broad Institute does not support this feature and returns an empty string.
-      signed:
-        type: boolean
-        description: >
-          Reports whether this tool has been signed.
-          The Broad Institute does not support this feature and returns false.
       versions:
         description: A list of versions for this tool
         type: array
         items:
           $ref: '#/definitions/ToolVersion'
   ToolVersion:
-    description: A tool version describes a particular iteration of a tool as described by a reference to a specific image and dockerfile.
+    description: A tool version describes a particular iteration of a tool.
     required:
       - url
       - id
@@ -5233,33 +5152,16 @@ definitions:
       id:
         type: string
         description: An identifier of the version of this tool for this particular tool registry, for example `v1`
-      image:
-        type: string
-        description: The docker path to the image (and version) for this tool. (e.g. quay.io/seqware/seqware_full/1.1)
       descriptor-type:
         type: array
         description: The type (or types) of descriptors available.
         items:
           type: string
           enum:
-            - CWL
             - WDL
-      dockerfile:
-        type: boolean
-        description: Reports if this tool has a dockerfile available.
       meta-version:
         type: string
         description: 'The version of this tool version in the registry. Iterates when fields like the description, author, etc. are updated.'
-      verified:
-        type: boolean
-        description: >
-          Reports whether this tool has been verified by a specific organization or individual
-          The Broad Institute does not support this feature and returns false.
-      verified-source:
-        type: string
-        description: >
-          Source of metadata that can support a verified tool, such as an email or URL
-          The Broad Institute does not support this feature and returns an empty string.
   ToolDescriptor:
     description: A tool descriptor is a metadata document that describes one or more tools.
     required:
@@ -5269,11 +5171,10 @@ definitions:
       type:
         type: string
         enum:
-          - CWL
           - WDL
       descriptor:
         type: string
-        description: The descriptor that represents this version of the tool. (CWL or WDL)
+        description: The descriptor that represents this version of the tool. (WDL)
       url:
         type: string
         description: 'Optional url to the tool descriptor used to build this image, should include version information, and can include a git hash (e.g. https://raw.githubusercontent.com/ICGC-TCGA-PanCancer/pcawg_delly_workflow/ea2a5db69bd20a42976838790bc29294df3af02b/delly_docker/Delly.cwl )'

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/Ga4ghApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/Ga4ghApiService.scala
@@ -11,17 +11,48 @@ trait Ga4ghApiService extends HttpService with FireCloudDirectives {
 
   private implicit val ec: ExecutionContext = actorRefFactory.dispatcher
 
-  private val agora = FireCloudConfig.Agora.baseUrl
+  private val agoraGA4GH = s"${FireCloudConfig.Agora.baseUrl}/ga4gh/v1"
 
   val ga4ghRoutes: Route =
     pathPrefix("ga4gh") {
       pathPrefix("v1") {
-        pathPrefix("tools") {
-          path(Segment / "versions" / Segment / Segment / "descriptor") { (id, versionId, descriptorType) =>
-            get {
-              val targetUri = Uri(s"$agora/ga4gh/v1/tools/$id/versions/$versionId/$descriptorType/descriptor")
-              passthrough(targetUri, HttpMethods.GET)
-            }
+        get {
+          path("metadata") {
+            val targetUri = Uri(s"$agoraGA4GH/metadata")
+            passthrough(targetUri, HttpMethods.GET)
+          } ~
+          path("tool-classes") {
+            val targetUri = Uri(s"$agoraGA4GH/tool-classes")
+            passthrough(targetUri, HttpMethods.GET)
+          } ~
+          path("tools") {
+            val targetUri = Uri(s"$agoraGA4GH/tools")
+            passthrough(targetUri, HttpMethods.GET)
+          } ~
+          path("tools" / Segment) { (id) =>
+            val targetUri = Uri(s"$agoraGA4GH/tools/$id")
+            passthrough(targetUri, HttpMethods.GET)
+          } ~
+          path("tools" / Segment / "versions") { (id) =>
+            val targetUri = Uri(s"$agoraGA4GH/tools/$id/versions")
+            passthrough(targetUri, HttpMethods.GET)
+          } ~
+          path("tools" / Segment / "versions" / Segment / "dockerfile") { (id, versionId) =>
+            complete(spray.http.StatusCodes.NotImplemented)
+          } ~
+          path("tools" / Segment / "versions" / Segment) { (id, versionId) =>
+            val targetUri = Uri(s"$agoraGA4GH/tools/$id/versions/$versionId")
+            passthrough(targetUri, HttpMethods.GET)
+          } ~
+          path("tools" / Segment / "versions" / Segment / Segment / "descriptor") { (id, versionId, descriptorType) =>
+            val targetUri = Uri(s"$agoraGA4GH/tools/$id/versions/$versionId/$descriptorType/descriptor")
+            passthrough(targetUri, HttpMethods.GET)
+          } ~
+          path("tools" / Segment / "versions" / Segment / Segment / "descriptor" / Segment) { (id, versionId, descriptorType, relativePath) =>
+            complete(spray.http.StatusCodes.NotImplemented)
+          } ~
+          path("tools" / Segment / "versions" / Segment / Segment / "tests") { (id, versionId, descriptorType) =>
+            complete(spray.http.StatusCodes.NotImplemented)
           }
         }
       }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/Ga4ghApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/Ga4ghApiService.scala
@@ -38,7 +38,8 @@ trait Ga4ghApiService extends HttpService with FireCloudDirectives {
             passthrough(targetUri, HttpMethods.GET)
           } ~
           path("tools" / Segment / "versions" / Segment / "dockerfile") { (id, versionId) =>
-            complete(spray.http.StatusCodes.NotImplemented)
+            val targetUri = Uri(s"$agoraGA4GH/tools/$id/versions/$versionId/dockerfile")
+            passthrough(targetUri, HttpMethods.GET)
           } ~
           path("tools" / Segment / "versions" / Segment) { (id, versionId) =>
             val targetUri = Uri(s"$agoraGA4GH/tools/$id/versions/$versionId")
@@ -49,10 +50,12 @@ trait Ga4ghApiService extends HttpService with FireCloudDirectives {
             passthrough(targetUri, HttpMethods.GET)
           } ~
           path("tools" / Segment / "versions" / Segment / Segment / "descriptor" / Segment) { (id, versionId, descriptorType, relativePath) =>
-            complete(spray.http.StatusCodes.NotImplemented)
+            val targetUri = Uri(s"$agoraGA4GH/tools/$id/versions/$versionId/$descriptorType/descriptor/$relativePath")
+            passthrough(targetUri, HttpMethods.GET)
           } ~
           path("tools" / Segment / "versions" / Segment / Segment / "tests") { (id, versionId, descriptorType) =>
-            complete(spray.http.StatusCodes.NotImplemented)
+            val targetUri = Uri(s"$agoraGA4GH/tools/$id/versions/$versionId/$descriptorType/tests")
+            passthrough(targetUri, HttpMethods.GET)
           }
         }
       }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/Ga4ghApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/Ga4ghApiService.scala
@@ -26,8 +26,15 @@ trait Ga4ghApiService extends HttpService with FireCloudDirectives {
             passthrough(targetUri, HttpMethods.GET)
           } ~
           path("tools") {
-            val targetUri = Uri(s"$agoraGA4GH/tools")
-            passthrough(targetUri, HttpMethods.GET)
+            parameterSeq { params =>
+              val targetUri = Uri(s"$agoraGA4GH/tools")
+              val uri = if (params.isEmpty) {
+                targetUri
+              } else {
+                targetUri.withQuery(params.toMap)
+              }
+              passthrough(uri, HttpMethods.GET)
+            }
           } ~
           path("tools" / Segment) { (id) =>
             val targetUri = Uri(s"$agoraGA4GH/tools/$id")

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/Ga4ghApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/Ga4ghApiServiceSpec.scala
@@ -27,8 +27,7 @@ class Ga4ghApiServiceSpec extends BaseServiceSpec with Ga4ghApiService with Befo
   val unImplementedPaths = List(
     "/ga4gh/v1/tools/namespace:name/versions/1/dockerfile",
     "/ga4gh/v1/tools/namespace:name/versions/1/WDL/descriptor/1",
-    "/ga4gh/v1/tools/namespace:name/versions/1/WDL/tests"
-  )
+    "/ga4gh/v1/tools/namespace:name/versions/1/WDL/tests")
 
   override def beforeAll(): Unit = {
     toolRegistryServer = startClientAndServer(MockUtils.methodsServerPort)

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/Ga4ghApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/Ga4ghApiServiceSpec.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.firecloud.webservice
 
+import akka.actor.ActorSystem
 import org.broadinstitute.dsde.firecloud.mock.MockUtils
 import org.broadinstitute.dsde.firecloud.service.BaseServiceSpec
 import org.mockserver.integration.ClientAndServer
@@ -11,19 +12,33 @@ import spray.http.StatusCodes._
 
 class Ga4ghApiServiceSpec extends BaseServiceSpec with Ga4ghApiService with BeforeAndAfterEach {
 
-  def actorRefFactory = system
+  def actorRefFactory: ActorSystem = system
 
   var toolRegistryServer: ClientAndServer = _
-  val toolRegistryDummyUrlPath = "/ga4gh/v1/tools/namespace:name/versions/1/WDL/descriptor"
+  val toolPaths = List(
+    "/ga4gh/v1/metadata",
+    "/ga4gh/v1/tool-classes",
+    "/ga4gh/v1/tools",
+    "/ga4gh/v1/tools/namespace:name",
+    "/ga4gh/v1/tools/namespace:name/versions",
+    "/ga4gh/v1/tools/namespace:name/versions/1",
+    "/ga4gh/v1/tools/namespace:name/versions/1/WDL/descriptor")
+
+  val unImplementedPaths = List(
+    "/ga4gh/v1/tools/namespace:name/versions/1/dockerfile",
+    "/ga4gh/v1/tools/namespace:name/versions/1/WDL/descriptor/1",
+    "/ga4gh/v1/tools/namespace:name/versions/1/WDL/tests"
+  )
 
   override def beforeAll(): Unit = {
     toolRegistryServer = startClientAndServer(MockUtils.methodsServerPort)
-
-    toolRegistryServer.when(request().withMethod(HttpMethods.GET.name).withPath(toolRegistryDummyUrlPath))
-      .respond(
-        org.mockserver.model.HttpResponse.response()
-          .withStatusCode(OK.intValue)
-      )
+    toolPaths.map { path =>
+      toolRegistryServer.when(request().withMethod(HttpMethods.GET.name).withPath(path))
+        .respond(
+          org.mockserver.model.HttpResponse.response()
+            .withStatusCode(OK.intValue)
+        )
+    }
   }
 
   override def afterAll(): Unit = {
@@ -32,19 +47,29 @@ class Ga4ghApiServiceSpec extends BaseServiceSpec with Ga4ghApiService with Befo
 
   "GA4GH API service" - {
     "Tool Registry" - {
-      "get-descriptor passthrough API" - {
-
+      "passthrough APIs" - {
+        "should handle un-implemented paths" in {
+          unImplementedPaths.map { path =>
+            Get(path) ~> ga4ghRoutes ~> check {
+              status should equal(NotImplemented)
+            }
+          }
+        }
         "should reject all but GET" in {
           List(HttpMethods.POST, HttpMethods.PUT, HttpMethods.PATCH, HttpMethods.DELETE, HttpMethods.HEAD) foreach {
             method =>
-              new RequestBuilder(method)(toolRegistryDummyUrlPath) ~> ga4ghRoutes ~> check {
-                assert(!handled)
+              (toolPaths ++ unImplementedPaths).map { path =>
+                new RequestBuilder(method)(path) ~> ga4ghRoutes ~> check {
+                  assert(!handled)
+                }
               }
           }
         }
         "should accept GET" in {
-          Get(toolRegistryDummyUrlPath) ~> ga4ghRoutes ~> check {
-           assert(handled)
+          toolPaths.map { path =>
+            Get(path) ~> ga4ghRoutes ~> check {
+              assert(handled)
+            }
           }
         }
       }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/Ga4ghApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/Ga4ghApiServiceSpec.scala
@@ -38,6 +38,14 @@ class Ga4ghApiServiceSpec extends BaseServiceSpec with Ga4ghApiService with Befo
             .withStatusCode(OK.intValue)
         )
     }
+    // Currently, Agora returns NotImplemented for these paths.
+    unImplementedPaths.map { path =>
+      toolRegistryServer.when(request().withMethod(HttpMethods.GET.name).withPath(path))
+        .respond(
+          org.mockserver.model.HttpResponse.response()
+            .withStatusCode(NotImplemented.intValue)
+        )
+    }
   }
 
   override def afterAll(): Unit = {


### PR DESCRIPTION
Partially addresses https://broadinstitute.atlassian.net/browse/GAWB-849

## Changes
* Update swagger doc with new endpoints supported by Agora
* Unimplemented GA4GH endpoints not documented, but handled, similarly to what Agora does.

Goes hand in hand with https://github.com/broadinstitute/agora/pull/221, but both PRs can be reviewed in isolation.

---

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [x] Get two thumbsworth of review and PO signoff if necessary
- [x] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
