### PR TITLE
GAWB-2829: Add passthrough for submissionsCount endpoint in Rawls

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -18,6 +18,7 @@ workspace {
   importEntitiesPath="/workspaces/%s/%s/importEntities"
   workspacesEntitiesCopyPath="/workspaces/entities/copy"
   submissionsPath="/workspaces/%s/%s/submissions"
+  submissionsCountPath="/workspaces/%s/%s/submissionsCount"
   submissionsIdPath="/workspaces/%s/%s/submissions/%s"
   submissionsWorkflowIdPath="/workspaces/%s/%s/submissions/%s/workflows/%s"
   submissionsWorkflowIdOutputsPath="/workspaces/%s/%s/submissions/%s/workflows/%s/outputs"

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -2714,10 +2714,16 @@ paths:
       responses:
         '200':
           description: Successful Request
+          schema:
+            $ref: '#/definitions/SubmissionsCountResponse'
         '404':
           description: Workspace not found
+          schema:
+            $ref: '#/definitions/ErrorReport'
         '500':
           description: Internal Error
+          schema:
+            $ref: '#/definitions/ErrorReport'
       parameters:
         - $ref: '#/parameters/workspaceNamespaceParam'
         - $ref: '#/parameters/workspaceNameParam'
@@ -4997,6 +5003,24 @@ definitions:
         description: What happens after a task fails. Choose from ContinueWhilePossible and NoNewCalls. Defaults to NoNewCalls if not specified. See Cromwell docs for more information.
         default: NoNewCalls
         enum: ["NoNewCalls", "ContinueWhilePossible"]
+
+  SubmissionsCountResponse:
+      type: object
+      properties:
+        Accepted:
+          type: integer
+        Evaluating:
+          type: integer
+        Submitting:
+          type: integer
+        Submitted:
+          type: integer
+        Aborting:
+          type: integer
+        Aborted:
+          type: integer
+        Done:
+          type: integer
 
   SubmissionValidationEntityInputs:
     description: the results of parsing each of the inputs for one entity

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -2704,6 +2704,44 @@ paths:
         500:
           description: Internal Error
 
+  /api/workspaces/{workspaceNamespace}/{workspaceName}/submissionsCount:
+      get:
+        responses:
+          '200':
+            description: Successful Request
+            schema:
+              type: object
+              description: Map[String,Int]
+          '404':
+            description: Workspace not found
+            schema:
+              $ref: '#/definitions/ErrorReport'
+          '500':
+            description: Internal Error
+            schema:
+              $ref: '#/definitions/ErrorReport'
+        description: Counts all submissions run in this workspace, grouped by status. Returns a map of status:count.
+        tags:
+          - Submissions
+        summary: Count submissions by status
+        operationId: countSubmissions
+        parameters:
+          - in: path
+            description: Workspace Namespace
+            name: workspaceNamespace
+            required: true
+            type: string
+          - in: path
+            description: Workspace Name
+            name: workspaceName
+            required: true
+            type: string
+        security:
+          - authorization:
+              - openid
+              - email
+              - profile
+
   /api/workspaces/{workspaceNamespace}/{workspaceName}/submissions/{submissionId}:
     delete:
       tags:

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -2720,7 +2720,7 @@ paths:
             description: Internal Error
             schema:
               $ref: '#/definitions/ErrorReport'
-        description: Counts all submissions run in this workspace, grouped by status. Returns a map of status:count.
+        description: Counts all submissions run in the workspace, grouped by status. Returns a map of status:count.
         tags:
           - Submissions
         summary: Count submissions by status
@@ -2736,11 +2736,6 @@ paths:
             name: workspaceName
             required: true
             type: string
-        security:
-          - authorization:
-              - openid
-              - email
-              - profile
 
   /api/workspaces/{workspaceNamespace}/{workspaceName}/submissions/{submissionId}:
     delete:

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -2705,37 +2705,22 @@ paths:
           description: Internal Error
 
   /api/workspaces/{workspaceNamespace}/{workspaceName}/submissionsCount:
-      get:
-        responses:
-          '200':
-            description: Successful Request
-            schema:
-              type: object
-              description: Map[String,Int]
-          '404':
-            description: Workspace not found
-            schema:
-              $ref: '#/definitions/ErrorReport'
-          '500':
-            description: Internal Error
-            schema:
-              $ref: '#/definitions/ErrorReport'
-        description: Counts all submissions run in the workspace, grouped by status. Returns a map of status:count.
-        tags:
-          - Submissions
-        summary: Count submissions by status
-        operationId: countSubmissions
-        parameters:
-          - in: path
-            description: Workspace Namespace
-            name: workspaceNamespace
-            required: true
-            type: string
-          - in: path
-            description: Workspace Name
-            name: workspaceName
-            required: true
-            type: string
+    get:
+      tags:
+        - Submissions
+      summary: Count submissions by status
+      description: Counts all submissions run in the workspace, grouped by status. Returns a map of status:count.
+      operationId: countSubmissions
+      responses:
+        '200':
+          description: Successful Request
+        '404':
+          description: Workspace not found
+        '500':
+          description: Internal Error
+      parameters:
+        - $ref: '#/parameters/workspaceNamespaceParam'
+        - $ref: '#/parameters/workspaceNameParam'
 
   /api/workspaces/{workspaceNamespace}/{workspaceName}/submissions/{submissionId}:
     delete:

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
@@ -50,6 +50,7 @@ object FireCloudConfig {
     val importEntitiesPath = workspace.getString("importEntitiesPath")
     val workspacesEntitiesCopyPath = workspace.getString("workspacesEntitiesCopyPath")
     def workspacesEntitiesCopyUrl(linkExistingEntities: Boolean) = authUrl + workspacesEntitiesCopyPath + "?linkExistingEntities=%s".format(linkExistingEntities)
+    val submissionsCountPath = workspace.getString("submissionsCountPath")
     val submissionsPath = workspace.getString("submissionsPath")
     val submissionsUrl = authUrl + submissionsPath
     val submissionsIdPath = workspace.getString("submissionsIdPath")

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/SubmissionService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/SubmissionService.scala
@@ -18,36 +18,43 @@ trait SubmissionService extends HttpService with PerRequestCreator with FireClou
         passthrough(submissionQueueStatusUrl, GET)
       }
     } ~
-    pathPrefix("workspaces" / Segment / Segment / "submissions") { (namespace, name) =>
-      pathEnd {
-        (get | post) {
-          extract(_.request.method) { method =>
-            passthrough(s"$workspacesUrl/$namespace/$name/submissions", method)
-          }
-        }
+    pathPrefix("workspaces" / Segment/ Segment) { (namespace, name) =>
+      path("submissionsCount") {
+         get {
+           passthrough(s"$workspacesUrl/$namespace/$name/submissionsCount", GET)
+         }
       } ~
-      path("validate") {
-        post {
-          passthrough(s"$workspacesUrl/$namespace/$name/submissions/validate", POST)
-        }
-      } ~
-      pathPrefix(Segment) { submissionId =>
+      pathPrefix("submissions") {
         pathEnd {
-          (delete | get) {
+          (get | post) {
             extract(_.request.method) { method =>
-              passthrough(s"$workspacesUrl/$namespace/$name/submissions/$submissionId", method)
+              passthrough(s"$workspacesUrl/$namespace/$name/submissions", method)
             }
           }
         } ~
-        pathPrefix("workflows" / Segment) { workflowId =>
+        path("validate") {
+          post {
+            passthrough(s"$workspacesUrl/$namespace/$name/submissions/validate", POST)
+          }
+        } ~
+        pathPrefix(Segment) { submissionId =>
           pathEnd {
-            get {
-              passthrough(s"$workspacesUrl/$namespace/$name/submissions/$submissionId/workflows/$workflowId", GET)
+            (delete | get) {
+              extract(_.request.method) { method =>
+                passthrough(s"$workspacesUrl/$namespace/$name/submissions/$submissionId", method)
+              }
             }
           } ~
-          pathPrefix("outputs") {
-            get {
-              passthrough(s"$workspacesUrl/$namespace/$name/submissions/$submissionId/workflows/$workflowId/outputs", GET)
+          pathPrefix("workflows" / Segment) { workflowId =>
+            pathEnd {
+              get {
+                passthrough(s"$workspacesUrl/$namespace/$name/submissions/$submissionId/workflows/$workflowId", GET)
+              }
+            } ~
+            pathPrefix("outputs") {
+              get {
+                passthrough(s"$workspacesUrl/$namespace/$name/submissions/$submissionId/workflows/$workflowId/outputs", GET)
+              }
             }
           }
         }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockWorkspaceServer.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockWorkspaceServer.scala
@@ -86,6 +86,19 @@ object MockWorkspaceServer {
     MockWorkspaceServer.workspaceServer
       .when(
         request()
+          .withMethod("GET")
+          .withPath(s"${workspaceBasePath}/%s/%s/submissionsCount"
+            .format(mockValidWorkspace.namespace, mockValidWorkspace.name))
+          .withHeader(authHeader))
+      .respond(
+        response()
+          .withHeaders(header)
+          .withStatusCode(OK.intValue)
+      )
+
+    MockWorkspaceServer.workspaceServer
+      .when(
+        request()
           .withMethod("POST")
           .withPath(s"${workspaceBasePath}/%s/%s/submissions"
             .format(mockValidWorkspace.namespace, mockValidWorkspace.name))

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/SubmissionServiceNegativeSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/SubmissionServiceNegativeSpec.scala
@@ -12,6 +12,10 @@ final class SubmissionServiceNegativeSpec extends ServiceSpec with SubmissionSer
 
   def actorRefFactory = system
 
+  val localSubmissionsCountPath = FireCloudConfig.Rawls.submissionsCountPath.format(
+    MockWorkspaceServer.mockValidWorkspace.namespace,
+    MockWorkspaceServer.mockValidWorkspace.name)
+
   val localSubmissionsPath = FireCloudConfig.Rawls.submissionsPath.format(
     MockWorkspaceServer.mockValidWorkspace.namespace,
     MockWorkspaceServer.mockValidWorkspace.name)
@@ -25,6 +29,12 @@ final class SubmissionServiceNegativeSpec extends ServiceSpec with SubmissionSer
     "non-GET requests hitting the /submissions/queueStatus path are not passed through" in {
       allHttpMethodsExcept(GET) foreach { method =>
         checkIfPassedThrough(routes, method, "/submissions/queueStatus", toBeHandled = false)
+      }
+    }
+
+    "non-GET requests hitting the /workspaces/*/*/submissionsCount path are not passed through" in {
+      allHttpMethodsExcept(GET) foreach { method =>
+        checkIfPassedThrough(routes, method, localSubmissionsCountPath, toBeHandled = false)
       }
     }
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/SubmissionServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/SubmissionServiceSpec.scala
@@ -19,6 +19,10 @@ final class SubmissionServiceSpec extends ServiceSpec with SubmissionService {
     MockWorkspaceServer.stopWorkspaceServer()
   }
 
+  val localSubmissionsCountPath = FireCloudConfig.Rawls.submissionsCountPath.format(
+    MockWorkspaceServer.mockValidWorkspace.namespace,
+    MockWorkspaceServer.mockValidWorkspace.name)
+
   val localSubmissionsPath = FireCloudConfig.Rawls.submissionsPath.format(
     MockWorkspaceServer.mockValidWorkspace.namespace,
     MockWorkspaceServer.mockValidWorkspace.name)
@@ -64,6 +68,15 @@ final class SubmissionServiceSpec extends ServiceSpec with SubmissionService {
           Get("/submissions/queueStatus") ~> dummyAuthHeaders ~> sealRoute(routes) ~> check {
             status should equal(OK)
           }
+        }
+      }
+    }
+
+    "when calling GET on the /workspaces/*/*/submissionsCount path" - {
+      "OK status is returned" in {
+        (Get(localSubmissionsCountPath)
+          ~> dummyAuthHeaders) ~> sealRoute(routes) ~> check {
+          status should equal(OK)
         }
       }
     }


### PR DESCRIPTION
This is to fix a regression introduced by #515. 

Having gone through the three `Orchestration` services (i.e. `NotificationsApiService`, `BillingService`,  `SubmissionService`) that used to use `passthroughAllPaths`, the `/api/workspaces/{workspaceNamespace}/{workspaceName}/submissionsCount` endpoint appears to be the only one that got lost in transition, which is now added.

Verified that 
- the Swagger page lists `submissionsCount` 
- workspaces can load their `Analysis Submissions` section (which uses `submissionsCount` endpoint)

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment