### PR TITLE
GAWB-2820: Add dataAccessInstructions property and question

### DIFF
--- a/src/main/resources/library/attribute-definitions.json
+++ b/src/main/resources/library/attribute-definitions.json
@@ -214,6 +214,12 @@
       "default": false,
       "inputHint": "i.e. approval from a second source is required in order to access the data"
     },
+    "library:dataAccessInstructions": {
+      "title": "Data Access Instructions",
+      "type": "string",
+      "renderHint": {"datatype": "markdown"},
+      "inputHint": "Users will see this message when attempting to access a workspace they are unauthorized to enter. Leave blank for a default message with the Contact Email above."
+    },
     "library:primaryDiseaseSite": {
       "title": "Primary Disease Site",
       "type": "string",
@@ -373,7 +379,7 @@
         "library:numSubjects", "library:projectName", "library:dataCategory", "library:datatype", "library:reference",
         "library:dataFileFormats", "library:technology", "library:profilingProtocol", "library:coverage",
         "library:dataUseRestriction", "library:studyDesign", "library:cellType", "library:ethnicity",
-        "library:cohortCountry", "library:requiresExternalApproval"
+        "library:cohortCountry", "library:requiresExternalApproval", "library:dataAccessInstructions"
       ]
     },
     {

--- a/src/main/resources/library/attribute-definitions.json
+++ b/src/main/resources/library/attribute-definitions.json
@@ -218,7 +218,8 @@
       "title": "Data Access Instructions",
       "type": "string",
       "renderHint": {"datatype": "markdown"},
-      "inputHint": "Users will see this message when attempting to access a workspace they are unauthorized to enter. Leave blank for a default message with the Contact Email above."
+      "inputHint": "Users will see this message when attempting to access a workspace they are unauthorized to enter. Leave blank for a default message with the Contact Email above.",
+      "indexable": false
     },
     "library:primaryDiseaseSite": {
       "title": "Primary Disease Site",


### PR DESCRIPTION
Pretty straightforward.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [x] Get two thumbsworth of review and PO signoff if necessary
- [x] Verify all tests go green
- [x] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [x] Test this change deployed correctly and works on dev environment after deployment
