### PR TITLE
GAWB-2858: health monitor

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -22,7 +22,7 @@ object Dependencies {
     "org.broadinstitute.dsde.vault" %% "vault-common"        % "0.1-19-ca8b927",
     "org.broadinstitute.dsde"       %% "rawls-model"         % "0.1-aab4976-SNAP"
       exclude("com.typesafe.scala-logging", "scala-logging_2.11"),
-    "org.broadinstitute.dsde.workbench" %% "workbench-util"  % "0.2-dcca21f",
+    "org.broadinstitute.dsde.workbench" %% "workbench-util"  % "0.2-0b34b93",
 
     "io.spray"                      %% "spray-can"           % sprayV,
     "io.spray"                      %% "spray-routing"       % sprayV,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -22,6 +22,7 @@ object Dependencies {
     "org.broadinstitute.dsde.vault" %% "vault-common"        % "0.1-19-ca8b927",
     "org.broadinstitute.dsde"       %% "rawls-model"         % "0.1-aab4976-SNAP"
       exclude("com.typesafe.scala-logging", "scala-logging_2.11"),
+    "org.broadinstitute.dsde.workbench" %% "workbench-util"  % "0.2-dcca21f",
 
     "io.spray"                      %% "spray-can"           % sprayV,
     "io.spray"                      %% "spray-routing"       % sprayV,

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/Application.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/Application.scala
@@ -21,14 +21,13 @@ case class Application(agoraDAO: AgoraDAO,
 
   def healthMonitorChecks: Map[Subsystem, Future[SubsystemStatus]] = Map(
     Agora -> agoraDAO.status,
+    Consent -> consentDAO.status,
     GoogleBuckets -> googleServicesDAO.status,
+    LibraryIndex -> searchDAO.status,
+    OntologyIndex -> ontologyDAO.status,
+    Rawls -> rawlsDAO.status,
     Sam -> samDAO.status,
     Thurloe -> thurloeDAO.status
-    // TODO: add the following subsystems
-    // Rawls
-    // LibraryIndex
-    // Consent
-    // OntologyIndex
   )
 
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/Application.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/Application.scala
@@ -1,18 +1,34 @@
 package org.broadinstitute.dsde.firecloud
 
 import org.broadinstitute.dsde.firecloud.dataaccess._
+import org.broadinstitute.dsde.workbench.util.health.SubsystemStatus
+import org.broadinstitute.dsde.workbench.util.health.Subsystems._
+
+import scala.concurrent.Future
 
 /**
   * Created by davidan on 9/23/16.
   */
 
-case class Application (agoraDAO: AgoraDAO,
-                   googleServicesDAO: GoogleServicesDAO,
-                   ontologyDAO: OntologyDAO,
-                   consentDAO: ConsentDAO,
-                   rawlsDAO: RawlsDAO,
-                   samDAO: SamDAO,
-                   searchDAO: SearchDAO,
-                   thurloeDAO: ThurloeDAO) {
+case class Application(agoraDAO: AgoraDAO,
+                       googleServicesDAO: GoogleServicesDAO,
+                       ontologyDAO: OntologyDAO,
+                       consentDAO: ConsentDAO,
+                       rawlsDAO: RawlsDAO,
+                       samDAO: SamDAO,
+                       searchDAO: SearchDAO,
+                       thurloeDAO: ThurloeDAO) {
+
+  def healthMonitorChecks: Map[Subsystem, Future[SubsystemStatus]] = Map(
+    Agora -> agoraDAO.status,
+    GoogleBuckets -> googleServicesDAO.status,
+    Sam -> samDAO.status,
+    Thurloe -> thurloeDAO.status
+    // TODO: add the following subsystems
+    // Rawls
+    // LibraryIndex
+    // Consent
+    // OntologyIndex
+  )
 
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudServiceActor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudServiceActor.scala
@@ -10,9 +10,13 @@ import spray.http._
 import spray.routing.{HttpServiceActor, Route}
 import org.broadinstitute.dsde.firecloud.service._
 import org.broadinstitute.dsde.firecloud.webservice._
+import org.broadinstitute.dsde.workbench.util.health.{HealthMonitor, SubsystemStatus}
+import org.broadinstitute.dsde.workbench.util.health.Subsystems._
 import org.elasticsearch.client.transport.TransportClient
 
+import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 import scala.language.postfixOps
 
 
@@ -54,6 +58,20 @@ class FireCloudServiceActor extends HttpServiceActor with FireCloudDirectives
   val app:Application = new Application(agoraDAO, googleServicesDAO, ontologyDAO, consentDAO, rawlsDAO, samDAO, searchDAO, thurloeDAO)
   val materializer: ActorMaterializer = ActorMaterializer()
 
+  val healthMonitorChecks: Map[Subsystem, Future[SubsystemStatus]] = Map(
+    Agora -> agoraDAO.status,
+    GoogleBuckets -> googleServicesDAO.status,
+    Sam -> samDAO.status,
+    Thurloe -> thurloeDAO.status
+    // TODO: add the following subsystems
+    // Rawls
+    // LibraryIndex
+    // Consent
+    // OntologyIndex
+  )
+  val healthMonitor = system.actorOf(HealthMonitor.props(healthMonitorChecks.keySet)( () => healthMonitorChecks ), "health-monitor")
+  system.scheduler.schedule(10.seconds, 1.minute, healthMonitor, HealthMonitor.CheckAll)
+
   val exportEntitiesByTypeConstructor: (ExportEntitiesByTypeArguments) => ExportEntitiesByTypeActor = ExportEntitiesByTypeActor.constructor(app, materializer)
   val libraryServiceConstructor: (UserInfo) => LibraryService = LibraryService.constructor(app)
   val ontologyServiceConstructor: () => OntologyService = OntologyService.constructor(app)
@@ -63,7 +81,7 @@ class FireCloudServiceActor extends HttpServiceActor with FireCloudDirectives
   val registerServiceConstructor: () => RegisterService = RegisterService.constructor(app)
   val storageServiceConstructor: (UserInfo) => StorageService = StorageService.constructor(app)
   val workspaceServiceConstructor: (WithAccessToken) => WorkspaceService = WorkspaceService.constructor(app)
-  val statusServiceConstructor: () => StatusService = StatusService.constructor(app)
+  val statusServiceConstructor: () => StatusService = StatusService.constructor(healthMonitor)
   val permissionReportServiceConstructor: (UserInfo) => PermissionReportService = PermissionReportService.constructor(app)
   val trialServiceConstructor: () => TrialService = TrialService.constructor(app)
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudServiceActor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudServiceActor.scala
@@ -58,17 +58,7 @@ class FireCloudServiceActor extends HttpServiceActor with FireCloudDirectives
   val app:Application = new Application(agoraDAO, googleServicesDAO, ontologyDAO, consentDAO, rawlsDAO, samDAO, searchDAO, thurloeDAO)
   val materializer: ActorMaterializer = ActorMaterializer()
 
-  val healthMonitorChecks: Map[Subsystem, Future[SubsystemStatus]] = Map(
-    Agora -> agoraDAO.status,
-    GoogleBuckets -> googleServicesDAO.status,
-    Sam -> samDAO.status,
-    Thurloe -> thurloeDAO.status
-    // TODO: add the following subsystems
-    // Rawls
-    // LibraryIndex
-    // Consent
-    // OntologyIndex
-  )
+  val healthMonitorChecks = app.healthMonitorChecks
   val healthMonitor = system.actorOf(HealthMonitor.props(healthMonitorChecks.keySet)( () => healthMonitorChecks ), "health-monitor")
   system.scheduler.schedule(10.seconds, 1.minute, healthMonitor, HealthMonitor.CheckAll)
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudServiceActor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudServiceActor.scala
@@ -60,7 +60,7 @@ class FireCloudServiceActor extends HttpServiceActor with FireCloudDirectives
 
   val healthMonitorChecks = app.healthMonitorChecks
   val healthMonitor = system.actorOf(HealthMonitor.props(healthMonitorChecks.keySet)( () => healthMonitorChecks ), "health-monitor")
-  system.scheduler.schedule(10.seconds, 1.minute, healthMonitor, HealthMonitor.CheckAll)
+  system.scheduler.schedule(3.seconds, 1.minute, healthMonitor, HealthMonitor.CheckAll)
 
   val exportEntitiesByTypeConstructor: (ExportEntitiesByTypeArguments) => ExportEntitiesByTypeActor = ExportEntitiesByTypeActor.constructor(app, materializer)
   val libraryServiceConstructor: (UserInfo) => LibraryService = LibraryService.constructor(app)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchDAO.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.dsde.firecloud.dataaccess
 
 import org.broadinstitute.dsde.firecloud.model._
 import org.broadinstitute.dsde.firecloud.service.LibraryService
+import org.broadinstitute.dsde.workbench.util.health.SubsystemStatus
 import org.elasticsearch.action.admin.indices.create.{CreateIndexRequest, CreateIndexRequestBuilder, CreateIndexResponse}
 import org.elasticsearch.action.admin.indices.delete.{DeleteIndexRequest, DeleteIndexRequestBuilder, DeleteIndexResponse}
 import org.elasticsearch.action.admin.indices.exists.indices.{IndicesExistsRequest, IndicesExistsRequestBuilder, IndicesExistsResponse}

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchOntologyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchOntologyDAO.scala
@@ -1,12 +1,12 @@
 package org.broadinstitute.dsde.firecloud.dataaccess
 import org.broadinstitute.dsde.firecloud.model.Ontology.TermResource
-import org.broadinstitute.dsde.firecloud.model.SubsystemStatus
 import org.elasticsearch.action.admin.indices.exists.indices.{IndicesExistsRequest, IndicesExistsRequestBuilder, IndicesExistsResponse}
 import org.elasticsearch.action.search.{SearchRequest, SearchRequestBuilder, SearchResponse}
 import org.elasticsearch.client.transport.TransportClient
 import org.elasticsearch.index.query.QueryBuilders._
 import spray.json._
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol.impOntologyTermResource
+import org.broadinstitute.dsde.workbench.util.health.SubsystemStatus
 import org.elasticsearch.action.get.{GetRequest, GetRequestBuilder, GetResponse}
 
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/GoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/GoogleServicesDAO.scala
@@ -3,8 +3,9 @@ package org.broadinstitute.dsde.firecloud.dataaccess
 import java.io.InputStream
 
 import akka.actor.ActorRefFactory
-import org.broadinstitute.dsde.firecloud.model.{ObjectMetadata, SubsystemStatus}
+import org.broadinstitute.dsde.firecloud.model.ObjectMetadata
 import org.broadinstitute.dsde.rawls.model.ErrorReportSource
+import org.broadinstitute.dsde.workbench.util.health.SubsystemStatus
 import spray.http.HttpResponse
 import spray.routing.RequestContext
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpAgoraDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpAgoraDAO.scala
@@ -4,8 +4,9 @@ import akka.actor.ActorSystem
 import org.broadinstitute.dsde.firecloud.FireCloudConfig
 import org.broadinstitute.dsde.firecloud.model.MethodRepository.{AgoraEntityType, AgoraPermission, EntityAccessControlAgora, Method}
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
-import org.broadinstitute.dsde.firecloud.model.{AgoraStatus, SubsystemStatus, UserInfo}
+import org.broadinstitute.dsde.firecloud.model.{AgoraStatus, UserInfo}
 import org.broadinstitute.dsde.firecloud.utils.RestJsonClient
+import org.broadinstitute.dsde.workbench.util.health.SubsystemStatus
 import spray.http.Uri
 import spray.httpx.SprayJsonSupport._
 import spray.json.DefaultJsonProtocol._
@@ -38,7 +39,7 @@ class HttpAgoraDAO(config: FireCloudConfig.Agora.type)(implicit val system: Acto
 
     agoraStatus map { agoraStatus =>
       agoraStatus.status match {
-        case "up" => SubsystemStatus(ok = true)
+        case "up" => SubsystemStatus(ok = true, None)
         case _ => SubsystemStatus(ok = false, if (agoraStatus.message.nonEmpty) Some(agoraStatus.message) else None)
       }
     }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpConsentDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpConsentDAO.scala
@@ -2,8 +2,8 @@ package org.broadinstitute.dsde.firecloud.dataaccess
 
 import akka.actor.ActorSystem
 import org.broadinstitute.dsde.firecloud.FireCloudConfig
-import org.broadinstitute.dsde.firecloud.model.SubsystemStatus
 import org.broadinstitute.dsde.firecloud.utils.RestJsonClient
+import org.broadinstitute.dsde.workbench.util.health.SubsystemStatus
 import spray.http.{HttpResponse, Uri}
 
 import scala.concurrent.{ExecutionContext, Future}

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
@@ -10,9 +10,10 @@ import org.broadinstitute.dsde.firecloud.model.ErrorReportExtensions.FCErrorRepo
 import org.broadinstitute.dsde.firecloud.{FireCloudConfig, FireCloudExceptionWithErrorReport}
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol.impGoogleObjectMetadata
 import org.broadinstitute.dsde.rawls.model.{ErrorReport, ErrorReportSource}
-import org.broadinstitute.dsde.firecloud.model.{OAuthUser, ObjectMetadata, SubsystemStatus}
+import org.broadinstitute.dsde.firecloud.model.{OAuthUser, ObjectMetadata}
 import org.broadinstitute.dsde.firecloud.service.FireCloudRequestBuilding
 import org.broadinstitute.dsde.firecloud.utils.RestJsonClient
+import org.broadinstitute.dsde.workbench.util.health.SubsystemStatus
 import org.slf4j.LoggerFactory
 import spray.client.pipelining._
 import spray.http.StatusCodes._

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpOntologyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpOntologyDAO.scala
@@ -7,9 +7,9 @@ import akka.util.Timeout
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
 import org.broadinstitute.dsde.firecloud.model.Ontology.TermResource
-import org.broadinstitute.dsde.firecloud.model.SubsystemStatus
 import org.broadinstitute.dsde.firecloud.utils.RestJsonClient
 import org.broadinstitute.dsde.firecloud.{FireCloudConfig, FireCloudException}
+import org.broadinstitute.dsde.workbench.util.health.SubsystemStatus
 import spray.can.Http
 import spray.http.{HttpResponse, Uri}
 import spray.httpx.SprayJsonSupport._

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpRawlsDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpRawlsDAO.scala
@@ -10,6 +10,7 @@ import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations._
 import org.broadinstitute.dsde.rawls.model.StatusJsonSupport._
 import org.broadinstitute.dsde.rawls.model.WorkspaceACLJsonSupport._
 import org.broadinstitute.dsde.rawls.model.{StatusCheckResponse => RawlsStatus, SubsystemStatus => RawlsSubsystemStatus, _}
+import org.broadinstitute.dsde.workbench.util.health.SubsystemStatus
 import org.joda.time.DateTime
 import spray.client.pipelining._
 import spray.http.StatusCodes._

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpSamDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpSamDAO.scala
@@ -2,7 +2,8 @@ package org.broadinstitute.dsde.firecloud.dataaccess
 
 import akka.actor.ActorSystem
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
-import org.broadinstitute.dsde.firecloud.model._
+import org.broadinstitute.dsde.firecloud.model.{RegistrationInfo, WithAccessToken}
+import org.broadinstitute.dsde.workbench.util.health.SubsystemStatus
 import org.broadinstitute.dsde.firecloud.utils.RestJsonClient
 import spray.client.pipelining.{Get, sendReceive}
 import spray.httpx.SprayJsonSupport._
@@ -27,7 +28,7 @@ class HttpSamDAO( implicit val system: ActorSystem, implicit val executionContex
     val pipeline = sendReceive
     pipeline(Get(samStatusUrl)) map { response =>
       val ok = response.status.isSuccess
-      SubsystemStatus(ok, if (ok) Option(List(response.entity.asString)) else None)
+      SubsystemStatus(ok, if (!ok) Option(List(response.entity.asString)) else None)
     }
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpThurloeDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpThurloeDAO.scala
@@ -8,6 +8,7 @@ import org.broadinstitute.dsde.firecloud.utils.RestJsonClient
 import org.broadinstitute.dsde.firecloud.webservice.UserApiService
 import org.broadinstitute.dsde.firecloud.{FireCloudConfig, FireCloudException, FireCloudExceptionWithErrorReport}
 import org.broadinstitute.dsde.rawls.model.ErrorReport
+import org.broadinstitute.dsde.workbench.util.health.SubsystemStatus
 import spray.client.pipelining._
 import spray.http._
 import spray.httpx.SprayJsonSupport._
@@ -88,7 +89,7 @@ class HttpThurloeDAO ( implicit val system: ActorSystem, implicit val executionC
     val thurloeStatus = unAuthedRequestToObject[ThurloeStatus](Get(Uri(FireCloudConfig.Thurloe.baseUrl).withPath(Uri.Path("/status"))), useFireCloudHeader = true)
     thurloeStatus map { thurloeStatus =>
       thurloeStatus.status match {
-        case "up" => SubsystemStatus(ok = true)
+        case "up" => SubsystemStatus(ok = true, None)
         case "down" => SubsystemStatus(ok = false, thurloeStatus.error.map(List(_)))
       }
     }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ReportsSubsystemStatus.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ReportsSubsystemStatus.scala
@@ -1,8 +1,8 @@
 package org.broadinstitute.dsde.firecloud.dataaccess
 
-import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
-import org.broadinstitute.dsde.firecloud.model.{DropwizardHealth, SubsystemStatus}
-import org.broadinstitute.dsde.rawls.model.ErrorReportSource
+import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol.impDropwizardHealth
+import org.broadinstitute.dsde.firecloud.model.DropwizardHealth
+import org.broadinstitute.dsde.workbench.util.health.SubsystemStatus
 import spray.http.HttpResponse
 import spray.json.DefaultJsonProtocol._
 import spray.json._
@@ -26,7 +26,7 @@ trait ReportsSubsystemStatus {
         filter(dw => !dw._2.healthy).
         map(dw => s"Error in ${dw._1}: ${dw._2.message.getOrElse("unspecified error")}").toList
       if (ok)
-        SubsystemStatus(ok)
+        SubsystemStatus(ok, None)
       else
         SubsystemStatus(ok, Some(errors))
     }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/SamDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/SamDAO.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.firecloud.dataaccess
 
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.FireCloudConfig
-import org.broadinstitute.dsde.firecloud.model.{RegistrationInfo, SubsystemStatus, UserInfo, WithAccessToken}
+import org.broadinstitute.dsde.firecloud.model.{RegistrationInfo, UserInfo, WithAccessToken}
 import org.broadinstitute.dsde.rawls.model.ErrorReportSource
 
 import scala.concurrent.Future

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
@@ -240,8 +240,6 @@ object ModelJsonProtocol extends WorkspaceJsonSupport {
   implicit val impOntologyTermResource = jsonFormat7(TermResource)
   implicit val impOntologyESTermParent = jsonFormat2(ESTermParent)
 
-  implicit val impSubsystemStatus = jsonFormat2(SubsystemStatus)
-  implicit val impSystemStatus = jsonFormat2(SystemStatus)
   implicit val impAgoraStatus = jsonFormat2(AgoraStatus)
   implicit val impThurloeStatus = jsonFormat2(ThurloeStatus)
   implicit val impDropwizardHealth = jsonFormat2(DropwizardHealth)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/SystemStatus.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/SystemStatus.scala
@@ -3,8 +3,6 @@ package org.broadinstitute.dsde.firecloud.model
 /**
   * Created by anichols on 4/7/17.
   */
-case class SystemStatus(ok: Boolean, systems: Map[String, SubsystemStatus])
-case class SubsystemStatus(ok: Boolean, messages: Option[List[String]] = None)
 case class AgoraStatus(status: String, message: List[String])
 case class ThurloeStatus(status: String, error: Option[String])
 case class DropwizardHealth(healthy: Boolean, message: Option[String])

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/StatusService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/StatusService.scala
@@ -29,8 +29,7 @@ object StatusService {
 
 class StatusService (val healthMonitor: ActorRef)
                     (implicit protected val executionContext: ExecutionContext) extends Actor with SprayJsonSupport {
-  implicit val timeout = Timeout(1.minute)
-
+  implicit val timeout = Timeout(1.minute) // timeout for the ask to healthMonitor for GetCurrentStatus
 
   override def receive: Receive = {
     case CollectStatusInfo => collectStatusInfo() pipeTo sender

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/StatusService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/StatusService.scala
@@ -1,17 +1,18 @@
 package org.broadinstitute.dsde.firecloud.service
 
-import akka.actor.{Actor, Props}
+import akka.actor.{Actor, ActorRef, Props}
 import akka.pattern._
-import org.broadinstitute.dsde.firecloud.dataaccess.ReportsSubsystemStatus
-import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol.impSystemStatus
-import org.broadinstitute.dsde.firecloud.model.{SubsystemStatus, SystemStatus}
+import akka.util.Timeout
 import org.broadinstitute.dsde.firecloud.service.PerRequest.{PerRequestMessage, RequestComplete}
 import org.broadinstitute.dsde.firecloud.service.StatusService.CollectStatusInfo
-import org.broadinstitute.dsde.firecloud.{Application, FireCloudException, FireCloudExceptionWithErrorReport}
+import org.broadinstitute.dsde.workbench.util.health.HealthMonitor.GetCurrentStatus
+import org.broadinstitute.dsde.workbench.util.health.StatusCheckResponse
+import org.broadinstitute.dsde.workbench.util.health.StatusJsonSupport.StatusCheckResponseFormat
 import spray.http.StatusCodes
 import spray.httpx.SprayJsonSupport
 
 import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.duration._
 
 /**
  * Created by anichols on 4/5/17.
@@ -19,45 +20,26 @@ import scala.concurrent.{ExecutionContext, Future}
 object StatusService {
   def props(statusServiceConstructor: () => StatusService): Props = Props(statusServiceConstructor())
 
-  def constructor(app: Application)()(implicit executionContext: ExecutionContext): StatusService = {
-    new StatusService(app)
+  def constructor(healthMonitor: ActorRef)()(implicit executionContext: ExecutionContext): StatusService = {
+    new StatusService(healthMonitor)
   }
 
   case class CollectStatusInfo()
 }
 
-class StatusService (val app: Application)
+class StatusService (val healthMonitor: ActorRef)
                     (implicit protected val executionContext: ExecutionContext) extends Actor with SprayJsonSupport {
+  implicit val timeout = Timeout(1.minute)
+
 
   override def receive: Receive = {
     case CollectStatusInfo => collectStatusInfo() pipeTo sender
   }
 
   def collectStatusInfo(): Future[PerRequestMessage] = {
-
-    val subsystemExceptionHandler: PartialFunction[Any, SubsystemStatus] = {
-      case fcExceptionWithError: FireCloudExceptionWithErrorReport => SubsystemStatus(ok = false, Some(List(fcExceptionWithError.errorReport.message)))
-      case fcException: FireCloudException => SubsystemStatus(ok = false, Some(List(fcException.getMessage)))
-      case t: Throwable => SubsystemStatus(ok = false, Some(List(t.getMessage)))
-      case x: Any => SubsystemStatus(ok = false, Some(List(x.toString)))
-    }
-
-    val daoList = List[ReportsSubsystemStatus](app.rawlsDAO, app.thurloeDAO, app.agoraDAO, app.searchDAO, app.consentDAO, app.ontologyDAO, app.googleServicesDAO, app.samDAO)
-    val futureStatusList: List[Future[(String, SubsystemStatus)]] = daoList map { dao =>
-      dao.status.map { status =>
-        dao.serviceName -> status
-      }.recover {
-        case t:Throwable => dao.serviceName -> subsystemExceptionHandler(t)
-      }
-    }
-    Future.sequence(futureStatusList).
-      map { fsl => fsl.toMap }.
-      map { statusMap =>
-        if (statusMap.values.forall(_.ok))
-          RequestComplete(SystemStatus(ok = true, statusMap))
-        else
-          RequestComplete(StatusCodes.InternalServerError, SystemStatus(ok = false, statusMap))
+    (healthMonitor ? GetCurrentStatus).mapTo[StatusCheckResponse].map { statusCheckResponse =>
+      val httpStatus = if (statusCheckResponse.ok) StatusCodes.OK else StatusCodes.InternalServerError
+      RequestComplete(httpStatus, statusCheckResponse)
     }
   }
-
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/StatusApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/StatusApiService.scala
@@ -14,8 +14,9 @@ trait StatusApiService extends HttpService with PerRequestCreator with FireCloud
 
   val statusRoutes: Route = {
     path("status") {
-      requestContext =>
+      get { requestContext =>
         perRequest(requestContext, StatusService.props(statusServiceConstructor), StatusService.CollectStatusInfo)
+      }
     }
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockAgoraDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockAgoraDAO.scala
@@ -30,7 +30,7 @@ class MockAgoraDAO extends AgoraDAO {
   }
 
   def status: Future[SubsystemStatus] = {
-    Future(throw new Exception("Agora Mock DAO exception"))
+    Future(SubsystemStatus(ok = true, None))
   }
 
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockAgoraDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockAgoraDAO.scala
@@ -1,7 +1,8 @@
 package org.broadinstitute.dsde.firecloud.dataaccess
 
 import org.broadinstitute.dsde.firecloud.model.MethodRepository.{ACLNames, AgoraPermission, EntityAccessControlAgora, Method}
-import org.broadinstitute.dsde.firecloud.model.{SubsystemStatus, UserInfo}
+import org.broadinstitute.dsde.firecloud.model.UserInfo
+import org.broadinstitute.dsde.workbench.util.health.SubsystemStatus
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockConsentDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockConsentDAO.scala
@@ -1,12 +1,12 @@
 package org.broadinstitute.dsde.firecloud.dataaccess
 
-import org.broadinstitute.dsde.firecloud.model.SubsystemStatus
-import scala.concurrent.ExecutionContext.Implicits.global
+import org.broadinstitute.dsde.workbench.util.health.SubsystemStatus
 
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 class MockConsentDAO extends ConsentDAO {
 
-  def status: Future[SubsystemStatus] = Future(SubsystemStatus(ok = true))
+  def status: Future[SubsystemStatus] = Future(SubsystemStatus(ok = true, None))
 
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockOntologyDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockOntologyDAO.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.dsde.firecloud.dataaccess
 import org.broadinstitute.dsde.firecloud.model.Ontology.{TermParent, TermResource}
-import org.broadinstitute.dsde.firecloud.model.SubsystemStatus
+import org.broadinstitute.dsde.workbench.util.health.SubsystemStatus
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -236,7 +236,7 @@ class MockOntologyDAO extends OntologyDAO {
 
   override def search(term: String): List[TermResource] = data.getOrElse(term, List.empty[TermResource])
 
-  def status: Future[SubsystemStatus] = Future(SubsystemStatus(ok = true))
+  def status: Future[SubsystemStatus] = Future(SubsystemStatus(ok = true, None))
 
   override def autocomplete(term: String) = List.empty[TermResource]
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockRawlsDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockRawlsDAO.scala
@@ -9,6 +9,7 @@ import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.AttributeUp
 import org.joda.time.DateTime
 import spray.http.StatusCodes
 import MockRawlsDAO._
+import org.broadinstitute.dsde.workbench.util.health.SubsystemStatus
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -356,7 +357,7 @@ class MockRawlsDAO  extends RawlsDAO {
   override def getMethodConfigs(workspaceNamespace: String, workspaceName: String)(implicit userToken: WithAccessToken) =
     Future.successful(Seq.empty[MethodConfigurationShort])
 
-  def status: Future[SubsystemStatus] = Future(SubsystemStatus(true))
+  def status: Future[SubsystemStatus] = Future(SubsystemStatus(true, None))
 
   def deleteWorkspace(workspaceNamespace: String, workspaceName: String)(implicit userToken: WithAccessToken): Future[WorkspaceDeleteResponse] = {
     Future.successful(WorkspaceDeleteResponse(Some("Your Google bucket 'bucketId' will be deleted within 24h.")))

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockSamDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockSamDAO.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.firecloud.dataaccess
-import org.broadinstitute.dsde.firecloud.model.{RegistrationInfo, SubsystemStatus, UserInfo, WithAccessToken, WorkbenchEnabled, WorkbenchUserInfo}
+import org.broadinstitute.dsde.firecloud.model.{RegistrationInfo, UserInfo, WithAccessToken, WorkbenchEnabled, WorkbenchUserInfo}
+import org.broadinstitute.dsde.workbench.util.health.SubsystemStatus
 
 import scala.concurrent.Future
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockSearchDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockSearchDAO.scala
@@ -1,6 +1,7 @@
 package org.broadinstitute.dsde.firecloud.dataaccess
 
 import org.broadinstitute.dsde.firecloud.model._
+import org.broadinstitute.dsde.workbench.util.health.SubsystemStatus
 import spray.json.JsValue
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -56,6 +57,6 @@ class MockSearchDAO extends SearchDAO {
     populateSuggestInvoked = false
   }
 
-  def status: Future[SubsystemStatus] = Future(SubsystemStatus(ok = true))
+  def status: Future[SubsystemStatus] = Future(SubsystemStatus(ok = true, None))
 
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockThurloeDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockThurloeDAO.scala
@@ -3,8 +3,9 @@ package org.broadinstitute.dsde.firecloud.dataaccess
 import java.util.NoSuchElementException
 
 import org.broadinstitute.dsde.firecloud.model.Trial.{TrialStates, UserTrialStatus}
-import org.broadinstitute.dsde.firecloud.model.{BasicProfile, FireCloudKeyValue, Profile, ProfileWrapper, SubsystemStatus, Trial, UserInfo}
+import org.broadinstitute.dsde.firecloud.model.{BasicProfile, FireCloudKeyValue, Profile, ProfileWrapper, Trial, UserInfo}
 import org.broadinstitute.dsde.firecloud.utils.DateUtils
+import org.broadinstitute.dsde.workbench.util.health.SubsystemStatus
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -121,7 +122,7 @@ class MockThurloeDAO extends ThurloeDAO {
     Future.successful(userValuesForKey)
   }
 
-  def status: Future[SubsystemStatus] = Future(SubsystemStatus(ok = true))
+  def status: Future[SubsystemStatus] = Future(SubsystemStatus(ok = true, None))
 
   override def getTrialStatus(userInfo: UserInfo) = Future.successful(Some(
     UserTrialStatus(userInfo.id, Some(TrialStates.Terminated), 0, 0, 0, 0

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockGoogleServicesDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockGoogleServicesDAO.scala
@@ -4,7 +4,8 @@ import java.io.{ByteArrayInputStream, InputStream}
 
 import akka.actor.ActorRefFactory
 import org.broadinstitute.dsde.firecloud.dataaccess._
-import org.broadinstitute.dsde.firecloud.model.{ObjectMetadata, SubsystemStatus}
+import org.broadinstitute.dsde.firecloud.model.ObjectMetadata
+import org.broadinstitute.dsde.workbench.util.health.SubsystemStatus
 import spray.http.HttpResponse
 import spray.routing.RequestContext
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/StatusApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/StatusApiServiceSpec.scala
@@ -1,312 +1,67 @@
 package org.broadinstitute.dsde.firecloud.service
 
-import java.io.IOException
-
-import akka.actor.ActorSystem
-import org.broadinstitute.dsde.firecloud.dataaccess._
-import org.broadinstitute.dsde.firecloud.mock.{MockGoogleServicesDAO, MockUtils}
-import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol.impSystemStatus
-import org.broadinstitute.dsde.firecloud.model.{SubsystemStatus, SystemStatus}
 import org.broadinstitute.dsde.firecloud.webservice.StatusApiService
-import org.broadinstitute.dsde.firecloud.{Application, FireCloudConfig, FireCloudException, FireCloudExceptionWithErrorReport}
-import org.broadinstitute.dsde.rawls.model.ErrorReport
-import org.mockserver.integration.ClientAndServer
-import org.mockserver.integration.ClientAndServer.startClientAndServer
-import org.mockserver.model.HttpRequest.request
-import org.mockserver.model.HttpResponse.response
-import org.mockserver.model.{HttpRequest, HttpResponse}
-import org.scalatest.BeforeAndAfter
-import spray.http.StatusCodes.{InternalServerError, OK}
+import org.broadinstitute.dsde.workbench.util.health.{HealthMonitor, StatusCheckResponse}
+import org.broadinstitute.dsde.workbench.util.health.StatusJsonSupport.StatusCheckResponseFormat
+import org.broadinstitute.dsde.workbench.util.health.Subsystems._
+import spray.http.HttpMethods.GET
+import spray.http.StatusCodes.OK
+
 import spray.httpx.SprayJsonSupport._
-import spray.routing.HttpService
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.duration._
 
-object StatusApiServiceSpec {
-  val numberOfStatusServices = 8
-}
 
-// Typically, the BaseServiceSpec provides an `app: Application` member that has all Mock DAOs.
-// In the following tests, we want to send some requests through to mocked endpoints create a new
-// Application with the customized DAOs
-class StatusApiServiceUpSpec extends BaseServiceSpec with HttpService with StatusApiService with BeforeAndAfter with StatusApiServiceMockDAOsServers {
+/*  We don't do much testing of the HealthMonitor itself, because that's tested as part of
+    workbench-libs. Here, we test routing, de/serialization, and the config we send into
+    the HealthMonitor.
+ */
+class StatusApiServiceSpec extends BaseServiceSpec with StatusApiService {
 
-  def actorRefFactory: ActorSystem = system
+  def actorRefFactory = system
 
-  val customApp = Application(agoraDAO, googleServicesUpDAO, ontologyDAO, consentDAO, rawlsDAO, samDAO, searchUpDAO, thurloeDAO)
-  val statusServiceConstructor: () => StatusService = StatusService.constructor(customApp)
+  val healthMonitorChecks = app.healthMonitorChecks
+  val healthMonitor = system.actorOf(HealthMonitor.props(healthMonitorChecks.keySet)( () => healthMonitorChecks ), "health-monitor")
+  val monitorSchedule = system.scheduler.schedule(Duration.Zero, 1.second, healthMonitor, HealthMonitor.CheckAll)
 
-  override def beforeAll(): Unit = startAll()
+  override def beforeAll = {
+    // wait for the healthMonitor to start up ...
+    Thread.sleep(3000)
+  }
 
-  override def afterAll(): Unit = stopAll()
+  override def afterAll = {
+    monitorSchedule.cancel
+  }
 
-  "StatusApiServicePositiveSpec" - {
-    "When all services are functional" - {
-      "StatusService indicates OK" in {
-        mockAllUp()
-        Get("/status") ~> sealRoute(statusRoutes) ~> check {
-          status.intValue should be(OK.intValue)
-          val statusResponse = responseAs[SystemStatus]
-          statusResponse.ok should be(true)
-          statusResponse.systems(GoogleServicesDAO.serviceName).ok should be(true)
-          statusResponse.systems(AgoraDAO.serviceName).ok should be(true)
-          statusResponse.systems(ThurloeDAO.serviceName).ok should be(true)
-          statusResponse.systems(RawlsDAO.serviceName).ok should be(true)
-          statusResponse.systems(SearchDAO.serviceName).ok should be(true)
-          statusResponse.systems(OntologyDAO.serviceName).ok should be(true)
-          statusResponse.systems(ConsentDAO.serviceName).ok should be(true)
-          statusResponse.systems(SamDAO.serviceName).ok should be(true)
-          statusResponse.systems.size should be(StatusApiServiceSpec.numberOfStatusServices)
+  override val statusServiceConstructor: () => StatusService = StatusService.constructor(healthMonitor)
+
+  val statusPath = "/status"
+
+  "Status endpoint" - {
+    allHttpMethodsExcept(GET) foreach { method =>
+      s"should reject ${method.toString} method" in {
+        new RequestBuilder(method)(statusPath) ~> statusRoutes ~> check {
+          assert(!handled)
         }
       }
     }
-  }
-}
-
-class StatusApiServiceDownSpec extends BaseServiceSpec with HttpService with StatusApiService with StatusApiServiceMockDAOsServers {
-
-  def actorRefFactory: ActorSystem = system
-
-  val customApp = Application(agoraDAO, googleServicesDownDAO, ontologyDAO, consentDAO, rawlsDAO, samDAO, searchDownDAO, thurloeDAO)
-  val statusServiceConstructor: () => StatusService = StatusService.constructor(customApp)
-
-  override def beforeAll(): Unit = startAll()
-
-  override def afterAll(): Unit = stopAll()
-
-  "StatusApiServiceNegativeSpec" - {
-
-    "When all services are nonfunctional" - {
-      "StatusService indicates failures" in {
-        mockAllDown()
-        Get("/status") ~> sealRoute(statusRoutes) ~> check {
-          status.intValue should be(InternalServerError.intValue)
-          val statusResponse = responseAs[SystemStatus]
-          statusResponse.ok should be(false)
-          statusResponse.systems(GoogleServicesDAO.serviceName).ok should be(false)
-          statusResponse.systems(AgoraDAO.serviceName).ok should be(false)
-          statusResponse.systems(ThurloeDAO.serviceName).ok should be(false)
-          statusResponse.systems(RawlsDAO.serviceName).ok should be(false)
-          statusResponse.systems(SearchDAO.serviceName).ok should be(false)
-          statusResponse.systems(OntologyDAO.serviceName).ok should be(false)
-          statusResponse.systems(OntologyDAO.serviceName).messages shouldNot be(None)
-          statusResponse.systems(OntologyDAO.serviceName).messages.get.size should be(3)
-          statusResponse.systems(ConsentDAO.serviceName).ok should be(false)
-          statusResponse.systems(ConsentDAO.serviceName).messages shouldNot be(None)
-          statusResponse.systems(ConsentDAO.serviceName).messages.get.size should be(2)
-          statusResponse.systems(SamDAO.serviceName).ok should be(false)
-          statusResponse.systems.size should be(StatusApiServiceSpec.numberOfStatusServices)
-        }
+    "should return OK for an unauthenticated GET" in {
+      Get(statusPath) ~> statusRoutes ~> check {
+        assert(status == OK)
       }
     }
-
-    "When some services are nonfunctional and some are functional" - {
-      "StatusService indicates both successes and failures" in {
-        mockSomeUp()
-        Get("/status") ~> sealRoute(statusRoutes) ~> check {
-          status.intValue should be(InternalServerError.intValue)
-          val statusResponse = responseAs[SystemStatus]
-          statusResponse.ok should be(false)
-          statusResponse.systems(GoogleServicesDAO.serviceName).ok should be(false)
-          statusResponse.systems(AgoraDAO.serviceName).ok should be(false)
-          statusResponse.systems(ThurloeDAO.serviceName).ok should be(true)
-          statusResponse.systems(RawlsDAO.serviceName).ok should be(true)
-          statusResponse.systems(SearchDAO.serviceName).ok should be(false)
-          statusResponse.systems(OntologyDAO.serviceName).ok should be(false)
-          statusResponse.systems(ConsentDAO.serviceName).ok should be(true)
-          statusResponse.systems(SamDAO.serviceName).ok should be(true)
-          statusResponse.systems.size should be(StatusApiServiceSpec.numberOfStatusServices)
-        }
-      }
-
-    }
-  }
-}
-
-class StatusApiServiceExceptionSpec extends BaseServiceSpec with HttpService with StatusApiService with StatusApiServiceMockDAOsServers {
-
-  def actorRefFactory: ActorSystem = system
-  val customApp = Application(agoraExceptionDAO, googleServicesExceptionDAO, ontologyExceptionDAO, consentExceptionDAO, rawlsExceptionDAO, samExceptionDAO, searchExceptionDAO, thurloeExceptionDAO)
-  val statusServiceConstructor: () => StatusService = StatusService.constructor(customApp)
-
-  "StatusApiServiceExceptionSpec" - {
-    "When all services are nonfunctional" - {
-      "StatusService indicates failures" in {
-        Get("/status") ~> sealRoute(statusRoutes) ~> check {
-          status.intValue should be(InternalServerError.intValue)
-          val statusResponse = responseAs[SystemStatus]
-          statusResponse.ok should be(false)
-          statusResponse.systems(GoogleServicesDAO.serviceName).ok should be(false)
-          statusResponse.systems(AgoraDAO.serviceName).ok should be(false)
-          statusResponse.systems(ThurloeDAO.serviceName).ok should be(false)
-          statusResponse.systems(RawlsDAO.serviceName).ok should be(false)
-          statusResponse.systems(SearchDAO.serviceName).ok should be(false)
-          statusResponse.systems(OntologyDAO.serviceName).ok should be(false)
-          statusResponse.systems(ConsentDAO.serviceName).ok should be(false)
-          statusResponse.systems(SamDAO.serviceName).ok should be(false)
-          statusResponse.systems.size should be(StatusApiServiceSpec.numberOfStatusServices)
-        }
+    "should deserialize to a StatusCheckResponse" in {
+      Get(statusPath) ~> statusRoutes ~> check {
+        responseAs[StatusCheckResponse]
       }
     }
-  }
-}
-
-// Mock daos that return "DOWN"
-class MockGoogleServicesDownDAO(implicit val executionContext: ExecutionContext) extends MockGoogleServicesDAO {
-  override def status: Future[SubsystemStatus] = Future(SubsystemStatus(ok = false, messages = Some(List("Google is broken"))))
-}
-
-class MockSearchDownDAO(implicit val executionContext: ExecutionContext) extends MockSearchDAO {
-  override def status: Future[SubsystemStatus] = Future(SubsystemStatus(ok = false, messages = Some(List("ES is broken"))))
-}
-
-// Mock daos that throw exceptions
-class MockGoogleServicesExceptionDAO(implicit val executionContext: ExecutionContext) extends MockGoogleServicesDAO {
-  override def status: Future[SubsystemStatus] = Future.failed(new Exception("Exception: Google"))
-}
-
-class MockSearchExceptionDAO(implicit val executionContext: ExecutionContext) extends MockSearchDAO {
-  override def status: Future[SubsystemStatus] = Future.failed(new FireCloudException("Exception: Search"))
-}
-
-class MockAgoraExceptionDAO(implicit val executionContext: ExecutionContext) extends MockAgoraDAO {
-  override def status: Future[SubsystemStatus] = Future.failed(new FireCloudExceptionWithErrorReport(ErrorReport("Exception: Agora")))
-}
-
-class MockRawlsExceptionDAO(implicit val executionContext: ExecutionContext) extends MockRawlsDAO {
-  override def status: Future[SubsystemStatus] = Future.failed(new FireCloudException("Exception: Rawls"))
-}
-
-class MockSamExceptionDAO(implicit val executionContext: ExecutionContext) extends MockSamDAO {
-  override def status: Future[SubsystemStatus] = Future.failed(new FireCloudException("Exception: Sam"))
-}
-
-class MockThurloeExceptionDAO(implicit val executionContext: ExecutionContext) extends MockThurloeDAO {
-  override def status: Future[SubsystemStatus] = Future.failed(new FireCloudException("Exception: Thurloe"))
-}
-
-class MockOntologyExceptionDAO(implicit val executionContext: ExecutionContext) extends MockOntologyDAO {
-  override def status: Future[SubsystemStatus] = Future.failed(new IOException("Exception: Ontology"))
-}
-
-class MockConsentExceptionDAO(implicit val executionContext: ExecutionContext) extends MockConsentDAO {
-  override def status: Future[SubsystemStatus] = Future.failed(new FireCloudException("Exception: Consent"))
-}
-
-trait StatusApiServiceMockDAOsServers {
-
-  implicit val system: ActorSystem
-  import scala.concurrent.ExecutionContext.Implicits.global
-
-  /**
-    * Most DAOs can be mocked via mock-server since they make http calls to their respective "/status" endpoints.
-    * Google uses the google client to check for project access, so instead we mock out two versions
-    * of the DAOs, one for positive tests, one for negative/mixed tests.
-    * Similarly, ES uses a transport client, not the rest client, so we don't mock those either.
-    */
-  // Services that are "UP"
-  val googleServicesUpDAO:GoogleServicesDAO = new MockGoogleServicesDAO()
-  val searchUpDAO:SearchDAO = new MockSearchDAO()
-  val agoraDAO:AgoraDAO = new HttpAgoraDAO(FireCloudConfig.Agora)
-  val rawlsDAO:RawlsDAO = new HttpRawlsDAO
-  val samDAO:SamDAO = new HttpSamDAO
-  val thurloeDAO:ThurloeDAO = new HttpThurloeDAO
-  val ontologyDAO:OntologyDAO = new HttpOntologyDAO
-  val consentDAO:ConsentDAO = new HttpConsentDAO
-
-  // Services that are "DOWN"
-  val googleServicesDownDAO:GoogleServicesDAO = new MockGoogleServicesDownDAO()
-  val searchDownDAO:SearchDAO = new MockSearchDownDAO()
-
-  // Services that throw "EXCEPTION"
-  val googleServicesExceptionDAO:GoogleServicesDAO = new MockGoogleServicesExceptionDAO()
-  val agoraExceptionDAO:AgoraDAO = new MockAgoraExceptionDAO()
-  val rawlsExceptionDAO:RawlsDAO = new MockRawlsExceptionDAO()
-  val searchExceptionDAO:SearchDAO = new MockSearchExceptionDAO()
-  val thurloeExceptionDAO:ThurloeDAO = new MockThurloeExceptionDAO()
-  val ontologyExceptionDAO:OntologyDAO = new MockOntologyExceptionDAO()
-  val consentExceptionDAO:ConsentDAO = new MockConsentExceptionDAO()
-  val samExceptionDAO:SamDAO = new MockSamExceptionDAO()
-
-  // No need for a mocked google or search servers/responses
-  var agoraServer: ClientAndServer = _
-  var rawlsServer: ClientAndServer = _
-  var thurloeServer: ClientAndServer = _
-  var ontologyServer: ClientAndServer = _
-  var consentServer: ClientAndServer = _
-  var samServer: ClientAndServer = _
-
-  def startAll(): Unit = {
-    agoraServer = startClientAndServer(MockUtils.methodsServerPort)
-    rawlsServer = startClientAndServer(MockUtils.workspaceServerPort)
-    thurloeServer = startClientAndServer(MockUtils.thurloeServerPort)
-    ontologyServer = startClientAndServer(MockUtils.ontologyServerPort)
-    consentServer = startClientAndServer(MockUtils.consentServerPort)
-    samServer = startClientAndServer(MockUtils.samServerPort)
-  }
-
-  def resetAll(): Unit = {
-    agoraServer.reset()
-    rawlsServer.reset()
-    thurloeServer.reset()
-    ontologyServer.reset()
-    consentServer.reset()
-    samServer.reset()
-  }
-
-  def stopAll(): Unit = {
-    agoraServer.stop()
-    rawlsServer.stop()
-    thurloeServer.stop()
-    ontologyServer.stop()
-    consentServer.stop()
-    samServer.stop()
-  }
-
-  val statusRequest: HttpRequest = request().withMethod("GET").withPath("/status")
-
-  val agoraDown: HttpResponse = response().withHeaders(MockUtils.header).withStatusCode(500).withBody("""{ "status": "down", "message": ["Agora is down"] }""")
-  val rawlsDown: HttpResponse = response().withHeaders(MockUtils.header).withStatusCode(500).withBody("""{ "ok": false, "systems": {"GooglePubSub": {"ok": false, "message": ["PubSub is broken"]}, "GoogleGenomics": {"ok": true}, "Database": {"ok": true}, "Agora": {"ok": true}, "Sam": {"ok": true}, "GoogleGroups": {"ok": true}, "GoogleBilling": {"ok": true}, "Cromwell": {"ok": true}, "GoogleBuckets": {"ok": true}}}""")
-  val samDown: HttpResponse = response().withHeaders(MockUtils.header).withStatusCode(500).withBody("""{ "ok": false, "systems": {"OpenDJ": {"ok": false, "message": ["OpenDJ is broken"]}, "GoogleGroups": {"ok": true}}}""")
-  val thurloeDown: HttpResponse = response().withHeaders(MockUtils.header).withStatusCode(500).withBody("""{ "status": "down", "error": "Thurloe is down" }""")
-  val ontologyDown: HttpResponse = response().withHeaders(MockUtils.header).withStatusCode(500).withBody("""{"deadlocks":{"healthy":false},"elastic-search":{"healthy":false,"message":"ClusterHealth is RED"},"google-cloud-storage":{"healthy":false,"message":"Storage Service is unavailable"}}""")
-  val consentDown: HttpResponse = response().withHeaders(MockUtils.header).withStatusCode(500).withBody("""{"deadlocks":{"healthy":false},"elastic-search":{"healthy":false,"message":"ClusterHealth is RED"},"google-cloud-storage":{"healthy":true},"mongodb":{"healthy":true},"mysql":{"healthy":true}}""")
-
-  def mockAllDown(): Unit = {
-    resetAll()
-    agoraServer.when(statusRequest).respond(agoraDown)
-    rawlsServer.when(statusRequest).respond(rawlsDown)
-    thurloeServer.when(statusRequest).respond(thurloeDown)
-    ontologyServer.when(statusRequest).respond(ontologyDown)
-    consentServer.when(statusRequest).respond(consentDown)
-    samServer.when(statusRequest).respond(samDown)
-  }
-
-  val agoraUp: HttpResponse = response().withHeaders(MockUtils.header).withStatusCode(200).withBody("""{ "status": "up", "message": [] }""")
-  val rawlsUp: HttpResponse = response().withHeaders(MockUtils.header).withStatusCode(200).withBody("""{ "ok": true, "systems": {"GooglePubSub": {"ok": true}, "GoogleGenomics": {"ok": true}, "Database": {"ok": true}, "Agora": {"ok": true}, "Sam": {"ok": true}, "GoogleGroups": {"ok": true}, "GoogleBilling": {"ok": true}, "Cromwell": {"ok": true}, "GoogleBuckets": {"ok": true}}}""")
-  val samUp: HttpResponse = response().withHeaders(MockUtils.header).withStatusCode(200).withBody("""{ "ok": true, "systems": {"OpenDJ": {"ok": true}, "GoogleGroups": {"ok": true}}}""")
-  val thurloeUp: HttpResponse = response().withHeaders(MockUtils.header).withStatusCode(200).withBody("""{ "status": "up" }""")
-  val ontologyUp: HttpResponse = response().withHeaders(MockUtils.header).withStatusCode(200).withBody("""{"deadlocks":{"healthy":true},"elastic-search":{"healthy":true,"message":"ClusterHealth is GREEN"},"google-cloud-storage":{"healthy":true}}""")
-  val consentUp: HttpResponse = response().withHeaders(MockUtils.header).withStatusCode(200).withBody("""{"deadlocks":{"healthy":true},"elastic-search":{"healthy":true,"message":"ClusterHealth is GREEN"},"google-cloud-storage":{"healthy":true},"mongodb":{"healthy":true},"mysql":{"healthy":true}}""")
-
-  def mockAllUp(): Unit = {
-    resetAll()
-    agoraServer.when(statusRequest).respond(agoraUp)
-    rawlsServer.when(statusRequest).respond(rawlsUp)
-    thurloeServer.when(statusRequest).respond(thurloeUp)
-    ontologyServer.when(statusRequest).respond(ontologyUp)
-    consentServer.when(statusRequest).respond(consentUp)
-    samServer.when(statusRequest).respond(samUp)
-  }
-
-  def mockSomeUp(): Unit = {
-    resetAll()
-    agoraServer.when(statusRequest).respond(agoraDown)
-    rawlsServer.when(statusRequest).respond(rawlsUp)
-    thurloeServer.when(statusRequest).respond(thurloeUp)
-    ontologyServer.when(statusRequest).respond(ontologyDown)
-    consentServer.when(statusRequest).respond(consentUp)
-    samServer.when(statusRequest).respond(samUp)
+    "should contain all the subsystems we care about" in {
+      Get(statusPath) ~> statusRoutes ~> check {
+        val statusCheckResponse = responseAs[StatusCheckResponse]
+        val expectedSystems = Set(Agora, GoogleBuckets, Sam, Thurloe)
+        assertResult(expectedSystems) { statusCheckResponse.systems.keySet }
+      }
+    }
   }
 
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/StatusApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/StatusApiServiceSpec.scala
@@ -57,7 +57,7 @@ class StatusApiServiceSpec extends BaseServiceSpec with StatusApiService {
     "should contain all the subsystems we care about" in {
       Get(statusPath) ~> statusRoutes ~> check {
         val statusCheckResponse = responseAs[StatusCheckResponse]
-        val expectedSystems = Set(Agora, GoogleBuckets, Sam, Thurloe)
+        val expectedSystems = Set(Agora, Consent, GoogleBuckets, LibraryIndex, OntologyIndex, Rawls, Sam, Thurloe)
         assertResult(expectedSystems) { statusCheckResponse.systems.keySet }
       }
     }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/StatusApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/StatusApiServiceSpec.scala
@@ -1,12 +1,11 @@
-package org.broadinstitute.dsde.firecloud.service
+package org.broadinstitute.dsde.firecloud.webservice
 
-import org.broadinstitute.dsde.firecloud.webservice.StatusApiService
-import org.broadinstitute.dsde.workbench.util.health.{HealthMonitor, StatusCheckResponse}
+import org.broadinstitute.dsde.firecloud.service.{BaseServiceSpec, StatusService}
 import org.broadinstitute.dsde.workbench.util.health.StatusJsonSupport.StatusCheckResponseFormat
 import org.broadinstitute.dsde.workbench.util.health.Subsystems._
+import org.broadinstitute.dsde.workbench.util.health.{HealthMonitor, StatusCheckResponse}
 import spray.http.HttpMethods.GET
 import spray.http.StatusCodes.OK
-
 import spray.httpx.SprayJsonSupport._
 
 import scala.concurrent.duration._


### PR DESCRIPTION
Remove orchestration's bespoke health-check code, and adopt the HealthMonitor from workbench-libs. The main reason for this is to gain the HealthMonitor's execution-context isolation and its timeouts. Previously, the orchestration health checks operated in the same execution context as other runtime requests. Any failures in subsystems could - and did - negatively affect runtime performance.

There's a lot of lines of code that have simple changes due to moving from `o.b.d.firecloud.model.SubsystemStatus` to `o.b.d.workbench.util.health.SubsystemStatus`, especially because the latter has a different constructor signature.

Also resolves _GAWB-2513: error not handled correctly for failed google bucket access on status endpoint_.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [x] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
