### PR TITLE
GAWB-2889: lenient library sort + helpful errors on search

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -4964,7 +4964,7 @@ definitions:
         description: How many results to return
       sortField:
         type: string
-        description: Field name on which to sort; defaults so sort by relevance if not specified
+        description: Field name on which to sort; defaults to sort by relevance if not specified
       sortDirection:
         type: string
         description: asc or desc; defaults to asc if not specified

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchDAOQuerySupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchDAOQuerySupport.scala
@@ -125,7 +125,7 @@ trait ElasticSearchDAOQuerySupport extends ElasticSearchDAOSupport with ElasticS
       .setFrom(from)
       .setSize(size)
 
-    if (sortField.isDefined) {
+    if (sortField.isDefined && sortField.get.trim.nonEmpty) {
       val direction = sortDirection match {
         case Some("desc") => SortOrder.DESC
         case _ => SortOrder.ASC

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/LibraryService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/LibraryService.scala
@@ -245,7 +245,7 @@ class LibraryService (protected val argUserInfo: UserInfo,
 
   private def errorMessageFromSearchException(ex: Throwable): String = {
     // elasticsearch errors are often nested, try to dig into them safely to find a message
-    if (ex.getCause != null) {
+    val message = if (ex.getCause != null) {
       val firstCause = ex.getCause
       if (firstCause.getCause != null) {
         firstCause.getCause.getMessage
@@ -255,6 +255,12 @@ class LibraryService (protected val argUserInfo: UserInfo,
     } else {
       ex.getMessage
     }
+
+    Option(message) match {
+      case Some(m:String) => m
+      case _ => "Unknown error during search."
+    }
+
   }
 
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/LibraryService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/LibraryService.scala
@@ -3,7 +3,7 @@ package org.broadinstitute.dsde.firecloud.service
 import akka.actor.{Actor, Props}
 import akka.pattern._
 import com.typesafe.scalalogging.slf4j.LazyLogging
-import org.broadinstitute.dsde.firecloud.{Application, FireCloudConfig, FireCloudException}
+import org.broadinstitute.dsde.firecloud.{Application, FireCloudConfig, FireCloudException, FireCloudExceptionWithErrorReport}
 import org.broadinstitute.dsde.firecloud.dataaccess.{OntologyDAO, RawlsDAO, SearchDAO}
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.firecloud.model._
@@ -218,14 +218,17 @@ class LibraryService (protected val argUserInfo: UserInfo,
   }
 
   def findDocuments(criteria: LibrarySearchParams): Future[PerRequestMessage] = {
-    getEffectiveDiscoverGroups(rawlsDAO) map { userGroups =>
+    getEffectiveDiscoverGroups(rawlsDAO) flatMap { userGroups =>
       val docsFuture = searchDAO.findDocuments(criteria, userGroups)
       val idsFuture = rawlsDAO.getWorkspaces
-      val searchResults = for {
+
+      (for {
         docs <- docsFuture
         ids <- idsFuture
-      } yield updateAccess(docs, ids)
-      RequestComplete(searchResults)
+      } yield RequestComplete(updateAccess(docs, ids))) recover {
+        case ex =>
+          throw new FireCloudExceptionWithErrorReport(ErrorReport(errorMessageFromSearchException(ex)))
+      }
     }
   }
 
@@ -239,4 +242,19 @@ class LibraryService (protected val argUserInfo: UserInfo,
       case e: FireCloudException => Future(RequestCompleteWithErrorReport(BadRequest, s"suggestions not available for field %s".format(field)))
     }
   }
+
+  private def errorMessageFromSearchException(ex: Throwable): String = {
+    // elasticsearch errors are often nested, try to dig into them safely to find a message
+    if (ex.getCause != null) {
+      val firstCause = ex.getCause
+      if (firstCause.getCause != null) {
+        firstCause.getCause.getMessage
+      } else {
+        firstCause.getMessage
+      }
+    } else {
+      ex.getMessage
+    }
+  }
+
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/LibraryService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/LibraryService.scala
@@ -219,6 +219,8 @@ class LibraryService (protected val argUserInfo: UserInfo,
 
   def findDocuments(criteria: LibrarySearchParams): Future[PerRequestMessage] = {
     getEffectiveDiscoverGroups(rawlsDAO) flatMap { userGroups =>
+      // we want docsFuture and ids to be parallelized - so declare them here, outside
+      // of the for-yield.
       val docsFuture = searchDAO.findDocuments(criteria, userGroups)
       val idsFuture = rawlsDAO.getWorkspaces
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/SortSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/SortSpec.scala
@@ -36,7 +36,14 @@ class SortSpec extends FreeSpec with Matchers with BeforeAndAfterAll with LazyLo
       }
     }
     "search with no sort (or filter) criteria" - {
-      "returns all results" in {
+      "returns all results in engine-defined order" in {
+        val searchResponse = sortBy(None, None)
+        assertResult(IntegrationTestFixtures.datasetTuples.size) {searchResponse.total}
+        // results are sorted by relevancy/native index order, which we won't test here
+      }
+    }
+    "search with empty string as sort criteria" - {
+      "returns all results in engine-defined order" in {
         val searchResponse = sortBy(None, None)
         assertResult(IntegrationTestFixtures.datasetTuples.size) {searchResponse.total}
         // results are sorted by relevancy/native index order, which we won't test here

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/SortSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/SortSpec.scala
@@ -44,7 +44,7 @@ class SortSpec extends FreeSpec with Matchers with BeforeAndAfterAll with LazyLo
     }
     "search with empty string as sort criteria" - {
       "returns all results in engine-defined order" in {
-        val searchResponse = sortBy(None, None)
+        val searchResponse = sortBy(Some(""), None)
         assertResult(IntegrationTestFixtures.datasetTuples.size) {searchResponse.total}
         // results are sorted by relevancy/native index order, which we won't test here
       }


### PR DESCRIPTION
no jira, found by Andrew. Two changes in this PR for the library search endpoint:

1. treat `"sortField": ""` in the payload the same as if the user omitted `"sortField"`: the search applies no explicit sort.
2. when ES encounters an exception in its query, make an attempt to bubble the ES error message up to the user. Previously, this endpoint just gave a plain 500 error with no ErrorReport.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
