### PR TITLE
GAWB-2781, GAWB-2782: read ontology ES index directly, bypass consent-ontology REST API

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
@@ -139,7 +139,8 @@ object FireCloudConfig {
     private val elasticsearch = config.getConfig("elasticsearch")
     val servers: Seq[Authority] = parseESServers(elasticsearch.getString("urls"))
     val clusterName = elasticsearch.getString("clusterName")
-    val indexName = elasticsearch.getString("index")
+    val indexName = elasticsearch.getString("index") // for library
+    val ontologyIndexName = elasticsearch.getString("ontologyIndex")
     val discoverGroupNames = elasticsearch.getStringList("discoverGroupNames")
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudServiceActor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudServiceActor.scala
@@ -43,7 +43,8 @@ class FireCloudServiceActor extends HttpServiceActor with FireCloudDirectives
   val samDAO:SamDAO = new HttpSamDAO
   val thurloeDAO:ThurloeDAO = new HttpThurloeDAO
   val googleServicesDAO:GoogleServicesDAO = HttpGoogleServicesDAO
-  val ontologyDAO:OntologyDAO = new HttpOntologyDAO
+  val ontologyDAO:OntologyDAO = new ElasticSearchOntologyDAO(FireCloudConfig.ElasticSearch.servers,
+    FireCloudConfig.ElasticSearch.clusterName, FireCloudConfig.ElasticSearch.ontologyIndexName)
   val consentDAO:ConsentDAO = new HttpConsentDAO
   val searchDAO:SearchDAO = new ElasticSearchDAO(FireCloudConfig.ElasticSearch.servers,
     FireCloudConfig.ElasticSearch.clusterName, FireCloudConfig.ElasticSearch.indexName, ontologyDAO)
@@ -53,6 +54,7 @@ class FireCloudServiceActor extends HttpServiceActor with FireCloudDirectives
 
   val exportEntitiesByTypeConstructor: (ExportEntitiesByTypeArguments) => ExportEntitiesByTypeActor = ExportEntitiesByTypeActor.constructor(app, materializer)
   val libraryServiceConstructor: (UserInfo) => LibraryService = LibraryService.constructor(app)
+  val ontologyServiceConstructor: () => OntologyService = OntologyService.constructor(app)
   val namespaceServiceConstructor: (UserInfo) => NamespaceService = NamespaceService.constructor(app)
   val nihServiceConstructor: () => NihServiceActor = NihService.constructor(app)
   val oauthServiceConstructor: () => OAuthService = OAuthService.constructor(app)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchDAO.scala
@@ -20,9 +20,8 @@ import collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class ElasticSearchDAO(servers: Seq[Authority], clusterName: String, indexName: String, ontologyDAO: OntologyDAO) extends SearchDAO with ElasticSearchDAOSupport with ElasticSearchDAOQuerySupport {
+class ElasticSearchDAO(client: TransportClient, indexName: String, ontologyDAO: OntologyDAO) extends SearchDAO with ElasticSearchDAOSupport with ElasticSearchDAOQuerySupport {
 
-  private val client: TransportClient = buildClient(servers, clusterName)
   private final val datatype = "dataset"
 
   initIndex

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchDAOSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchDAOSupport.scala
@@ -19,15 +19,7 @@ import scala.util.{Failure, Success, Try}
 
 trait ElasticSearchDAOSupport extends LazyLogging {
 
-  def buildClient(servers:Seq[Authority], clusterName: String): TransportClient = {
-    val settings = Settings.builder
-      .put("cluster.name", clusterName)
-      .build
-    val addresses = servers map { server =>
-      new InetSocketTransportAddress(InetAddress.getByName(server.host.address), server.port)
-    }
-    new PreBuiltTransportClient(settings).addTransportAddresses(addresses: _*)
-  }
+
 
   def executeESRequest[T <: ActionRequest, U <: ActionResponse, V <: ActionRequestBuilder[T, U, V]](req: V): U = {
     val tick = System.currentTimeMillis

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchOntologyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchOntologyDAO.scala
@@ -1,0 +1,53 @@
+package org.broadinstitute.dsde.firecloud.dataaccess
+import org.broadinstitute.dsde.firecloud.model.Ontology.TermResource
+import org.broadinstitute.dsde.firecloud.model.SubsystemStatus
+import org.elasticsearch.action.admin.indices.exists.indices.{IndicesExistsRequest, IndicesExistsRequestBuilder, IndicesExistsResponse}
+import org.elasticsearch.action.search.{SearchRequest, SearchRequestBuilder, SearchResponse}
+import org.elasticsearch.client.transport.TransportClient
+import org.elasticsearch.index.query.QueryBuilders._
+import spray.http.Uri.Authority
+import spray.json._
+
+import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol.impOntologyTermResource
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class ElasticSearchOntologyDAO(servers: Seq[Authority], clusterName: String, indexName: String) extends OntologyDAO with ElasticSearchDAOSupport {
+
+  private val client: TransportClient = buildClient(servers, clusterName)
+
+  private final val datatype = "ontology_term"
+
+
+  override def search(term: String): Future[Option[List[TermResource]]] = Future(None)
+
+  override def autocomplete(term: String): List[TermResource] = {
+    val prefix = term.toLowerCase
+    // user's term must be a prefix in either label or synonyms
+    val query = boolQuery()
+      .should(prefixQuery("label", prefix))
+      .should(prefixQuery("synonyms", prefix))
+
+    val searchRequest = client.prepareSearch(indexName)
+      .setQuery(query)
+        .setFetchSource(List("id","ontology","usable","label","synonyms","definition").toArray, null)
+
+    val autocompleteResults = executeESRequest[SearchRequest, SearchResponse, SearchRequestBuilder](searchRequest)
+
+    val allHits = autocompleteResults.getHits.getHits
+    allHits.map { hit =>
+      hit.getSourceAsString.parseJson.convertTo[TermResource]
+    }.toList
+  }
+
+  private def indexExists: Boolean = {
+    executeESRequest[IndicesExistsRequest, IndicesExistsResponse, IndicesExistsRequestBuilder](
+      client.admin.indices.prepareExists(indexName)
+    ).isExists
+  }
+
+  override def status: Future[SubsystemStatus] = {
+    Future(SubsystemStatus(indexExists, None))
+  }
+}

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchOntologyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchOntologyDAO.scala
@@ -13,9 +13,7 @@ import org.elasticsearch.action.get.{GetRequest, GetRequestBuilder, GetResponse}
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-class ElasticSearchOntologyDAO(servers: Seq[Authority], clusterName: String, indexName: String) extends OntologyDAO with ElasticSearchDAOSupport {
-
-  private val client: TransportClient = buildClient(servers, clusterName)
+class ElasticSearchOntologyDAO(client: TransportClient, indexName: String) extends OntologyDAO with ElasticSearchDAOSupport {
 
   private final val datatype = "ontology_term"
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpOntologyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpOntologyDAO.scala
@@ -64,4 +64,5 @@ class HttpOntologyDAO(implicit val system: ActorSystem, implicit val executionCo
     getStatusFromDropwizardChecks(unAuthedRequest(Get(ontologyUri.withPath(Uri.Path("/status")))))
   }
 
+  override def autocomplete(term: String) = List.empty[TermResource]
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpOntologyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpOntologyDAO.scala
@@ -19,7 +19,7 @@ import spray.json.DefaultJsonProtocol._
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 
-
+@deprecated("use ElasticSearchOntologyDAO instead", "2017-11-17")
 class HttpOntologyDAO(implicit val system: ActorSystem, implicit val executionContext: ExecutionContext)
   extends OntologyDAO with RestJsonClient with LazyLogging {
 
@@ -35,9 +35,12 @@ class HttpOntologyDAO(implicit val system: ActorSystem, implicit val executionCo
 
   private val ontologyHostSetup = Http.HostConnectorSetup(ontologyUri.authority.host.address, ontologyPort, sslEncryption)
 
-  override def search(term: String): Future[Option[List[TermResource]]] = {
-    searchAsync(term)
-  }
+  override def search(term: String): List[TermResource] = List.empty[TermResource]
+  override def autocomplete(term: String) = List.empty[TermResource]
+
+//  override def search(term: String): Future[Option[List[TermResource]]] = {
+//    searchAsync(term)
+//  }
 
   private def searchAsync(term: String): Future[Option[List[TermResource]]] = {
     getHostConnector flatMap { hostConnector =>
@@ -64,5 +67,5 @@ class HttpOntologyDAO(implicit val system: ActorSystem, implicit val executionCo
     getStatusFromDropwizardChecks(unAuthedRequest(Get(ontologyUri.withPath(Uri.Path("/status")))))
   }
 
-  override def autocomplete(term: String) = List.empty[TermResource]
+
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpOntologyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpOntologyDAO.scala
@@ -38,10 +38,6 @@ class HttpOntologyDAO(implicit val system: ActorSystem, implicit val executionCo
   override def search(term: String): List[TermResource] = List.empty[TermResource]
   override def autocomplete(term: String) = List.empty[TermResource]
 
-//  override def search(term: String): Future[Option[List[TermResource]]] = {
-//    searchAsync(term)
-//  }
-
   private def searchAsync(term: String): Future[Option[List[TermResource]]] = {
     getHostConnector flatMap { hostConnector =>
       val targetUri = Uri(ontologySearchUrl).withQuery(("id", term))

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/OntologyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/OntologyDAO.scala
@@ -16,7 +16,7 @@ trait OntologyDAO extends ReportsSubsystemStatus {
 
   implicit val errorReportSource = ErrorReportSource(OntologyDAO.serviceName)
 
-  def search(term: String): Future[Option[List[TermResource]]]
+  def search(term: String): List[TermResource]
 
   def autocomplete(term: String): List[TermResource]
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/OntologyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/OntologyDAO.scala
@@ -18,6 +18,8 @@ trait OntologyDAO extends ReportsSubsystemStatus {
 
   def search(term: String): Future[Option[List[TermResource]]]
 
+  def autocomplete(term: String): List[TermResource]
+
   override def serviceName:String = OntologyDAO.serviceName
 
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/elastic/ElasticUtils.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/elastic/ElasticUtils.scala
@@ -1,0 +1,21 @@
+package org.broadinstitute.dsde.firecloud.elastic
+
+import java.net.InetAddress
+
+import org.elasticsearch.client.transport.TransportClient
+import org.elasticsearch.common.settings.Settings
+import org.elasticsearch.common.transport.InetSocketTransportAddress
+import org.elasticsearch.transport.client.PreBuiltTransportClient
+import spray.http.Uri.Authority
+
+object ElasticUtils {
+  def buildClient(servers:Seq[Authority], clusterName: String): TransportClient = {
+    val settings = Settings.builder
+      .put("cluster.name", clusterName)
+      .build
+    val addresses = servers map { server =>
+      new InetSocketTransportAddress(InetAddress.getByName(server.host.address), server.port)
+    }
+    new PreBuiltTransportClient(settings).addTransportAddresses(addresses: _*)
+  }
+}

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/Ontology.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/Ontology.scala
@@ -16,12 +16,12 @@ object Ontology {
   case class TermParent(
     id: String,
     order: Int,
-    label: String,
+    label: Option[String],
     definition: Option[String] = None,
     synonyms: Option[List[String]] = None
   ) {
     def toESTermParent: ESTermParent =
-      ESTermParent(label, order)
+      ESTermParent(label.getOrElse(""), order)
   }
 
   case class ESTermParent(label: String, order: Int)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/OntologyService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/OntologyService.scala
@@ -1,0 +1,43 @@
+package org.broadinstitute.dsde.firecloud.service
+
+import akka.actor.{Actor, Props}
+import akka.pattern._
+import com.typesafe.scalalogging.slf4j.LazyLogging
+import org.broadinstitute.dsde.firecloud.Application
+import org.broadinstitute.dsde.firecloud.dataaccess.OntologyDAO
+import org.broadinstitute.dsde.firecloud.service.OntologyService.AutocompleteOntology
+import org.broadinstitute.dsde.firecloud.service.PerRequest.{PerRequestMessage, RequestComplete}
+import spray.json.DefaultJsonProtocol._
+import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol.impOntologyTermResource
+import spray.httpx.SprayJsonSupport
+import spray.json._
+import spray.json.DefaultJsonProtocol._
+
+import scala.concurrent.{ExecutionContext, Future}
+
+object OntologyService {
+  sealed trait OntologyServiceMessage
+  case class AutocompleteOntology(term: String) extends OntologyServiceMessage
+
+  def props(ontologyServiceConstructor: () => OntologyService): Props = {
+    Props(ontologyServiceConstructor())
+  }
+
+  def constructor(app: Application)()(implicit executionContext: ExecutionContext) =
+    new OntologyService(app.ontologyDAO)
+}
+
+class OntologyService(val ontologyDAO: OntologyDAO)
+                     (implicit protected val executionContext: ExecutionContext)
+  extends Actor with SprayJsonSupport with LazyLogging {
+
+  override def receive = {
+    case AutocompleteOntology(term: String) => autocompleteOntology(term) pipeTo sender
+  }
+
+  def autocompleteOntology(term: String): Future[PerRequestMessage] = {
+    Future(RequestComplete(ontologyDAO.autocomplete(term)))
+  }
+
+
+}

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/LibraryApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/LibraryApiService.scala
@@ -27,7 +27,6 @@ trait LibraryApiService extends HttpService with FireCloudRequestBuilding
   val libraryServiceConstructor: UserInfo => LibraryService
   val ontologyServiceConstructor: () => OntologyService
 
-  val duosAutocompleteUrl = FireCloudConfig.Duos.baseOntologyUrl + "/autocomplete"
   val consentUrl = FireCloudConfig.Duos.baseConsentUrl + "/api/consent"
 
   val libraryRoutes: Route =

--- a/src/test/resources/reference.conf
+++ b/src/test/resources/reference.conf
@@ -63,6 +63,7 @@ elasticsearch {
   urls = "localhost:9292"
   clusterName = "elasticsearch5a"
   index = "unittest"
+  ontologyIndex = "unittest-ontology"
   discoverGroupNames = ["all_broad_users","demo_users"]
 }
 

--- a/src/test/resources/reference.conf
+++ b/src/test/resources/reference.conf
@@ -63,7 +63,7 @@ elasticsearch {
   urls = "localhost:9292"
   clusterName = "elasticsearch5a"
   index = "unittest"
-  ontologyIndex = "unittest-ontology"
+  ontologyIndex = "ontology-unittest"
   discoverGroupNames = ["all_broad_users","demo_users"]
 }
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpOntologyDAOConcurrencySpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpOntologyDAOConcurrencySpec.scala
@@ -42,31 +42,31 @@ class HttpOntologyDAOConcurrencySpec extends FreeSpec with Matchers with BeforeA
 
   "HttpOntologyDAO concurrency" - {
 
-    "should obey the spray max-clients throttle" in {
-      assert(throttleCount > 0, "spray.can.host-connector.max-connections should be greater than 0")
-
-      var maxCount = 0
-      var minCount = Int.MaxValue
-
-      // start, in parallel, (throttleCount * 5) requests
-      val futures = Await.result(
-        Future.sequence(Seq.fill(throttleCount * 5)(dao.search("123"))),
-        5.minutes
-      )
-
-      futures foreach { searchResult =>
-        assert(searchResult.isDefined)
-        val sr = searchResult.get
-        assertResult(1) { sr.size }
-        assertResult("disease") { sr.head.label }
-        val responseCount = sr.head.id.toInt
-        if (responseCount > maxCount) maxCount = responseCount
-        if (responseCount < minCount) minCount = responseCount
-      }
-
-      assert(maxCount <= throttleCount, s"request count should always be under $throttleCount; found $maxCount")
-      assertResult(throttleCount, s"request count should have reached its maximum throttle limit") { maxCount }
-      assert(0 < minCount, s"request count should always be > 0; found $minCount")
+    "should obey the spray max-clients throttle" ignore {
+//      assert(throttleCount > 0, "spray.can.host-connector.max-connections should be greater than 0")
+//
+//      var maxCount = 0
+//      var minCount = Int.MaxValue
+//
+//      // start, in parallel, (throttleCount * 5) requests
+//      val futures = Await.result(
+//        Future.sequence(Seq.fill(throttleCount * 5)(dao.search("123"))),
+//        5.minutes
+//      )
+//
+//      futures foreach { searchResult =>
+//        assert(searchResult.isDefined)
+//        val sr = searchResult.get
+//        assertResult(1) { sr.size }
+//        assertResult("disease") { sr.head.label }
+//        val responseCount = sr.head.id.toInt
+//        if (responseCount > maxCount) maxCount = responseCount
+//        if (responseCount < minCount) minCount = responseCount
+//      }
+//
+//      assert(maxCount <= throttleCount, s"request count should always be under $throttleCount; found $maxCount")
+//      assertResult(throttleCount, s"request count should have reached its maximum throttle limit") { maxCount }
+//      assert(0 < minCount, s"request count should always be > 0; found $minCount")
     }
   }
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockOntologyDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockOntologyDAO.scala
@@ -55,13 +55,13 @@ class MockOntologyDAO extends OntologyDAO {
       parents=Some(List(
         TermParent(
           id="http://purl.obolibrary.org/obo/DOID_150",
-          order=3,
+          order=1,
           label=Some("disease of mental health"),
           definition=Some("A disease that involves a psychological or behavioral pattern generally associated with subjective distress or disability that occurs in an individual, and which are not a part of normal development or culture.")
         ),
         TermParent(
           id="http://purl.obolibrary.org/obo/DOID_4",
-          order=4,
+          order=2,
           label=Some("disease"),
           definition=Some("A disease is a disposition (i) to undergo pathological processes that (ii) exists in an organism because of one or more disorders in that organism.")
         )
@@ -234,10 +234,9 @@ class MockOntologyDAO extends OntologyDAO {
     ))
   )
 
-  override def search(term: String): Future[Option[List[TermResource]]] = Future(data.get(term))
+  override def search(term: String): List[TermResource] = data.getOrElse(term, List.empty[TermResource])
 
   def status: Future[SubsystemStatus] = Future(SubsystemStatus(ok = true))
 
-  // TODO: implement
   override def autocomplete(term: String) = List.empty[TermResource]
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockOntologyDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockOntologyDAO.scala
@@ -20,26 +20,26 @@ class MockOntologyDAO extends OntologyDAO {
         TermParent(
           id="http://purl.obolibrary.org/obo/DOID_0050847",
           order=1,
-          label="sleep apnea",
+          label=Some("sleep apnea"),
           definition=Some("A sleep disorder characterized by repeated cessation and commencing of breathing that repeatedly disrupts sleep.")
         ),
         TermParent(
           id="http://purl.obolibrary.org/obo/DOID_535",
           order=2,
-          label="sleep disorder",
+          label=Some("sleep disorder"),
           definition=Some("A disease of mental health that involves disruption of sleep patterns."),
           synonyms=Some(List("Non-organic sleep disorder"))
         ),
         TermParent(
           id="http://purl.obolibrary.org/obo/DOID_150",
           order=3,
-          label="disease of mental health",
+          label=Some("disease of mental health"),
           definition=Some("A disease that involves a psychological or behavioral pattern generally associated with subjective distress or disability that occurs in an individual, and which are not a part of normal development or culture.")
         ),
         TermParent(
           id="http://purl.obolibrary.org/obo/DOID_4",
           order=4,
-          label="disease",
+          label=Some("disease"),
           definition=Some("A disease is a disposition (i) to undergo pathological processes that (ii) exists in an organism because of one or more disorders in that organism.")
         )
       )))),
@@ -56,13 +56,13 @@ class MockOntologyDAO extends OntologyDAO {
         TermParent(
           id="http://purl.obolibrary.org/obo/DOID_150",
           order=3,
-          label="disease of mental health",
+          label=Some("disease of mental health"),
           definition=Some("A disease that involves a psychological or behavioral pattern generally associated with subjective distress or disability that occurs in an individual, and which are not a part of normal development or culture.")
         ),
         TermParent(
           id="http://purl.obolibrary.org/obo/DOID_4",
           order=4,
-          label="disease",
+          label=Some("disease"),
           definition=Some("A disease is a disposition (i) to undergo pathological processes that (ii) exists in an organism because of one or more disorders in that organism.")
         )
       )))),
@@ -79,19 +79,19 @@ class MockOntologyDAO extends OntologyDAO {
         TermParent(
           id="http://purl.obolibrary.org/obo/DOID_934",
           order=1,
-          label="viral infectious disease",
+          label=Some("viral infectious disease"),
           definition=Some("A disease by infectious agent that results_in infection, has_material_basis_in Viruses.")
         ),
         TermParent(
           id="http://purl.obolibrary.org/obo/DOID_0050117",
           order=2,
-          label="disease by infectious agent",
+          label=Some("disease by infectious agent"),
           definition=Some("A disease that is the consequence of the presence of pathogenic microbial agents, including pathogenic viruses, pathogenic bacteria, fungi, protozoa, multicellular parasites, and aberrant proteins known as prions.")
         ),
         TermParent(
           id="http://purl.obolibrary.org/obo/DOID_4",
           order=3,
-          label="disease",
+          label=Some("disease"),
           definition=Some("A disease is a disposition (i) to undergo pathological processes that (ii) exists in an organism because of one or more disorders in that organism.")
         )
       )))),
@@ -107,38 +107,38 @@ class MockOntologyDAO extends OntologyDAO {
         TermParent(
           id="http://purl.obolibrary.org/obo/DOID_2531",
           order=1,
-          label="hematologic cancer",
+          label=Some("hematologic cancer"),
           definition=Some("An immune system cancer located_in the hematological system that is characterized by uncontrolled cellular proliferation in blood, bone marrow and lymph nodes.")
         ),
         TermParent(
           id="http://purl.obolibrary.org/obo/DOID_0060083",
           order=2,
-          label="immune system cancer",
+          label=Some("immune system cancer"),
           definition=Some("An organ system cancer located_in the immune system that is characterized by uncontrolled cellular proliferation in organs of the immune system.")
         ),
         TermParent(
           id="http://purl.obolibrary.org/obo/DOID_0050686",
           order=3,
-          label="organ system cancer",
+          label=Some("organ system cancer"),
           definition=Some("A cancer that is classified based on the organ it starts in.")
         ),
         TermParent(
           id="http://purl.obolibrary.org/obo/DOID_162",
           order=4,
-          label="cancer",
+          label=Some("cancer"),
           definition=Some("A disease of cellular proliferation that is malignant and primary, characterized by uncontrolled cellular proliferation, local cell invasion and metastasis."),
           synonyms=Some(List("primary cancer","malignant tumor ","malignant neoplasm"))
         ),
         TermParent(
           id="http://purl.obolibrary.org/obo/DOID_14566",
           order=5,
-          label="disease of cellular proliferation",
+          label=Some("disease of cellular proliferation"),
           definition=Some("A disease that is characterized by abnormally rapid cell division.")
         ),
         TermParent(
           id="http://purl.obolibrary.org/obo/DOID_4",
           order=6,
-          label="disease",
+          label=Some("disease"),
           definition=Some("A disease is a disposition (i) to undergo pathological processes that (ii) exists in an organism because of one or more disorders in that organism.")
         )
       )))),
@@ -154,32 +154,32 @@ class MockOntologyDAO extends OntologyDAO {
         TermParent(
           id="http://purl.obolibrary.org/obo/DOID_0060083",
           order=1,
-          label="immune system cancer",
+          label=Some("immune system cancer"),
           definition=Some("An organ system cancer located_in the immune system that is characterized by uncontrolled cellular proliferation in organs of the immune system.")
         ),
         TermParent(
           id="http://purl.obolibrary.org/obo/DOID_0050686",
           order=2,
-          label="organ system cancer",
+          label=Some("organ system cancer"),
           definition=Some("A cancer that is classified based on the organ it starts in.")
         ),
         TermParent(
           id="http://purl.obolibrary.org/obo/DOID_162",
           order=3,
-          label="cancer",
+          label=Some("cancer"),
           definition=Some("A disease of cellular proliferation that is malignant and primary, characterized by uncontrolled cellular proliferation, local cell invasion and metastasis."),
           synonyms=Some(List("primary cancer","malignant tumor ","malignant neoplasm"))
         ),
         TermParent(
           id="http://purl.obolibrary.org/obo/DOID_14566",
           order=4,
-          label="disease of cellular proliferation",
+          label=Some("disease of cellular proliferation"),
           definition=Some("A disease that is characterized by abnormally rapid cell division.")
         ),
         TermParent(
           id="http://purl.obolibrary.org/obo/DOID_4",
           order=5,
-          label="disease",
+          label=Some("disease"),
           definition=Some("A disease is a disposition (i) to undergo pathological processes that (ii) exists in an organism because of one or more disorders in that organism.")
         )
       )))),
@@ -195,31 +195,31 @@ class MockOntologyDAO extends OntologyDAO {
         TermParent(
           id="http://purl.obolibrary.org/obo/DOID_0080015",
           order=1,
-          label="physical disorder",
+          label=Some("physical disorder"),
           definition=Some("A disease that has_material_basis_in a genetic abnormality, error with embryonic development, infection or compromised intrauterine environment.")
         ),
         TermParent(
           id="http://purl.obolibrary.org/obo/DOID_0080015",
           order=1,
-          label="specific developmental disorder",
+          label=Some("specific developmental disorder"),
           definition=Some("A developmental disorder of mental health that categorizes specific learning disabilities and developmental disorders affecting coordination.")
         ),
         TermParent(
           id="http://purl.obolibrary.org/obo/DOID_0060083",
           order=2,
-          label="developmental disorder of mental health",
+          label=Some("developmental disorder of mental health"),
           definition=Some("A disease of mental health that occur during a child's developmental period between birth and age 18 resulting in retarding of the child's psychological or physical development.")
         ),
         TermParent(
           id="http://purl.obolibrary.org/obo/DOID_150",
           order=3,
-          label="disease of mental health",
+          label=Some("disease of mental health"),
           definition=Some("A disease that involves a psychological or behavioral pattern generally associated with subjective distress or disability that occurs in an individual, and which are not a part of normal development or culture.")
         ),
         TermParent(
           id="http://purl.obolibrary.org/obo/DOID_4",
           order=4,
-          label="disease",
+          label=Some("disease"),
           definition=Some("A disease is a disposition (i) to undergo pathological processes that (ii) exists in an organism because of one or more disorders in that organism.")
         )
       )))),
@@ -237,4 +237,7 @@ class MockOntologyDAO extends OntologyDAO {
   override def search(term: String): Future[Option[List[TermResource]]] = Future(data.get(term))
 
   def status: Future[SubsystemStatus] = Future(SubsystemStatus(ok = true))
+
+  // TODO: implement
+  override def autocomplete(term: String) = List.empty[TermResource]
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/ESIntegrationSupport.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/ESIntegrationSupport.scala
@@ -3,8 +3,11 @@ package org.broadinstitute.dsde.firecloud.integrationtest
 import java.text.SimpleDateFormat
 import java.util.Calendar
 
+import org.broadinstitute.dsde.firecloud.FireCloudConfig
 import org.broadinstitute.dsde.firecloud.dataaccess.{ElasticSearchDAO, MockOntologyDAO, SearchDAO}
+import org.broadinstitute.dsde.firecloud.elastic.ElasticUtils
 import org.broadinstitute.dsde.firecloud.model.LibrarySearchParams
+import org.elasticsearch.client.transport.TransportClient
 
 import scala.util.{Failure, Success, Try}
 
@@ -32,7 +35,8 @@ object ESIntegrationSupport extends IntegrationTestConfig {
   lazy val searchDAO:SearchDAO = {
     // construct a dao, using IntegrationTestConfig's server names (which should be the runtime server names)
     // and the index name defined above
-    new ElasticSearchDAO(ITElasticSearch.servers, ITElasticSearch.clusterName, itTestIndexName, new MockOntologyDAO)
+    val client: TransportClient = ElasticUtils.buildClient(ITElasticSearch.servers, ITElasticSearch.clusterName)
+    new ElasticSearchDAO(client, itTestIndexName, new MockOntologyDAO)
   }
 
   lazy val emptyCriteria = LibrarySearchParams(None,Map.empty[String,Seq[String]],None,Map.empty[String,Int],None,None,None,None)

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/ESIntegrationSupport.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/ESIntegrationSupport.scala
@@ -4,7 +4,7 @@ import java.text.SimpleDateFormat
 import java.util.Calendar
 
 import org.broadinstitute.dsde.firecloud.FireCloudConfig
-import org.broadinstitute.dsde.firecloud.dataaccess.{ElasticSearchDAO, MockOntologyDAO, SearchDAO}
+import org.broadinstitute.dsde.firecloud.dataaccess._
 import org.broadinstitute.dsde.firecloud.elastic.ElasticUtils
 import org.broadinstitute.dsde.firecloud.model.LibrarySearchParams
 import org.elasticsearch.client.transport.TransportClient
@@ -32,11 +32,17 @@ object ESIntegrationSupport extends IntegrationTestConfig {
     Seq(tag, username, hostname, timeStr).mkString("_")
   }
 
+  // construct a client, using IntegrationTestConfig's server names (which should be the runtime server names)
+  lazy val client: TransportClient = ElasticUtils.buildClient(ITElasticSearch.servers, ITElasticSearch.clusterName)
+
   lazy val searchDAO:SearchDAO = {
-    // construct a dao, using IntegrationTestConfig's server names (which should be the runtime server names)
-    // and the index name defined above
-    val client: TransportClient = ElasticUtils.buildClient(ITElasticSearch.servers, ITElasticSearch.clusterName)
+    // use the temporary index name defined above
     new ElasticSearchDAO(client, itTestIndexName, new MockOntologyDAO)
+  }
+
+  lazy val ontologyDAO:OntologyDAO = {
+    // use the index name defined in reference.conf, since we execute read-only
+    new ElasticSearchOntologyDAO(client, FireCloudConfig.ElasticSearch.ontologyIndexName)
   }
 
   lazy val emptyCriteria = LibrarySearchParams(None,Map.empty[String,Seq[String]],None,Map.empty[String,Int],None,None,None,None)

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/OntologyAutocompleteSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/OntologyAutocompleteSpec.scala
@@ -1,0 +1,60 @@
+package org.broadinstitute.dsde.firecloud.integrationtest
+
+import org.broadinstitute.dsde.firecloud.integrationtest.ESIntegrationSupport._
+import org.broadinstitute.dsde.firecloud.model.Ontology.TermResource
+import org.scalatest.FreeSpec
+
+class OntologyAutocompleteSpec extends FreeSpec {
+
+
+  "Ontology Autocompete" - {
+    "should match prefixes" in {
+      val terms:List[TermResource] = ontologyDAO.autocomplete("bipo")
+      val labels = terms.map(_.label)
+      // NB: yes, what's in the index is actually "ll", not "II"
+      assertResult(Set("bipolar disorder", "bipolar I disorder", "bipolar ll disorder")) { labels.toSet }
+    }
+    "should return empty list for unknown prefix" in {
+      val terms:List[TermResource] = ontologyDAO.autocomplete("Mxyzptlk")
+      assertResult(List.empty[TermResource]) { terms }
+    }
+    "should limit results to 20" in {
+      // search for a common prefix
+      val terms:List[TermResource] = ontologyDAO.autocomplete("dis")
+      assertResult(20) { terms.size }
+    }
+    "should search in both synonyms and labels" in {
+      // search for a common prefix
+      val terms:List[TermResource] = ontologyDAO.autocomplete("leukoe")
+      val labels = terms.map(_.label)
+      val expected = Set(
+        // matches in label:
+        "acute hemorrhagic leukoencephalitis",
+        "COL4A1-related familial vascular leukoencephalopathy",
+        "hypomyelinating leukoencephalopathy",
+        "leukoencephalopathy with vanishing white matter",
+        "oral leukoedema",
+        "progressive multifocal leukoencephalopathy",
+
+        // matches in a synonym:
+        "CADASIL 1",
+        "CADASIL 2",
+        "CADASIL",
+        "hypomyelinating leukodystrophy 7 with or without oligodontia and-or hypogonadotropic hypogonadism", // note label is "leuko" without the "e"
+        "Krabbe disease",
+        "myelophthisic anemia",
+        "Nasu-Hakola disease",
+        "subacute sclerosing panencephalitis"
+
+        // following should not match; consent-ontology service matches in their definitions; orch does not
+        // "hypomyelinating leukodystrophy 4",
+        // "mitochondrial complex I deficiency",
+      )
+      assertResult(expected) { labels.toSet }
+
+    }
+  }
+
+
+
+}

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/OntologyTermResourceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/OntologyTermResourceSpec.scala
@@ -1,0 +1,46 @@
+package org.broadinstitute.dsde.firecloud.integrationtest
+
+import org.broadinstitute.dsde.firecloud.dataaccess.MockOntologyDAO
+import org.broadinstitute.dsde.firecloud.integrationtest.ESIntegrationSupport._
+import org.broadinstitute.dsde.firecloud.model.Ontology.TermParent
+import org.scalatest.FreeSpec
+
+class OntologyTermResourceSpec extends FreeSpec {
+
+  val mockdata = new MockOntologyDAO().data
+
+  "Ontology TermResource lookup" - {
+    "should find central sleep apnea" in {
+      val id = "http://purl.obolibrary.org/obo/DOID_9220"
+      val terms = ontologyDAO.search(id)
+      assertResult(getExpected(id)) { Some(terms) }
+    }
+    "should find sleep apnea" in {
+      val id = "http://purl.obolibrary.org/obo/DOID_535"
+      val terms = ontologyDAO.search(id)
+      assertResult(getExpected(id)) { Some(terms) }
+    }
+    "should find ebola" in {
+      val id = "http://purl.obolibrary.org/obo/DOID_4325"
+      val terms = ontologyDAO.search(id)
+      assertResult(getExpected(id)) { Some(terms) }
+    }
+  }
+
+  // the term search returns a slimmer version of parents than are stored
+  // in our mock data; strip out the mock data.
+  private def getExpected(id: String) = {
+    mockdata.get(id) map { terms =>
+      terms.map { term =>
+        val slimParents:Option[List[TermParent]] = term.parents match {
+          case None => None
+          case Some(ps) => Some(ps.map { p =>
+            p.copy(definition = None, synonyms = None)
+          })
+        }
+        term.copy(parents = slimParents)
+      }
+    }
+  }
+
+}

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/ElasticSearchDAOQuerySupportSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/ElasticSearchDAOQuerySupportSpec.scala
@@ -3,6 +3,7 @@ package org.broadinstitute.dsde.firecloud.service
 
 import org.broadinstitute.dsde.firecloud.FireCloudConfig
 import org.broadinstitute.dsde.firecloud.dataaccess.{ElasticSearchDAOQuerySupport, ElasticSearchDAOSupport, MockOntologyDAO, OntologyDAO}
+import org.broadinstitute.dsde.firecloud.elastic.ElasticUtils
 import org.broadinstitute.dsde.firecloud.model._
 import org.elasticsearch.action.search.SearchRequestBuilder
 import org.elasticsearch.client.transport.TransportClient
@@ -24,7 +25,7 @@ class ElasticSearchDAOQuerySupportSpec extends FreeSpec with ElasticSearchDAOQue
 
   // create an ElasticSearch client. Client requires legal urls for its servers argument, but those
   // urls don't have to point to an actual ES instance.
-  val client: TransportClient = buildClient(FireCloudConfig.ElasticSearch.servers, FireCloudConfig.ElasticSearch.clusterName)
+  val client: TransportClient = ElasticUtils.buildClient(FireCloudConfig.ElasticSearch.servers, FireCloudConfig.ElasticSearch.clusterName)
 
   // create a mock ontology dao
   val ontologyDao: OntologyDAO = new MockOntologyDAO

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/LibraryApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/LibraryApiServiceSpec.scala
@@ -42,6 +42,7 @@ class LibraryApiServiceSpec extends BaseServiceSpec with LibraryApiService with 
   private def duosConsentOrspIdPath(orspId: String): String = "/api/duos/consent/orsp/%s".format(orspId)
 
   val libraryServiceConstructor: (UserInfo) => LibraryService = LibraryService.constructor(app)
+  val ontologyServiceConstructor: () => OntologyService = OntologyService.constructor(app)
 
   val testLibraryMetadata =
     """


### PR DESCRIPTION
Orchestration queries consent-ontology REST API when:
* getting ontology autocomplete results (research purpose search, dataset cataloging)
* indexing a dataset or reindexing all datasets

we've seen some instability in these requests - intermittent errors. This PR bypasses the consent-ontology REST API and queries the ontology Elasticsearch index directly. Hopefully this is more performant and stable.

I have NOT deleted obsolete code in this PR - `HttpOntologyDAO`, `HttpOntologyDAOConcurrencySpec` to make it easy to reverse this change/compare. But maybe I should just delete them and rely on git history if we need to reverse. Thoughts?

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
