### PR TITLE
GAWB-2854: read trial duration days from config

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
@@ -160,4 +160,10 @@ object FireCloudConfig {
     val baseConsentUrl = duos.getString("baseConsentUrl")
     val baseOntologyUrl = duos.getString("baseOntologyUrl")
   }
+
+  object Trial {
+    private val trial = config.getConfig("trial")
+    val durationDays = trial.getInt("durationDays")
+    val managerGroup = trial.getString("managerGroup")
+  }
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/TrialService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/TrialService.scala
@@ -6,7 +6,7 @@ import java.time.temporal.ChronoUnit
 import akka.actor.{Actor, Props}
 import akka.pattern._
 import com.typesafe.scalalogging.slf4j.LazyLogging
-import org.broadinstitute.dsde.firecloud.Application
+import org.broadinstitute.dsde.firecloud.{Application, FireCloudConfig}
 import org.broadinstitute.dsde.firecloud.dataaccess.{SamDAO, ThurloeDAO}
 import org.broadinstitute.dsde.firecloud.model.Trial.{TrialStates, UserTrialStatus}
 import org.broadinstitute.dsde.firecloud.model.{RequestCompleteWithErrorReport, UserInfo}
@@ -67,8 +67,7 @@ class TrialService
             case Some(TrialStates.Enabled) => {
               // build the new state that we want to persist to indicate the user is enrolled
               val now = Instant.now
-              // TODO: read expiration-date duration from config instead of hardcoding!
-              val expirationDate = now.plus(60, ChronoUnit.DAYS)
+              val expirationDate = now.plus(FireCloudConfig.Trial.durationDays, ChronoUnit.DAYS)
               val enrolledStatus = status.copy(
                 currentState = Some(TrialStates.Enrolled),
                 enrolledDate = now,

--- a/src/test/resources/reference.conf
+++ b/src/test/resources/reference.conf
@@ -71,6 +71,11 @@ duos {
   baseOntologyUrl = "http://localhost:8993"
 }
 
+trial {
+  durationDays = 60
+  managerGroup = "trial_managers"
+}
+
 # these are the settings currently used at runtime; copy them here
 # so we're testing under similar conditions.
 spray.can.host-connector {

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/TrialApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/TrialApiServiceSpec.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.dsde.firecloud.webservice
 
 import java.time.temporal.ChronoUnit
 
+import org.broadinstitute.dsde.firecloud.FireCloudConfig
 import org.broadinstitute.dsde.firecloud.dataaccess.HttpThurloeDAO
 import org.broadinstitute.dsde.firecloud.mock.MockUtils
 import org.broadinstitute.dsde.firecloud.mock.MockUtils.thurloeServerPort
@@ -131,8 +132,7 @@ class TrialApiServiceSpec extends BaseServiceSpec with UserApiService {
       // result in InternalServerErrors instead of appearing nicely in unit test output.
       userInfo.id match {
         case `enabledUser` => {
-          // TODO: read duration from conf, once runtime also reads it from conf
-          val expectedExpirationDate = trialStatus.enrolledDate.plus(60,ChronoUnit.DAYS)
+          val expectedExpirationDate = trialStatus.enrolledDate.plus(FireCloudConfig.Trial.durationDays, ChronoUnit.DAYS)
           assertResult(Some(TrialStates.Enrolled)) { trialStatus.currentState }
           assert(trialStatus.enrolledDate.toEpochMilli > 0)
           assert(trialStatus.expirationDate.toEpochMilli > 0)


### PR DESCRIPTION
duration now in config, not hardcoded. I also added the managerGroup to `FireCloudConfig` because we'll need that soon.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
