### PR TITLE
GAWB-2834: Index data use restriction display codes as a list of easily displayed terms

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/DataUse.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/DataUse.scala
@@ -27,11 +27,6 @@ object DataUse {
       val numericId = stringid.stripPrefix(doid_prefix).toInt
       new DiseaseOntologyNodeId(uri, numericId)
     }
-    def apply(numericId: Int) = {
-      val uri = Uri(doid_prefix + numericId.toString)
-      new DiseaseOntologyNodeId(uri, numericId)
-
-    }
   }
 
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/DataUse.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/DataUse.scala
@@ -4,7 +4,7 @@ import spray.http.Uri
 
 object DataUse {
 
-  final val doid_prefix = "http://purl.obolibrary.org/obo/DOID_"
+  private final val doid_prefix = "http://purl.obolibrary.org/obo/DOID_"
 
   case class ResearchPurpose(
     DS:    Seq[DiseaseOntologyNodeId],

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/DataUse.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/DataUse.scala
@@ -4,7 +4,7 @@ import spray.http.Uri
 
 object DataUse {
 
-  private final val doid_prefix = "http://purl.obolibrary.org/obo/DOID_"
+  final val doid_prefix = "http://purl.obolibrary.org/obo/DOID_"
 
   case class ResearchPurpose(
     DS:    Seq[DiseaseOntologyNodeId],

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/DataUse.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/DataUse.scala
@@ -27,6 +27,11 @@ object DataUse {
       val numericId = stringid.stripPrefix(doid_prefix).toInt
       new DiseaseOntologyNodeId(uri, numericId)
     }
+    def apply(numericId: Int) = {
+      val uri = Uri(doid_prefix + numericId.toString)
+      new DiseaseOntologyNodeId(uri, numericId)
+
+    }
   }
 
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupport.scala
@@ -14,7 +14,7 @@ trait DataUseRestrictionSupport extends LazyLogging {
   private val booleanCodes: Seq[String] = Seq("GRU", "HMB", "NCU", "NPU", "NDMS", "NAGR", "NCTRL", "RS-PD")
   private val genderCodes: Seq[String] = Seq("RS-G", "RS-FM", "RS-M")
   private val duRestrictionFieldNames: Seq[String] = booleanCodes ++ genderCodes ++ Seq("DS_URL", "RS-POP")
-  val allDurFieldNames: Seq[String] = booleanCodes ++ genderCodes ++ Seq("DS", "DS_URL", "RS-POP")
+  val allDurFieldNames: Seq[String] = duRestrictionFieldNames ++ Seq("DS")
 
   private val diseaseLabelsAttributeName: AttributeName = AttributeName.withLibraryNS("DS")
   val structuredUseRestrictionAttributeName: AttributeName = AttributeName.withLibraryNS("structuredUseRestriction")

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupport.scala
@@ -1,12 +1,9 @@
 package org.broadinstitute.dsde.firecloud.service
 
 import com.typesafe.scalalogging.slf4j.LazyLogging
-import org.broadinstitute.dsde.firecloud.model.DataUse
 import org.broadinstitute.dsde.firecloud.model.DataUse.DiseaseOntologyNodeId
-import org.broadinstitute.dsde.firecloud.model.Ontology.{TermParent, TermResource}
 import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport.AttributeNameFormat
 import org.broadinstitute.dsde.rawls.model._
-import spray.http.Uri
 import spray.json.DefaultJsonProtocol._
 import spray.json._
 
@@ -14,8 +11,11 @@ trait DataUseRestrictionSupport extends LazyLogging {
 
   private val booleanCodes: Seq[String] = Seq("GRU", "HMB", "NCU", "NPU", "NDMS", "NAGR", "NCTRL", "RS-PD")
   private val listCodes: Seq[String] = Seq("DS", "RS-POP")
-  val durFieldNames: Seq[String] = booleanCodes ++ listCodes ++ Seq("RS-G")
+  private val genderCodes: Seq[String] = Seq("RS-G", "RS-FM", "RS-M")
+  val durFieldNames: Seq[String] = booleanCodes ++ listCodes ++ genderCodes
 
+  // TODO: This value will change depending on what is implemented for GAWB-2758
+  val diseaseLabelsAttributeName: AttributeName = AttributeName.withLibraryNS("DS-labels")
   val structuredUseRestrictionAttributeName: AttributeName = AttributeName.withLibraryNS("structuredUseRestriction")
   val dataUseDisplayAttributeName: AttributeName = AttributeName.withLibraryNS("dataUseDisplay")
 
@@ -31,15 +31,30 @@ trait DataUseRestrictionSupport extends LazyLogging {
     * @param workspace The Workspace
     * @return A structured data use restriction Attribute Map
     */
-  def generateStructuredUseRestriction(workspace: Workspace): Map[AttributeName, Attribute] = {
+  def generateStructuredUseRestrictionAttribute(workspace: Workspace): Map[AttributeName, Attribute] = {
     implicit val impAttributeFormat: AttributeFormat with PlainArrayAttributeListSerializer =
       new AttributeFormat with PlainArrayAttributeListSerializer
-    val allAttrs = makeAttributes(workspace)
-    if (allAttrs.nonEmpty) {
-      Map(structuredUseRestrictionAttributeName -> AttributeValueRawJson.apply(allAttrs.toJson.compactPrint))
-    } else {
-      Map.empty[AttributeName, Attribute]
+
+    getDataUseAttributes(workspace).filter { t => durFieldNames.contains(t._1.name) } match {
+      case x if x.isEmpty => Map.empty[AttributeName, Attribute]
+      case existingAttrs =>
+
+        val existingKeyNames = existingAttrs.keys.map(_.name).toSeq
+
+        // Missing boolean codes default to false
+        val booleanAttrs: Map[AttributeName, Attribute] = ((booleanCodes ++ genderCodes) diff existingKeyNames).map { code =>
+          AttributeName.withDefaultNS(code) -> AttributeBoolean(false)
+        }.toMap
+
+        // Missing list codes default to empty lists
+        val listAttrs: Map[AttributeName, Attribute] = (listCodes diff existingKeyNames).map { code =>
+          AttributeName.withDefaultNS(code) -> AttributeValueList(Seq.empty)
+        }.toMap
+
+        val allAttrs = existingAttrs ++ booleanAttrs ++ listAttrs
+        Map(structuredUseRestrictionAttributeName -> AttributeValueRawJson.apply(allAttrs.toJson.compactPrint))
     }
+
   }
 
   /**
@@ -49,43 +64,33 @@ trait DataUseRestrictionSupport extends LazyLogging {
     * @param workspace The Workspace
     * @return An Attribute Map representing a data use display
     */
-  def generateUseRestrictionDisplay(workspace: Workspace, termCache: Map[String, TermResource]): Map[AttributeName, Attribute] = {
-    makeAttributes(workspace).flatMap {
+  def generateUseRestrictionDisplayAttribute(workspace: Workspace): Map[AttributeName, Attribute] = {
+    getDataUseAttributes(workspace).flatMap {
       case (attr: AttributeName, value: AttributeBoolean) if value.value =>  Seq(attr.name)
-      case (attr: AttributeName, value: AttributeBoolean) =>  Seq.empty[String]
-      case (attr: AttributeName, value: AttributeValueList) => value.list.map {
-        case avl@(a: AttributeString) =>
-          termCache.get(a.value) match {
-            case None =>
-              logger.warn(s"Missing ontology term (workspace-id: ${workspace.workspaceId}, attribute name: ${attr.name}, attribute value: ${a.value})")
-              ""
-            case Some(o) => "DS:" + o.label
-          }
-        case avl@(a: AttributeNumber) =>
-          val nodeId = DiseaseOntologyNodeId(DataUse.doid_prefix + a.value.intValue().toString)
-          termCache.get(nodeId.uri.toString()) match {
-            case None =>
-              logger.warn(s"Missing ontology term (workspace-id: ${workspace.workspaceId}, attribute name: ${attr.name}, attribute value: ${nodeId.toString})")
-              ""
-            case Some(o) => "DS:" + o.label
-          }
-        case a =>
-          logger.warn(s"Attribute value list is of the wrong type (workspace-id: ${workspace.workspaceId}, attribute name: ${attr.name}, value type: ${a.getClass})")
+      case (attr: AttributeName, value: AttributeValueList) if attr.name.equals(diseaseLabelsAttributeName.name) => value.list.map {
+        case avl@(a: AttributeString) => "DS:" + a.value
+        case _ =>
+          logger.warn(s"Attribute value list is of the wrong type (workspace-id: ${workspace.workspaceId}, attribute name: ${attr.name}, value type: ${value.getClass})")
           ""
       }
+      case (attr: AttributeName, value: Attribute) =>
+        logger.debug(s"Ignored attribute: ${attr.name}; value: ${value.getClass.getName}")
+        Seq.empty[String]
     }.toSeq.filter(_.nonEmpty) match {
       case x if x.nonEmpty => Map(dataUseDisplayAttributeName -> AttributeValueList(x.map(AttributeString)))
       case _ => Map.empty[AttributeName, Attribute]
     }
   }
 
-  private def makeAttributes(workspace: Workspace): Map[AttributeName, Attribute] = {
-    val libraryAttrs = workspace.attributes.filter { case (attr, value) => durFieldNames.contains(attr.name) }
+  private def getDataUseAttributes(workspace: Workspace): Map[AttributeName, Attribute] = {
 
-    if (libraryAttrs.isEmpty) {
+    // Find all library attributes that contribute to data use restrictions
+    val dataUseAttributes = workspace.attributes.filter { case (attr, value) => (durFieldNames ++ Seq(diseaseLabelsAttributeName.name)).contains(attr.name) }
+
+    if (dataUseAttributes.isEmpty) {
       Map.empty[AttributeName, Attribute]
     } else {
-      val existingAttrs: Map[AttributeName, Attribute] = libraryAttrs.flatMap {
+      dataUseAttributes.flatMap {
         // Handle the known String->Boolean conversion cases first
         case (attr: AttributeName, value: AttributeString) =>
           attr.name match {
@@ -115,25 +120,23 @@ trait DataUseRestrictionSupport extends LazyLogging {
           }
         // Handle only what is correctly tagged and ignore anything improperly tagged
         case (attr: AttributeName, value: AttributeBoolean) => Map(AttributeName.withDefaultNS(attr.name) -> value)
+        // Turn DS string ids into numeric IDs for ES indexing
+        case (attr: AttributeName, value: AttributeValueList) if attr.name.equals("DS") =>
+          val diseaseNumericIdValues: Seq[AttributeNumber] = value match {
+            case x: AttributeValueList => x.list.map {
+              case avl@(a: AttributeString) => AttributeNumber(DiseaseOntologyNodeId(a.value).numericId)
+              case avl@(a: AttributeNumber) => AttributeNumber(a.value.toInt)
+              case _ => AttributeNumber(0)
+            }
+            case _ => Seq.empty[AttributeNumber]
+          }
+          val filteredValues = diseaseNumericIdValues.filter(_.value > 0)
+          Map(AttributeName.withDefaultNS(attr.name) -> AttributeValueList(filteredValues))
         case (attr: AttributeName, value: AttributeValueList) => Map(AttributeName.withDefaultNS(attr.name) -> value)
         case unmatched =>
           logger.warn(s"Unexpected data use attribute type: (workspace-id: ${workspace.workspaceId}, attribute name: ${unmatched._1.name}, attribute value: ${unmatched._2.toString})")
           Map.empty[AttributeName, Attribute]
       }
-
-      val existingKeyNames = existingAttrs.keys.map(_.name).toSeq
-
-      // Missing boolean codes default to false
-      val booleanAttrs: Map[AttributeName, Attribute] = ((booleanCodes ++ List("RS-G", "RS-FM", "RS-M")) diff existingKeyNames).map { code =>
-        AttributeName.withDefaultNS(code) -> AttributeBoolean(false)
-      }.toMap
-
-      // Missing list codes default to empty lists
-      val listAttrs: Map[AttributeName, Attribute] = (listCodes diff existingKeyNames).map { code =>
-        AttributeName.withDefaultNS(code) -> AttributeValueList(Seq.empty)
-      }.toMap
-
-      existingAttrs ++ booleanAttrs ++ listAttrs
     }
 
   }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupport.scala
@@ -127,8 +127,7 @@ trait DataUseRestrictionSupport extends LazyLogging {
           val diseaseNumericIdValues: Seq[AttributeNumber] = value match {
             case x: AttributeValueList => x.list.map {
               case avl@(a: AttributeString) =>
-                val nodeId = Try(DiseaseOntologyNodeId.apply(a.value))
-                nodeId match {
+                Try(DiseaseOntologyNodeId.apply(a.value)) match {
                   case Success(id) => AttributeNumber(id.numericId)
                   case Failure(e) =>
                     logger.warn(s"Unable to coerce term ${a.value} into a node id for workspace-id: ${workspace.workspaceId}")
@@ -139,8 +138,10 @@ trait DataUseRestrictionSupport extends LazyLogging {
             }
             case _ => Seq.empty[AttributeNumber]
           }
-          val filteredValues = diseaseNumericIdValues.filter(_.value > 0)
-          Map(AttributeName.withDefaultNS(attr.name) -> AttributeValueList(filteredValues))
+          diseaseNumericIdValues.filter(_.value > 0) match {
+            case values if values.nonEmpty => Map(AttributeName.withDefaultNS(attr.name) -> AttributeValueList(values))
+            case _ => Map.empty[AttributeName, Attribute]
+          }
         case (attr: AttributeName, value: AttributeValueList) => Map(AttributeName.withDefaultNS(attr.name) -> value)
         case unmatched =>
           logger.warn(s"Unexpected data use attribute type: (workspace-id: ${workspace.workspaceId}, attribute name: ${unmatched._1.name}, attribute value: ${unmatched._2.toString})")

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupport.scala
@@ -1,8 +1,12 @@
 package org.broadinstitute.dsde.firecloud.service
 
 import com.typesafe.scalalogging.slf4j.LazyLogging
+import org.broadinstitute.dsde.firecloud.model.DataUse
+import org.broadinstitute.dsde.firecloud.model.DataUse.DiseaseOntologyNodeId
+import org.broadinstitute.dsde.firecloud.model.Ontology.{TermParent, TermResource}
 import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport.AttributeNameFormat
 import org.broadinstitute.dsde.rawls.model._
+import spray.http.Uri
 import spray.json.DefaultJsonProtocol._
 import spray.json._
 
@@ -13,6 +17,7 @@ trait DataUseRestrictionSupport extends LazyLogging {
   val durFieldNames: Seq[String] = booleanCodes ++ listCodes ++ Seq("RS-G")
 
   val structuredUseRestrictionAttributeName: AttributeName = AttributeName.withLibraryNS("structuredUseRestriction")
+  val dataUseDisplayAttributeName: AttributeName = AttributeName.withLibraryNS("dataUseDisplay")
 
   /**
     * This method looks at all of the library attributes that are associated to Consent Codes and
@@ -27,10 +32,54 @@ trait DataUseRestrictionSupport extends LazyLogging {
     * @return A structured data use restriction Attribute Map
     */
   def generateStructuredUseRestriction(workspace: Workspace): Map[AttributeName, Attribute] = {
-
     implicit val impAttributeFormat: AttributeFormat with PlainArrayAttributeListSerializer =
       new AttributeFormat with PlainArrayAttributeListSerializer
+    val allAttrs = makeAttributes(workspace)
+    if (allAttrs.nonEmpty) {
+      Map(structuredUseRestrictionAttributeName -> AttributeValueRawJson.apply(allAttrs.toJson.compactPrint))
+    } else {
+      Map.empty[AttributeName, Attribute]
+    }
+  }
 
+  /**
+    * Create a display-friendly version of the structured data use restriction in the form of a
+    * list of code strings.
+    *
+    * @param workspace The Workspace
+    * @return An Attribute Map representing a data use display
+    */
+  def generateUseRestrictionDisplay(workspace: Workspace, termCache: Map[String, TermResource]): Map[AttributeName, Attribute] = {
+    makeAttributes(workspace).flatMap {
+      case (attr: AttributeName, value: AttributeBoolean) if value.value =>  Seq(attr.name)
+      case (attr: AttributeName, value: AttributeBoolean) =>  Seq.empty[String]
+      case (attr: AttributeName, value: AttributeValueList) => value.list.map {
+        case avl@(a: AttributeString) =>
+          termCache.get(a.value) match {
+            case None =>
+              logger.warn(s"Missing ontology term (workspace-id: ${workspace.workspaceId}, attribute name: ${attr.name}, attribute value: ${a.value})")
+              ""
+            case Some(o) => "DS:" + o.label
+          }
+        case avl@(a: AttributeNumber) =>
+          val nodeId = DiseaseOntologyNodeId(DataUse.doid_prefix + a.value.intValue().toString)
+          termCache.get(nodeId.uri.toString()) match {
+            case None =>
+              logger.warn(s"Missing ontology term (workspace-id: ${workspace.workspaceId}, attribute name: ${attr.name}, attribute value: ${nodeId.toString})")
+              ""
+            case Some(o) => "DS:" + o.label
+          }
+        case a =>
+          logger.warn(s"Attribute value list is of the wrong type (workspace-id: ${workspace.workspaceId}, attribute name: ${attr.name}, value type: ${a.getClass})")
+          ""
+      }
+    }.toSeq.filter(_.nonEmpty) match {
+      case x if x.nonEmpty => Map(dataUseDisplayAttributeName -> AttributeValueList(x.map(AttributeString)))
+      case _ => Map.empty[AttributeName, Attribute]
+    }
+  }
+
+  private def makeAttributes(workspace: Workspace): Map[AttributeName, Attribute] = {
     val libraryAttrs = workspace.attributes.filter { case (attr, value) => durFieldNames.contains(attr.name) }
 
     if (libraryAttrs.isEmpty) {
@@ -84,9 +133,7 @@ trait DataUseRestrictionSupport extends LazyLogging {
         AttributeName.withDefaultNS(code) -> AttributeValueList(Seq.empty)
       }.toMap
 
-      val allAttrs = existingAttrs ++ booleanAttrs ++ listAttrs
-
-      Map(structuredUseRestrictionAttributeName -> AttributeValueRawJson.apply(allAttrs.toJson.compactPrint))
+      existingAttrs ++ booleanAttrs ++ listAttrs
     }
 
   }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/LibraryServiceSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/LibraryServiceSupport.scala
@@ -81,7 +81,7 @@ trait LibraryServiceSupport extends DataUseRestrictionSupport with LazyLogging {
       case None => Map()
     }
 
-    val durAttributeNames = durFieldNames.map(AttributeName.withLibraryNS)
+    val durAttributeNames = allDurFieldNames.map(AttributeName.withLibraryNS)
     val dur: Map[AttributeName, Attribute] = generateStructuredUseRestrictionAttribute(workspace)
     val displayDur: Map[AttributeName, Attribute] = generateUseRestrictionDisplayAttribute(workspace)
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/LibraryServiceSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/LibraryServiceSupport.scala
@@ -3,7 +3,7 @@ package org.broadinstitute.dsde.firecloud.service
 import com.typesafe.scalalogging.slf4j.LazyLogging
 import org.broadinstitute.dsde.firecloud.FireCloudConfig
 import org.broadinstitute.dsde.firecloud.dataaccess.{OntologyDAO, RawlsDAO}
-import org.broadinstitute.dsde.firecloud.model.Ontology.TermParent
+import org.broadinstitute.dsde.firecloud.model.Ontology.{TermParent, TermResource}
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.{AddUpdateAttribute, AttributeUpdateOperation, RemoveAttribute}
 import org.broadinstitute.dsde.firecloud.model.{Document, ElasticSearch, LibrarySearchResponse, UserInfo}
@@ -34,27 +34,31 @@ trait LibraryServiceSupport extends DataUseRestrictionSupport with LazyLogging {
   def indexableDocuments(workspaces: Seq[Workspace], ontologyDAO: OntologyDAO)(implicit ec: ExecutionContext): Future[Seq[Document]] = {
     // find all the ontology nodes in this list of workspaces
     val nodesSeq:Seq[String] = workspaces.collect {
-        case w if w.attributes.contains(AttributeName.withLibraryNS("diseaseOntologyID")) =>
-          w.attributes(AttributeName.withLibraryNS("diseaseOntologyID"))
-      }.collect {
-        case s:AttributeString => s.value
-      }
-    logger.debug(s"found ${nodesSeq.size} workspaces with ontology nodes assigned")
+      case w if w.attributes.contains(AttributeName.withLibraryNS("diseaseOntologyID")) =>
+        w.attributes(AttributeName.withLibraryNS("diseaseOntologyID"))
+      case x if x.attributes.contains(AttributeName.withLibraryNS("DS")) =>
+        x.attributes(AttributeName.withLibraryNS("DS"))
+    }.collect {
+      case s:AttributeString => s.value
+    }
+    logger.debug(s"found ${nodesSeq.size} ontology terms in workspaces with ontology nodes or DS:X nodes assigned")
 
     val nodes = nodesSeq.toSet
     logger.debug(s"found ${nodes.size} unique ontology nodes")
 
     // query ontology for this set of nodes, save in a map
-    val parentCache = Future.sequence(nodes map {id =>
-      lookupParentNodes(id, ontologyDAO) map {parents:Seq[TermParent] => (id, parents)}
-    })
+    val termCache = Future.sequence {
+      nodes map { id => lookupTermNodes(id, ontologyDAO) }
+    }
 
-    // using the cached parent information, build the indexable documents
-    val docsResult: Future[Seq[Document]] = parentCache map { parentSet =>
-      val parentMap = parentSet.toMap.filter(e => e._2.nonEmpty) // remove nodes that have no parent
+    // using the cached term information, build the indexable documents
+    val docsResult: Future[Seq[Document]] = termCache map { termSeq =>
+      val termMap: Map[String, TermResource] = termSeq.flatten.map { t => t.id -> t }.toMap
+      val parentMap: Map[String, List[TermParent]] = termSeq.flatten.filter(_.parents.nonEmpty).map { t => t.id -> t.parents.get }.toMap
+      logger.debug(s"have term results for ${termMap.size} ontology nodes")
       logger.debug(s"have parent results for ${parentMap.size} ontology nodes")
       workspaces map {w =>
-       indexableDocument(w, parentMap)
+        indexableDocument(w, termMap, parentMap)
       }
     }
 
@@ -62,7 +66,7 @@ trait LibraryServiceSupport extends DataUseRestrictionSupport with LazyLogging {
 
   }
 
-  private def indexableDocument(workspace: Workspace, parentCache: Map[String,Seq[TermParent]])(implicit ec: ExecutionContext): Document = {
+  private def indexableDocument(workspace: Workspace, termCache: Map[String, TermResource], parentCache: Map[String,Seq[TermParent]])(implicit ec: ExecutionContext): Document = {
     val attrfields_subset = workspace.attributes.filter(_._1.namespace == AttributeName.libraryNamespace)
     val attrfields = attrfields_subset map { case (attr, value) =>
       attr.name match {
@@ -82,10 +86,11 @@ trait LibraryServiceSupport extends DataUseRestrictionSupport with LazyLogging {
       case None => Map()
     }
 
-    val dur: Map[AttributeName, Attribute] = generateStructuredUseRestriction(workspace)
     val durAttributeNames = durFieldNames.map(AttributeName.withLibraryNS)
+    val dur: Map[AttributeName, Attribute] = generateStructuredUseRestriction(workspace)
+    val displayDur: Map[AttributeName, Attribute] = generateUseRestrictionDisplay(workspace, termCache)
 
-    val fields = (attrfields -- durAttributeNames) ++ idfields ++ tagfields ++ dur
+    val fields = (attrfields -- durAttributeNames) ++ idfields ++ tagfields ++ dur ++ displayDur
 
     workspace.attributes.get(AttributeName.withLibraryNS("diseaseOntologyID")) match {
       case Some(id: AttributeString) =>
@@ -102,16 +107,14 @@ trait LibraryServiceSupport extends DataUseRestrictionSupport with LazyLogging {
 
   // wraps the ontologyDAO call, handles Nones/nulls, and returns a [Future[Seq].
   // the Seq is populated if the leaf node exists and has parents; Seq is empty otherwise.
-  def lookupParentNodes(leafId:String, ontologyDAO: OntologyDAO)(implicit ec: ExecutionContext):Future[Seq[TermParent]] = {
+  def lookupTermNodes(leafId:String, ontologyDAO: OntologyDAO)(implicit ec: ExecutionContext):Future[Seq[TermResource]] = {
     ontologyDAO.search(leafId) map {
-      case Some(terms) if terms.nonEmpty =>
-        terms.head.parents.getOrElse(Seq.empty)
-      case None => Seq.empty[TermParent]
+      case Some(terms) if terms.nonEmpty => terms
+      case None => Seq.empty[TermResource]
     } recoverWith {
-      case ex:Exception => {
+      case ex:Exception =>
         logger.warn(s"exception getting term and parents from ontology: ${ex.getMessage}")
-        Future(Seq.empty[TermParent])
-      }
+        Future(Seq.empty[TermResource])
     }
   }
 
@@ -135,7 +138,7 @@ trait LibraryServiceSupport extends DataUseRestrictionSupport with LazyLogging {
     rawlsDAO.getGroupsForUser map {FireCloudConfig.ElasticSearch.discoverGroupNames intersect _}
   }
 
-  def updateAccess(docs: LibrarySearchResponse, workspaces: Seq[WorkspaceListResponse]) = {
+  def updateAccess(docs: LibrarySearchResponse, workspaces: Seq[WorkspaceListResponse]): LibrarySearchResponse = {
 
     val accessMap = workspaces map { workspaceResponse: WorkspaceListResponse =>
       workspaceResponse.workspace.workspaceId -> workspaceResponse.accessLevel

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/LibraryServiceSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/LibraryServiceSupport.scala
@@ -54,14 +54,11 @@ trait LibraryServiceSupport extends DataUseRestrictionSupport with LazyLogging {
         DiseaseOntologyNodeId(s.value.toInt).uri.toString()
     }.filter(_.nonEmpty).distinct
 
-    logger.debug(s"found ${nodesSeq.size} ontology terms in workspaces with ontology nodes or DS:X nodes assigned")
-
-    val nodes = nodesSeq.toSet
-    logger.debug(s"found ${nodes.size} unique ontology nodes")
+    logger.info(s"found ${nodesSeq.size} ontology terms in workspaces with ontology nodes or DS:X nodes assigned")
 
     // query ontology for this set of nodes, save in a map
     val termCache = Future.sequence {
-      nodes map { id => lookupTermNodes(id, ontologyDAO) }
+      nodesSeq map { id => lookupTermNodes(id, ontologyDAO) }
     }
 
     // using the cached term information, build the indexable documents

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/DataUseRestrictionSearchSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/DataUseRestrictionSearchSpec.scala
@@ -5,12 +5,13 @@ import org.broadinstitute.dsde.firecloud.integrationtest.ESIntegrationSupport._
 import org.broadinstitute.dsde.firecloud.model.LibrarySearchResponse
 import org.broadinstitute.dsde.firecloud.service.DataUseRestrictionTestFixtures.DataUseRestriction
 import org.broadinstitute.dsde.firecloud.service.{DataUseRestrictionTestFixtures, LibraryServiceSupport}
-import org.broadinstitute.dsde.rawls.model.Workspace
+import org.broadinstitute.dsde.rawls.model.{AttributeName, Workspace}
 import org.scalatest.{BeforeAndAfterAll, FreeSpec, Matchers}
 
 import scala.concurrent.Await
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.language.postfixOps
+import spray.json.DefaultJsonProtocol._
 
 class DataUseRestrictionSearchSpec extends FreeSpec with SearchResultValidation with BeforeAndAfterAll with Matchers with LibraryServiceSupport {
 
@@ -55,33 +56,33 @@ class DataUseRestrictionSearchSpec extends FreeSpec with SearchResultValidation 
       }
 
       "GRU dataset should be indexed as true" in {
-        val searchResponse = searchFor("GRU")
-        assertDataUseRestrictions(searchResponse, DataUseRestriction(GRU = true))
+        val searchResponse = searchFor("GRU-unique")
+        assertDataUseRestrictions(searchResponse, DataUseRestriction(GRU = true), Seq("GRU"))
       }
 
       "HMB dataset should be indexed as true" in {
-        val searchResponse = searchFor("HMB")
-        assertDataUseRestrictions(searchResponse, DataUseRestriction(HMB = true))
+        val searchResponse = searchFor("HMB-unique")
+        assertDataUseRestrictions(searchResponse, DataUseRestriction(HMB = true), Seq("HMB"))
       }
 
       "NCU dataset should be indexed as true" in {
-        val searchResponse = searchFor("NCU")
-        assertDataUseRestrictions(searchResponse, DataUseRestriction(NCU = true))
+        val searchResponse = searchFor("NCU-unique")
+        assertDataUseRestrictions(searchResponse, DataUseRestriction(NCU = true), Seq("NCU"))
       }
 
       "NPU dataset should be indexed as true" in {
-        val searchResponse = searchFor("NPU")
-        assertDataUseRestrictions(searchResponse, DataUseRestriction(NPU = true))
+        val searchResponse = searchFor("NPU-unique")
+        assertDataUseRestrictions(searchResponse, DataUseRestriction(NPU = true), Seq("NPU"))
       }
 
       "NDMS dataset should be indexed as true" in {
-        val searchResponse = searchFor("NDMS")
-        assertDataUseRestrictions(searchResponse, DataUseRestriction(NDMS = true))
+        val searchResponse = searchFor("NDMS-unique")
+        assertDataUseRestrictions(searchResponse, DataUseRestriction(NDMS = true), Seq("NDMS"))
       }
 
       "NAGR:Yes should be indexed as true" in {
         val searchResponse = searchFor("NAGRYes")
-        assertDataUseRestrictions(searchResponse, DataUseRestriction(NAGR = true))
+        assertDataUseRestrictions(searchResponse, DataUseRestriction(NAGR = true), Seq("NAGR"))
       }
 
       "NAGR:No should be indexed as false" in {
@@ -95,23 +96,23 @@ class DataUseRestrictionSearchSpec extends FreeSpec with SearchResultValidation 
       }
 
       "NCTRL dataset should be indexed as true" in {
-        val searchResponse = searchFor("NCTRL")
-        assertDataUseRestrictions(searchResponse, DataUseRestriction(NCTRL = true))
+        val searchResponse = searchFor("NCTRL-unique")
+        assertDataUseRestrictions(searchResponse, DataUseRestriction(NCTRL = true), Seq("NCTRL"))
       }
 
       "RS-PD dataset should be indexed as true" in {
-        val searchResponse = searchFor("RS-PD")
-        assertDataUseRestrictions(searchResponse, DataUseRestriction(`RS-PD` = true))
+        val searchResponse = searchFor("RSPD-unique")
+        assertDataUseRestrictions(searchResponse, DataUseRestriction(`RS-PD` = true), Seq("RS-PD"))
       }
 
       "RS-G:Female should be indexed as RS-G:true, RS-FM:true" in {
         val searchResponse = searchFor("RSGFemale")
-        assertDataUseRestrictions(searchResponse, DataUseRestriction(`RS-G` = true, `RS-FM` = true))
+        assertDataUseRestrictions(searchResponse, DataUseRestriction(`RS-G` = true, `RS-FM` = true), Seq("RS-G", "RS-FM"))
       }
 
       "RS-G:Male should be indexed as RS-G:true, RS-M:true" in {
         val searchResponse = searchFor("RSGMale")
-        assertDataUseRestrictions(searchResponse, DataUseRestriction(`RS-G` = true, `RS-M` = true))
+        assertDataUseRestrictions(searchResponse, DataUseRestriction(`RS-G` = true, `RS-M` = true), Seq("RS-G", "RS-M"))
       }
 
       "RS-G:N/A should be indexed as RS-G:false" in {
@@ -120,18 +121,18 @@ class DataUseRestrictionSearchSpec extends FreeSpec with SearchResultValidation 
       }
 
       "RS-FM dataset should be indexed as true" in {
-        val searchResponse = searchFor("RS-FM")
-        assertDataUseRestrictions(searchResponse, DataUseRestriction(`RS-G` = true, `RS-FM` = true))
+        val searchResponse = searchFor("RSGFemale")
+        assertDataUseRestrictions(searchResponse, DataUseRestriction(`RS-G` = true, `RS-FM` = true), Seq("RS-G", "RS-FM"))
       }
 
       "RS-M dataset should be indexed as true" in {
-        val searchResponse = searchFor("RS-M")
-        assertDataUseRestrictions(searchResponse, DataUseRestriction(`RS-G` = true, `RS-M` = true))
+        val searchResponse = searchFor("RSGMale")
+        assertDataUseRestrictions(searchResponse, DataUseRestriction(`RS-G` = true, `RS-M` = true), Seq("RS-G", "RS-M"))
       }
 
       "DS:non-empty list dataset should have values" in {
         val searchResponse = searchFor("DS")
-        assertDataUseRestrictions(searchResponse, DataUseRestriction(DS = Seq(123, 456)))
+        assertDataUseRestrictions(searchResponse, DataUseRestriction(DS = DataUseRestrictionTestFixtures.diseaseValues))
       }
 
       "RS-POP:non-empty list dataset should have values" in {
@@ -145,7 +146,7 @@ class DataUseRestrictionSearchSpec extends FreeSpec with SearchResultValidation 
           DataUseRestriction(
             GRU = true,
             HMB = true,
-            DS = Seq(123, 456),
+            DS = DataUseRestrictionTestFixtures.diseaseValues,
             NCU = true,
             NPU = true,
             NDMS = true,
@@ -155,7 +156,8 @@ class DataUseRestrictionSearchSpec extends FreeSpec with SearchResultValidation 
             `RS-G` = true,
             `RS-FM` = true,
             `RS-POP` = Seq("TERM-1", "TERM-2")
-          )
+          ),
+          Seq("NPU", "RS-G", "NCU", "HMB", "NDMS", "RS-FM", "NCTRL", "RS-PD", "NAGR", "GRU")
         )
       }
 
@@ -165,8 +167,9 @@ class DataUseRestrictionSearchSpec extends FreeSpec with SearchResultValidation 
           DataUseRestriction(
             GRU = true,
             HMB = true,
-            DS = Seq(123, 456)
-          )
+            DS = DataUseRestrictionTestFixtures.diseaseValues
+          ),
+          Seq("GRU", "HMB")
         )
       }
 
@@ -189,13 +192,28 @@ class DataUseRestrictionSearchSpec extends FreeSpec with SearchResultValidation 
 
   private def getDataUseRestrictions(searchResponse: LibrarySearchResponse): Seq[DataUseRestriction] = {
     searchResponse.results.map { hit =>
-      val sdur = hit.asJsObject.fields("library:structuredUseRestriction").asJsObject
+      val sdur = hit.asJsObject.fields(AttributeName.toDelimitedName(structuredUseRestrictionAttributeName)).asJsObject
       sdur.convertTo[DataUseRestriction]
     }
   }
 
-  private def assertDataUseRestrictions(searchResponse: LibrarySearchResponse, expected: DataUseRestriction): Unit = {
+  private def getDataUseDisplayCodes(searchResponse: LibrarySearchResponse): Seq[String] = {
+    searchResponse.results.flatMap { hit =>
+      val jsObj = hit.asJsObject
+      if (jsObj.getFields(AttributeName.toDelimitedName(dataUseDisplayAttributeName)).nonEmpty) {
+        jsObj.fields(AttributeName.toDelimitedName(dataUseDisplayAttributeName)).convertTo[Seq[String]]
+      } else { Seq.empty}
+    }
+  }
+
+  private def assertDataUseRestrictions(searchResponse: LibrarySearchResponse, expected: DataUseRestriction, expectedCodes: Seq[String] = Seq.empty[String]): Unit = {
     searchResponse shouldNot be(null)
+
+    if (searchResponse.results.size != 1) {
+      logger.error(s"Size: ${searchResponse.results.size}")
+      searchResponse.results.map { sr => logger.error(s"${sr.toString}")}
+    }
+
     searchResponse.results.size should be(1)
     val listActual = getDataUseRestrictions(searchResponse)
     listActual.foreach { actual =>
@@ -203,6 +221,9 @@ class DataUseRestrictionSearchSpec extends FreeSpec with SearchResultValidation 
         actual
       }
     }
+
+    val ddulCodes: Seq[String] = getDataUseDisplayCodes(searchResponse)
+    expectedCodes should contain theSameElementsAs ddulCodes
 
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/DataUseRestrictionSearchSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/DataUseRestrictionSearchSpec.scala
@@ -131,8 +131,8 @@ class DataUseRestrictionSearchSpec extends FreeSpec with SearchResultValidation 
       }
 
       "DS:non-empty list dataset should have values" in {
-        val searchResponse = searchFor("DS")
-        assertDataUseRestrictions(searchResponse, DataUseRestriction(DS = DataUseRestrictionTestFixtures.diseaseValues))
+        val searchResponse = searchFor("DS-unique")
+        assertDataUseRestrictions(searchResponse, DataUseRestriction(DS = DataUseRestrictionTestFixtures.diseaseValuesInts), DataUseRestrictionTestFixtures.diseaseValuesLabels.map("DS:" + _))
       }
 
       "RS-POP:non-empty list dataset should have values" in {
@@ -146,7 +146,7 @@ class DataUseRestrictionSearchSpec extends FreeSpec with SearchResultValidation 
           DataUseRestriction(
             GRU = true,
             HMB = true,
-            DS = DataUseRestrictionTestFixtures.diseaseValues,
+            DS = DataUseRestrictionTestFixtures.diseaseValuesInts,
             NCU = true,
             NPU = true,
             NDMS = true,
@@ -157,7 +157,8 @@ class DataUseRestrictionSearchSpec extends FreeSpec with SearchResultValidation 
             `RS-FM` = true,
             `RS-POP` = Seq("TERM-1", "TERM-2")
           ),
-          Seq("NPU", "RS-G", "NCU", "HMB", "NDMS", "RS-FM", "NCTRL", "RS-PD", "NAGR", "GRU")
+          Seq("NPU", "RS-G", "NCU", "HMB", "NDMS", "RS-FM", "NCTRL", "RS-PD", "NAGR", "GRU") ++
+            DataUseRestrictionTestFixtures.diseaseValuesLabels.map("DS:" + _)
         )
       }
 
@@ -167,9 +168,10 @@ class DataUseRestrictionSearchSpec extends FreeSpec with SearchResultValidation 
           DataUseRestriction(
             GRU = true,
             HMB = true,
-            DS = DataUseRestrictionTestFixtures.diseaseValues
+            DS = DataUseRestrictionTestFixtures.diseaseValuesInts
           ),
-          Seq("GRU", "HMB")
+          Seq("GRU", "HMB") ++
+            DataUseRestrictionTestFixtures.diseaseValuesLabels.map("DS:" + _)
         )
       }
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupportSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupportSpec.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.dsde.firecloud.service
 
 import java.lang.reflect.Field
 
+import org.broadinstitute.dsde.firecloud.model.DataUse
 import org.broadinstitute.dsde.firecloud.model.Ontology.TermResource
 import org.broadinstitute.dsde.firecloud.service.DataUseRestrictionTestFixtures._
 import org.broadinstitute.dsde.rawls.model.{ManagedGroupRef, Workspace, _}
@@ -199,6 +200,7 @@ class DataUseRestrictionSupportSpec extends FreeSpec with Matchers with DataUseR
         att match {
           case x: AttributeValueList => x.list.map {
             case avl@(a: AttributeString) => a.value
+            case avl@(a: AttributeNumber) => DataUse.doid_prefix + a.value.intValue().toString
             case _ => ""
           }
           case unhandled => Seq.empty[String]

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupportSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupportSpec.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.dsde.firecloud.service
 
 import java.lang.reflect.Field
 
+import org.broadinstitute.dsde.firecloud.model.Ontology.TermResource
 import org.broadinstitute.dsde.firecloud.service.DataUseRestrictionTestFixtures._
 import org.broadinstitute.dsde.rawls.model.{ManagedGroupRef, Workspace, _}
 import org.scalatest.{FreeSpec, Matchers}
@@ -13,105 +14,177 @@ class DataUseRestrictionSupportSpec extends FreeSpec with Matchers with DataUseR
 
   "DataUseRestrictionSupport" - {
 
-    "when there are library data use restriction fields" - {
+    "Structured Use Restriction" - {
 
-      "dataset should have a fully populated data use restriction attribute" in {
-        allDatasets.map { ds =>
-          val attrs = generateStructuredUseRestriction(ds)
-          val durAtt: Attribute = attrs.getOrElse(structuredUseRestrictionAttributeName, AttributeNull)
-          durAtt shouldNot be(AttributeNull)
-          val dur: DataUseRestriction = makeDurFromWorkspace(ds)
-          dur shouldNot be(null)
-        }
-      }
+      "when there are library data use restriction fields" - {
 
-      "dur should have appropriate gender codes populated" in {
-        genderDatasets.map { ds =>
-          val dur: DataUseRestriction = makeDurFromWorkspace(ds)
-          if (ds.name.equalsIgnoreCase("Female")) {
-            dur.`RS-G` should be(true)
-            dur.`RS-FM` should be(true)
-            dur.`RS-M` should be(false)
-          } else if (ds.name.equalsIgnoreCase("Male")) {
-            dur.`RS-G` should be(true)
-            dur.`RS-FM` should be(false)
-            dur.`RS-M` should be(true)
-          } else {
-            dur.`RS-G` should be(false)
-            dur.`RS-FM` should be(false)
-            dur.`RS-M` should be(false)
+        "dataset should have a fully populated data use restriction attribute" in {
+          allDatasets.map { ds =>
+            val attrs: Map[AttributeName, Attribute] = generateStructuredUseRestriction(ds)
+            val durAtt: Attribute = attrs.getOrElse(structuredUseRestrictionAttributeName, AttributeNull)
+            durAtt shouldNot be(AttributeNull)
+            val dur: DataUseRestriction = makeDurFromWorkspace(ds)
+            dur shouldNot be(null)
           }
         }
-      }
 
-      "dur should have appropriate NAGR code populated" in {
-        nagrDatasets.map { ds =>
-          val dur: DataUseRestriction = makeDurFromWorkspace(ds)
-          if (ds.name.equalsIgnoreCase("Yes")) {
-            dur.NAGR should be (true)
-          } else {
-            dur.NAGR should be (false)
+        "dur should have appropriate gender codes populated" in {
+          genderDatasets.map { ds =>
+            val dur: DataUseRestriction = makeDurFromWorkspace(ds)
+            if (ds.name.equalsIgnoreCase("Female")) {
+              dur.`RS-G` should be(true)
+              dur.`RS-FM` should be(true)
+              dur.`RS-M` should be(false)
+            } else if (ds.name.equalsIgnoreCase("Male")) {
+              dur.`RS-G` should be(true)
+              dur.`RS-FM` should be(false)
+              dur.`RS-M` should be(true)
+            } else {
+              dur.`RS-G` should be(false)
+              dur.`RS-FM` should be(false)
+              dur.`RS-M` should be(false)
+            }
           }
         }
+
+        "dur should have appropriate NAGR code populated" in {
+          nagrDatasets.map { ds =>
+            val dur: DataUseRestriction = makeDurFromWorkspace(ds)
+            if (ds.name.equalsIgnoreCase("Yes")) {
+              dur.NAGR should be(true)
+            } else {
+              dur.NAGR should be(false)
+            }
+          }
+        }
+
+        "dataset should have a true value for the consent code for which it was specified" in {
+          val durs: Map[String, DataUseRestriction] = booleanDatasets.flatMap { ds =>
+            Map(ds.name -> makeDurFromWorkspace(ds))
+          }.toMap
+
+          booleanCodes.map { code =>
+            val dur: DataUseRestriction = durs(code)
+            checkBooleanTrue(dur, code) should be(true)
+          }
+        }
+
+        "dataset should have the correct list values for the consent code for which it was specified" in {
+          val durs: Map[String, DataUseRestriction] = listDatasets.flatMap { ds =>
+            Map(ds.name -> makeDurFromWorkspace(ds))
+          }.toMap
+
+          listCodes.foreach { code =>
+            val dur: DataUseRestriction = durs(code)
+            checkListValues(dur, code)
+          }
+        }
+
+        "dataset should have the correct disease values for the consent code for which it was specified" in {
+          val durs: Map[String, DataUseRestriction] = diseaseDatasets.flatMap { ds =>
+            Map(ds.name -> makeDurFromWorkspace(ds))
+          }.toMap
+
+          diseaseCodes.foreach { code =>
+            val dur: DataUseRestriction = durs(code)
+            checkDiseaseValues(dur, code)
+          }
+        }
+
       }
 
-      "dataset should have a true value for the consent code for which it was specified" in {
-        val durs: Map[String, DataUseRestriction] = booleanDatasets.flatMap { ds =>
-          Map(ds.name -> makeDurFromWorkspace(ds))
-        }.toMap
+      "when there are no library data use restriction fields" - {
 
-        booleanCodes.map { code =>
-          val dur: DataUseRestriction = durs(code)
-          checkBooleanTrue(dur, code) should be(true)
+        "dataset should not have any data use restriction for empty attributes" in {
+          val workspace: Workspace = mkWorkspace(Map.empty[AttributeName, Attribute], "empty", "empty")
+          val attrs: Map[AttributeName, Attribute] = generateStructuredUseRestriction(workspace)
+          attrs should be(empty)
         }
-      }
 
-      "dataset should have the correct list values for the consent code for which it was specified" in {
-        val durs: Map[String, DataUseRestriction] = listDatasets.flatMap { ds =>
-          Map(ds.name -> makeDurFromWorkspace(ds))
-        }.toMap
-
-        listCodes.foreach { code =>
-          val dur: DataUseRestriction = durs(code)
-          checkListValues(dur, code)
+        "dataset should not have any data use restriction for non-library attributes" in {
+          val nonLibraryAttributes = Map(
+            AttributeName.withDefaultNS("name") -> AttributeString("one"),
+            AttributeName.withDefaultNS("namespace") -> AttributeString("two"),
+            AttributeName.withDefaultNS("workspaceId") -> AttributeString("three"),
+            AttributeName.withDefaultNS("authorizationDomain") -> AttributeValueList(Seq(AttributeString("one"), AttributeString("two"), AttributeString("three")))
+          )
+          val workspace: Workspace = mkWorkspace(nonLibraryAttributes, "non-library", "non-library")
+          val attrs: Map[AttributeName, Attribute] = generateStructuredUseRestriction(workspace)
+          attrs should be(empty)
         }
-      }
 
-      "dataset should have the correct disease values for the consent code for which it was specified" in {
-        val durs: Map[String, DataUseRestriction] = diseaseDatasets.flatMap { ds =>
-          Map(ds.name -> makeDurFromWorkspace(ds))
-        }.toMap
-
-        diseaseCodes.foreach { code =>
-          val dur: DataUseRestriction = durs(code)
-          checkDiseaseValues(dur, code)
-        }
       }
 
     }
 
-    "when there are no library data use restriction fields" - {
+    "Display Use Restriction" - {
 
-      "dataset should not have any data use restriction for empty attributes" in {
-        val workspace = mkWorkspace(Map.empty[AttributeName, Attribute], "empty", "empty")
-        val attrs = generateStructuredUseRestriction(workspace)
-        attrs should be(empty)
+      "when there are library data use restriction fields" - {
+
+        "valid datasets should have some form of data use display attribute" in {
+          validDisplayDatasets.map { ds =>
+            val attrs: Map[AttributeName, Attribute] = generateUseRestrictionDisplay(ds, termCache)
+            val codes: Seq[String] = getValuesFromAttributeValueListAsAttribute(attrs.get(dataUseDisplayAttributeName))
+            codes shouldNot be(empty)
+          }
+        }
+
+        "datasets with single boolean code should have that single display code" in {
+          booleanDatasets.map { ds =>
+            val attrs: Map[AttributeName, Attribute] = generateUseRestrictionDisplay(ds, termCache)
+            val codes: Seq[String] = getValuesFromAttributeValueListAsAttribute(attrs.get(dataUseDisplayAttributeName))
+            // Boolean datasets are named with the same code value
+            codes should contain(ds.name)
+            codes.size should be(1)
+          }
+        }
+
+        "'EVERYTHING' dataset should have the right codes" in {
+          val attrs: Map[AttributeName, Attribute] = generateUseRestrictionDisplay(everythingDataset.head, termCache)
+          val codes: Seq[String] = getValuesFromAttributeValueListAsAttribute(attrs.get(dataUseDisplayAttributeName))
+          (booleanCodes ++ Seq("RS-G", "RS-FM", "NAGR")).map { c => codes should contain(c) }
+          Seq("DS:central sleep apnea", "DS:sleep disorder").map { c => codes should contain(c) }
+          Seq("RS-M", "RS-POP").map { c => codes shouldNot contain(c) }
+        }
+
+        "'TOP_THREE' dataset should have the right codes" in {
+          val attrs: Map[AttributeName, Attribute] = generateUseRestrictionDisplay(topThreeDataset.head, termCache)
+          val codes: Seq[String] = getValuesFromAttributeValueListAsAttribute(attrs.get(dataUseDisplayAttributeName))
+          Seq("GRU", "HMB", "DS:central sleep apnea", "DS:sleep disorder").map { c => codes should contain(c) }
+          Seq("NCU", "NPU", "NDMS", "NCTRL", "RS-PD", "NAGR", "RS-G", "RS-FM", "RS-M", "RS-POP").map { c => codes shouldNot contain(c) }
+        }
       }
 
-      "dataset should not have any data use restriction for non-library attributes" in {
-        val nonLibraryAttributes = Map(
-          AttributeName.withDefaultNS("name") -> AttributeString("one"),
-          AttributeName.withDefaultNS("namespace") -> AttributeString("two"),
-          AttributeName.withDefaultNS("workspaceId") -> AttributeString("three"),
-          AttributeName.withDefaultNS("authorizationDomain") -> AttributeValueList(Seq(AttributeString("one"), AttributeString("two"), AttributeString("three")))
-        )
-        val workspace = mkWorkspace(nonLibraryAttributes, "non-library", "non-library")
-        val attrs = generateStructuredUseRestriction(workspace)
-        attrs should be(empty)
+      "when there are missing/invalid library data use restriction terms" - {
+
+        "dataset should not have any data use display codes for empty attributes" in {
+          val workspace: Workspace = mkWorkspace(Map.empty[AttributeName, Attribute], "empty", "empty")
+          val attrs: Map[AttributeName, Attribute] = generateUseRestrictionDisplay(workspace, termCache)
+          attrs should be(empty)
+        }
+
+        "dataset should not have any data use restriction for non-library attributes" in {
+          val nonLibraryAttributes: Map[AttributeName, Attribute] = Map(
+            AttributeName.withDefaultNS("name") -> AttributeString("one"),
+            AttributeName.withDefaultNS("namespace") -> AttributeString("two"),
+            AttributeName.withDefaultNS("workspaceId") -> AttributeString("three"),
+            AttributeName.withDefaultNS("authorizationDomain") -> AttributeValueList(Seq(AttributeString("one"), AttributeString("two"), AttributeString("three")))
+          )
+          val workspace: Workspace = mkWorkspace(nonLibraryAttributes, "non-library", "non-library")
+          val attrs: Map[AttributeName, Attribute] = generateUseRestrictionDisplay(workspace, termCache)
+          attrs should be(empty)
+        }
+
+        "dataset should not have any data use display codes for missing/not-found disease terms" in {
+          listDatasets.map { ds =>
+            val attrs: Map[AttributeName, Attribute] = generateUseRestrictionDisplay(ds, Map.empty[String, TermResource])
+            attrs should be(empty)
+          }
+        }
+
       }
 
     }
-
   }
 
 
@@ -120,8 +193,23 @@ class DataUseRestrictionSupportSpec extends FreeSpec with Matchers with DataUseR
   //////////////////
 
 
+  private def getValuesFromAttributeValueListAsAttribute(attrs: Option[Attribute]): Seq[String] = {
+    val results: Seq[String] = attrs match {
+      case Some(att) =>
+        att match {
+          case x: AttributeValueList => x.list.map {
+            case avl@(a: AttributeString) => a.value
+            case _ => ""
+          }
+          case unhandled => Seq.empty[String]
+        }
+      case None => Seq.empty[String]
+    }
+    results.distinct.filter(_.nonEmpty)
+  }
+
   private def makeDurFromWorkspace(ds: Workspace): DataUseRestriction = {
-    val attrs = generateStructuredUseRestriction(ds)
+    val attrs: Map[AttributeName, Attribute] = generateStructuredUseRestriction(ds)
     val durAtt: Attribute = attrs.getOrElse(structuredUseRestrictionAttributeName, AttributeNull)
     durAtt.toJson.convertTo[DataUseRestriction]
   }
@@ -149,6 +237,8 @@ class DataUseRestrictionSupportSpec extends FreeSpec with Matchers with DataUseR
 
   // Since we have dashes in DUR field names, the value that comes back from Field.getName
   // looks like "RS$minusPOP" instead of "RS-POP"
-  private def getFieldName(f: Field): String = { f.getName.replace("$minus", "-") }
+  private def getFieldName(f: Field): String = {
+    f.getName.replace("$minus", "-")
+  }
 
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupportSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupportSpec.scala
@@ -201,7 +201,6 @@ class DataUseRestrictionSupportSpec extends FreeSpec with Matchers with DataUseR
         att match {
           case x: AttributeValueList => x.list.map {
             case avl@(a: AttributeString) => a.value
-            case avl@(a: AttributeNumber) => DataUse.doid_prefix + a.value.intValue().toString
             case _ => ""
           }
           case unhandled => Seq.empty[String]

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupportSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupportSpec.scala
@@ -84,7 +84,7 @@ class DataUseRestrictionSupportSpec extends FreeSpec with Matchers with DataUseR
             Map(ds.name -> makeDurFromWorkspace(ds))
           }.toMap
 
-          diseaseCodes.foreach { code =>
+          Seq("DS").foreach { code =>
             val dur: DataUseRestriction = durs(code)
             checkDiseaseValues(dur, code)
           }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupportSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupportSpec.scala
@@ -134,7 +134,6 @@ class DataUseRestrictionSupportSpec extends FreeSpec with Matchers with DataUseR
             val codes: Seq[String] = getValuesFromAttributeValueListAsAttribute(attrs.get(dataUseDisplayAttributeName))
             // Boolean datasets are named with the same code value
             codes should contain theSameElementsAs Seq(ds.name)
-            codes.size should be(1)
           }
         }
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupportSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupportSpec.scala
@@ -2,8 +2,6 @@ package org.broadinstitute.dsde.firecloud.service
 
 import java.lang.reflect.Field
 
-import org.broadinstitute.dsde.firecloud.model.DataUse
-import org.broadinstitute.dsde.firecloud.model.Ontology.TermResource
 import org.broadinstitute.dsde.firecloud.service.DataUseRestrictionTestFixtures._
 import org.broadinstitute.dsde.rawls.model.{ManagedGroupRef, Workspace, _}
 import org.scalatest.{FreeSpec, Matchers}

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionTestFixtures.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionTestFixtures.scala
@@ -2,8 +2,6 @@ package org.broadinstitute.dsde.firecloud.service
 
 import java.util.UUID
 
-import org.broadinstitute.dsde.firecloud.dataaccess.MockOntologyDAO
-import org.broadinstitute.dsde.firecloud.model.Ontology
 import org.broadinstitute.dsde.rawls.model._
 import org.joda.time.DateTime
 import spray.json.DefaultJsonProtocol.{jsonFormat13, _}

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionTestFixtures.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionTestFixtures.scala
@@ -2,6 +2,8 @@ package org.broadinstitute.dsde.firecloud.service
 
 import java.util.UUID
 
+import org.broadinstitute.dsde.firecloud.dataaccess.MockOntologyDAO
+import org.broadinstitute.dsde.firecloud.model.Ontology
 import org.broadinstitute.dsde.rawls.model._
 import org.joda.time.DateTime
 import spray.json.DefaultJsonProtocol.{jsonFormat13, _}
@@ -32,7 +34,7 @@ object DataUseRestrictionTestFixtures {
   val booleanCodes: Seq[String] = Seq("GRU", "HMB", "NCU", "NPU", "NDMS", "NCTRL", "RS-PD")
   val booleanDatasets: Seq[Workspace] = booleanCodes.map { code =>
     val attributes = Map(AttributeName.withLibraryNS(code) -> AttributeBoolean(true))
-    mkWorkspace(attributes, code, code)
+    mkWorkspace(attributes, code, s"{${code.replace("-","")}}-unique")
   }
 
   val listCodes: Seq[String] = Seq("RS-POP")
@@ -43,7 +45,7 @@ object DataUseRestrictionTestFixtures {
   }
 
   val diseaseCodes: Seq[String] = Seq("DS")
-  val diseaseValues: Seq[Int] = Seq(123, 456)
+  val diseaseValues: Seq[Int] = Seq(9220, 535)
   val diseaseDatasets: Seq[Workspace] = diseaseCodes.map { code =>
     val attributes = Map(AttributeName.withLibraryNS(code) -> AttributeValueList(diseaseValues.map(n => AttributeNumber(BigDecimal(n)))))
     mkWorkspace(attributes, code, code)
@@ -81,6 +83,8 @@ object DataUseRestrictionTestFixtures {
   )
 
   val allDatasets: Seq[Workspace] = booleanDatasets ++ listDatasets ++ diseaseDatasets ++ genderDatasets ++ nagrDatasets ++ everythingDataset ++ topThreeDataset
+
+  val validDisplayDatasets: Seq[Workspace] = booleanDatasets ++ diseaseDatasets ++ everythingDataset ++ topThreeDataset
 
   def mkWorkspace(attributes: Map[AttributeName, Attribute], wsName: String, wsDescription: String): Workspace = {
     val testUUID: UUID = UUID.randomUUID()
@@ -123,5 +127,7 @@ object DataUseRestrictionTestFixtures {
       accessLevels=Map.empty,
       authDomainACLs=Map())
   }
+
+  val termCache: Map[String, Ontology.TermResource] = new MockOntologyDAO().data.values.flatten.map { t => t.id -> t }.toMap
 
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionTestFixtures.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionTestFixtures.scala
@@ -45,10 +45,15 @@ object DataUseRestrictionTestFixtures {
   }
 
   val diseaseCodes: Seq[String] = Seq("DS")
-  val diseaseValues: Seq[Int] = Seq(9220, 535)
+  val diseaseValues: Seq[String] = Seq("http://purl.obolibrary.org/obo/DOID_9220", "http://purl.obolibrary.org/obo/DOID_535")
+  val diseaseValuesLabels: Seq[String] = Seq("central sleep apnea", "sleep disorder")
+  val diseaseValuesInts: Seq[Int] = Seq(9220, 535)
   val diseaseDatasets: Seq[Workspace] = diseaseCodes.map { code =>
-    val attributes = Map(AttributeName.withLibraryNS(code) -> AttributeValueList(diseaseValues.map(n => AttributeNumber(BigDecimal(n)))))
-    mkWorkspace(attributes, code, code)
+    val attributes = Map(
+      AttributeName.withLibraryNS(code) -> AttributeValueList(diseaseValues.map(AttributeString)),
+      AttributeName.withLibraryNS("DS-labels") -> AttributeValueList(diseaseValuesLabels.map(AttributeString))
+    )
+    mkWorkspace(attributes, code, s"{${code.replace("-","")}}-unique")
   }
 
   // Gender datasets are named by the gender value for easier identification in tests
@@ -68,7 +73,8 @@ object DataUseRestrictionTestFixtures {
   val everythingDataset = Seq(mkWorkspace(
     booleanCodes.map(AttributeName.withLibraryNS(_) -> AttributeBoolean(true)).toMap ++
       listCodes.map(AttributeName.withLibraryNS(_) -> AttributeValueList(listValues.map(AttributeString))).toMap ++
-      diseaseCodes.map(AttributeName.withLibraryNS(_) -> AttributeValueList(diseaseValues.map(n => AttributeNumber(BigDecimal(n))))).toMap ++
+      diseaseCodes.map(AttributeName.withLibraryNS(_) -> AttributeValueList(diseaseValues.map(AttributeString))).toMap ++
+      Map(AttributeName.withLibraryNS("DS-labels") -> AttributeValueList(diseaseValuesLabels.map(AttributeString))) ++
       Map(AttributeName.withLibraryNS("NAGR") -> AttributeString("Yes")) ++
       Map(AttributeName.withLibraryNS("RS-G") -> AttributeString("Female")),
     "EVERYTHING",
@@ -77,14 +83,15 @@ object DataUseRestrictionTestFixtures {
 
   val topThreeDataset = Seq(mkWorkspace(
     Seq("GRU", "HMB").map(AttributeName.withLibraryNS(_) -> AttributeBoolean(true)).toMap ++
-      Seq("DS").map(AttributeName.withLibraryNS(_) -> AttributeValueList(diseaseValues.map(n => AttributeNumber(BigDecimal(n))))).toMap,
+      diseaseCodes.map(AttributeName.withLibraryNS(_) -> AttributeValueList(diseaseValues.map(AttributeString))).toMap ++
+      Map(AttributeName.withLibraryNS("DS-labels") -> AttributeValueList(diseaseValuesLabels.map(AttributeString))),
     "TOP_THREE",
     "TOP_THREE")
   )
 
   val allDatasets: Seq[Workspace] = booleanDatasets ++ listDatasets ++ diseaseDatasets ++ genderDatasets ++ nagrDatasets ++ everythingDataset ++ topThreeDataset
 
-  val validDisplayDatasets: Seq[Workspace] = booleanDatasets ++ diseaseDatasets ++ everythingDataset ++ topThreeDataset
+  val validDisplayDatasets: Seq[Workspace] = booleanDatasets ++ everythingDataset ++ topThreeDataset
 
   def mkWorkspace(attributes: Map[AttributeName, Attribute], wsName: String, wsDescription: String): Workspace = {
     val testUUID: UUID = UUID.randomUUID()

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionTestFixtures.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionTestFixtures.scala
@@ -51,7 +51,7 @@ object DataUseRestrictionTestFixtures {
   val diseaseDatasets: Seq[Workspace] = diseaseCodes.map { code =>
     val attributes = Map(
       AttributeName.withLibraryNS(code) -> AttributeValueList(diseaseValues.map(AttributeString)),
-      AttributeName.withLibraryNS("DS-labels") -> AttributeValueList(diseaseValuesLabels.map(AttributeString))
+      AttributeName.withLibraryNS("DS_URL") -> AttributeValueList(diseaseValuesLabels.map(AttributeString))
     )
     mkWorkspace(attributes, code, s"{${code.replace("-","")}}-unique")
   }
@@ -74,7 +74,7 @@ object DataUseRestrictionTestFixtures {
     booleanCodes.map(AttributeName.withLibraryNS(_) -> AttributeBoolean(true)).toMap ++
       listCodes.map(AttributeName.withLibraryNS(_) -> AttributeValueList(listValues.map(AttributeString))).toMap ++
       diseaseCodes.map(AttributeName.withLibraryNS(_) -> AttributeValueList(diseaseValues.map(AttributeString))).toMap ++
-      Map(AttributeName.withLibraryNS("DS-labels") -> AttributeValueList(diseaseValuesLabels.map(AttributeString))) ++
+      Map(AttributeName.withLibraryNS("DS_URL") -> AttributeValueList(diseaseValuesLabels.map(AttributeString))) ++
       Map(AttributeName.withLibraryNS("NAGR") -> AttributeString("Yes")) ++
       Map(AttributeName.withLibraryNS("RS-G") -> AttributeString("Female")),
     "EVERYTHING",
@@ -84,7 +84,7 @@ object DataUseRestrictionTestFixtures {
   val topThreeDataset = Seq(mkWorkspace(
     Seq("GRU", "HMB").map(AttributeName.withLibraryNS(_) -> AttributeBoolean(true)).toMap ++
       diseaseCodes.map(AttributeName.withLibraryNS(_) -> AttributeValueList(diseaseValues.map(AttributeString))).toMap ++
-      Map(AttributeName.withLibraryNS("DS-labels") -> AttributeValueList(diseaseValuesLabels.map(AttributeString))),
+      Map(AttributeName.withLibraryNS("DS_URL") -> AttributeValueList(diseaseValuesLabels.map(AttributeString))),
     "TOP_THREE",
     "TOP_THREE")
   )

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionTestFixtures.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionTestFixtures.scala
@@ -135,6 +135,4 @@ object DataUseRestrictionTestFixtures {
       authDomainACLs=Map())
   }
 
-  val termCache: Map[String, Ontology.TermResource] = new MockOntologyDAO().data.values.flatten.map { t => t.id -> t }.toMap
-
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionTestFixtures.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionTestFixtures.scala
@@ -42,16 +42,16 @@ object DataUseRestrictionTestFixtures {
     mkWorkspace(attributes, code, code)
   }
 
-  val diseaseCodes: Seq[String] = Seq("DS")
-  val diseaseValues: Seq[String] = Seq("http://purl.obolibrary.org/obo/DOID_9220", "http://purl.obolibrary.org/obo/DOID_535")
+  val diseaseCodes: Seq[String] = Seq("DS_URL")
+  val diseaseURLs: Seq[String] = Seq("http://purl.obolibrary.org/obo/DOID_9220", "http://purl.obolibrary.org/obo/DOID_535")
   val diseaseValuesLabels: Seq[String] = Seq("central sleep apnea", "sleep disorder")
   val diseaseValuesInts: Seq[Int] = Seq(9220, 535)
   val diseaseDatasets: Seq[Workspace] = diseaseCodes.map { code =>
     val attributes = Map(
-      AttributeName.withLibraryNS(code) -> AttributeValueList(diseaseValues.map(AttributeString)),
-      AttributeName.withLibraryNS("DS_URL") -> AttributeValueList(diseaseValuesLabels.map(AttributeString))
+      AttributeName.withLibraryNS(code) -> AttributeValueList(diseaseURLs.map(AttributeString)),
+      AttributeName.withLibraryNS("DS") -> AttributeValueList(diseaseValuesLabels.map(AttributeString))
     )
-    mkWorkspace(attributes, code, s"{${code.replace("-","")}}-unique")
+    mkWorkspace(attributes, "DS", s"{${code.replace("-","")}}-unique")
   }
 
   // Gender datasets are named by the gender value for easier identification in tests
@@ -71,8 +71,8 @@ object DataUseRestrictionTestFixtures {
   val everythingDataset = Seq(mkWorkspace(
     booleanCodes.map(AttributeName.withLibraryNS(_) -> AttributeBoolean(true)).toMap ++
       listCodes.map(AttributeName.withLibraryNS(_) -> AttributeValueList(listValues.map(AttributeString))).toMap ++
-      diseaseCodes.map(AttributeName.withLibraryNS(_) -> AttributeValueList(diseaseValues.map(AttributeString))).toMap ++
-      Map(AttributeName.withLibraryNS("DS_URL") -> AttributeValueList(diseaseValuesLabels.map(AttributeString))) ++
+      diseaseCodes.map(AttributeName.withLibraryNS(_) -> AttributeValueList(diseaseURLs.map(AttributeString))).toMap ++
+      Map(AttributeName.withLibraryNS("DS") -> AttributeValueList(diseaseValuesLabels.map(AttributeString))) ++
       Map(AttributeName.withLibraryNS("NAGR") -> AttributeString("Yes")) ++
       Map(AttributeName.withLibraryNS("RS-G") -> AttributeString("Female")),
     "EVERYTHING",
@@ -81,8 +81,8 @@ object DataUseRestrictionTestFixtures {
 
   val topThreeDataset = Seq(mkWorkspace(
     Seq("GRU", "HMB").map(AttributeName.withLibraryNS(_) -> AttributeBoolean(true)).toMap ++
-      diseaseCodes.map(AttributeName.withLibraryNS(_) -> AttributeValueList(diseaseValues.map(AttributeString))).toMap ++
-      Map(AttributeName.withLibraryNS("DS_URL") -> AttributeValueList(diseaseValuesLabels.map(AttributeString))),
+      diseaseCodes.map(AttributeName.withLibraryNS(_) -> AttributeValueList(diseaseURLs.map(AttributeString))).toMap ++
+      Map(AttributeName.withLibraryNS("DS") -> AttributeValueList(diseaseValuesLabels.map(AttributeString))),
     "TOP_THREE",
     "TOP_THREE")
   )


### PR DESCRIPTION
Addresses https://broadinstitute.atlassian.net/browse/GAWB-2834

Builds and indexes a display version of the data use restriction in a list format. 

Note that there are a bunch of new logger warnings that we might need to add loggly alerts for. Confirm with David An.

---
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
