### PR TITLE
GAWB-2795: user-initiated endpoint to enroll in free trial

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -1519,6 +1519,18 @@ paths:
         500:
           description: Internal Server Error
 
+  /api/profile/trial:
+    post:
+      tags:
+        - Profile
+      operationId: enrollTrial
+      summary: Enroll yourself in FireCloud free trial
+      responses:
+        204:
+          description: Success (No Content)
+        500:
+          description: Internal Server Error
+
   /api/refresh-token-status:
     get:
       tags:

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudServiceActor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudServiceActor.scala
@@ -29,6 +29,7 @@ class FireCloudServiceActor extends HttpServiceActor with FireCloudDirectives
   with StatusApiService
   with MethodsApiService
   with Ga4ghApiService
+  with UserApiService
   {
 
   implicit val system = context.system
@@ -60,6 +61,7 @@ class FireCloudServiceActor extends HttpServiceActor with FireCloudDirectives
   val workspaceServiceConstructor: (WithAccessToken) => WorkspaceService = WorkspaceService.constructor(app)
   val statusServiceConstructor: () => StatusService = StatusService.constructor(app)
   val permissionReportServiceConstructor: (UserInfo) => PermissionReportService = PermissionReportService.constructor(app)
+  val trialServiceConstructor: () => TrialService = TrialService.constructor(app)
 
   // routes under /api
   val methodConfigurationService = new MethodConfigurationService with ActorRefFactoryContext
@@ -69,7 +71,6 @@ class FireCloudServiceActor extends HttpServiceActor with FireCloudDirectives
     methodConfigurationService.routes ~ submissionsService.routes ~
     nihRoutes ~ billingService.routes
 
-  val userService = new UserApiService with ActorRefFactoryContext
   val healthService = new HealthService with ActorRefFactoryContext
 
   override lazy val log = LoggerFactory.getLogger(getClass)
@@ -112,7 +113,7 @@ class FireCloudServiceActor extends HttpServiceActor with FireCloudDirectives
         storageRoutes ~
         swaggerUiService ~
         syncRoute ~
-        userService.routes ~
+        userServiceRoutes ~
         workspaceRoutes ~
         notificationsRoutes ~
         statusRoutes ~

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ThurloeDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ThurloeDAO.scala
@@ -24,6 +24,7 @@ trait ThurloeDAO extends LazyLogging with ReportsSubsystemStatus {
   def saveProfile(userInfo: UserInfo, profile: BasicProfile): Future[Unit]
   def saveKeyValues(userInfo: UserInfo, keyValues: Map[String, String]): Future[Try[Unit]]
 
+  // methods to work with free-trial objects
   def getTrialStatus(userInfo: UserInfo): Future[Option[UserTrialStatus]]
   def saveTrialStatus(userInfo: UserInfo, trialStatus: UserTrialStatus): Future[Unit]
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ThurloeDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ThurloeDAO.scala
@@ -1,6 +1,7 @@
 package org.broadinstitute.dsde.firecloud.dataaccess
 
 import com.typesafe.scalalogging.slf4j.LazyLogging
+import org.broadinstitute.dsde.firecloud.model.Trial.UserTrialStatus
 import org.broadinstitute.dsde.firecloud.model.{BasicProfile, Profile, UserInfo}
 import org.broadinstitute.dsde.rawls.model.ErrorReportSource
 
@@ -22,5 +23,10 @@ trait ThurloeDAO extends LazyLogging with ReportsSubsystemStatus {
   def getAllUserValuesForKey(key: String): Future[Map[String, String]]
   def saveProfile(userInfo: UserInfo, profile: BasicProfile): Future[Unit]
   def saveKeyValues(userInfo: UserInfo, keyValues: Map[String, String]): Future[Try[Unit]]
+
+  def getTrialStatus(userInfo: UserInfo): Future[Option[UserTrialStatus]]
+  def saveTrialStatus(userInfo: UserInfo, trialStatus: UserTrialStatus): Future[Unit]
+
+
   override def serviceName:String = ThurloeDAO.serviceName
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/Trial.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/Trial.scala
@@ -1,0 +1,85 @@
+package org.broadinstitute.dsde.firecloud.model
+
+import org.broadinstitute.dsde.firecloud.FireCloudException
+import org.broadinstitute.dsde.firecloud.model.Trial.TrialStates.TrialState
+
+import scala.util.Try
+
+object Trial {
+
+  object TrialStates {
+    sealed trait TrialState  {
+      override def toString: String = TrialStates.stringify(this)
+      def withName(name: String): TrialState = TrialStates.withName(name)
+    }
+
+    def withName(name: String): TrialState = {
+      name match {
+        case "Enabled" => Enabled
+        case "Enrolled" => Enrolled
+        case "Terminated" => Terminated
+        case _ => throw new FireCloudException(s"invalid TrialState [$name]")
+      }
+    }
+
+    def stringify(state: TrialState): String = {
+      state match {
+        case Enabled => "Enabled"
+        case Enrolled => "Enrolled"
+        case Terminated => "Terminated"
+        case _ => throw new FireCloudException(s"invalid TrialState [${state.getClass.getName}]")
+      }
+    }
+
+    case object Enabled extends TrialState
+    case object Enrolled extends TrialState
+    case object Terminated extends TrialState
+  }
+
+  case class UserTrialStatus(
+    userId: String,
+    currentState: Option[TrialState],
+    enabledDate: Long,    // timestamp a campaign manager granted the user trial permissions
+    enrolledDate: Long,   // timestamp user started their trial
+    terminatedDate: Long, // timestamp user was actually terminated
+    expirationDate: Long  // timestamp user is due to face termination
+    )
+
+  object UserTrialStatus {
+    def apply(profileWrapper:ProfileWrapper) = {
+
+      def profileDate(key: String, kvps: Map[String,String], default: Int = 0): Int = {
+        Try(kvps.getOrElse(key, default.toString).toInt).toOption.getOrElse(default)
+      }
+
+      val mappedKVPs:Map[String,String] = (profileWrapper.keyValuePairs collect {
+        case kvp if kvp.key.nonEmpty && kvp.value.nonEmpty => kvp.key.get -> kvp.value.get
+      }).toMap
+
+      val enabledDate = profileDate("trialEnabledDate", mappedKVPs)
+      val enrolledDate = profileDate("trialEnrolledDate", mappedKVPs)
+      val terminatedDate = profileDate("trialTerminatedDate", mappedKVPs)
+      val expirationDate = profileDate("trialExpirationDate", mappedKVPs)
+
+      val currentState = mappedKVPs.get("trialCurrentState") map TrialStates.withName
+
+      new UserTrialStatus(profileWrapper.userId, currentState,
+        enabledDate, enrolledDate, terminatedDate, expirationDate)
+    }
+
+    def toKVPs(userTrialStatus: UserTrialStatus): Map[String,String] = {
+      val stateKV:Map[String,String] = userTrialStatus.currentState match {
+        case Some(state) => Map("trialCurrentState" -> state.toString)
+        case None => Map.empty[String,String]
+      }
+      Map(
+        "trialEnabledDate" -> userTrialStatus.enabledDate.toString,
+        "trialEnrolledDate" -> userTrialStatus.enrolledDate.toString,
+        "trialTerminatedDate" -> userTrialStatus.terminatedDate.toString,
+        "trialExpirationDate" -> userTrialStatus.expirationDate.toString
+      ) ++ stateKV
+    }
+
+  }
+
+}

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/Trial.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/Trial.scala
@@ -9,6 +9,7 @@ import scala.util.Try
 
 object Trial {
 
+  // enum-style case objects to track a user's progress through the free trial
   object TrialStates {
     sealed trait TrialState  {
       override def toString: String = TrialStates.stringify(this)
@@ -38,6 +39,7 @@ object Trial {
     case object Terminated extends TrialState
   }
 
+  // "profile" object to hold all free trial-related information for a single user
   case class UserTrialStatus(
     userId: String,
     currentState: Option[TrialState],
@@ -58,6 +60,7 @@ object Trial {
         Instant.ofEpochMilli(expirationEpoch)
       )
     }
+    // apply method to create a UserTrialStatus from raw Thurloe KVPs
     def apply(profileWrapper:ProfileWrapper) = {
 
       def profileDate(key: String, kvps: Map[String,String], default: Instant = Instant.ofEpochMilli(0)): Instant = {
@@ -79,6 +82,7 @@ object Trial {
         enabledDate, enrolledDate, terminatedDate, expirationDate)
     }
 
+    // translates a UserTrialStatus to Thurloe KVPs
     def toKVPs(userTrialStatus: UserTrialStatus): Map[String,String] = {
       val stateKV:Map[String,String] = userTrialStatus.currentState match {
         case Some(state) => Map("trialCurrentState" -> state.toString)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/TrialService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/TrialService.scala
@@ -1,0 +1,90 @@
+package org.broadinstitute.dsde.firecloud.service
+
+import akka.actor.{Actor, Props}
+import akka.pattern._
+import com.typesafe.scalalogging.slf4j.LazyLogging
+import org.broadinstitute.dsde.firecloud.Application
+import org.broadinstitute.dsde.firecloud.dataaccess.{SamDAO, ThurloeDAO}
+import org.broadinstitute.dsde.firecloud.model.Trial.{TrialStates, UserTrialStatus}
+import org.broadinstitute.dsde.firecloud.model.{RequestCompleteWithErrorReport, UserInfo}
+import org.broadinstitute.dsde.firecloud.service.PerRequest.{PerRequestMessage, RequestComplete}
+import org.broadinstitute.dsde.firecloud.service.TrialService.{EnableUser, EnrollUser, TerminateUser}
+import spray.http.StatusCodes._
+
+import scala.concurrent.{ExecutionContext, Future}
+
+object TrialService {
+  sealed trait TrialServiceMessage
+  case class EnableUser(userInfo:UserInfo) extends TrialServiceMessage
+  case class EnrollUser(userInfo:UserInfo) extends TrialServiceMessage
+  case class TerminateUser(userInfo:UserInfo) extends TrialServiceMessage
+
+  def props(service: () => TrialService): Props = {
+    Props(service())
+  }
+
+  def constructor(app: Application)()(implicit executionContext: ExecutionContext) =
+    new TrialService(app.samDAO, app.thurloeDAO)
+}
+
+class TrialService
+  (val samDao: SamDAO, val thurloeDao: ThurloeDAO)
+  (implicit protected val executionContext: ExecutionContext)
+  extends Actor with LazyLogging {
+
+  override def receive = {
+    case EnableUser(userInfo) => enableUser(userInfo) pipeTo sender
+    case EnrollUser(userInfo) => enrollUser(userInfo) pipeTo sender
+    case TerminateUser(userInfo) => terminateUser(userInfo) pipeTo sender
+  }
+
+  // TODO: implement fully! Check that the user does not already have a state, before overwriting.
+  // this method exists solely for developer-testing purposes right now.
+  private def enableUser(userInfo: UserInfo): Future[PerRequestMessage] = {
+    // build the state that we want to persist to indicate the user is enabled
+    val now = System.currentTimeMillis
+    val enabledStatus = UserTrialStatus(userInfo.id, Some(TrialStates.Enabled), now, 0, 0, 0)
+    thurloeDao.saveTrialStatus(userInfo, enabledStatus) map { _ =>
+      RequestComplete(spray.http.StatusCodes.OK)
+    }
+  }
+
+  private def enrollUser(userInfo:UserInfo): Future[PerRequestMessage] = {
+    // get user's trial status, then check the current state
+    thurloeDao.getTrialStatus(userInfo) flatMap { userTrialStatus =>
+      userTrialStatus match {
+        // can't determine the user's trial status; don't enroll
+        case None => Future(RequestCompleteWithErrorReport(BadRequest, "You are not eligible for a free trial."))
+        case Some(status) =>
+          status.currentState match {
+            // user already enrolled; don't re-enroll
+            case Some(TrialStates.Enrolled) => Future(RequestCompleteWithErrorReport(BadRequest, "You are already enrolled in a free trial."))
+            // user enabled (eligible) for trial, enroll!
+            case Some(TrialStates.Enabled) => {
+              // build the new state that we want to persist to indicate the user is enrolled
+              val now = System.currentTimeMillis
+              val enrolledStatus = status.copy(
+                currentState = Some(TrialStates.Enrolled),
+                enrolledDate = now,
+                expirationDate = now + (60 * 24 * 60 * 60 * 1000) // add 60 days from now
+              )
+              // TODO: read expiration-date duration from config instead of hardcoding!
+              thurloeDao.saveTrialStatus(userInfo, enrolledStatus) map { _ =>
+                // TODO: add user to free-trial billing project / create said project if necessary
+                RequestComplete(NoContent)
+              }
+            }
+            // user in some other state; don't enroll
+            case _ => Future(RequestCompleteWithErrorReport(BadRequest, "You are not eligible for a free trial."))
+          }
+      }
+    }
+  }
+
+  // TODO: implement
+  private def terminateUser(userInfo: UserInfo): Future[PerRequestMessage] = {
+    Future(RequestCompleteWithErrorReport(NotImplemented, "not implemented"))
+  }
+
+}
+

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockThurloeDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockThurloeDAO.scala
@@ -2,7 +2,8 @@ package org.broadinstitute.dsde.firecloud.dataaccess
 
 import java.util.NoSuchElementException
 
-import org.broadinstitute.dsde.firecloud.model.{BasicProfile, FireCloudKeyValue, Profile, ProfileWrapper, SubsystemStatus, UserInfo}
+import org.broadinstitute.dsde.firecloud.model.Trial.{TrialStates, UserTrialStatus}
+import org.broadinstitute.dsde.firecloud.model.{BasicProfile, FireCloudKeyValue, Profile, ProfileWrapper, SubsystemStatus, Trial, UserInfo}
 import org.broadinstitute.dsde.firecloud.utils.DateUtils
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -122,4 +123,9 @@ class MockThurloeDAO extends ThurloeDAO {
 
   def status: Future[SubsystemStatus] = Future(SubsystemStatus(ok = true))
 
+  override def getTrialStatus(userInfo: UserInfo) = Future.successful(Some(
+    UserTrialStatus(userInfo.id, Some(TrialStates.Terminated), 0, 0, 0, 0
+  )))
+
+  override def saveTrialStatus(userInfo: UserInfo, trialStatus: Trial.UserTrialStatus) = Future.successful(())
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/model/TrialSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/model/TrialSpec.scala
@@ -1,0 +1,98 @@
+package org.broadinstitute.dsde.firecloud.model
+
+import org.broadinstitute.dsde.firecloud.FireCloudException
+import org.broadinstitute.dsde.firecloud.model.Trial.{TrialStates, UserTrialStatus}
+import org.scalatest.FreeSpec
+
+class TrialSpec extends FreeSpec  {
+
+  "TrialStates" - {
+    "should create from known strings" in {
+      assertResult(TrialStates.Enabled) { TrialStates.withName("Enabled") }
+      assertResult(TrialStates.Enrolled) { TrialStates.withName("Enrolled") }
+      assertResult(TrialStates.Terminated) { TrialStates.withName("Terminated") }
+    }
+    "should error from unknown strings" in {
+      intercept[FireCloudException] {
+        TrialStates.withName("enabled") // incorrect case
+      }
+      intercept[FireCloudException] {
+        TrialStates.withName("")
+      }
+      intercept[FireCloudException] {
+        TrialStates.withName("Impending") // haven't implemented Impending state
+      }
+    }
+    "should toString predictably" in {
+      assertResult("Enabled") { TrialStates.Enabled.toString }
+      assertResult("Enrolled") { TrialStates.Enrolled.toString }
+      assertResult("Terminated") { TrialStates.Terminated.toString }
+    }
+  }
+
+  "UserTrialStatus" - {
+    "should create from fully-populated Thurloe profile" in {
+      val profileWrapper = ProfileWrapper("userid", List(
+        FireCloudKeyValue(Some("trialEnabledDate"), Some("12")),
+        FireCloudKeyValue(Some("trialEnrolledDate"), Some("34")),
+        FireCloudKeyValue(Some("trialTerminatedDate"), Some("56")),
+        FireCloudKeyValue(Some("trialExpirationDate"), Some("78")),
+        FireCloudKeyValue(Some("trialCurrentState"), Some("Enrolled"))
+      ))
+      val actual = UserTrialStatus(profileWrapper)
+      val expected = UserTrialStatus("userid", Some(TrialStates.Enrolled), 12, 34, 56, 78)
+      assertResult(expected) { actual }
+    }
+    "should create with empty state and zero timestamps when nothing in profile" in {
+      val profileWrapper = ProfileWrapper("userid", List.empty[FireCloudKeyValue])
+      val actual = UserTrialStatus(profileWrapper)
+      val expected = UserTrialStatus("userid", None, 0, 0, 0, 0)
+      assertResult(expected) { actual }
+    }
+    "should partially populate timestamps when only some in profile" in {
+      val profileWrapper = ProfileWrapper("userid", List(
+        FireCloudKeyValue(Some("trialEnabledDate"), Some("12")),
+        FireCloudKeyValue(Some("trialCurrentState"), Some("Enabled"))
+      ))
+      val actual = UserTrialStatus(profileWrapper)
+      val expected = UserTrialStatus("userid", Some(TrialStates.Enabled), 12, 0, 0, 0)
+      assertResult(expected) { actual }
+    }
+    "should convert full UserTrialStatus to Thurloe KVPs" in {
+      val userTrialStatus = UserTrialStatus("userid", Some(TrialStates.Terminated), 12, 34, 56, 78)
+      val actual = UserTrialStatus.toKVPs(userTrialStatus)
+      val expected = Map(
+        "trialEnabledDate" -> "12",
+        "trialEnrolledDate" -> "34",
+        "trialTerminatedDate" -> "56",
+        "trialExpirationDate" -> "78",
+        "trialCurrentState" -> "Terminated"
+      )
+      assertResult(expected) { actual }
+    }
+    "should convert partial UserTrialStatus to Thurloe KVPs" in {
+      val userTrialStatus = UserTrialStatus("userid", Some(TrialStates.Enabled), 12, 0, 0, 0)
+      val actual = UserTrialStatus.toKVPs(userTrialStatus)
+      val expected = Map(
+        "trialEnabledDate" -> "12",
+        "trialEnrolledDate" -> "0",
+        "trialTerminatedDate" -> "0",
+        "trialExpirationDate" -> "0",
+        "trialCurrentState" -> "Enabled"
+      )
+      assertResult(expected) { actual }
+    }
+    "should convert empty UserTrialStatus to Thurloe KVPs" in {
+      val userTrialStatus = UserTrialStatus("userid", None, 0, 0, 0, 0)
+      val actual = UserTrialStatus.toKVPs(userTrialStatus)
+      val expected = Map(
+        "trialEnabledDate" -> "0",
+        "trialEnrolledDate" -> "0",
+        "trialTerminatedDate" -> "0",
+        "trialExpirationDate" -> "0"
+      )
+      assertResult(expected) { actual }
+    }
+  }
+
+}

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/UserApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/UserApiServiceSpec.scala
@@ -18,6 +18,7 @@ class UserApiServiceSpec extends BaseServiceSpec with RegisterApiService with Us
 
   def actorRefFactory = system
   val registerServiceConstructor:() => RegisterService = RegisterService.constructor(app)
+  val trialServiceConstructor:() => TrialService = TrialService.constructor(app)
   var workspaceServer: ClientAndServer = _
   var profileServer: ClientAndServer = _
   var samServer: ClientAndServer = _
@@ -192,7 +193,7 @@ class UserApiServiceSpec extends BaseServiceSpec with RegisterApiService with Us
 
     "when calling GET for the user registration service" - {
       "MethodNotAllowed response is not returned" in {
-        Get("/register") ~> dummyUserIdHeaders(uniqueId) ~> sealRoute(routes) ~> check {
+        Get("/register") ~> dummyUserIdHeaders(uniqueId) ~> sealRoute(userServiceRoutes) ~> check {
           log.debug("/register: " + status)
           status shouldNot equal(MethodNotAllowed)
         }
@@ -201,7 +202,7 @@ class UserApiServiceSpec extends BaseServiceSpec with RegisterApiService with Us
 
     "when calling GET for user billing service" - {
       "MethodNotAllowed response is not returned" in {
-        Get("/api/profile/billing") ~> dummyUserIdHeaders(uniqueId) ~> sealRoute(routes) ~> check {
+        Get("/api/profile/billing") ~> dummyUserIdHeaders(uniqueId) ~> sealRoute(userServiceRoutes) ~> check {
           log.debug("/api/profile/billing: " + status)
           status shouldNot equal(MethodNotAllowed)
         }
@@ -210,7 +211,7 @@ class UserApiServiceSpec extends BaseServiceSpec with RegisterApiService with Us
 
     "when calling GET for user refresh token date service" - {
       "MethodNotAllowed response is not returned" in {
-        Get("/api/profile/refreshTokenDate") ~> dummyUserIdHeaders(uniqueId) ~> sealRoute(routes) ~> check {
+        Get("/api/profile/refreshTokenDate") ~> dummyUserIdHeaders(uniqueId) ~> sealRoute(userServiceRoutes) ~> check {
           status shouldNot equal(MethodNotAllowed)
         }
       }
@@ -218,7 +219,7 @@ class UserApiServiceSpec extends BaseServiceSpec with RegisterApiService with Us
 
     "when GET-ting all profile information" - {
       "MethodNotAllowed response is not returned" in {
-        Get(s"/$ApiPrefix") ~> dummyUserIdHeaders(uniqueId) ~> sealRoute(routes) ~> check {
+        Get(s"/$ApiPrefix") ~> dummyUserIdHeaders(uniqueId) ~> sealRoute(userServiceRoutes) ~> check {
           log.debug(s"GET /$ApiPrefix: " + status)
           status shouldNot equal(MethodNotAllowed)
         }
@@ -249,7 +250,7 @@ class UserApiServiceSpec extends BaseServiceSpec with RegisterApiService with Us
     "when GET-ting my group membership" - {
       "OK response is returned" in {
         Get("/api/groups") ~>
-          dummyUserIdHeaders(uniqueId) ~> sealRoute(routes) ~> check {
+          dummyUserIdHeaders(uniqueId) ~> sealRoute(userServiceRoutes) ~> check {
           status should equal(OK)
         }
       }
@@ -258,7 +259,7 @@ class UserApiServiceSpec extends BaseServiceSpec with RegisterApiService with Us
     "when POST-ing to create a group" - {
       "Created response is returned" in {
         Post("/api/groups/example-group") ~>
-          dummyUserIdHeaders(uniqueId) ~> sealRoute(routes) ~> check {
+          dummyUserIdHeaders(uniqueId) ~> sealRoute(userServiceRoutes) ~> check {
           status should equal(Created)
         }
       }
@@ -267,7 +268,7 @@ class UserApiServiceSpec extends BaseServiceSpec with RegisterApiService with Us
     "when GET-ting membership of a group" - {
       "OK response is returned" in {
         Get("/api/groups/example-group") ~>
-          dummyUserIdHeaders(uniqueId) ~> sealRoute(routes) ~> check {
+          dummyUserIdHeaders(uniqueId) ~> sealRoute(userServiceRoutes) ~> check {
           status should equal(OK)
         }
       }
@@ -276,7 +277,7 @@ class UserApiServiceSpec extends BaseServiceSpec with RegisterApiService with Us
     "when DELETE-ing to create a group" - {
       "OK response is returned" in {
         Delete("/api/groups/example-group") ~>
-          dummyUserIdHeaders(uniqueId) ~> sealRoute(routes) ~> check {
+          dummyUserIdHeaders(uniqueId) ~> sealRoute(userServiceRoutes) ~> check {
           status should equal(OK)
         }
       }
@@ -285,7 +286,7 @@ class UserApiServiceSpec extends BaseServiceSpec with RegisterApiService with Us
     "when PUT-ting to add a member to a group" - {
       "OK response is returned" in {
         Put("/api/groups/example-group/owner/test@test.test") ~>
-          dummyUserIdHeaders(uniqueId) ~> sealRoute(routes) ~> check {
+          dummyUserIdHeaders(uniqueId) ~> sealRoute(userServiceRoutes) ~> check {
           status should equal(OK)
         }
       }
@@ -294,7 +295,7 @@ class UserApiServiceSpec extends BaseServiceSpec with RegisterApiService with Us
     "when DELETE-ing to remove a member from a group" - {
       "OK response is returned" in {
         Delete("/api/groups/example-group/owner/test@test.test") ~>
-          dummyUserIdHeaders(uniqueId) ~> sealRoute(routes) ~> check {
+          dummyUserIdHeaders(uniqueId) ~> sealRoute(userServiceRoutes) ~> check {
           status should equal(OK)
         }
       }
@@ -303,7 +304,7 @@ class UserApiServiceSpec extends BaseServiceSpec with RegisterApiService with Us
     "when POST-ing to request access to a group" - {
       "OK response is returned" in {
         Post("/api/groups/example-group/requestAccess") ~>
-          dummyUserIdHeaders(uniqueId) ~> sealRoute(routes) ~> check {
+          dummyUserIdHeaders(uniqueId) ~> sealRoute(userServiceRoutes) ~> check {
           status should equal(NoContent)
         }
       }
@@ -362,7 +363,7 @@ class UserApiServiceSpec extends BaseServiceSpec with RegisterApiService with Us
 
     "when calling /me without Authorization header" - {
       "Unauthorized response is returned" in {
-        Get(s"/me") ~> sealRoute(routes) ~> check {
+        Get(s"/me") ~> sealRoute(userServiceRoutes) ~> check {
           status should equal(Unauthorized)
         }
       }
@@ -378,7 +379,7 @@ class UserApiServiceSpec extends BaseServiceSpec with RegisterApiService with Us
             org.mockserver.model.HttpResponse.response()
               .withHeaders(MockUtils.header).withStatusCode(Unauthorized.intValue)
           )
-        Get(s"/me") ~> dummyAuthHeaders ~> sealRoute(routes) ~> check {
+        Get(s"/me") ~> dummyAuthHeaders ~> sealRoute(userServiceRoutes) ~> check {
           status should equal(Unauthorized)
         }
       }
@@ -394,7 +395,7 @@ class UserApiServiceSpec extends BaseServiceSpec with RegisterApiService with Us
             org.mockserver.model.HttpResponse.response()
               .withHeaders(MockUtils.header).withStatusCode(NotFound.intValue)
           )
-        Get(s"/me") ~> dummyAuthHeaders ~> sealRoute(routes) ~> check {
+        Get(s"/me") ~> dummyAuthHeaders ~> sealRoute(userServiceRoutes) ~> check {
           status should equal(NotFound)
         }
       }
@@ -410,7 +411,7 @@ class UserApiServiceSpec extends BaseServiceSpec with RegisterApiService with Us
             org.mockserver.model.HttpResponse.response()
               .withHeaders(MockUtils.header).withStatusCode(InternalServerError.intValue)
           )
-        Get(s"/me") ~> dummyAuthHeaders ~> sealRoute(routes) ~> check {
+        Get(s"/me") ~> dummyAuthHeaders ~> sealRoute(userServiceRoutes) ~> check {
           status should equal(InternalServerError)
         }
       }
@@ -427,7 +428,7 @@ class UserApiServiceSpec extends BaseServiceSpec with RegisterApiService with Us
               .withBody("""{"enabled": {"google": false, "ldap": true, "allUsersGroup": true}, "userInfo": {"userSubjectId": "1111111111", "userEmail": "no@nope.org"}}""")
               .withHeaders(MockUtils.header).withStatusCode(OK.intValue)
           )
-        Get(s"/me") ~> dummyAuthHeaders ~> sealRoute(routes) ~> check {
+        Get(s"/me") ~> dummyAuthHeaders ~> sealRoute(userServiceRoutes) ~> check {
           status should equal(Forbidden)
         }
       }
@@ -444,7 +445,7 @@ class UserApiServiceSpec extends BaseServiceSpec with RegisterApiService with Us
               .withBody("""{"enabled": {"google": true, "ldap": false, "allUsersGroup": true}, "userInfo": {"userSubjectId": "1111111111", "userEmail": "no@nope.org"}}""")
               .withHeaders(MockUtils.header).withStatusCode(OK.intValue)
           )
-        Get(s"/me") ~> dummyAuthHeaders ~> sealRoute(routes) ~> check {
+        Get(s"/me") ~> dummyAuthHeaders ~> sealRoute(userServiceRoutes) ~> check {
           status should equal(Forbidden)
         }
       }
@@ -463,7 +464,7 @@ class UserApiServiceSpec extends BaseServiceSpec with RegisterApiService with Us
               .withBody("""{"enabled": {"google": true, "ldap": true, "allUsersGroup": true}, "userInfo": {"userSubjectId": "1111111111", "userEmail": "no@nope.org"}}""")
               .withHeaders(MockUtils.header).withStatusCode(OK.intValue)
           )
-        Get(s"/me") ~> dummyAuthHeaders ~> sealRoute(routes) ~> check {
+        Get(s"/me") ~> dummyAuthHeaders ~> sealRoute(userServiceRoutes) ~> check {
           status should equal(OK)
         }
       }
@@ -480,7 +481,7 @@ class UserApiServiceSpec extends BaseServiceSpec with RegisterApiService with Us
               .withBody("""{"userInfo": "whaaaaaaat??"}""")
               .withHeaders(MockUtils.header).withStatusCode(OK.intValue)
           )
-        Get(s"/me") ~> dummyAuthHeaders ~> sealRoute(routes) ~> check {
+        Get(s"/me") ~> dummyAuthHeaders ~> sealRoute(userServiceRoutes) ~> check {
           status should equal(InternalServerError)
         }
       }
@@ -496,7 +497,7 @@ class UserApiServiceSpec extends BaseServiceSpec with RegisterApiService with Us
             org.mockserver.model.HttpResponse.response()
               .withHeaders(MockUtils.header).withStatusCode(EnhanceYourCalm.intValue)
           )
-        Get(s"/me") ~> dummyAuthHeaders ~> sealRoute(routes) ~> check {
+        Get(s"/me") ~> dummyAuthHeaders ~> sealRoute(userServiceRoutes) ~> check {
           status should equal(EnhanceYourCalm)
         }
       }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/TrialApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/TrialApiServiceSpec.scala
@@ -1,0 +1,146 @@
+package org.broadinstitute.dsde.firecloud.webservice
+
+import org.broadinstitute.dsde.firecloud.dataaccess.HttpThurloeDAO
+import org.broadinstitute.dsde.firecloud.mock.MockUtils
+import org.broadinstitute.dsde.firecloud.mock.MockUtils.thurloeServerPort
+import org.broadinstitute.dsde.firecloud.model.{FireCloudKeyValue, ProfileWrapper, UserInfo}
+import org.broadinstitute.dsde.firecloud.service.{BaseServiceSpec, TrialService}
+import org.mockserver.integration.ClientAndServer
+import org.mockserver.integration.ClientAndServer.startClientAndServer
+import org.mockserver.model.HttpRequest.request
+import spray.http.StatusCodes.{BadRequest, NoContent, OK}
+import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol.impProfileWrapper
+import org.broadinstitute.dsde.firecloud.model.Trial.{TrialStates, UserTrialStatus}
+import spray.http.HttpMethods.POST
+import spray.json._
+
+import scala.concurrent.Future
+
+class TrialApiServiceSpec extends BaseServiceSpec with UserApiService {
+  // note that the endpoint tested in this class lives in UserApiService, but I'm breaking it out into
+  // a standalone test class for modularity.
+
+  def actorRefFactory = system
+  val trialServiceConstructor:() => TrialService = TrialService.constructor(app.copy(thurloeDAO = new TrialApiServiceSpecThurloeDAO))
+
+  var profileServer: ClientAndServer = _
+
+  val disabledUser = "disabled-user"
+  val enabledUser = "enabled-user"
+  val enrolledUser = "enrolled-user"
+  val terminatedUser = "terminated-user"
+
+  val disabledProps = Map.empty[String,String]
+  val enabledProps = Map(
+    "trialCurrentState" -> "Enabled",
+    "trialEnabledDate" -> "1"
+  )
+  val enrolledProps = Map(
+    "trialCurrentState" -> "Enrolled",
+    "trialEnabledDate" -> "11",
+    "trialEnrolledDate" -> "22",
+    "trialExpirationDate" -> "99"
+  )
+  val terminatedProps = Map(
+    "trialCurrentState" -> "Terminated",
+    "trialEnabledDate" -> "111",
+    "trialEnrolledDate" -> "222",
+    "trialTerminatedDate" -> "333",
+    "trialExpirationDate" -> "999"
+  )
+
+  private def profile(user:String, props:Map[String,String]): ProfileWrapper =
+    ProfileWrapper(user, props.toList.map {
+      case (k:String, v:String) => FireCloudKeyValue(Some(k), Some(v))
+    })
+
+
+  override protected def beforeAll(): Unit = {
+    profileServer = startClientAndServer(thurloeServerPort)
+
+    List((disabledUser,disabledProps),(enabledUser,enabledProps),(enrolledUser,enrolledProps),(terminatedUser,terminatedProps)).foreach {
+      case (user, props) =>
+        profileServer
+          .when(request()
+            .withMethod("GET")
+            .withHeader(fireCloudHeader.name, fireCloudHeader.value)
+            .withPath(UserApiService.remoteGetAllPath.format(user)))
+          .respond(
+            org.mockserver.model.HttpResponse.response()
+              .withHeaders(MockUtils.header).withStatusCode(OK.intValue)
+              .withBody(profile(user, props).toJson.compactPrint)
+          )
+    }
+  }
+
+  override protected def afterAll(): Unit = {
+    profileServer.stop()
+  }
+
+  val enrollPath = "/api/profile/trial"
+
+  "Free Trial Endpoints" - {
+    "User-initiated enrollment endpoint" - {
+      allHttpMethodsExcept(POST) foreach { method =>
+        s"should reject ${method.toString} method" in {
+          new RequestBuilder(method)(enrollPath) ~> dummyUserIdHeaders(enabledUser) ~> userServiceRoutes ~> check {
+            assert(!handled)
+          }
+        }
+      }
+    }
+
+    "attempting to enroll as a disabled user" - {
+      "should be a BadRequest" in {
+        Post(enrollPath) ~> dummyUserIdHeaders(disabledUser) ~> userServiceRoutes ~> check {
+          status should equal(BadRequest)
+        }
+      }
+    }
+
+    "attempting to enroll as an enabled user" - {
+      "should be NoContent success" in {
+        Post(enrollPath) ~> dummyUserIdHeaders(enabledUser) ~> userServiceRoutes ~> check {
+          assertResult(NoContent, response.entity.asString) { status }
+        }
+      }
+    }
+
+    "attempting to enroll as an enrolled user" - {
+      "should be a BadRequest" in {
+        Post(enrollPath) ~> dummyUserIdHeaders(enrolledUser) ~> userServiceRoutes ~> check {
+          status should equal(BadRequest)
+        }
+      }
+    }
+
+    "attempting to enroll as a terminated user" - {
+      "should be a BadRequest" in {
+        Post(enrollPath) ~> dummyUserIdHeaders(terminatedUser) ~> userServiceRoutes ~> check {
+          status should equal(BadRequest)
+        }
+      }
+    }
+  }
+
+  class TrialApiServiceSpecThurloeDAO extends HttpThurloeDAO {
+    override def saveTrialStatus(userInfo: UserInfo, trialStatus: UserTrialStatus) = {
+      // Note: because HttpThurloeDAO catches exceptions, the assertions here will
+      // result in InternalServerErrors instead of appearing nicely in unit test output.
+      userInfo.id match {
+        case `enabledUser` => {
+          assertResult(Some(TrialStates.Enrolled)) { trialStatus.currentState }
+          assert(trialStatus.enrolledDate > 0)
+          assert(trialStatus.expirationDate > 0)
+          assertResult( trialStatus.enrolledDate + 60*24*60*60*1000 ) { trialStatus.expirationDate }
+          assertResult(0) { trialStatus.terminatedDate }
+          Future.successful(())
+        }
+        case _ => fail("should only be updating the enabled user")
+      }
+    }
+  }
+
+}
+
+


### PR DESCRIPTION
Basic endpoint, model objects, some scaffolding for a user to initiate their own start in the free trial.

This does NOT include billing account/project work - that's for a future story. This is a pretty rudimentary endpoint - the big goal of this story is to deal with daos and model objects and such, so that future stories are easier.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
