### PR TITLE
scalalogging -> scala-logging

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,7 +17,7 @@ object Dependencies {
     "org.apache.logging.log4j"       % "log4j-to-slf4j"      % "2.8.2", // ... but we redirect log4j to logback.
     "ch.qos.logback"                 % "logback-classic"     % "1.2.2",
     "com.getsentry.raven"            % "raven-logback"       % "7.8.6",
-    "com.typesafe.scala-logging"    %% "scala-logging-slf4j" % "2.1.2",
+    "com.typesafe.scala-logging"    %% "scala-logging"       % "3.7.2",
 
     "org.broadinstitute.dsde.vault" %% "vault-common"        % "0.1-19-ca8b927",
     "org.broadinstitute.dsde"       %% "rawls-model"         % "0.1-aab4976-SNAP"

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/EntityClient.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/EntityClient.scala
@@ -4,7 +4,7 @@ import java.text.SimpleDateFormat
 
 import akka.actor.{Actor, Props}
 import akka.pattern.pipe
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.EntityClient._
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudApp.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudApp.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.firecloud
 
 import scala.concurrent.duration._
 import akka.actor.{ActorSystem, Props}
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.vault.common.util.ServerInitializer
 
 object FireCloudApp extends LazyLogging {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchDAOResearchPurposeSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchDAOResearchPurposeSupport.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.dsde.firecloud.dataaccess
 
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.model.DataUse.{DiseaseOntologyNodeId, ResearchPurpose}
 import org.broadinstitute.dsde.firecloud.model.Ontology.{TermParent, TermResource}
 import org.broadinstitute.dsde.firecloud.service.DataUseRestrictionSupport

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchDAOSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchDAOSupport.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.firecloud.dataaccess
 
 import java.net.InetAddress
 
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.{FireCloudConfig, FireCloudException}
 import org.broadinstitute.dsde.firecloud.model._
 import org.broadinstitute.dsde.firecloud.model.ElasticSearch._

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpOntologyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpOntologyDAO.scala
@@ -4,7 +4,7 @@ import akka.actor.{ActorRef, ActorSystem}
 import akka.io.IO
 import akka.pattern.ask
 import akka.util.Timeout
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
 import org.broadinstitute.dsde.firecloud.model.Ontology.TermResource
 import org.broadinstitute.dsde.firecloud.model.SubsystemStatus

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/RawlsDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/RawlsDAO.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.dsde.firecloud.dataaccess
 
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.FireCloudConfig
 import org.broadinstitute.dsde.firecloud.model._
 import org.broadinstitute.dsde.rawls.model._

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/SamDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/SamDAO.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.dsde.firecloud.dataaccess
 
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.FireCloudConfig
 import org.broadinstitute.dsde.firecloud.model.{RegistrationInfo, SubsystemStatus, UserInfo, WithAccessToken}
 import org.broadinstitute.dsde.rawls.model.ErrorReportSource

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/SearchDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/SearchDAO.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.dsde.firecloud.dataaccess
 
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.model._
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
 import org.broadinstitute.dsde.rawls.model.ErrorReportSource

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ThurloeDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ThurloeDAO.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.dsde.firecloud.dataaccess
 
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.model.Trial.UserTrialStatus
 import org.broadinstitute.dsde.firecloud.model.{BasicProfile, Profile, UserInfo}
 import org.broadinstitute.dsde.rawls.model.ErrorReportSource

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupport.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.dsde.firecloud.service
 
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.model.DataUse.DiseaseOntologyNodeId
 import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport.AttributeNameFormat
 import org.broadinstitute.dsde.rawls.model._

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/ExportEntitiesByTypeActor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/ExportEntitiesByTypeActor.scala
@@ -7,7 +7,7 @@ import akka.stream._
 import akka.stream.scaladsl._
 import akka.util.{ByteString, Timeout}
 import better.files.File
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.dataaccess.RawlsDAO
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
 import org.broadinstitute.dsde.firecloud.model.{UserInfo, _}

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/LibraryService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/LibraryService.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.firecloud.service
 
 import akka.actor.{Actor, Props}
 import akka.pattern._
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.{Application, FireCloudConfig, FireCloudException, FireCloudExceptionWithErrorReport}
 import org.broadinstitute.dsde.firecloud.dataaccess.{OntologyDAO, RawlsDAO, SearchDAO}
 import org.broadinstitute.dsde.rawls.model._

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/LibraryServiceSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/LibraryServiceSupport.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.dsde.firecloud.service
 
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.FireCloudConfig
 import org.broadinstitute.dsde.firecloud.dataaccess.{OntologyDAO, RawlsDAO}
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/NihService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/NihService.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.firecloud.service
 
 import akka.actor.{Actor, ActorRefFactory, Props}
 import akka.pattern._
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.{Application, FireCloudConfig, FireCloudExceptionWithErrorReport}
 import org.broadinstitute.dsde.firecloud.dataaccess.{GoogleServicesDAO, RawlsDAO, ThurloeDAO}
 import org.broadinstitute.dsde.firecloud.model._

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/OAuthService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/OAuthService.scala
@@ -10,7 +10,7 @@ import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport
 import com.google.api.client.json.jackson2.JacksonFactory
 import com.google.api.services.compute.ComputeScopes
 import com.google.api.services.storage.StorageScopes
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.dataaccess.{RawlsDAO, ThurloeDAO}
 import org.broadinstitute.dsde.firecloud.model.UserInfo
 import org.broadinstitute.dsde.firecloud.service.OAuthService.{GetRefreshTokenStatus, HandleOauthCode}

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/OntologyService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/OntologyService.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.firecloud.service
 
 import akka.actor.{Actor, Props}
 import akka.pattern._
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.Application
 import org.broadinstitute.dsde.firecloud.dataaccess.OntologyDAO
 import org.broadinstitute.dsde.firecloud.service.OntologyService.AutocompleteOntology

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/PermissionReportService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/PermissionReportService.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.firecloud.service
 
 import akka.actor.{Actor, Props}
 import akka.pattern._
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.{Application, FireCloudExceptionWithErrorReport}
 import org.broadinstitute.dsde.firecloud.core.AgoraPermissionHandler
 import org.broadinstitute.dsde.firecloud.dataaccess.{AgoraDAO, RawlsDAO}

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/RegisterService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/RegisterService.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.firecloud.service
 
 import akka.actor.{Actor, Props}
 import akka.pattern._
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.{Application, FireCloudExceptionWithErrorReport}
 import org.broadinstitute.dsde.firecloud.dataaccess.{RawlsDAO, SamDAO, ThurloeDAO}
 import org.broadinstitute.dsde.firecloud.model._

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/TrialService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/TrialService.scala
@@ -5,7 +5,7 @@ import java.time.temporal.ChronoUnit
 
 import akka.actor.{Actor, Props}
 import akka.pattern._
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.{Application, FireCloudConfig}
 import org.broadinstitute.dsde.firecloud.dataaccess.{SamDAO, ThurloeDAO}
 import org.broadinstitute.dsde.firecloud.model.Trial.{TrialStates, UserTrialStatus}

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/utils/StreamingActor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/utils/StreamingActor.scala
@@ -1,7 +1,7 @@
 package org.broadinstitute.dsde.firecloud.utils
 
 import akka.actor.{Actor, Props}
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.utils.StreamingActor._
 import spray.http.{ContentType, _}
 import spray.routing.RequestContext

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/CookieAuthedApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/CookieAuthedApiService.scala
@@ -1,7 +1,7 @@
 package org.broadinstitute.dsde.firecloud.webservice
 
 import akka.actor.Props
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.dataaccess.HttpGoogleServicesDAO
 import org.broadinstitute.dsde.firecloud.model.UserInfo
 import org.broadinstitute.dsde.firecloud.service._

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/ExportEntitiesApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/ExportEntitiesApiService.scala
@@ -1,7 +1,7 @@
 package org.broadinstitute.dsde.firecloud.webservice
 
 import akka.actor.Props
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.service.{ExportEntitiesByTypeActor, ExportEntitiesByTypeArguments, FireCloudDirectives, FireCloudRequestBuilding}
 import org.broadinstitute.dsde.firecloud.utils.StandardUserInfoDirectives
 import spray.routing.{HttpService, Route}

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpOntologyDAOConcurrencySpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpOntologyDAOConcurrencySpec.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.firecloud.dataaccess
 
 import akka.actor.ActorSystem
 import com.typesafe.config.ConfigFactory
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.mock.MockUtils
 import org.broadinstitute.dsde.firecloud.mock.MockUtils._
 import org.mockserver.integration.ClientAndServer

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/AutoSuggestSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/AutoSuggestSpec.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.dsde.firecloud.integrationtest
 
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.dataaccess.ElasticSearchDAOQuerySupport
 import org.broadinstitute.dsde.firecloud.integrationtest.ESIntegrationSupport._
 import org.scalatest.{BeforeAndAfterAll, FreeSpec, Ignore, Matchers}

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/OntologySearchSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/OntologySearchSpec.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.dsde.firecloud.integrationtest
 
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.integrationtest.ESIntegrationSupport._
 import org.scalatest.{BeforeAndAfterAll, FreeSpec, Ignore, Matchers}
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/ResearchPurposeSearchSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/ResearchPurposeSearchSpec.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.dsde.firecloud.integrationtest
 
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.integrationtest.ESIntegrationSupport.searchDAO
 import org.broadinstitute.dsde.firecloud.model.DataUse.{DiseaseOntologyNodeId, ResearchPurpose}
 import org.scalatest.{BeforeAndAfterAll, FreeSpec, Matchers}

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/ResearchPurposeSearchUseCasesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/ResearchPurposeSearchUseCasesSpec.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.dsde.firecloud.integrationtest
 
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.integrationtest.ESIntegrationSupport.searchDAO
 import org.broadinstitute.dsde.firecloud.model.DataUse.{DiseaseOntologyNodeId, ResearchPurpose}
 import org.broadinstitute.dsde.firecloud.model.LibrarySearchResponse

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/SortSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/SortSpec.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.dsde.firecloud.integrationtest
 
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.integrationtest.ESIntegrationSupport._
 import org.broadinstitute.dsde.firecloud.model.{LibrarySearchParams, LibrarySearchResponse}
 import org.scalatest.{BeforeAndAfterAll, FreeSpec, Ignore, Matchers}

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/TextSearchSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/TextSearchSpec.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.dsde.firecloud.integrationtest
 
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.integrationtest.ESIntegrationSupport._
 import org.scalatest.{BeforeAndAfterAll, FreeSpec, Ignore, Matchers}
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/MethodsApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/MethodsApiServiceSpec.scala
@@ -1,7 +1,7 @@
 package org.broadinstitute.dsde.firecloud.webservice
 
 import akka.actor.ActorSystem
-import com.typesafe.scalalogging.slf4j.LazyLogging
+import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.mock.MockUtils
 import org.broadinstitute.dsde.firecloud.service.ServiceSpec
 import org.mockserver.integration.ClientAndServer


### PR DESCRIPTION
no jira.

upgrade scalalogging (https://github.com/typesafehub/scalalogging) to scala-logging (https://github.com/typesafehub/scala-logging). This amounts to a prereq to adopting the HealthMonitor in orchestration - HealthMonitor uses the newer scala-logging and orch used the old scalalogging, and we shouldn't have both in the same app.

Lots of files touched, but it's just an import that changes.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [x] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
