### PR TITLE
show consent codes and tags as tags in the data library page

### DIFF
--- a/src/main/resources/library/attribute-definitions.json
+++ b/src/main/resources/library/attribute-definitions.json
@@ -398,9 +398,9 @@
   [
     "library:datasetName",
     "library:indication",
-    "library:dataUseRestriction",
     "library:numSubjects",
     "library:consentCodes",
+    "tag:tags",
     "library:datasetVersion",
     "library:datasetDescription",
     "library:datasetOwner",
@@ -423,6 +423,6 @@
     "library:cellType",
     "library:ethnicity",
     "library:cohortCountry",
-    "tag:tags"
+    "library:dataUseRestriction"
   ]
 }

--- a/src/main/resources/library/attribute-definitions.json
+++ b/src/main/resources/library/attribute-definitions.json
@@ -195,6 +195,12 @@
       "type": "string",
       "typeahead": "populate"
     },
+    "library:consentCodes" : {
+      "title": "Consent Codes",
+      "type": "array",
+      "items": { "type": "string" },
+      "renderHint": { "type": "tag" }
+    },
     "library:requiresExternalApproval": {
       "title": "Requires External Approval",
       "type": "boolean",
@@ -324,6 +330,7 @@
       "title": "Tags",
       "type": "array",
       "items": { "type": "string" },
+      "renderHint": { "type": "tag" },
       "aggregate": {
         "renderHint": "typeahead-multiselect"
       }
@@ -393,6 +400,7 @@
     "library:indication",
     "library:dataUseRestriction",
     "library:numSubjects",
+    "library:consentCodes",
     "library:datasetVersion",
     "library:datasetDescription",
     "library:datasetOwner",
@@ -414,6 +422,7 @@
     "library:coverage",
     "library:cellType",
     "library:ethnicity",
-    "library:cohortCountry"
+    "library:cohortCountry",
+    "tag:tags"
   ]
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupport.scala
@@ -18,7 +18,7 @@ trait DataUseRestrictionSupport extends LazyLogging {
 
   private val diseaseLabelsAttributeName: AttributeName = AttributeName.withLibraryNS("DS")
   val structuredUseRestrictionAttributeName: AttributeName = AttributeName.withLibraryNS("structuredUseRestriction")
-  val dataUseDisplayAttributeName: AttributeName = AttributeName.withLibraryNS("dataUseDisplay")
+  val consentCodesAttributeName: AttributeName = AttributeName.withLibraryNS("consentCodes")
 
   /**
     * This method looks at all of the library attributes that are associated to Consent Codes and
@@ -80,7 +80,7 @@ trait DataUseRestrictionSupport extends LazyLogging {
     val displayCodes = booleanCodes ++ dsLabels
 
     if (displayCodes.nonEmpty)
-      Map(dataUseDisplayAttributeName -> AttributeValueList(displayCodes.map(AttributeString)))
+      Map(consentCodesAttributeName -> AttributeValueList(displayCodes.map(AttributeString)))
     else
       Map.empty[AttributeName, Attribute]
   }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/DataUseRestrictionSearchSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/DataUseRestrictionSearchSpec.scala
@@ -205,11 +205,11 @@ class DataUseRestrictionSearchSpec extends FreeSpec with SearchResultValidation 
     }
   }
 
-  private def getDataUseDisplayCodes(searchResponse: LibrarySearchResponse): Seq[String] = {
+  private def getConsentCodes(searchResponse: LibrarySearchResponse): Seq[String] = {
     searchResponse.results.flatMap { hit =>
       val jsObj = hit.asJsObject
-      if (jsObj.getFields(AttributeName.toDelimitedName(dataUseDisplayAttributeName)).nonEmpty) {
-        jsObj.fields(AttributeName.toDelimitedName(dataUseDisplayAttributeName)).convertTo[Seq[String]]
+      if (jsObj.getFields(AttributeName.toDelimitedName(consentCodesAttributeName)).nonEmpty) {
+        jsObj.fields(AttributeName.toDelimitedName(consentCodesAttributeName)).convertTo[Seq[String]]
       } else { Seq.empty}
     }
   }
@@ -230,7 +230,7 @@ class DataUseRestrictionSearchSpec extends FreeSpec with SearchResultValidation 
       }
     }
 
-    val ddulCodes: Seq[String] = getDataUseDisplayCodes(searchResponse)
+    val ddulCodes: Seq[String] = getConsentCodes(searchResponse)
     expectedCodes should contain theSameElementsAs ddulCodes
 
   }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupportSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupportSpec.scala
@@ -123,7 +123,7 @@ class DataUseRestrictionSupportSpec extends FreeSpec with Matchers with DataUseR
         "valid datasets should have some form of data use display attribute" in {
           validDisplayDatasets.map { ds =>
             val attrs: Map[AttributeName, Attribute] = generateUseRestrictionDisplayAttribute(ds)
-            val codes: Seq[String] = getValuesFromAttributeValueListAsAttribute(attrs.get(dataUseDisplayAttributeName))
+            val codes: Seq[String] = getValuesFromAttributeValueListAsAttribute(attrs.get(consentCodesAttributeName))
             codes shouldNot be(empty)
           }
         }
@@ -131,7 +131,7 @@ class DataUseRestrictionSupportSpec extends FreeSpec with Matchers with DataUseR
         "datasets with single boolean code should have that single display code" in {
           booleanDatasets.map { ds =>
             val attrs: Map[AttributeName, Attribute] = generateUseRestrictionDisplayAttribute(ds)
-            val codes: Seq[String] = getValuesFromAttributeValueListAsAttribute(attrs.get(dataUseDisplayAttributeName))
+            val codes: Seq[String] = getValuesFromAttributeValueListAsAttribute(attrs.get(consentCodesAttributeName))
             // Boolean datasets are named with the same code value
             codes should contain theSameElementsAs Seq(ds.name)
           }
@@ -139,14 +139,14 @@ class DataUseRestrictionSupportSpec extends FreeSpec with Matchers with DataUseR
 
         "'EVERYTHING' dataset should have the right codes" in {
           val attrs: Map[AttributeName, Attribute] = generateUseRestrictionDisplayAttribute(everythingDataset.head)
-          val codes: Seq[String] = getValuesFromAttributeValueListAsAttribute(attrs.get(dataUseDisplayAttributeName))
+          val codes: Seq[String] = getValuesFromAttributeValueListAsAttribute(attrs.get(consentCodesAttributeName))
           val expected = booleanCodes ++ Seq("RS-G", "RS-FM", "NAGR") ++ diseaseValuesLabels.map(s => s"DS:$s")
           codes should contain theSameElementsAs expected
         }
 
         "'TOP_THREE' dataset should have the right codes" in {
           val attrs: Map[AttributeName, Attribute] = generateUseRestrictionDisplayAttribute(topThreeDataset.head)
-          val codes: Seq[String] = getValuesFromAttributeValueListAsAttribute(attrs.get(dataUseDisplayAttributeName))
+          val codes: Seq[String] = getValuesFromAttributeValueListAsAttribute(attrs.get(consentCodesAttributeName))
           val expected = Seq("GRU", "HMB") ++ diseaseValuesLabels.map(s => s"DS:$s")
           codes should contain theSameElementsAs expected
         }


### PR DESCRIPTION
Addresses:
* https://broadinstitute.atlassian.net/browse/GAWB-2769
* https://broadinstitute.atlassian.net/browse/GAWB-2564

Requires UI PR:
* https://github.com/broadinstitute/firecloud-ui/pull/1050


Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [x] Get two thumbsworth of review and PO signoff if necessary
- [x] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
