### PR TITLE
GAWB-2746: DUL search API

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -4861,6 +4861,30 @@ definitions:
         items:
           $ref: '#/definitions/KeyValuePair'
 
+  ResearchPurpose:
+    type: object
+    properties:
+      DS:
+        type: array
+        items:
+          type: string
+        description: Disease focused research. Values are DOID ontology node ids in the form http://purl.obolibrary.org/obo/DOID_NNN.
+      NDMS:
+        type: boolean
+        description: Methods development/Validation study
+      NCTRL:
+        type: boolean
+        description: Control set
+      NAGR:
+        type: boolean
+        description: Aggregate analysis to understand variation in the general population
+      POA:
+        type: boolean
+        description: Study population origins or ancestry
+      NCU:
+        type: boolean
+        description: Commercial purpose/by a commercial entity
+
   SearchTermRef:
     type: object
     properties:
@@ -4870,6 +4894,10 @@ definitions:
       filters:
         type: object
         description: Map[String, Array[String]] Each entry contains the column name (i.e. "library:indication") and a list of terms that will be or'ed in the query (["cancer", "sleep apnea"])
+      researchPurpose:
+        type: object
+        schema:
+          $ref: '#/definitions/ResearchPurpose'
       fieldAggregations:
         type: object
         description: Map[String, Int] The list of fields for which you would like to retrieve aggregations and the number of aggregations to return. Default is 5. Specify 0 to get all

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchDAOQuerySupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchDAOQuerySupport.scala
@@ -23,7 +23,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.matching.Regex
 
 
-trait ElasticSearchDAOQuerySupport extends ElasticSearchDAOSupport {
+trait ElasticSearchDAOQuerySupport extends ElasticSearchDAOSupport with ElasticSearchDAOResearchPurposeSupport {
 
   final val HL_START = "<strong class='es-highlight'>"
   final val HL_END = "</strong>"
@@ -94,6 +94,10 @@ trait ElasticSearchDAOQuerySupport extends ElasticSearchDAOSupport {
       values foreach { value:String => fieldQuery.should(termQuery(field+".keyword", value))}
       query.must(fieldQuery)
     }
+    criteria.researchPurpose map { rp =>
+      query.must(researchPurposeFilters(rp))
+    }
+
     query
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchDAOResearchPurposeSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchDAOResearchPurposeSupport.scala
@@ -2,23 +2,27 @@ package org.broadinstitute.dsde.firecloud.dataaccess
 
 import com.typesafe.scalalogging.slf4j.LazyLogging
 import org.broadinstitute.dsde.firecloud.model.DataUse.ResearchPurpose
+import org.broadinstitute.dsde.firecloud.service.DataUseRestrictionSupport
+import org.broadinstitute.dsde.rawls.model.AttributeName
 import org.elasticsearch.index.query.BoolQueryBuilder
 import org.elasticsearch.index.query.QueryBuilders.{boolQuery, termQuery}
 
-trait ElasticSearchDAOResearchPurposeSupport extends LazyLogging {
+trait ElasticSearchDAOResearchPurposeSupport extends DataUseRestrictionSupport with LazyLogging {
 
   def researchPurposeFilters(rp: ResearchPurpose): BoolQueryBuilder = {
     val bool = boolQuery
+
+    val durRoot = AttributeName.toDelimitedName(structuredUseRestrictionAttributeName)
 
     /*
       purpose: NAGR: Aggregate analysis to understand variation in the general population
       dul:     Any dataset where NAGR is false and is (GRU or HMB)
      */
     if (rp.NAGR) {
-      bool.must(termQuery("dataUseRestriction.NAGR", false))
+      bool.must(termQuery(s"$durRoot.NAGR", false))
       bool.must(boolQuery()
-        .should(termQuery("dataUseRestriction.GRU", true))
-        .should(termQuery("dataUseRestriction.HMB", true))
+        .should(termQuery(s"$durRoot.GRU", true))
+        .should(termQuery(s"$durRoot.HMB", true))
       )
     }
 
@@ -27,8 +31,8 @@ trait ElasticSearchDAOResearchPurposeSupport extends LazyLogging {
       dul:     Any dataset where NPU and NCU are both false
      */
     if (rp.NCU) {
-      bool.must(termQuery("dataUseRestriction.NPU", false))
-      bool.must(termQuery("dataUseRestriction.NCU", false))
+      bool.must(termQuery(s"$durRoot.NPU", false))
+      bool.must(termQuery(s"$durRoot.NCU", false))
     }
 
     /*
@@ -36,7 +40,7 @@ trait ElasticSearchDAOResearchPurposeSupport extends LazyLogging {
       dul:     Any dataset tagged with GRU
     */
     if (rp.POA)
-      bool.must(termQuery("dataUseRestriction.GRU", true))
+      bool.must(termQuery(s"$durRoot.GRU", true))
 
 
     bool

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchDAOResearchPurposeSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchDAOResearchPurposeSupport.scala
@@ -1,0 +1,45 @@
+package org.broadinstitute.dsde.firecloud.dataaccess
+
+import com.typesafe.scalalogging.slf4j.LazyLogging
+import org.broadinstitute.dsde.firecloud.model.DataUse.ResearchPurpose
+import org.elasticsearch.index.query.BoolQueryBuilder
+import org.elasticsearch.index.query.QueryBuilders.{boolQuery, termQuery}
+
+trait ElasticSearchDAOResearchPurposeSupport extends LazyLogging {
+
+  def researchPurposeFilters(rp: ResearchPurpose): BoolQueryBuilder = {
+    val bool = boolQuery
+
+    /*
+      purpose: NAGR: Aggregate analysis to understand variation in the general population
+      dul:     Any dataset where NAGR is false and is (GRU or HMB)
+     */
+    if (rp.NAGR) {
+      bool.must(termQuery("dataUseRestriction.NAGR", false))
+      bool.must(boolQuery()
+        .should(termQuery("dataUseRestriction.GRU", true))
+        .should(termQuery("dataUseRestriction.HMB", true))
+      )
+    }
+
+    /*
+      purpose: NCU:  Commercial purpose/by a commercial entity
+      dul:     Any dataset where NPU and NCU are both false
+     */
+    if (rp.NCU) {
+      bool.must(termQuery("dataUseRestriction.NPU", false))
+      bool.must(termQuery("dataUseRestriction.NCU", false))
+    }
+
+    /*
+      purpose: POA: Study population origins or ancestry
+      dul:     Any dataset tagged with GRU
+    */
+    if (rp.POA)
+      bool.must(termQuery("dataUseRestriction.GRU", true))
+
+
+    bool
+  }
+
+}

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/DataUse.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/DataUse.scala
@@ -1,0 +1,32 @@
+package org.broadinstitute.dsde.firecloud.model
+
+import spray.http.Uri
+
+object DataUse {
+
+  private final val doid_prefix = "http://purl.obolibrary.org/obo/DOID_"
+
+  case class ResearchPurpose(
+    DS:    Seq[DiseaseOntologyNodeId],
+    NDMS:  Boolean,
+    NCTRL: Boolean,
+    NAGR:  Boolean,
+    POA:   Boolean,
+    NCU:   Boolean)
+  object ResearchPurpose {
+    def default = {
+      new ResearchPurpose(Seq.empty[DiseaseOntologyNodeId], NDMS=false, NCTRL=false, NAGR=false, POA=false, NCU=false)
+    }
+  }
+
+  case class DiseaseOntologyNodeId(uri: Uri, numericId: Int)
+  object DiseaseOntologyNodeId {
+    def apply(stringid:String) = {
+      require(stringid.startsWith(doid_prefix), s"Disease Ontology node id must be in the form '${doid_prefix}NNN'")
+      val uri = Uri(stringid)
+      val numericId = stringid.stripPrefix(doid_prefix).toInt
+      new DiseaseOntologyNodeId(uri, numericId)
+    }
+  }
+
+}

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ElasticSearch.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ElasticSearch.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.firecloud.model
 
+import org.broadinstitute.dsde.firecloud.model.DataUse.ResearchPurpose
 import org.broadinstitute.dsde.rawls.model.{AttributeFormat, PlainArrayAttributeListSerializer}
 import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport.AttributeNameFormat
 import org.broadinstitute.dsde.rawls.model.Attributable.AttributeMap
@@ -120,6 +121,7 @@ object Document {
 case class LibrarySearchParams(
   searchString: Option[String],
   filters: Map[String, Seq[String]],
+  researchPurpose: Option[ResearchPurpose],
   fieldAggregations: Map[String, Int],
   from: Int = 0,
   size: Int = 10,
@@ -127,8 +129,8 @@ case class LibrarySearchParams(
   sortDirection: Option[String] = None)
 
 object LibrarySearchParams {
-  def apply(searchString: Option[String], filters: Map[String, Seq[String]], fieldAggregations: Map[String, Int], from: Option[Int], size: Option[Int], sortField: Option[String], sortDirection: Option[String]) = {
-    new LibrarySearchParams(searchString, filters, fieldAggregations, from.getOrElse(0), size.getOrElse(10), sortField, sortDirection)
+  def apply(searchString: Option[String], filters: Map[String, Seq[String]], researchPurpose: Option[ResearchPurpose], fieldAggregations: Map[String, Int], from: Option[Int], size: Option[Int], sortField: Option[String], sortDirection: Option[String]) = {
+    new LibrarySearchParams(searchString, filters, researchPurpose, fieldAggregations, from.getOrElse(0), size.getOrElse(10), sortField, sortDirection)
   }
 }
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/ESIntegrationSupport.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/ESIntegrationSupport.scala
@@ -6,6 +6,7 @@ import java.util.Calendar
 import com.typesafe.config.ConfigFactory
 import org.broadinstitute.dsde.firecloud.FireCloudConfig
 import org.broadinstitute.dsde.firecloud.dataaccess.{ElasticSearchDAO, SearchDAO}
+import org.broadinstitute.dsde.firecloud.model.DataUse.ResearchPurpose
 import org.broadinstitute.dsde.firecloud.model.LibrarySearchParams
 
 import scala.util.{Failure, Success, Try}
@@ -37,6 +38,6 @@ object ESIntegrationSupport extends IntegrationTestConfig {
     new ElasticSearchDAO(ITElasticSearch.servers, ITElasticSearch.clusterName, itTestIndexName)
   }
 
-  lazy val emptyCriteria = LibrarySearchParams(None,Map.empty[String,Seq[String]],Map.empty[String,Int],None,None,None,None)
+  lazy val emptyCriteria = LibrarySearchParams(None,Map.empty[String,Seq[String]],None,Map.empty[String,Int],None,None,None,None)
 
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/ResearchPurposeSearchSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/ResearchPurposeSearchSpec.scala
@@ -1,0 +1,69 @@
+package org.broadinstitute.dsde.firecloud.integrationtest
+
+import com.typesafe.scalalogging.slf4j.LazyLogging
+import org.broadinstitute.dsde.firecloud.integrationtest.ESIntegrationSupport.searchDAO
+import org.broadinstitute.dsde.firecloud.model.DataUse.ResearchPurpose
+import org.scalatest.{BeforeAndAfterAll, FreeSpec, Matchers}
+
+class ResearchPurposeSearchSpec extends FreeSpec with SearchResultValidation with Matchers with BeforeAndAfterAll with LazyLogging {
+
+  override def beforeAll = {
+    // use re-create here, since instantiating the DAO will create it in the first place
+    searchDAO.recreateIndex()
+    // make sure we specify refresh=true here; otherwise, the documents may not be available in the index by the
+    // time the tests start, leading to test failures.
+    logger.info("indexing fixtures ...")
+    searchDAO.bulkIndex(ResearchPurposeSearchTestFixtures.fixtureDocs, refresh = true)
+    logger.info("... fixtures indexed.")
+  }
+
+  override def afterAll = {
+    searchDAO.deleteIndex()
+  }
+
+  "Library research-purpose-aware search" - {
+    "Elastic Search" - {
+      "Index exists" in {
+        assert(searchDAO.indexExists())
+      }
+    }
+    "Research purpose for aggregate analysis (NAGR)" - {
+      "should return any dataset where NAGR is false and is (GRU or HMB)" in {
+        val researchPurpose = ResearchPurpose.default.copy(NAGR = true)
+        val searchResponse = searchWithPurpose(researchPurpose)
+        assertResult(2) {searchResponse.total}
+        validateResultNames(
+          Set("CSA_9220", "L_1240"),
+          searchResponse
+        )
+      }
+    }
+    "Research purpose for population origins/ancestry (POA)" - {
+      "should return any dataset where GRU is true" in {
+        val researchPurpose = ResearchPurpose.default.copy(POA = true)
+        val searchResponse = searchWithPurpose(researchPurpose)
+        assertResult(1) {searchResponse.total}
+        validateResultNames(
+          Set("CSA_9220"),
+          searchResponse
+        )
+      }
+    }
+    "Research purpose for commercial use (NCU)" - {
+      "should return any dataset where NPU and NCU are both false" in {
+        val researchPurpose = ResearchPurpose.default.copy(NCU = true)
+        val searchResponse = searchWithPurpose(researchPurpose)
+        assertResult(3) {searchResponse.total}
+        validateResultNames(
+          Set("CSA_9220", "L_1240", "FASD_0050696"),
+          searchResponse
+        )
+      }
+    }
+    // TODO: autosuggest tests
+    // TODO: RP + filter tests
+    // TODO: RP + search tests
+    // TODO: RPs that specify multiple selections
+  }
+
+}

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/ResearchPurposeSearchTestFixtures.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/ResearchPurposeSearchTestFixtures.scala
@@ -17,20 +17,40 @@ object ResearchPurposeSearchTestFixtures {
 
   implicit val impRestrictionFormat = jsonFormat5(Restriction)
 
-  val datasetTuples:Seq[(String,String,Restriction)] = Seq(
-    ("CSA_9220", "Kombucha vaporware flexitarian chambray bespoke", Restriction(GRU=true)),
-    ("L_1240", "3 wolf moon vape try-hard knausgaard", Restriction(HMB=true)),
-    ("HC_2531", "wolf freegan irony lomo", Restriction(NCU=true)),
-    ("FASD_0050696", "gastropub tattooed hammock mustache", Restriction(NAGR=true)),
-    ("D_4", "Neutra selvage chicharrones, prism taxidermy cray squid", Restriction(NPU=true))
+  // tuples in this order:
+  //   dataset name: used to validate results
+  //   project name: used to test facet filters
+  //   indication: used to test suggestions
+  //   datasetCustodian: used to test text search
+  //   restriction: used to test research purpose matching
+  val datasetTuples:Seq[(String,String,String,String,Restriction)] = Seq(
+    ("one",      "hydrogen", "antiaging",     "the quick brown fox", Restriction(GRU=true, NCU=true)),
+    ("two",      "hydrogen", "antialias",     "the quick brown fox", Restriction(HMB=true)),
+    ("three",    "hydrogen", "antianxiety",   "the quick brown fox", Restriction(NCU=true)),
+    ("four",     "hydrogen", "antibacterial", "the quick brown fox", Restriction(NAGR=true)),
+    ("five",     "hydrogen", "antibiotic",    "the quick brown fox", Restriction(NPU=true)),
+
+    ("six",      "helium",   "antibody",      "jumped over the",     Restriction(GRU=true, NCU=true)),
+    ("seven",    "helium",   "antic",         "jumped over the",     Restriction(HMB=true)),
+    ("eight",    "helium",   "anticavity",    "jumped over the",     Restriction(NCU=true)),
+    ("nine",     "helium",   "anticipate",    "jumped over the",     Restriction(NAGR=true)),
+    ("ten",      "helium",   "anticlimactic", "jumped over the",     Restriction(NPU=true)),
+
+    ("eleven",   "lithium",  "anticoagulant",                "lazy dog", Restriction(GRU=true, NCU=true)),
+    ("twelve",   "lithium",  "anticorruption",               "lazy dog", Restriction(HMB=true)),
+    ("thirteen", "lithium",  "antidepressant",               "lazy dog", Restriction(NCU=true)),
+    ("fourteen", "lithium",  "antidisestablishmentarianism", "lazy dog", Restriction(NAGR=true)),
+    ("fifteen",  "lithium",  "antidote",                     "lazy dog", Restriction(NPU=true))
+
   )
 
-  val fixtureDocs:Seq[Document] = datasetTuples map {x:(String,String,Restriction) =>
+  val fixtureDocs:Seq[Document] = datasetTuples map {x:(String,String,String,String,Restriction) =>
     Document(x._1, Map(
-      AttributeName("library","projectName") -> AttributeString(x._1),
       AttributeName("library","datasetName") -> AttributeString(x._1),
-      AttributeName("library","indication") -> AttributeString(x._2),
-      AttributeName.withDefaultNS("dataUseRestriction") -> AttributeValueRawJson(x._3.toJson)
+      AttributeName("library","projectName") -> AttributeString(x._2),
+      AttributeName("library","indication") -> AttributeString(x._3),
+      AttributeName("library","datasetCustodian") -> AttributeString(x._4),
+      AttributeName.withDefaultNS("dataUseRestriction") -> AttributeValueRawJson(x._5.toJson)
     ))
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/ResearchPurposeSearchTestFixtures.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/ResearchPurposeSearchTestFixtures.scala
@@ -1,11 +1,12 @@
 package org.broadinstitute.dsde.firecloud.integrationtest
 
 import org.broadinstitute.dsde.firecloud.model.Document
+import org.broadinstitute.dsde.firecloud.service.DataUseRestrictionSupport
 import org.broadinstitute.dsde.rawls.model._
 import spray.json.DefaultJsonProtocol._
 import spray.json._
 
-object ResearchPurposeSearchTestFixtures {
+object ResearchPurposeSearchTestFixtures extends DataUseRestrictionSupport {
 
   case class Restriction(
     GRU: Boolean = false,
@@ -50,7 +51,7 @@ object ResearchPurposeSearchTestFixtures {
       AttributeName("library","projectName") -> AttributeString(x._2),
       AttributeName("library","indication") -> AttributeString(x._3),
       AttributeName("library","datasetCustodian") -> AttributeString(x._4),
-      AttributeName.withDefaultNS("dataUseRestriction") -> AttributeValueRawJson(x._5.toJson)
+      structuredUseRestrictionAttributeName -> AttributeValueRawJson(x._5.toJson)
     ))
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/ResearchPurposeSearchTestFixtures.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/ResearchPurposeSearchTestFixtures.scala
@@ -1,0 +1,37 @@
+package org.broadinstitute.dsde.firecloud.integrationtest
+
+import org.broadinstitute.dsde.firecloud.model.Document
+import org.broadinstitute.dsde.rawls.model._
+import spray.json.DefaultJsonProtocol._
+import spray.json._
+
+object ResearchPurposeSearchTestFixtures {
+
+  case class Restriction(
+    GRU: Boolean = false,
+    HMB: Boolean = false,
+    NCU: Boolean = false,
+    NAGR: Boolean = false,
+    NPU: Boolean = false
+    )
+
+  implicit val impRestrictionFormat = jsonFormat5(Restriction)
+
+  val datasetTuples:Seq[(String,String,Restriction)] = Seq(
+    ("CSA_9220", "Kombucha vaporware flexitarian chambray bespoke", Restriction(GRU=true)),
+    ("L_1240", "3 wolf moon vape try-hard knausgaard", Restriction(HMB=true)),
+    ("HC_2531", "wolf freegan irony lomo", Restriction(NCU=true)),
+    ("FASD_0050696", "gastropub tattooed hammock mustache", Restriction(NAGR=true)),
+    ("D_4", "Neutra selvage chicharrones, prism taxidermy cray squid", Restriction(NPU=true))
+  )
+
+  val fixtureDocs:Seq[Document] = datasetTuples map {x:(String,String,Restriction) =>
+    Document(x._1, Map(
+      AttributeName("library","projectName") -> AttributeString(x._1),
+      AttributeName("library","datasetName") -> AttributeString(x._1),
+      AttributeName("library","indication") -> AttributeString(x._2),
+      AttributeName.withDefaultNS("dataUseRestriction") -> AttributeValueRawJson(x._3.toJson)
+    ))
+  }
+
+}

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/ResearchPurposeSearchTestFixtures.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/ResearchPurposeSearchTestFixtures.scala
@@ -2,21 +2,11 @@ package org.broadinstitute.dsde.firecloud.integrationtest
 
 import org.broadinstitute.dsde.firecloud.model.Document
 import org.broadinstitute.dsde.firecloud.service.DataUseRestrictionSupport
+import org.broadinstitute.dsde.firecloud.service.DataUseRestrictionTestFixture.{DataUseRestriction, impDataUseRestriction}
 import org.broadinstitute.dsde.rawls.model._
-import spray.json.DefaultJsonProtocol._
 import spray.json._
 
 object ResearchPurposeSearchTestFixtures extends DataUseRestrictionSupport {
-
-  case class Restriction(
-    GRU: Boolean = false,
-    HMB: Boolean = false,
-    NCU: Boolean = false,
-    NAGR: Boolean = false,
-    NPU: Boolean = false
-    )
-
-  implicit val impRestrictionFormat = jsonFormat5(Restriction)
 
   // tuples in this order:
   //   dataset name: used to validate results
@@ -24,28 +14,28 @@ object ResearchPurposeSearchTestFixtures extends DataUseRestrictionSupport {
   //   indication: used to test suggestions
   //   datasetCustodian: used to test text search
   //   restriction: used to test research purpose matching
-  val datasetTuples:Seq[(String,String,String,String,Restriction)] = Seq(
-    ("one",      "hydrogen", "antiaging",     "the quick brown fox", Restriction(GRU=true, NCU=true)),
-    ("two",      "hydrogen", "antialias",     "the quick brown fox", Restriction(HMB=true)),
-    ("three",    "hydrogen", "antianxiety",   "the quick brown fox", Restriction(NCU=true)),
-    ("four",     "hydrogen", "antibacterial", "the quick brown fox", Restriction(NAGR=true)),
-    ("five",     "hydrogen", "antibiotic",    "the quick brown fox", Restriction(NPU=true)),
+  val datasetTuples:Seq[(String,String,String,String,DataUseRestriction)] = Seq(
+    ("one",      "hydrogen", "antiaging",     "the quick brown fox", DataUseRestriction(GRU=true, NCU=true)),
+    ("two",      "hydrogen", "antialias",     "the quick brown fox", DataUseRestriction(HMB=true)),
+    ("three",    "hydrogen", "antianxiety",   "the quick brown fox", DataUseRestriction(NCU=true)),
+    ("four",     "hydrogen", "antibacterial", "the quick brown fox", DataUseRestriction(NAGR=true)),
+    ("five",     "hydrogen", "antibiotic",    "the quick brown fox", DataUseRestriction(NPU=true)),
 
-    ("six",      "helium",   "antibody",      "jumped over the",     Restriction(GRU=true, NCU=true)),
-    ("seven",    "helium",   "antic",         "jumped over the",     Restriction(HMB=true)),
-    ("eight",    "helium",   "anticavity",    "jumped over the",     Restriction(NCU=true)),
-    ("nine",     "helium",   "anticipate",    "jumped over the",     Restriction(NAGR=true)),
-    ("ten",      "helium",   "anticlimactic", "jumped over the",     Restriction(NPU=true)),
+    ("six",      "helium",   "antibody",      "jumped over the",     DataUseRestriction(GRU=true, NCU=true)),
+    ("seven",    "helium",   "antic",         "jumped over the",     DataUseRestriction(HMB=true)),
+    ("eight",    "helium",   "anticavity",    "jumped over the",     DataUseRestriction(NCU=true)),
+    ("nine",     "helium",   "anticipate",    "jumped over the",     DataUseRestriction(NAGR=true)),
+    ("ten",      "helium",   "anticlimactic", "jumped over the",     DataUseRestriction(NPU=true)),
 
-    ("eleven",   "lithium",  "anticoagulant",                "lazy dog", Restriction(GRU=true, NCU=true)),
-    ("twelve",   "lithium",  "anticorruption",               "lazy dog", Restriction(HMB=true)),
-    ("thirteen", "lithium",  "antidepressant",               "lazy dog", Restriction(NCU=true)),
-    ("fourteen", "lithium",  "antidisestablishmentarianism", "lazy dog", Restriction(NAGR=true)),
-    ("fifteen",  "lithium",  "antidote",                     "lazy dog", Restriction(NPU=true))
+    ("eleven",   "lithium",  "anticoagulant",                "lazy dog", DataUseRestriction(GRU=true, NCU=true)),
+    ("twelve",   "lithium",  "anticorruption",               "lazy dog", DataUseRestriction(HMB=true)),
+    ("thirteen", "lithium",  "antidepressant",               "lazy dog", DataUseRestriction(NCU=true)),
+    ("fourteen", "lithium",  "antidisestablishmentarianism", "lazy dog", DataUseRestriction(NAGR=true)),
+    ("fifteen",  "lithium",  "antidote",                     "lazy dog", DataUseRestriction(NPU=true))
 
   )
 
-  val fixtureDocs:Seq[Document] = datasetTuples map {x:(String,String,String,String,Restriction) =>
+  val fixtureDocs:Seq[Document] = datasetTuples map {x:(String,String,String,String,DataUseRestriction) =>
     Document(x._1, Map(
       AttributeName("library","datasetName") -> AttributeString(x._1),
       AttributeName("library","projectName") -> AttributeString(x._2),

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/SearchResultValidation.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/SearchResultValidation.scala
@@ -1,6 +1,7 @@
 package org.broadinstitute.dsde.firecloud.integrationtest
 
 import org.broadinstitute.dsde.firecloud.integrationtest.ESIntegrationSupport.{emptyCriteria, searchDAO}
+import org.broadinstitute.dsde.firecloud.model.DataUse.ResearchPurpose
 import org.broadinstitute.dsde.firecloud.model.LibrarySearchResponse
 import org.scalatest.Assertions._
 import spray.json.JsValue
@@ -17,6 +18,18 @@ trait SearchResultValidation {
     val criteria = emptyCriteria.copy(searchString = Some(txt))
     Await.result(searchDAO.findDocuments(criteria, Seq.empty[String]), dur)
   }
+
+  def searchWithPurpose(researchPurpose: Option[ResearchPurpose], term:Option[String], filters:Option[Map[String, Seq[String]]]): LibrarySearchResponse = {
+    val criteria = emptyCriteria.copy(
+      searchString = term,
+      researchPurpose = researchPurpose,
+      filters = filters.getOrElse(Map.empty[String, Seq[String]])
+    )
+    Await.result(searchDAO.findDocuments(criteria, Seq.empty[String]), dur)
+  }
+
+  def searchWithPurpose(researchPurpose: ResearchPurpose): LibrarySearchResponse =
+    searchWithPurpose(Some(researchPurpose), None, None)
 
   def validateResultNames(expectedNames:Set[String], response:LibrarySearchResponse) = {
     validateResultField("library:datasetName", expectedNames, response)

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/SearchResultValidation.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/SearchResultValidation.scala
@@ -31,6 +31,19 @@ trait SearchResultValidation {
   def searchWithPurpose(researchPurpose: ResearchPurpose): LibrarySearchResponse =
     searchWithPurpose(Some(researchPurpose), None, None)
 
+  def searchWithPurpose(researchPurpose: ResearchPurpose, term: String): LibrarySearchResponse =
+    searchWithPurpose(Some(researchPurpose), Some(term), None)
+
+  def searchWithPurpose(researchPurpose: ResearchPurpose, filters: Map[String, Seq[String]]): LibrarySearchResponse =
+    searchWithPurpose(Some(researchPurpose), None, Some(filters))
+
+  def suggestWithPurpose(researchPurpose: ResearchPurpose, term: String) = {
+    val criteria = emptyCriteria.copy(
+      searchString = Some(term),
+      researchPurpose = Some(researchPurpose))
+    Await.result(searchDAO.suggestionsFromAll(criteria, Seq.empty[String]), dur)
+  }
+
   def validateResultNames(expectedNames:Set[String], response:LibrarySearchResponse) = {
     validateResultField("library:datasetName", expectedNames, response)
   }
@@ -38,6 +51,11 @@ trait SearchResultValidation {
   def validateResultIndications(expectedIndications:Set[String], response:LibrarySearchResponse) = {
     validateResultField("library:indication", expectedIndications, response)
   }
+
+  def validateSuggestions(expectedSuggestions:Set[String], response:LibrarySearchResponse) = {
+    validateResultField("suggestion", expectedSuggestions, response)
+  }
+
   def validateResultField(attrName:String, expectedValues:Set[String], response:LibrarySearchResponse) = {
     val actualValues:Set[String] = getResultField(attrName, response)
     assertResult(expectedValues) {actualValues}

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/model/ElasticSearchSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/model/ElasticSearchSpec.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.firecloud.model
 
+import org.broadinstitute.dsde.firecloud.model.DataUse.{DiseaseOntologyNodeId, ResearchPurpose}
 import org.scalatest.{Assertions, FreeSpec}
 import spray.json.JsString
 import spray.json._
@@ -35,15 +36,67 @@ class ElasticSearchSpec  extends FreeSpec with Assertions {
         assertResult(None) {params.sortField}
         assertResult(None) {params.sortDirection}
       }
+      "should create params with missing research purpose if none specified" in {
+        val testData = """ {"filters": {"library:datatype":["cancer"]},"fieldAggregations":{"library:indication":5}} """
+        val item = testData.parseJson.convertTo[LibrarySearchParams]
+        assert(item.researchPurpose.isEmpty, s"research purpose was non-empty: ${item.researchPurpose}")
+      }
+      "should handle a valid research purpose" in {
+        val testData =
+          """ {"filters": {"library:datatype":["cancer"]},"fieldAggregations":{"library:indication":5},
+            |  "researchPurpose": {"NDMS": true, "NCTRL": false, "NAGR": true, "POA": false, "NCU": true,
+            |    "DS": ["http://purl.obolibrary.org/obo/DOID_123", "http://purl.obolibrary.org/obo/DOID_456"]}
+            | } """.stripMargin
+        val item = testData.parseJson.convertTo[LibrarySearchParams]
+        val expectedResearchPurpose = ResearchPurpose(
+          Seq(DiseaseOntologyNodeId("http://purl.obolibrary.org/obo/DOID_123"), DiseaseOntologyNodeId("http://purl.obolibrary.org/obo/DOID_456")),
+          NDMS=true, NCTRL=false, NAGR=true, POA=false, NCU=true
+        )
+        assertResult(Some(expectedResearchPurpose)) {item.researchPurpose}
+      }
+      "should reject an incomplete research purpose" in {
+        // testData is missing NDMS
+        val testData =
+          """ {"filters": {"library:datatype":["cancer"]},"fieldAggregations":{"library:indication":5},
+            |  "researchPurpose": {"NCTRL": false, "NAGR": true, "POA": false, "NCU": true,
+            |    "DS": ["http://purl.obolibrary.org/obo/DOID_123", "http://purl.obolibrary.org/obo/DOID_456"]}
+            | } """.stripMargin
+        intercept[DeserializationException] {
+          testData.parseJson.convertTo[LibrarySearchParams]
+        }
+      }
+      "should reject a complete research purpose with invalid node ids" in {
+        // testData has bad DOID uris
+        val testData =
+          """ {"filters": {"library:datatype":["cancer"]},"fieldAggregations":{"library:indication":5},
+            |  "researchPurpose": {"NDMS": true, "NCTRL": false, "NAGR": true, "POA": false, "NCU": true,
+            |    "DS": ["DOID:123"]}
+            | } """.stripMargin
+        intercept[IllegalArgumentException] {
+          testData.parseJson.convertTo[LibrarySearchParams]
+        }
+      }
     }
     "when marshalling to json" - {
       "should handle arbitrary namespace" in {
-        val testData = LibrarySearchParams(None, Map.empty, Map.empty)
+        val testData = LibrarySearchParams(None, Map.empty, None, Map.empty)
         assertResult("""{"filters":{},"fieldAggregations":{},"from":0,"size":10}""".parseJson) {testData.toJson.toString.parseJson}
       }
       "should handle sort field and direction" in {
-        val testData = LibrarySearchParams(None, Map.empty, Map.empty, sortField=Some("field"), sortDirection=Some("direction"))
+        val testData = LibrarySearchParams(None, Map.empty, None, Map.empty, sortField=Some("field"), sortDirection=Some("direction"))
         assertResult("""{"filters":{},"fieldAggregations":{},"from":0,"size":10,"sortField":"field","sortDirection":"direction"}""".parseJson) {testData.toJson.toString.parseJson}
+      }
+      "should properly serialize research purpose" in {
+        val researchPurpose = ResearchPurpose(
+          Seq(DiseaseOntologyNodeId("http://purl.obolibrary.org/obo/DOID_123"), DiseaseOntologyNodeId("http://purl.obolibrary.org/obo/DOID_456")),
+          NDMS=true, NCTRL=false, NAGR=true, POA=false, NCU=true
+        )
+        val testData = LibrarySearchParams(None, Map.empty, Some(researchPurpose), Map.empty)
+        assertResult(
+          """{"filters":{},
+            | "researchPurpose":{"POA":false,"NCU":true,"NAGR":true,"NDMS":true,"NCTRL":false,
+            |  "DS":["http://purl.obolibrary.org/obo/DOID_123","http://purl.obolibrary.org/obo/DOID_456"]},
+            | "fieldAggregations":{},"from":0,"size":10}""".stripMargin.parseJson) {testData.toJson.toString.parseJson}
       }
     }
   }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupportSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupportSpec.scala
@@ -30,6 +30,8 @@ object DataUseRestrictionTestFixture {
     `RS-M`: Boolean = false,
     `RS-POP`: Seq[String] = Seq.empty[String])
 
+  implicit val impAttributeFormat: AttributeFormat with PlainArrayAttributeListSerializer = new AttributeFormat with PlainArrayAttributeListSerializer
+  implicit val impDataUseRestriction: RootJsonFormat[DataUseRestriction] = jsonFormat13(DataUseRestriction)
 
   // Datasets are named by the code for easier identification in tests
   val booleanCodes: Seq[String] = Seq("GRU", "HMB", "NCU", "NPU", "NDMS", "NCTRL", "RS-PD")
@@ -81,8 +83,7 @@ object DataUseRestrictionTestFixture {
 
 class DataUseRestrictionSupportSpec extends FreeSpec with SearchResultValidation with Matchers with BeforeAndAfterAll with DataUseRestrictionSupport {
 
-  implicit val impAttributeFormat: AttributeFormat with PlainArrayAttributeListSerializer = new AttributeFormat with PlainArrayAttributeListSerializer
-  implicit val impDataUseRestriction: RootJsonFormat[DataUseRestriction] = jsonFormat13(DataUseRestriction)
+  import DataUseRestrictionTestFixture.{impAttributeFormat, impDataUseRestriction}
 
   "DataUseRestrictionSupport" - {
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/ElasticSearchDAOQuerySupportSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/ElasticSearchDAOQuerySupportSpec.scala
@@ -18,6 +18,7 @@ class ElasticSearchDAOQuerySupportSpec extends FreeSpec with ElasticSearchDAOQue
 
   val criteria = LibrarySearchParams(Some("searchString"),
     Map.empty[String, Seq[String]],
+    None,
     Map.empty[String, Int],
     from = 0, size=10)
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/LibraryServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/LibraryServiceSpec.scala
@@ -635,7 +635,7 @@ class LibraryServiceSpec extends BaseServiceSpec with FreeSpecLike with LibraryS
       }
     }
     "when finding documents" - {
-      val params = LibrarySearchParams(Some("test"), Map(), Map())
+      val params = LibrarySearchParams(Some("test"), Map(), None, Map())
       "don't add workspaceAccess to document if can't find workspace id for a document" in {
         val doc = LibrarySearchResponse(params, 1, Seq(testLibraryMetadataJsObject: JsValue), Seq())
         assertResult(doc) {


### PR DESCRIPTION
API support for the first stage of DUL search.

See the tech doc at https://docs.google.com/a/broadinstitute.org/document/d/1P70Gt5wCru0YzvJWNru9Nt4tCADhEsBWpKPp7qs_n2M/edit?usp=sharing for discussion of the API changes and their effect on backwards compatibility (summary: I tried real hard to make it backwards compatible).

You should definitey look at this PR and the tech doc if:
* you are working on the UI and need to understand how the underlying APIs changed (see the swagger)
* you are working on indexing consent codes and need to know what the runtime queries expect (see ElasticSearchDAOResearchPurposeSupport.scala)
* you are working on indexing consent codes and are curious about how your model objects might interact with mine



- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
