### PR TITLE
GAWB-2863: de-duplicate per-field suggestions for catalog wizard

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchDAOQuerySupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchDAOQuerySupport.scala
@@ -233,7 +233,7 @@ trait ElasticSearchDAOQuerySupport extends ElasticSearchDAOSupport with ElasticS
     results map { suggestResult =>
       val compSugg: CompletionSuggestion = suggestResult.getSuggest.getSuggestion(suggestionName)
       val options : Seq[CompletionSuggestion.Entry.Option] = compSugg.getEntries.get(0).getOptions.asScala
-      options map { option: CompletionSuggestion.Entry.Option => option.getText.string }
+      (options map { option: CompletionSuggestion.Entry.Option => option.getText.string }).distinct
     }
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchDAOQuerySupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchDAOQuerySupport.scala
@@ -232,8 +232,16 @@ trait ElasticSearchDAOQuerySupport extends ElasticSearchDAOSupport with ElasticS
 
     results map { suggestResult =>
       val compSugg: CompletionSuggestion = suggestResult.getSuggest.getSuggestion(suggestionName)
-      val options : Seq[CompletionSuggestion.Entry.Option] = compSugg.getEntries.get(0).getOptions.asScala
-      (options map { option: CompletionSuggestion.Entry.Option => option.getText.string }).distinct
+      if (compSugg != null) {
+        val entries = compSugg.getEntries
+        if (!entries.isEmpty) {
+          entries.get(0).getOptions.asScala.map(_.getText.string).distinct
+        } else {
+          Seq.empty[String] // getEntries returned empty
+        }
+      } else {
+        Seq.empty[String] // getSuggestion(suggestionName) returned null
+      }
     }
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/AutoSuggestSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/AutoSuggestSpec.scala
@@ -90,6 +90,18 @@ class AutoSuggestSpec extends FreeSpec with Matchers with BeforeAndAfterAll with
     }
   }
 
+  "Per-field autocomplete suggestions for populating the catalog wizard" - {
+    "should not return duplicates" in {
+      // "Pancreatic adenocarcinoma" exists twice, but should be de-duplicated
+      val results = Await.result(searchDAO.suggestionsForFieldPopulate("library:datasetOwner", "pan"), dur)
+      assertResult(Seq("Pancreatic adenocarcinoma")) { results }
+    }
+    "should return multiple distinct suggestions" in {
+      val results = Await.result(searchDAO.suggestionsForFieldPopulate("library:datasetOwner", "thy"), dur)
+      assertResult(Set("Thyroid carcinoma", "Thymoma")) { results.toSet }
+    }
+  }
+
   val dur = Duration(2, MINUTES)
   private def suggestionsFor(txt:String) = {
     val criteria = emptyCriteria.copy(searchString = Some(txt))

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/IntegrationTestFixtures.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/IntegrationTestFixtures.scala
@@ -43,6 +43,7 @@ object IntegrationTestFixtures {
     Document(x._1, Map(
       AttributeName("library","datasetName") -> AttributeString(x._1),
       AttributeName("library","indication") -> AttributeString(x._2),
+      AttributeName("library","datasetOwner") -> AttributeString(x._2),
       AttributeName("library","numSubjects") -> AttributeNumber(x._3)
     ))
   }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/IntegrationTestFixtures.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/IntegrationTestFixtures.scala
@@ -39,13 +39,14 @@ object IntegrationTestFixtures {
     ("ZZZ <encodingtest>&foo", "results won't be escaped", 1)
   )
 
-  val fixtureDocs:Seq[Document] = datasetTuples map {x:(String,String,Int) =>
-    Document(x._1, Map(
-      AttributeName("library","datasetName") -> AttributeString(x._1),
-      AttributeName("library","indication") -> AttributeString(x._2),
-      AttributeName("library","datasetOwner") -> AttributeString(x._2),
-      AttributeName("library","numSubjects") -> AttributeNumber(x._3)
-    ))
+  val fixtureDocs:Seq[Document] = datasetTuples map {
+    case (name, phenotype, count) =>
+      Document(name, Map(
+        AttributeName("library","datasetName") -> AttributeString(name),
+        AttributeName("library","indication") -> AttributeString(phenotype),
+        AttributeName("library","datasetOwner") -> AttributeString(phenotype),
+        AttributeName("library","numSubjects") -> AttributeNumber(count)
+      ))
   }
 
 }


### PR DESCRIPTION
11 characters for the runtime fix, then a couple tests ...

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
