### PR TITLE
GAWB-2767 Index consent codes as a structured object

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupport.scala
@@ -11,6 +11,8 @@ trait DataUseRestrictionSupport {
   private val listCodes = List("DS", "RS-POP")
   private val durNames = booleanCodes ++ listCodes ++ List("RS-G")
 
+  val dataUseRestrictionAttributeName: AttributeName = AttributeName.withLibraryNS("dataUseRestriction")
+
   /**
     * This method looks at all of the library attributes that are associated to Consent Codes and
     * builds a set of Data Use Restriction attributes from the values. Most are boolean values, some are lists
@@ -27,7 +29,7 @@ trait DataUseRestrictionSupport {
     val libraryAttrs = workspace.attributes.filter { case (attr, value) => durNames.contains(attr.name) }
 
     if (libraryAttrs.isEmpty) {
-      Map(AttributeName.withLibraryNS("dataUseRestriction") -> AttributeNull)
+      Map.empty
     } else {
       val existingAttrs: Map[AttributeName, Attribute] = libraryAttrs.flatMap {
         // Handle the String->Boolean case first
@@ -52,14 +54,14 @@ trait DataUseRestrictionSupport {
 
       val existingKeyNames = existingAttrs.keys.map(_.name).toSeq
 
-      // Missing boolean codes with default false
+      // Missing boolean codes default to false
       val booleanAttrs: Map[AttributeName, AttributeBoolean] = (booleanCodes ++ List("RS-G", "RS-FM", "RS-M")).
         filter(!existingKeyNames.contains(_)).
         flatMap { code =>
           Map(AttributeName.withDefaultNS(code) -> AttributeBoolean(false))
         }.toMap
 
-      // Missing list codes with default empty lists
+      // Missing list codes default to empty lists
       val listAttrs = listCodes.
         filter(!existingKeyNames.contains(_)).
         flatMap { code =>
@@ -68,8 +70,7 @@ trait DataUseRestrictionSupport {
 
       val allAttrs = existingAttrs ++ booleanAttrs ++ listAttrs
 
-      Map(AttributeName.withLibraryNS("dataUseRestriction") ->
-        AttributeValueRawJson.apply(allAttrs.toJson.compactPrint))
+      Map(dataUseRestrictionAttributeName -> AttributeValueRawJson.apply(allAttrs.toJson.compactPrint))
     }
 
   }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupport.scala
@@ -1,0 +1,81 @@
+package org.broadinstitute.dsde.firecloud.service
+
+import org.broadinstitute.dsde.rawls.model.Attributable.AttributeMap
+import org.broadinstitute.dsde.rawls.model.{Attribute, AttributeListElementable, _}
+
+// TODO: Do we need this at all?
+object DataUseRestrictionSupport {
+  case class DataUseRestriction(
+    GRU: Boolean = false,
+    HMB: Boolean = false,
+    DS: Seq[String] = Seq.empty[String],
+    NCU: Boolean = false,
+    NPU: Boolean = false,
+    NDMS: Boolean = false,
+    NAGR: Boolean = false,
+    NCTRL: Boolean = false,
+    `RS-PD`: Boolean = false,
+    `RS-G`: Boolean = false,
+    `RS-FM`: Boolean = false,
+    `RS-M`: Boolean = false,
+    `RS-POP`: Seq[String] = Seq.empty[String])
+}
+
+trait DataUseRestrictionSupport {
+
+  private val booleanCodes = List("GRU", "HMB", "NCU", "NPU", "NDMS", "NAGR", "NCTRL","RS-PD")
+  private val listCodes = List("DS", "RS-POP")
+
+  /**
+    * This method looks at all of the library attributes that are associated to Consent Codes and
+    * builds a Data Use Restriction object from the values. Most are boolean values, some are lists
+    * of strings, and in the case of gender, we need to transform a string value to a trio of booleans.
+    *
+    * @param libraryAttrs Library Attributes
+    * @return 'dataUseRestriction' Attribute Map
+    */
+  def makeDataUseRestriction(libraryAttrs: Map[AttributeName, Attribute]): Map[AttributeName, Attribute] = {
+    if (libraryAttrs.isEmpty) {
+      Map(AttributeName.withLibraryNS("dataUseRestriction") -> AttributeValueEmptyList[Attribute])
+    } else {
+      val durAttributes: AttributeMap = libraryAttrs.flatMap {
+        case (attr: AttributeName, value: AttributeBoolean) if booleanCodes.contains(attr.name) => Map(AttributeName.withDefaultNS(attr.name) -> value)
+        case (attr: AttributeName, value: AttributeList[String]) if listCodes.contains(attr.name) => Map(AttributeName.withDefaultNS(attr.name) -> value)
+        case (attr: AttributeName, value: AttributeString) if attr.name.equals("RS-G") =>
+          value.value match {
+            case x if x.equalsIgnoreCase("female") =>
+              Map(AttributeName.withDefaultNS("RS-G") -> AttributeBoolean(true),
+                AttributeName.withDefaultNS("RS-FM") -> AttributeBoolean(true),
+                AttributeName.withDefaultNS("RS-M") -> AttributeBoolean(false))
+            case x if x.equalsIgnoreCase("male") =>
+              Map(AttributeName.withDefaultNS("RS-G") -> AttributeBoolean(true),
+                AttributeName.withDefaultNS("RS-FM") -> AttributeBoolean(false),
+                AttributeName.withDefaultNS("RS-M") -> AttributeBoolean(true))
+            case _ =>
+              Map(AttributeName.withDefaultNS("RS-G") -> AttributeBoolean(false),
+                AttributeName.withDefaultNS("RS-FM") -> AttributeBoolean(false),
+                AttributeName.withDefaultNS("RS-M") -> AttributeBoolean(false))
+          }
+      } ++ (booleanCodes ++ List("RS-G", "RS-FM", "RS-M")).map { code =>
+        // Populate missing boolean codes with default false
+        val attr = AttributeName.withDefaultNS(code)
+        if (!durAttributes.isDefinedAt(attr)) {
+          Map(attr -> AttributeBoolean(false))
+        }
+      }.flatten ++ listCodes.map { code =>
+        // Populate missing list codes with default empty lists
+        val attr = AttributeName.withDefaultNS(code)
+        if (!durAttributes.isDefinedAt(attr)) {
+          Map(attr -> AttributeValueList(Seq.empty))
+        }
+      }.flatten
+
+      // TODO: Figure out how to take this Map(AttributeName -> AttributeMap) and make it a Map(AttributeName -> Attribute)
+      Map(AttributeName.withLibraryNS("dataUseRestriction") -> durAttributes)
+    }
+
+
+    Map(AttributeName.withLibraryNS("dataUseRestriction") -> AttributeValueEmptyList[Attribute])
+  }
+
+}

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupport.scala
@@ -1,46 +1,31 @@
 package org.broadinstitute.dsde.firecloud.service
 
-import org.broadinstitute.dsde.rawls.model.Attributable.AttributeMap
-import org.broadinstitute.dsde.rawls.model.{Attribute, AttributeListElementable, _}
-
-// TODO: Do we need this at all?
-object DataUseRestrictionSupport {
-  case class DataUseRestriction(
-    GRU: Boolean = false,
-    HMB: Boolean = false,
-    DS: Seq[String] = Seq.empty[String],
-    NCU: Boolean = false,
-    NPU: Boolean = false,
-    NDMS: Boolean = false,
-    NAGR: Boolean = false,
-    NCTRL: Boolean = false,
-    `RS-PD`: Boolean = false,
-    `RS-G`: Boolean = false,
-    `RS-FM`: Boolean = false,
-    `RS-M`: Boolean = false,
-    `RS-POP`: Seq[String] = Seq.empty[String])
-}
+import org.broadinstitute.dsde.rawls.model._
+import spray.json._
+import spray.json.DefaultJsonProtocol._
 
 trait DataUseRestrictionSupport {
 
   private val booleanCodes = List("GRU", "HMB", "NCU", "NPU", "NDMS", "NAGR", "NCTRL","RS-PD")
   private val listCodes = List("DS", "RS-POP")
+  private val durNames = booleanCodes ++ listCodes ++ "RS-G"
 
   /**
     * This method looks at all of the library attributes that are associated to Consent Codes and
     * builds a Data Use Restriction object from the values. Most are boolean values, some are lists
     * of strings, and in the case of gender, we need to transform a string value to a trio of booleans.
     *
-    * @param libraryAttrs Library Attributes
+    * @param workspace The Workspace
     * @return 'dataUseRestriction' Attribute Map
     */
-  def makeDataUseRestriction(libraryAttrs: Map[AttributeName, Attribute]): Map[AttributeName, Attribute] = {
+  def generateDataUseRestriction(workspace: Workspace): Map[AttributeName, Attribute] = {
+
+    val libraryAttrs = workspace.attributes.filter{case (attr, value) => durNames.contains(attr.name)}
+
     if (libraryAttrs.isEmpty) {
-      Map(AttributeName.withLibraryNS("dataUseRestriction") -> AttributeValueEmptyList[Attribute])
+      Map(AttributeName.withLibraryNS("dataUseRestriction") -> AttributeNull)
     } else {
-      val durAttributes: AttributeMap = libraryAttrs.flatMap {
-        case (attr: AttributeName, value: AttributeBoolean) if booleanCodes.contains(attr.name) => Map(AttributeName.withDefaultNS(attr.name) -> value)
-        case (attr: AttributeName, value: AttributeList[String]) if listCodes.contains(attr.name) => Map(AttributeName.withDefaultNS(attr.name) -> value)
+      val existingAttrs: Map[AttributeName, AttributeValue] = libraryAttrs.flatMap {
         case (attr: AttributeName, value: AttributeString) if attr.name.equals("RS-G") =>
           value.value match {
             case x if x.equalsIgnoreCase("female") =>
@@ -56,26 +41,31 @@ trait DataUseRestrictionSupport {
                 AttributeName.withDefaultNS("RS-FM") -> AttributeBoolean(false),
                 AttributeName.withDefaultNS("RS-M") -> AttributeBoolean(false))
           }
-      } ++ (booleanCodes ++ List("RS-G", "RS-FM", "RS-M")).map { code =>
-        // Populate missing boolean codes with default false
-        val attr = AttributeName.withDefaultNS(code)
-        if (!durAttributes.isDefinedAt(attr)) {
-          Map(attr -> AttributeBoolean(false))
-        }
-      }.flatten ++ listCodes.map { code =>
-        // Populate missing list codes with default empty lists
-        val attr = AttributeName.withDefaultNS(code)
-        if (!durAttributes.isDefinedAt(attr)) {
-          Map(attr -> AttributeValueList(Seq.empty))
-        }
-      }.flatten
+        case (attr: AttributeName, value: AttributeValue) => Map(AttributeName.withDefaultNS(attr.name) -> value)
+      }
 
-      // TODO: Figure out how to take this Map(AttributeName -> AttributeMap) and make it a Map(AttributeName -> Attribute)
-      Map(AttributeName.withLibraryNS("dataUseRestriction") -> durAttributes)
+      // Missing boolean codes with default false
+      val booleanAttrs: Map[AttributeName, AttributeBoolean] = (booleanCodes ++ List("RS-G", "RS-FM", "RS-M")).flatMap { code =>
+        val attr = AttributeName.withDefaultNS(code)
+        code match {
+          case x if !existingAttrs.isDefinedAt(attr) => Map(attr -> AttributeBoolean(false))
+        }
+      }.toMap
+
+      // Missing list codes with default empty lists
+      val listAttrs: Map[AttributeName, AttributeValueList] = listCodes.flatMap { code =>
+        val attr = AttributeName.withDefaultNS(code)
+        code match {
+          case x if !existingAttrs.isDefinedAt(attr) => Map(attr -> AttributeValueList(Seq.empty))
+        }
+      }.toMap
+
+      val allAttrs = existingAttrs ++ booleanAttrs ++ listAttrs
+
+      Map(AttributeName.withLibraryNS("dataUseRestriction") ->
+        AttributeValueRawJson.apply(allAttrs.toJson.compactPrint))
     }
 
-
-    Map(AttributeName.withLibraryNS("dataUseRestriction") -> AttributeValueEmptyList[Attribute])
   }
 
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupport.scala
@@ -9,7 +9,7 @@ trait DataUseRestrictionSupport {
 
   private val booleanCodes = List("GRU", "HMB", "NCU", "NPU", "NDMS", "NAGR", "NCTRL","RS-PD")
   private val listCodes = List("DS", "RS-POP")
-  private val durNames = booleanCodes ++ listCodes ++ "RS-G"
+  private val durNames = booleanCodes ++ listCodes ++ List("RS-G")
 
   /**
     * This method looks at all of the library attributes that are associated to Consent Codes and
@@ -29,7 +29,7 @@ trait DataUseRestrictionSupport {
     if (libraryAttrs.isEmpty) {
       Map(AttributeName.withLibraryNS("dataUseRestriction") -> AttributeNull)
     } else {
-      val existingAttrs: Map[AttributeName, AttributeValue] = libraryAttrs.flatMap {
+      val existingAttrs: Map[AttributeName, Attribute] = libraryAttrs.flatMap {
         // Handle the String->Boolean case first
         case (attr: AttributeName, value: AttributeString) if attr.name.equals("RS-G") =>
           value.value match {
@@ -47,7 +47,7 @@ trait DataUseRestrictionSupport {
                 AttributeName.withDefaultNS("RS-M") -> AttributeBoolean(false))
           }
         // Everything else can be added as is.
-        case (attr: AttributeName, value: AttributeValue) => Map(AttributeName.withDefaultNS(attr.name) -> value)
+        case (attr: AttributeName, value: Attribute) => Map(AttributeName.withDefaultNS(attr.name) -> value)
       }
 
       val existingKeyNames = existingAttrs.keys.map(_.name).toSeq

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupport.scala
@@ -23,7 +23,7 @@ trait DataUseRestrictionSupport {
     * populate using values specified in attribute-definitions.json
     *
     * @param workspace The Workspace
-    * @return 'dataUseRestriction' Attribute Map
+    * @return A structured data use restriction Attribute Map
     */
   def generateStructuredUseRestriction(workspace: Workspace): Map[AttributeName, Attribute] = {
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupport.scala
@@ -7,7 +7,7 @@ import spray.json._
 
 trait DataUseRestrictionSupport {
 
-  private val booleanCodes = List("GRU", "HMB", "NCU", "NPU", "NDMS", "NAGR", "NCTRL","RS-PD")
+  private val booleanCodes = List("GRU", "HMB", "NCU", "NPU", "NDMS", "NAGR", "NCTRL", "RS-PD")
   private val listCodes = List("DS", "RS-POP")
   private val durNames = booleanCodes ++ listCodes ++ List("RS-G")
 
@@ -32,7 +32,12 @@ trait DataUseRestrictionSupport {
       Map.empty
     } else {
       val existingAttrs: Map[AttributeName, Attribute] = libraryAttrs.flatMap {
-        // Handle the String->Boolean case first
+        // Handle the String->Boolean conversion cases first
+        case (attr: AttributeName, value: AttributeString) if attr.name.equals("NAGR") =>
+          value.value match {
+            case x if x.equalsIgnoreCase("yes") => Map(AttributeName.withDefaultNS("NAGR") -> AttributeBoolean(true))
+            case _ => Map(AttributeName.withDefaultNS("NAGR") -> AttributeBoolean(false))
+          }
         case (attr: AttributeName, value: AttributeString) if attr.name.equals("RS-G") =>
           value.value match {
             case x if x.equalsIgnoreCase("female") =>

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/LibraryServiceSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/LibraryServiceSupport.scala
@@ -82,7 +82,7 @@ trait LibraryServiceSupport extends DataUseRestrictionSupport with LazyLogging {
       case None => Map()
     }
 
-    val dur: Map[AttributeName, Attribute] = generateDataUseRestriction(workspace)
+    val dur: Map[AttributeName, Attribute] = generateStructuredUseRestriction(workspace)
 
     val fields = attrfields ++ idfields ++ tagfields ++ dur
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/LibraryServiceSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/LibraryServiceSupport.scala
@@ -83,14 +83,9 @@ trait LibraryServiceSupport extends DataUseRestrictionSupport with LazyLogging {
     }
 
     val dur: Map[AttributeName, Attribute] = generateStructuredUseRestriction(workspace)
+    val durAttributeNames = durFieldNames.map(AttributeName.withLibraryNS)
 
-    val fields = dur match {
-      case x if x.isEmpty => attrfields ++ idfields ++ tagfields
-      case _ =>
-        // remove the data use attributes so we don't index them twice
-        val durAttributeNames = durFieldNames.map(AttributeName.withLibraryNS)
-        attrfields.filterKeys { key => !durAttributeNames.contains(key) } ++ idfields ++ tagfields ++ dur
-    }
+    val fields = (attrfields -- durAttributeNames) ++ idfields ++ tagfields ++ dur
 
     workspace.attributes.get(AttributeName.withLibraryNS("diseaseOntologyID")) match {
       case Some(id: AttributeString) =>

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/LibraryServiceSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/LibraryServiceSupport.scala
@@ -84,7 +84,13 @@ trait LibraryServiceSupport extends DataUseRestrictionSupport with LazyLogging {
 
     val dur: Map[AttributeName, Attribute] = generateStructuredUseRestriction(workspace)
 
-    val fields = attrfields ++ idfields ++ tagfields ++ dur
+    val fields = dur match {
+      case x if x.isEmpty => attrfields ++ idfields ++ tagfields
+      case _ =>
+        // remove the data use attributes so we don't index them twice
+        val durAttributeNames = durFieldNames.map(AttributeName.withLibraryNS)
+        attrfields.filterKeys { key => !durAttributeNames.contains(key) } ++ idfields ++ tagfields ++ dur
+    }
 
     workspace.attributes.get(AttributeName.withLibraryNS("diseaseOntologyID")) match {
       case Some(id: AttributeString) =>

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/LibraryServiceSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/LibraryServiceSupport.scala
@@ -24,7 +24,7 @@ import scala.language.postfixOps
 /**
   * Created by davidan on 10/2/16.
   */
-trait LibraryServiceSupport extends LazyLogging {
+trait LibraryServiceSupport extends DataUseRestrictionSupport with LazyLogging {
 
   def updatePublishAttribute(value: Boolean): Seq[AttributeUpdateOperation] = {
     if (value) Seq(AddUpdateAttribute(LibraryService.publishedFlag, AttributeBoolean(true)))
@@ -82,7 +82,9 @@ trait LibraryServiceSupport extends LazyLogging {
       case None => Map()
     }
 
-    val fields = attrfields ++ idfields ++ tagfields
+    val dur: Map[AttributeName, Attribute] = generateDataUseRestriction(workspace)
+
+    val fields = attrfields ++ idfields ++ tagfields ++ dur
 
     workspace.attributes.get(AttributeName.withLibraryNS("diseaseOntologyID")) match {
       case Some(id: AttributeString) =>

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupportSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupportSpec.scala
@@ -2,8 +2,8 @@ package org.broadinstitute.dsde.firecloud.service
 
 import java.util.UUID
 
-import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport.AttributeNameFormat
 import org.broadinstitute.dsde.firecloud.integrationtest.SearchResultValidation
+import org.broadinstitute.dsde.firecloud.service.DataUseRestrictionTestFixture.DataUseRestriction
 import org.broadinstitute.dsde.rawls.model.{ManagedGroupRef, Workspace, _}
 import org.joda.time.DateTime
 import org.scalatest.{BeforeAndAfterAll, FreeSpec, Matchers}
@@ -12,23 +12,50 @@ import spray.json._
 
 object DataUseRestrictionTestFixture {
 
-  val datasets: Seq[Workspace] = List("GRU", "HMB", "NCU", "NPU", "NDMS", "NAGR", "NCTRL","RS-PD").map { code =>
+  case class DataUseRestriction(
+    GRU: Boolean = false,
+    HMB: Boolean = false,
+    DS: Seq[String] = Seq.empty[String],
+    NCU: Boolean = false,
+    NPU: Boolean = false,
+    NDMS: Boolean = false,
+    NAGR: Boolean = false,
+    NCTRL: Boolean = false,
+    `RS-PD`: Boolean = false,
+    `RS-G`: Boolean = false,
+    `RS-FM`: Boolean = false,
+    `RS-M`: Boolean = false,
+    `RS-POP`: Seq[String] = Seq.empty[String])
+
+
+  // Datasets are named by the code for easier identification in tests
+  val booleanCodes = Seq("GRU", "HMB", "NCU", "NPU", "NDMS", "NAGR", "NCTRL","RS-PD")
+  val booleanDatasets: Seq[Workspace] = booleanCodes.map { code =>
     val attributes = Map(AttributeName.withLibraryNS(code) -> AttributeBoolean(true))
     mkWorkspace(attributes, code)
-  } ++ List("DS", "RS-POP").map { code =>
-    val attributes = Map(AttributeName.withLibraryNS(code) -> AttributeValueList(Seq(AttributeString("TERM-1"), AttributeString("TERM-2"))))
-    mkWorkspace(attributes, code)
-  } ++ List("Female", "Male", "N/A").map { gender =>
-    val attributes = Map(AttributeName.withLibraryNS("RS-G") -> AttributeString(gender))
-    mkWorkspace(attributes, "RS-G")
   }
 
-  private def mkWorkspace(attributes: Map[AttributeName, Attribute], code: String): Workspace = {
+  val listCodes = Seq("DS", "RS-POP")
+  val listDatasets: Seq[Workspace] = listCodes.map { code =>
+    val attributes = Map(AttributeName.withLibraryNS(code) -> AttributeValueList(Seq(AttributeString("TERM-1"), AttributeString("TERM-2"))))
+    mkWorkspace(attributes, code)
+  }
+
+  // Gender datasets are named by the gender value for easier identification in tests
+  val genderVals = Seq("Female", "Male", "N/A")
+  val genderDatasets: Seq[Workspace] = genderVals.map { gender =>
+    val attributes = Map(AttributeName.withLibraryNS("RS-G") -> AttributeString(gender))
+    mkWorkspace(attributes, gender)
+  }
+
+  val allDatasets: Seq[Workspace] = booleanDatasets ++ listDatasets ++ genderDatasets
+
+  def mkWorkspace(attributes: Map[AttributeName, Attribute], wsName: String): Workspace = {
     val testUUID: UUID = UUID.randomUUID()
     Workspace(
       workspaceId=testUUID.toString,
       namespace="testWorkspaceNamespace",
-      name=code,
+      name=wsName,
       authorizationDomain=Set.empty[ManagedGroupRef],
       isLocked=false,
       createdBy="createdBy",
@@ -44,44 +71,84 @@ object DataUseRestrictionTestFixture {
 
 class DataUseRestrictionSupportSpec extends FreeSpec with SearchResultValidation with Matchers with BeforeAndAfterAll with DataUseRestrictionSupport {
 
-  implicit val impAttributeFormat: AttributeFormat with PlainArrayAttributeListSerializer =
-    new AttributeFormat with PlainArrayAttributeListSerializer
+  implicit val impAttributeFormat: AttributeFormat with PlainArrayAttributeListSerializer = new AttributeFormat with PlainArrayAttributeListSerializer
+  implicit val impDataUseRestriction: RootJsonFormat[DataUseRestriction] = jsonFormat13(DataUseRestriction)
 
   "DataUseRestrictionSupport" - {
 
     "when there are library data use restriction fields" - {
 
-      "workspace should have a fully populated data use restriction attribute" in {
-        DataUseRestrictionTestFixture.datasets.map { ds =>
+      "dataset should have a fully populated data use restriction attribute" in {
+        DataUseRestrictionTestFixture.allDatasets.map { ds =>
           val attrs = generateDataUseRestriction(ds)
-          attrs.map { attrs => println(attrs.toJson.prettyPrint) }
-          // TODO ... flesh out asserts
+          val durAtt: Attribute = attrs.getOrElse(dataUseRestrictionAttributeName, AttributeNull)
+          durAtt shouldNot be(AttributeNull)
+          val dur: DataUseRestriction = makeDURFromWorkspace(ds)
+          dur shouldNot be(null)
         }
-
       }
 
-      "dur should have 'RS-FM' populated if 'RS-G' is 'Female'" in {
-        // TODO
+      "dur should have appropriate gender codes populated" in {
+        DataUseRestrictionTestFixture.genderDatasets.map { ds =>
+          val attrs = generateDataUseRestriction(ds)
+          val dur: DataUseRestriction = makeDURFromWorkspace(ds)
+          if (ds.name.equalsIgnoreCase("Female")) {
+            dur.`RS-G` should be(true)
+            dur.`RS-FM` should be(true)
+            dur.`RS-M` should be(false)
+          } else if (ds.name.equalsIgnoreCase("Male")) {
+            dur.`RS-G` should be(true)
+            dur.`RS-FM` should be(false)
+            dur.`RS-M` should be(true)
+          } else {
+            dur.`RS-G` should be(false)
+            dur.`RS-FM` should be(false)
+            dur.`RS-M` should be(false)
+          }
+        }
       }
 
-      "dur should have 'RS-M' populated if 'RS-G' is 'Male'" in {
-        // TODO
-      }
+      "dataset should have a true value for the consent code for which it was specified" in {
+        val durs: Map[String, DataUseRestriction] = DataUseRestrictionTestFixture.allDatasets.flatMap { ds =>
+          Map(ds.name -> makeDURFromWorkspace(ds))
+        }.toMap
 
-      "dur should have 'RS-G' false if 'RS-G' is neither 'Male' or 'Female'" in {
-        // TODO
+        DataUseRestrictionTestFixture.booleanCodes.map { code =>
+          val dur: DataUseRestriction = durs(code)
+          // todo: test that the right field name is populated
+        }
       }
 
     }
 
     "when there are no library data use restriction fields" - {
 
-      "workspace should not have a populated data use restriction attribute" in {
-        // TODO
+      "dataset should not have any data use restriction for empty attributes" in {
+        val workspace = DataUseRestrictionTestFixture.mkWorkspace(Map.empty[AttributeName, Attribute], "empty")
+        val attrs = generateDataUseRestriction(workspace)
+        assert(attrs.isEmpty)
+      }
+
+      "dataset should not have any data use restriction for non-library attributes" in {
+        val nonLibraryAttributes = Map(
+          AttributeName.withDefaultNS("name") -> AttributeString("one"),
+          AttributeName.withDefaultNS("namespace") -> AttributeString("two"),
+          AttributeName.withDefaultNS("workspaceId") -> AttributeString("three"),
+          AttributeName.withDefaultNS("authorizationDomain") -> AttributeValueList(Seq(AttributeString("one"), AttributeString("two"), AttributeString("three")))
+        )
+        val workspace = DataUseRestrictionTestFixture.mkWorkspace(nonLibraryAttributes, "non-library")
+        val attrs = generateDataUseRestriction(workspace)
+        assert(attrs.isEmpty)
       }
 
     }
 
+  }
+
+  private def makeDURFromWorkspace(ds: Workspace): DataUseRestriction = {
+    val attrs = generateDataUseRestriction(ds)
+    val durAtt: Attribute = attrs.getOrElse(dataUseRestrictionAttributeName, AttributeNull)
+    durAtt.toJson.convertTo[DataUseRestriction]
   }
 
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupportSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupportSpec.scala
@@ -90,8 +90,8 @@ class DataUseRestrictionSupportSpec extends FreeSpec with SearchResultValidation
 
       "dataset should have a fully populated data use restriction attribute" in {
         allDatasets.map { ds =>
-          val attrs = generateDataUseRestriction(ds)
-          val durAtt: Attribute = attrs.getOrElse(dataUseRestrictionAttributeName, AttributeNull)
+          val attrs = generateStructuredUseRestriction(ds)
+          val durAtt: Attribute = attrs.getOrElse(structuredUseRestrictionAttributeName, AttributeNull)
           durAtt shouldNot be(AttributeNull)
           val dur: DataUseRestriction = makeDurFromWorkspace(ds)
           dur shouldNot be(null)
@@ -156,7 +156,7 @@ class DataUseRestrictionSupportSpec extends FreeSpec with SearchResultValidation
 
       "dataset should not have any data use restriction for empty attributes" in {
         val workspace = mkWorkspace(Map.empty[AttributeName, Attribute], "empty")
-        val attrs = generateDataUseRestriction(workspace)
+        val attrs = generateStructuredUseRestriction(workspace)
         attrs should be(empty)
       }
 
@@ -168,7 +168,7 @@ class DataUseRestrictionSupportSpec extends FreeSpec with SearchResultValidation
           AttributeName.withDefaultNS("authorizationDomain") -> AttributeValueList(Seq(AttributeString("one"), AttributeString("two"), AttributeString("three")))
         )
         val workspace = mkWorkspace(nonLibraryAttributes, "non-library")
-        val attrs = generateDataUseRestriction(workspace)
+        val attrs = generateStructuredUseRestriction(workspace)
         attrs should be(empty)
       }
 
@@ -183,8 +183,8 @@ class DataUseRestrictionSupportSpec extends FreeSpec with SearchResultValidation
 
 
   private def makeDurFromWorkspace(ds: Workspace): DataUseRestriction = {
-    val attrs = generateDataUseRestriction(ds)
-    val durAtt: Attribute = attrs.getOrElse(dataUseRestrictionAttributeName, AttributeNull)
+    val attrs = generateStructuredUseRestriction(ds)
+    val durAtt: Attribute = attrs.getOrElse(structuredUseRestrictionAttributeName, AttributeNull)
     durAtt.toJson.convertTo[DataUseRestriction]
   }
 
@@ -204,7 +204,7 @@ class DataUseRestrictionSupportSpec extends FreeSpec with SearchResultValidation
     } toMap
   }
 
-  // Since we have dashes in field names, the value that comes back from Field.getName
+  // Since we have dashes in DUR field names, the value that comes back from Field.getName
   // looks like "RS$minusPOP" instead of "RS-POP"
   private def getFieldName(f: Field): String = { f.getName.replace("$minus", "-") }
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupportSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupportSpec.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.dsde.firecloud.service
 
 import java.util.UUID
 
+import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport.AttributeNameFormat
 import org.broadinstitute.dsde.firecloud.integrationtest.SearchResultValidation
 import org.broadinstitute.dsde.rawls.model.{ManagedGroupRef, Workspace, _}
 import org.joda.time.DateTime
@@ -11,46 +12,23 @@ import spray.json._
 
 object DataUseRestrictionTestFixture {
 
-  case class DataUseRestriction(
-    GRU: Boolean = false,
-    HMB: Boolean = false,
-    DS: Seq[String] = Seq.empty[String],
-    NCU: Boolean = false,
-    NPU: Boolean = false,
-    NDMS: Boolean = false,
-    NAGR: Boolean = false,
-    NCTRL: Boolean = false,
-    `RS-PD`: Boolean = false,
-    `RS-G`: String = "",
-    `RS-POP`: Seq[String] = Seq.empty[String])
+  val datasets: Seq[Workspace] = List("GRU", "HMB", "NCU", "NPU", "NDMS", "NAGR", "NCTRL","RS-PD").map { code =>
+    val attributes = Map(AttributeName.withLibraryNS(code) -> AttributeBoolean(true))
+    mkWorkspace(attributes, code)
+  } ++ List("DS", "RS-POP").map { code =>
+    val attributes = Map(AttributeName.withLibraryNS(code) -> AttributeValueList(Seq(AttributeString("TERM-1"), AttributeString("TERM-2"))))
+    mkWorkspace(attributes, code)
+  } ++ List("Female", "Male", "N/A").map { gender =>
+    val attributes = Map(AttributeName.withLibraryNS("RS-G") -> AttributeString(gender))
+    mkWorkspace(attributes, "RS-G")
+  }
 
-  implicit val impDataUseRestriction: RootJsonFormat[DataUseRestriction] = jsonFormat11(DataUseRestriction)
-
-  val testCases: Map[String, DataUseRestriction] =
-    Map(
-      "GRU" -> DataUseRestriction(GRU = true),
-      "HMB" -> DataUseRestriction(HMB = true),
-      "DS" -> DataUseRestriction(DS = Seq("DS-1", "DS-2")),
-      "NCU" -> DataUseRestriction(NCU = true),
-      "NPU" -> DataUseRestriction(NPU = true),
-      "NDMS" -> DataUseRestriction(NDMS = true),
-      "NAGR" -> DataUseRestriction(NAGR = true),
-      "NCTRL" -> DataUseRestriction(NCTRL = true),
-      "RS-PD" -> DataUseRestriction(`RS-PD` = true)
-// TODO: How to test for the three gender cases
-//      "rs-fm" -> DataUseRestriction(`RS-G` = "Female"),
-//      "rs-m" -> DataUseRestriction(`RS-G` = "Male"),
-//      "rs-n/a" -> DataUseRestriction(`RS-G` = "NA"),
-//      "RS-POP" -> DataUseRestriction(`RS-POP` = Seq("POP-1", "POP-2"))
-    )
-
-  val datasets: Seq[Workspace] = testCases.map { tc =>
+  private def mkWorkspace(attributes: Map[AttributeName, Attribute], code: String): Workspace = {
     val testUUID: UUID = UUID.randomUUID()
-    val attributes = Map(AttributeName.withLibraryNS(tc._1) -> AttributeValueRawJson(tc._2.toJson.compactPrint))
     Workspace(
       workspaceId=testUUID.toString,
       namespace="testWorkspaceNamespace",
-      name=tc._1,
+      name=code,
       authorizationDomain=Set.empty[ManagedGroupRef],
       isLocked=false,
       createdBy="createdBy",
@@ -60,12 +38,14 @@ object DataUseRestrictionTestFixture {
       bucketName="bucketName",
       accessLevels=Map.empty,
       authDomainACLs=Map())
-  }.toSeq
+  }
 
 }
 
 class DataUseRestrictionSupportSpec extends FreeSpec with SearchResultValidation with Matchers with BeforeAndAfterAll with DataUseRestrictionSupport {
 
+  implicit val impAttributeFormat: AttributeFormat with PlainArrayAttributeListSerializer =
+    new AttributeFormat with PlainArrayAttributeListSerializer
 
   "DataUseRestrictionSupport" - {
 
@@ -74,7 +54,7 @@ class DataUseRestrictionSupportSpec extends FreeSpec with SearchResultValidation
       "workspace should have a fully populated data use restriction attribute" in {
         DataUseRestrictionTestFixture.datasets.map { ds =>
           val attrs = generateDataUseRestriction(ds)
-          attrs.map(println)
+          attrs.map { attrs => println(attrs.toJson.prettyPrint) }
           // TODO ... flesh out asserts
         }
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupportSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupportSpec.scala
@@ -93,14 +93,14 @@ class DataUseRestrictionSupportSpec extends FreeSpec with SearchResultValidation
           val attrs = generateDataUseRestriction(ds)
           val durAtt: Attribute = attrs.getOrElse(dataUseRestrictionAttributeName, AttributeNull)
           durAtt shouldNot be(AttributeNull)
-          val dur: DataUseRestriction = makeDURFromWorkspace(ds)
+          val dur: DataUseRestriction = makeDurFromWorkspace(ds)
           dur shouldNot be(null)
         }
       }
 
       "dur should have appropriate gender codes populated" in {
         genderDatasets.map { ds =>
-          val dur: DataUseRestriction = makeDURFromWorkspace(ds)
+          val dur: DataUseRestriction = makeDurFromWorkspace(ds)
           if (ds.name.equalsIgnoreCase("Female")) {
             dur.`RS-G` should be(true)
             dur.`RS-FM` should be(true)
@@ -119,7 +119,7 @@ class DataUseRestrictionSupportSpec extends FreeSpec with SearchResultValidation
 
       "dur should have appropriate NAGR code populated" in {
         nagrDatasets.map { ds =>
-          val dur: DataUseRestriction = makeDURFromWorkspace(ds)
+          val dur: DataUseRestriction = makeDurFromWorkspace(ds)
           if (ds.name.equalsIgnoreCase("Yes")) {
             dur.NAGR should be (true)
           } else {
@@ -130,7 +130,7 @@ class DataUseRestrictionSupportSpec extends FreeSpec with SearchResultValidation
 
       "dataset should have a true value for the consent code for which it was specified" in {
         val durs: Map[String, DataUseRestriction] = booleanDatasets.flatMap { ds =>
-          Map(ds.name -> makeDURFromWorkspace(ds))
+          Map(ds.name -> makeDurFromWorkspace(ds))
         }.toMap
 
         booleanCodes.map { code =>
@@ -141,7 +141,7 @@ class DataUseRestrictionSupportSpec extends FreeSpec with SearchResultValidation
 
       "dataset should have the correct list values for the consent code for which it was specified" in {
         val durs: Map[String, DataUseRestriction] = listDatasets.flatMap { ds =>
-          Map(ds.name -> makeDURFromWorkspace(ds))
+          Map(ds.name -> makeDurFromWorkspace(ds))
         }.toMap
 
         listCodes.map { code =>
@@ -177,12 +177,12 @@ class DataUseRestrictionSupportSpec extends FreeSpec with SearchResultValidation
   }
 
 
-  //////////////////////////////////
+  //////////////////
   // Utility methods
-  //////////////////////////////////
+  //////////////////
 
 
-  private def makeDURFromWorkspace(ds: Workspace): DataUseRestriction = {
+  private def makeDurFromWorkspace(ds: Workspace): DataUseRestriction = {
     val attrs = generateDataUseRestriction(ds)
     val durAtt: Attribute = attrs.getOrElse(dataUseRestrictionAttributeName, AttributeNull)
     durAtt.toJson.convertTo[DataUseRestriction]

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupportSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupportSpec.scala
@@ -1,0 +1,107 @@
+package org.broadinstitute.dsde.firecloud.service
+
+import java.util.UUID
+
+import org.broadinstitute.dsde.firecloud.integrationtest.SearchResultValidation
+import org.broadinstitute.dsde.rawls.model.{ManagedGroupRef, Workspace, _}
+import org.joda.time.DateTime
+import org.scalatest.{BeforeAndAfterAll, FreeSpec, Matchers}
+import spray.json.DefaultJsonProtocol._
+import spray.json._
+
+object DataUseRestrictionTestFixture {
+
+  case class DataUseRestriction(
+    GRU: Boolean = false,
+    HMB: Boolean = false,
+    DS: Seq[String] = Seq.empty[String],
+    NCU: Boolean = false,
+    NPU: Boolean = false,
+    NDMS: Boolean = false,
+    NAGR: Boolean = false,
+    NCTRL: Boolean = false,
+    `RS-PD`: Boolean = false,
+    `RS-G`: String = "",
+    `RS-POP`: Seq[String] = Seq.empty[String])
+
+  implicit val impDataUseRestriction: RootJsonFormat[DataUseRestriction] = jsonFormat11(DataUseRestriction)
+
+  val testCases: Map[String, DataUseRestriction] =
+    Map(
+      "GRU" -> DataUseRestriction(GRU = true),
+      "HMB" -> DataUseRestriction(HMB = true),
+      "DS" -> DataUseRestriction(DS = Seq("DS-1", "DS-2")),
+      "NCU" -> DataUseRestriction(NCU = true),
+      "NPU" -> DataUseRestriction(NPU = true),
+      "NDMS" -> DataUseRestriction(NDMS = true),
+      "NAGR" -> DataUseRestriction(NAGR = true),
+      "NCTRL" -> DataUseRestriction(NCTRL = true),
+      "RS-PD" -> DataUseRestriction(`RS-PD` = true)
+// TODO: How to test for the three gender cases
+//      "rs-fm" -> DataUseRestriction(`RS-G` = "Female"),
+//      "rs-m" -> DataUseRestriction(`RS-G` = "Male"),
+//      "rs-n/a" -> DataUseRestriction(`RS-G` = "NA"),
+//      "RS-POP" -> DataUseRestriction(`RS-POP` = Seq("POP-1", "POP-2"))
+    )
+
+  val datasets: Seq[Workspace] = testCases.map { tc =>
+    val testUUID: UUID = UUID.randomUUID()
+    val attributes = Map(AttributeName.withLibraryNS(tc._1) -> AttributeValueRawJson(tc._2.toJson.compactPrint))
+    Workspace(
+      workspaceId=testUUID.toString,
+      namespace="testWorkspaceNamespace",
+      name=tc._1,
+      authorizationDomain=Set.empty[ManagedGroupRef],
+      isLocked=false,
+      createdBy="createdBy",
+      createdDate=DateTime.now(),
+      lastModified=DateTime.now(),
+      attributes=attributes,
+      bucketName="bucketName",
+      accessLevels=Map.empty,
+      authDomainACLs=Map())
+  }.toSeq
+
+}
+
+class DataUseRestrictionSupportSpec extends FreeSpec with SearchResultValidation with Matchers with BeforeAndAfterAll with DataUseRestrictionSupport {
+
+
+  "DataUseRestrictionSupport" - {
+
+    "when there are library data use restriction fields" - {
+
+      "workspace should have a fully populated data use restriction attribute" in {
+        DataUseRestrictionTestFixture.datasets.map { ds =>
+          val attrs = generateDataUseRestriction(ds)
+          attrs.map(println)
+          // TODO ... flesh out asserts
+        }
+
+      }
+
+      "dur should have 'RS-FM' populated if 'RS-G' is 'Female'" in {
+        // TODO
+      }
+
+      "dur should have 'RS-M' populated if 'RS-G' is 'Male'" in {
+        // TODO
+      }
+
+      "dur should have 'RS-G' false if 'RS-G' is neither 'Male' or 'Female'" in {
+        // TODO
+      }
+
+    }
+
+    "when there are no library data use restriction fields" - {
+
+      "workspace should not have a populated data use restriction attribute" in {
+        // TODO
+      }
+
+    }
+
+  }
+
+}


### PR DESCRIPTION
Addresses https://broadinstitute.atlassian.net/browse/GAWB-2767

## Changes
* This PR adds one more element to the workspace document that is indexed to ES. In the case where there are consent code library attributes, we collect the valid ones and flesh that out into a full object. 

## Testing
* Run this against a custom index if running locally.
* Make sure there is at least one workspace that is catalogued with answers to the data use questionnaire.
* Run a reindex
* Search your local index for something like this:
```
http://elasticsearch5a3.dsde-dev.broadinstitute.org:9200/librarylocalgr/dataset/_search?q=_id=df7d1e4a-0956-436c-bf29-5d17a6af9483
```
You should see an indexed workspace with the following object:
```
          "library:structuredUseRestriction": {
            "DS": [
              "Diabetes Mellitus"
            ], 
            "GRU": false, 
            "HMB": true, 
            "NAGR": false, 
            "NCTRL": false, 
            "NCU": false, 
            "NDMS": false, 
            "NPU": false, 
            "RS-FM": false, 
            "RS-G": false, 
            "RS-M": false, 
            "RS-PD": false, 
            "RS-POP": [
              "N/A"
            ]
          }, 
``` 

---
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [x] Get two thumbsworth of review and PO signoff if necessary
- [x] Verify all tests go green
- [x] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [x] Test this change deployed correctly and works on dev environment after deployment
