### PR TITLE
simple performance logging for developer goodness

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -15,6 +15,9 @@
         </filter>
     </appender>
 
+    <logger name="PerformanceLogging" level="warn" additivity="false">
+        <appender-ref ref="console"/>
+    </logger>
 
     <logger name="org.broadinstitute.dsde" level="info" additivity="false">
         <appender-ref ref="console"/>

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchDAOSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchDAOSupport.scala
@@ -7,6 +7,7 @@ import org.broadinstitute.dsde.firecloud.{FireCloudConfig, FireCloudException}
 import org.broadinstitute.dsde.firecloud.model._
 import org.broadinstitute.dsde.firecloud.model.ElasticSearch._
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
+import org.broadinstitute.dsde.firecloud.utils.PerformanceLogging
 import org.elasticsearch.action.{ActionRequest, ActionRequestBuilder, ActionResponse}
 import org.elasticsearch.client.transport.TransportClient
 import org.elasticsearch.common.settings.Settings
@@ -17,7 +18,7 @@ import spray.json._
 
 import scala.util.{Failure, Success, Try}
 
-trait ElasticSearchDAOSupport extends LazyLogging {
+trait ElasticSearchDAOSupport extends LazyLogging with PerformanceLogging {
 
 
 
@@ -27,9 +28,10 @@ trait ElasticSearchDAOSupport extends LazyLogging {
     val elapsed = System.currentTimeMillis - tick
     responseTry match {
       case Success(s) =>
-        logger.debug(s"ElasticSearch %s request succeeded in %s ms.".format(req.getClass.getName, elapsed))
+        perfLogger.info(perfmsg(req.getClass.getSimpleName, elapsed, "success"))
         s
       case Failure(f) =>
+        perfLogger.info(perfmsg(req.getClass.getSimpleName, elapsed, "failure"))
         logger.warn(s"ElasticSearch %s request failed in %s ms: %s".format(req.getClass.getName, elapsed, f.getMessage))
         throw new FireCloudException("ElasticSearch request failed", f)
     }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchDAOSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchDAOSupport.scala
@@ -3,17 +3,12 @@ package org.broadinstitute.dsde.firecloud.dataaccess
 import java.net.InetAddress
 
 import com.typesafe.scalalogging.LazyLogging
-import org.broadinstitute.dsde.firecloud.{FireCloudConfig, FireCloudException}
+import org.broadinstitute.dsde.firecloud.FireCloudException
 import org.broadinstitute.dsde.firecloud.model._
 import org.broadinstitute.dsde.firecloud.model.ElasticSearch._
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
 import org.broadinstitute.dsde.firecloud.utils.PerformanceLogging
 import org.elasticsearch.action.{ActionRequest, ActionRequestBuilder, ActionResponse}
-import org.elasticsearch.client.transport.TransportClient
-import org.elasticsearch.common.settings.Settings
-import org.elasticsearch.common.transport.InetSocketTransportAddress
-import org.elasticsearch.transport.client.PreBuiltTransportClient
-import spray.http.Uri.Authority
 import spray.json._
 
 import scala.util.{Failure, Success, Try}

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpRawlsDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpRawlsDAO.scala
@@ -62,13 +62,13 @@ class HttpRawlsDAO( implicit val system: ActorSystem, implicit val executionCont
   }
 
   override def getGroupsForUser(implicit userToken: WithAccessToken): Future[Seq[String]] =
-    authedRequestToObject[Seq[String]]( Get(rawlsGroupsForUserUrl) )
+    authedRequestToObject[Seq[String]]( Get(rawlsGroupsForUserUrl), label=Some("HttpRawlsDAO.getGroupsForUser") )
 
   override def getBucketUsage(ns: String, name: String)(implicit userInfo: WithAccessToken): Future[BucketUsageResponse] =
     authedRequestToObject[BucketUsageResponse]( Get(rawlsBucketUsageUrl(ns, name)) )
 
   override def getWorkspaces(implicit userInfo: WithAccessToken): Future[Seq[WorkspaceListResponse]] =
-    authedRequestToObject[Seq[WorkspaceListResponse]] ( Get(rawlsWorkpacesUrl))
+    authedRequestToObject[Seq[WorkspaceListResponse]] ( Get(rawlsWorkpacesUrl), label=Some("HttpRawlsDAO.getWorkspaces") )
 
   override def getWorkspace(ns: String, name: String)(implicit userToken: WithAccessToken): Future[WorkspaceResponse] =
     authedRequestToObject[WorkspaceResponse]( Get(getWorkspaceUrl(ns, name)) )
@@ -133,7 +133,7 @@ class HttpRawlsDAO( implicit val system: ActorSystem, implicit val executionCont
   private def workspaceCatalogUrl(ns: String, name: String) = FireCloudConfig.Rawls.authUrl + FireCloudConfig.Rawls.workspacesPath + s"/%s/%s/catalog".format(ns, name)
 
   override def getRefreshTokenStatus(userInfo: UserInfo): Future[Option[DateTime]] = {
-    userAuthedRequest(Get(RawlsDAO.refreshTokenDateUrl))(userInfo) map { response =>
+    userAuthedRequest(Get(RawlsDAO.refreshTokenDateUrl), label=Some("HttpRawlsDAO.getRefreshTokenStatus"))(userInfo) map { response =>
       response.status match {
         case OK =>
           Option(DateTime.parse(unmarshal[RawlsTokenDate].apply(response).refreshTokenUpdatedDate))

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/utils/PerformanceLogging.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/utils/PerformanceLogging.scala
@@ -1,0 +1,13 @@
+package org.broadinstitute.dsde.firecloud.utils
+
+import com.typesafe.scalalogging.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+trait PerformanceLogging {
+
+  val perfLogger: Logger = Logger(LoggerFactory.getLogger("PerformanceLogging"))
+
+  def perfmsg(caller: String, time: Long) =              s"[$caller] took [$time]"
+  def perfmsg(caller: String, time: Long, msg: String) = s"[$caller] took [$time]: $msg"
+
+}

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/utils/PerformanceLogging.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/utils/PerformanceLogging.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.dsde.firecloud.utils
 
-import com.typesafe.scalalogging.slf4j.Logger
+import com.typesafe.scalalogging.Logger
 import org.slf4j.LoggerFactory
 
 trait PerformanceLogging {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/utils/PerformanceLogging.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/utils/PerformanceLogging.scala
@@ -7,7 +7,7 @@ trait PerformanceLogging {
 
   val perfLogger: Logger = Logger(LoggerFactory.getLogger("PerformanceLogging"))
 
-  def perfmsg(caller: String, time: Long) =              s"[$caller] took [$time]"
-  def perfmsg(caller: String, time: Long, msg: String) = s"[$caller] took [$time]: $msg"
+  def perfmsg(caller: String, time: Long) =              s"[$caller] took [$time] ms"
+  def perfmsg(caller: String, time: Long, msg: String) = s"[$caller] took [$time] ms: $msg"
 
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/utils/RestJsonClient.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/utils/RestJsonClient.scala
@@ -19,22 +19,24 @@ import scala.concurrent.{ExecutionContext, Future}
 /**
   * Created by davidan on 10/7/16.
   */
-trait RestJsonClient extends FireCloudRequestBuilding {
+trait RestJsonClient extends FireCloudRequestBuilding with PerformanceLogging {
   implicit val system: ActorSystem
   implicit val executionContext: ExecutionContext
 
-  def unAuthedRequest(req: HttpRequest, compressed: Boolean = false, useFireCloudHeader: Boolean = false, connector: Option[ActorRef] = None): Future[HttpResponse] = {
+  def unAuthedRequest(req: HttpRequest, compressed: Boolean = false, useFireCloudHeader: Boolean = false, connector: Option[ActorRef] = None, label: Option[String] = None): Future[HttpResponse] = {
     implicit val userInfo:WithAccessToken = null
-    doRequest(None)(req, compressed, useFireCloudHeader, connector)
+    doRequest(None)(req, compressed, useFireCloudHeader, connector, label)
   }
 
-  def userAuthedRequest(req: HttpRequest, compressed: Boolean = false, useFireCloudHeader: Boolean = false, connector: Option[ActorRef] = None)(implicit userInfo: WithAccessToken): Future[HttpResponse] =
-    doRequest(Option(addCredentials(userInfo.accessToken)))(req, compressed, useFireCloudHeader, connector)
+  def userAuthedRequest(req: HttpRequest, compressed: Boolean = false, useFireCloudHeader: Boolean = false, connector: Option[ActorRef] = None, label: Option[String] = None)(implicit userInfo: WithAccessToken): Future[HttpResponse] =
+    doRequest(Option(addCredentials(userInfo.accessToken)))(req, compressed, useFireCloudHeader, connector, label)
 
-  def adminAuthedRequest(req: HttpRequest, compressed: Boolean = false, useFireCloudHeader: Boolean = false, connector: Option[ActorRef] = None): Future[HttpResponse] =
-    doRequest(Option(addAdminCredentials))(req, compressed, useFireCloudHeader, connector)
+  def adminAuthedRequest(req: HttpRequest, compressed: Boolean = false, useFireCloudHeader: Boolean = false, connector: Option[ActorRef] = None, label: Option[String] = None): Future[HttpResponse] =
+    doRequest(Option(addAdminCredentials))(req, compressed, useFireCloudHeader, connector, label)
 
-  private def doRequest(addCreds: Option[RequestTransformer])(req: HttpRequest, compressed: Boolean = false, useFireCloudHeader: Boolean = false, connector: Option[ActorRef] = None): Future[HttpResponse] = {
+  private def doRequest(addCreds: Option[RequestTransformer])(req: HttpRequest, compressed: Boolean = false, useFireCloudHeader: Boolean = false, connector: Option[ActorRef] = None, label: Option[String] = None): Future[HttpResponse] = {
+    val tick = if (label.nonEmpty) System.currentTimeMillis() else -1
+
     val sr = if (connector.isDefined) {
       sendReceive(connector.get)(executionContext, futureTimeout = 60.seconds)
     } else {
@@ -49,33 +51,49 @@ trait RestJsonClient extends FireCloudRequestBuilding {
     }
 
     val finalPipeline = addCreds.map(creds => creds ~> pipeline).getOrElse(pipeline)
-    finalPipeline(req)
+    finalPipeline(req) map { res =>
+      if (label.nonEmpty && tick != -1) {
+        val elapsed = System.currentTimeMillis() - tick
+        perfLogger.info(perfmsg(label.get, elapsed))
+      }
+
+      res
+    }
   }
 
-  def authedRequestToObject[T](req: HttpRequest, compressed: Boolean = false, useFireCloudHeader: Boolean = false, connector: Option[ActorRef] = None)(implicit userInfo: WithAccessToken, unmarshaller: Unmarshaller[T], ers: ErrorReportSource): Future[T] = {
-    requestToObject(true, req, compressed, useFireCloudHeader, connector)
+  def authedRequestToObject[T](req: HttpRequest, compressed: Boolean = false, useFireCloudHeader: Boolean = false, connector: Option[ActorRef] = None, label: Option[String] = None)(implicit userInfo: WithAccessToken, unmarshaller: Unmarshaller[T], ers: ErrorReportSource): Future[T] = {
+    requestToObject(true, req, compressed, useFireCloudHeader, connector, label)
   }
 
-  def unAuthedRequestToObject[T](req: HttpRequest, compressed: Boolean = false, useFireCloudHeader: Boolean = false, connector: Option[ActorRef] = None)(implicit unmarshaller: Unmarshaller[T], ers: ErrorReportSource): Future[T] = {
+  def unAuthedRequestToObject[T](req: HttpRequest, compressed: Boolean = false, useFireCloudHeader: Boolean = false, connector: Option[ActorRef] = None, label: Option[String] = None)(implicit unmarshaller: Unmarshaller[T], ers: ErrorReportSource): Future[T] = {
     implicit val userInfo:WithAccessToken = null
-    requestToObject(false, req, compressed, useFireCloudHeader, connector)
+    requestToObject(false, req, compressed, useFireCloudHeader, connector, label)
   }
 
+  // zero usages in the codebase
   def adminAuthedRequestToObject[T](req:HttpRequest, compressed: Boolean = false, useFireCloudHeader: Boolean = false)(implicit unmarshaller: Unmarshaller[T], ers: ErrorReportSource): Future[T] = {
     resultsToObject(adminAuthedRequest(req, compressed, useFireCloudHeader))
   }
 
-  def requestToObject[T](auth: Boolean, req: HttpRequest, compressed: Boolean = false, useFireCloudHeader: Boolean = false, connector: Option[ActorRef] = None)(implicit userInfo: WithAccessToken, unmarshaller: Unmarshaller[T], ers: ErrorReportSource): Future[T] = {
+  private def requestToObject[T](auth: Boolean, req: HttpRequest, compressed: Boolean = false, useFireCloudHeader: Boolean = false, connector: Option[ActorRef] = None, label: Option[String] = None)(implicit userInfo: WithAccessToken, unmarshaller: Unmarshaller[T], ers: ErrorReportSource): Future[T] = {
+    val tick = if (label.nonEmpty) System.currentTimeMillis() else -1
+
     val resp = if(auth) {
       userAuthedRequest(req, compressed, useFireCloudHeader, connector)
     } else {
       unAuthedRequest(req, compressed, useFireCloudHeader, connector)
     }
-    resultsToObject(resp)
+    resultsToObject(resp, label, tick)
   }
 
-  def resultsToObject[T](resp: Future[HttpResponse])(implicit unmarshaller: Unmarshaller[T], ers: ErrorReportSource): Future[T] = {
+  private def resultsToObject[T](resp: Future[HttpResponse], label: Option[String] = None, tick: Long = -1)(implicit unmarshaller: Unmarshaller[T], ers: ErrorReportSource): Future[T] = {
     resp map { response =>
+
+      if (label.nonEmpty && tick != -1) {
+        val elapsed = System.currentTimeMillis() - tick
+        perfLogger.info(perfmsg(label.get, elapsed))
+      }
+
       response.status match {
         case s if s.isSuccess =>
           response.entity.as[T] match {


### PR DESCRIPTION
No jira. Quick and dirty utility for developer goodness. Not meant to be a comprehensive instrumentation suite, nor something we can use to analyze performance of our prod systems. Purely meant to help individual developers during development.

Also not meant to work everywhere in the orch codebase - it'll work for a bunch of cases, though. Going for incremental improvement.

To use:
1. in logback.xml, set the PerformanceLogging loglevel to info.
2. make requests in library
3. view your console output

if you want to "instrument" your own requests, make sure they have a label set - see HttpRawlsDAO for examples.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [x] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
