### PR TITLE
show research purpose fields as required in swagger

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -4902,6 +4902,13 @@ definitions:
 
   ResearchPurpose:
     type: object
+    required:
+      - DS
+      - NDMS
+      - NCTRL
+      - NAGR
+      - POA
+      - NCU
     properties:
       DS:
         type: array


### PR DESCRIPTION
no jira, found by Andrew.

in Library search, the `researchPurpose` field is properly noted as optional. However, if the user specifies a `researchPurpose`, all fields underneath it are required. This PR notes them as such.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
