### PR TITLE
GAWB-2863: better generation of per-field population suggestions

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchDAOQuerySupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchDAOQuerySupport.scala
@@ -9,17 +9,16 @@ import org.elasticsearch.client.transport.TransportClient
 import org.elasticsearch.action.search.{SearchRequest, SearchRequestBuilder, SearchResponse}
 import org.elasticsearch.index.query.{BoolQueryBuilder, QueryBuilder}
 import org.elasticsearch.index.query.QueryBuilders._
-import org.elasticsearch.search.aggregations.bucket.terms.Terms
+import org.elasticsearch.search.aggregations.bucket.terms.{StringTerms, Terms}
 import org.elasticsearch.search.fetch.subphase.highlight.HighlightBuilder
 import org.elasticsearch.search.sort.SortOrder
-import org.elasticsearch.search.suggest.{SuggestBuilder, SuggestBuilders}
-import org.elasticsearch.search.suggest.completion.CompletionSuggestion
 import spray.json._
 import spray.json.DefaultJsonProtocol._
 
 import scala.collection.JavaConverters._
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.util.{Failure, Success, Try}
 import scala.util.matching.Regex
 
 
@@ -219,29 +218,45 @@ trait ElasticSearchDAOQuerySupport extends ElasticSearchDAOSupport with ElasticS
   }
 
   def populateSuggestions(client: TransportClient, indexName: String, field: String, text: String) : Future[Seq[String]] = {
-    val suggestionName = "populateSuggestion"
-    val suggestion = new SuggestBuilder()
-        .addSuggestion(suggestionName,
-          SuggestBuilders.completionSuggestion(field + ".suggest")
-            .text(text))
+    /*
+      goal:
+        generate suggestions for populating a single field in the catalog wizard,
+        based off what other users have entered for this field.
+      implementation:
+        perform a matchPhrasePrefixQuery within the target field to filter the corpus
+        to the set of documents where the field has a phrase starting with the user's term.
+        Then, calculate a terms aggregation, in order to return the top 10 unique values
+        for the field, within our filtered corpus.
+     */
+    val prefixQuery = matchPhrasePrefixQuery(field, text)
 
-    val suggestQuery = client.prepareSearch(indexName).suggest(suggestion)
+    val aggregationName = "suggTerms"
+    val termsAgg = AggregationBuilders.terms(aggregationName).field(field + ".suggestKeyword").size(10)
 
-    logger.debug(s"populate suggestions query: $suggestQuery.toJson")
-    val results = Future[SearchResponse](executeESRequest[SearchRequest, SearchResponse, SearchRequestBuilder](suggestQuery))
+    val suggestQuery = client.prepareSearch(indexName)
+                                .setQuery(prefixQuery)
+                                .addAggregation(termsAgg)
+                                .setFetchSource(false)
+                                .setSize(0)
 
-    results map { suggestResult =>
-      val compSugg: CompletionSuggestion = suggestResult.getSuggest.getSuggestion(suggestionName)
-      if (compSugg != null) {
-        val entries = compSugg.getEntries
-        if (!entries.isEmpty) {
-          entries.get(0).getOptions.asScala.map(_.getText.string).distinct
-        } else {
-          Seq.empty[String] // getEntries returned empty
+    val suggestTry = Try(executeESRequest[SearchRequest, SearchResponse, SearchRequestBuilder](suggestQuery))
+
+    suggestTry match {
+      case Success(suggestResult) =>
+        val allAggs = suggestResult.getAggregations.asMap().asScala
+        val termsAgg = allAggs.get(aggregationName)
+        val buckets = termsAgg match {
+          case Some(st:StringTerms) =>
+            st.getBuckets.asScala.map(_.getKey.toString)
+          case _ =>
+            logger.warn(s"failed to get populate suggestions for field [$field] and term [$text]")
+            Seq.empty[String]
         }
-      } else {
-        Seq.empty[String] // getSuggestion(suggestionName) returned null
-      }
+        Future(buckets)
+
+      case Failure(ex) =>
+        logger.warn(s"failed to get populate suggestions for field [$field] and term [$text]: ${ex.getMessage}")
+        Future(Seq.empty[String])
     }
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ElasticSearch.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ElasticSearch.scala
@@ -62,7 +62,7 @@ object ESType extends ESPropertyFields {
       else
         Map("sort" -> ESInnerField(`type`))) ++
       (if (isAggregatable) Map("keyword" -> keywordField(`type`)) else Nil) ++
-      (if (hasPopulateSuggest) Map("suggest" -> completionField) else Nil)
+      (if (hasPopulateSuggest) Map("suggestKeyword" -> keywordField(`type`)) else Nil)
     if (hasSearchSuggest)
       new ESType(`type`, Option(innerFields), Option(ElasticSearch.fieldSuggest))
     else


### PR DESCRIPTION
I was unhappy with the end-user functionality of my pr #537 ... that other PR could easily result in showing only a single suggestion to the end user, even when multiple suggestions exist. I totally rewrote the elasticsearch query to make the functionality better; here's my new PR.

Old behavior in #537: query ES for any document that matches the user's term (as a prefix), return the top 10 values, then `distinct` them in Scala. If the top 10 ES values all have the same value, this means that the result of `distinct` would be a single value.

New behavior in this PR: in the ES query, use a matchPhrasePrefix to filter to the set of documents that match the user's term (as a prefix). Then, still inside the ES query, use a terms aggregation to return the top 10 unique values. No post-processing in Scala.

*important*: this PR requires a full library reindex to work.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
