### PR TITLE
GAWB-2860: query param to conditionally validate Library metadata

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -895,8 +895,8 @@ paths:
         - $ref: '#/parameters/workspaceNameParam'
         - name: validate
           description: >
-            should the payload be validated for correctness and completeness? Defaults to false if unpublished
-            and true if published.
+            Should the payload be validated? Validation is always enabled
+            for published datasets and defaults to false for unpublished datasets.
           in: query
           type: boolean
           required: false

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -893,6 +893,13 @@ paths:
       parameters:
         - $ref: '#/parameters/workspaceNamespaceParam'
         - $ref: '#/parameters/workspaceNameParam'
+        - name: validate
+          description: >
+            should the payload be validated for correctness and completeness? Defaults to false if unpublished
+            and true if published.
+          in: query
+          type: boolean
+          required: false
         - name: libraryMetadataJson
           description: Library metadata
           required: true

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/LibraryApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/LibraryApiService.scala
@@ -81,10 +81,14 @@ trait LibraryApiService extends HttpService with FireCloudRequestBuilding
           pathPrefix(Segment / Segment) { (namespace, name) =>
             path("metadata") {
               put {
-                entity(as[String]) { rawAttrsString => requestContext =>
-                  perRequest(requestContext,
-                    LibraryService.props(libraryServiceConstructor, userInfo),
-                    LibraryService.UpdateLibraryMetadata(namespace, name, rawAttrsString))
+                parameter("validate" ? "false") { validationParam =>
+                  val doValidate = java.lang.Boolean.valueOf(validationParam) // for lenient parsing
+                  entity(as[String]) { rawAttrsString =>
+                    requestContext =>
+                      perRequest(requestContext,
+                        LibraryService.props(libraryServiceConstructor, userInfo),
+                        LibraryService.UpdateLibraryMetadata(namespace, name, rawAttrsString, doValidate))
+                  }
                 }
               } ~ {
                 get {

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/LibraryApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/LibraryApiServiceSpec.scala
@@ -162,12 +162,41 @@ class LibraryApiServiceSpec extends BaseServiceSpec with LibraryApiService with 
         }
       }
 
-      "cannot save incomplete data save if already published dataset" in {
+      "cannot save incomplete data if already published dataset" in {
         val content = HttpEntity(ContentTypes.`application/json`, incompleteMetadata)
         new RequestBuilder(HttpMethods.PUT)(setMetadataPath("publishedwriter"), content) ~> dummyUserIdHeaders("1234") ~> sealRoute(libraryRoutes) ~> check {
           status should equal(BadRequest)
         }
       }
+
+      "validates for unpublished dataset if user specifies validate=true" in {
+        val content = HttpEntity(ContentTypes.`application/json`, incompleteMetadata)
+        new RequestBuilder(HttpMethods.PUT)(setMetadataPath("unpublishedwriter") + "?validate=true", content) ~> dummyUserIdHeaders("1234") ~> sealRoute(libraryRoutes) ~> check {
+          status should equal(BadRequest)
+        }
+      }
+
+      "validation defaults to false if user specifies a non-boolean value" in {
+        val content = HttpEntity(ContentTypes.`application/json`, incompleteMetadata)
+        new RequestBuilder(HttpMethods.PUT)(setMetadataPath("unpublishedwriter") + "?validate=cat", content) ~> dummyUserIdHeaders("1234") ~> sealRoute(libraryRoutes) ~> check {
+          status should equal(OK)
+        }
+      }
+
+      "always validates for published workspace even if user specifies validate=false" in {
+        val content = HttpEntity(ContentTypes.`application/json`, incompleteMetadata)
+        new RequestBuilder(HttpMethods.PUT)(setMetadataPath("publishedwriter") + "?validate=false", content) ~> dummyUserIdHeaders("1234") ~> sealRoute(libraryRoutes) ~> check {
+          status should equal(BadRequest)
+        }
+      }
+
+      "always validates for published workspace even if user specifies a non-boolean value" in {
+        val content = HttpEntity(ContentTypes.`application/json`, incompleteMetadata)
+        new RequestBuilder(HttpMethods.PUT)(setMetadataPath("publishedwriter") + "?validate=cat", content) ~> dummyUserIdHeaders("1234") ~> sealRoute(libraryRoutes) ~> check {
+          status should equal(BadRequest)
+        }
+      }
+
     }
 
     "when getting metadata" - {


### PR DESCRIPTION
Addresses an issue Kathleen ran into.

This PR adds a `validate` query param to the PUT-library metadata endpoint, so users can conditionally turn on validation. Previously, we always validated for published workspaces, never validated for unpublished workspaces. This means that API users (like Kathleen and team) who were trying to upload Library metadata had no programmatic guidance for their API calls.

Now, they can toggle `validate=true` and get feedback.

if the user does not specify a value for `validate` or specifies a value that doesn't parse to a Boolean, behavior is as before: don't validate for unpublished, do validate for published.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
