### PR TITLE
GAWB-2912: free trial project-pool dao

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
@@ -141,6 +141,7 @@ object FireCloudConfig {
     val clusterName = elasticsearch.getString("clusterName")
     val indexName = elasticsearch.getString("index") // for library
     val ontologyIndexName = elasticsearch.getString("ontologyIndex")
+    val trialIndexName = elasticsearch.getString("trialIndex")
     val discoverGroupNames = elasticsearch.getStringList("discoverGroupNames")
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchTrialDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchTrialDAO.scala
@@ -1,9 +1,10 @@
 package org.broadinstitute.dsde.firecloud.dataaccess
 import org.broadinstitute.dsde.firecloud.FireCloudException
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol.impTrialProject
-import org.broadinstitute.dsde.firecloud.model.{SubsystemStatus, WorkbenchUserInfo}
+import org.broadinstitute.dsde.firecloud.model.WorkbenchUserInfo
 import org.broadinstitute.dsde.firecloud.model.Trial.TrialProject
 import org.broadinstitute.dsde.rawls.model.RawlsBillingProjectName
+import org.broadinstitute.dsde.workbench.util.health.SubsystemStatus
 import org.elasticsearch.action.admin.indices.exists.indices.{IndicesExistsRequest, IndicesExistsRequestBuilder, IndicesExistsResponse}
 import org.elasticsearch.action.get.{GetRequest, GetRequestBuilder, GetResponse}
 import org.elasticsearch.action.index.{IndexRequest, IndexRequestBuilder, IndexResponse}

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchTrialDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchTrialDAO.scala
@@ -1,0 +1,170 @@
+package org.broadinstitute.dsde.firecloud.dataaccess
+import org.broadinstitute.dsde.firecloud.FireCloudException
+import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol.impTrialProject
+import org.broadinstitute.dsde.firecloud.model.{SubsystemStatus, WorkbenchUserInfo}
+import org.broadinstitute.dsde.firecloud.model.Trial.TrialProject
+import org.broadinstitute.dsde.rawls.model.RawlsBillingProjectName
+import org.elasticsearch.action.admin.indices.exists.indices.{IndicesExistsRequest, IndicesExistsRequestBuilder, IndicesExistsResponse}
+import org.elasticsearch.action.index.{IndexRequest, IndexRequestBuilder, IndexResponse}
+import org.elasticsearch.action.search.{SearchRequest, SearchRequestBuilder, SearchResponse}
+import org.elasticsearch.action.support.WriteRequest.RefreshPolicy
+import org.elasticsearch.action.update.{UpdateRequest, UpdateRequestBuilder, UpdateResponse}
+import org.elasticsearch.client.transport.TransportClient
+import org.elasticsearch.common.xcontent.XContentType
+import org.elasticsearch.index.query.QueryBuilders._
+import org.elasticsearch.search.sort.SortOrder
+import spray.json._
+
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
+
+
+class ElasticSearchTrialDAO(client: TransportClient, indexName: String, refreshMode: RefreshPolicy = RefreshPolicy.NONE) extends TrialDAO with ElasticSearchDAOSupport {
+
+  lazy private final val datatype = "billingproject"
+
+  init // check for the presence of the index
+
+  private def getProjectInternal(projectName: RawlsBillingProjectName): (Long, TrialProject) = {
+    val verifyProjectQuery = termQuery("name.keyword", projectName.value)
+
+    val verifyProjectRequest = client
+      .prepareSearch(indexName)
+      .setQuery(verifyProjectQuery)
+      .addSort("name.keyword", SortOrder.ASC)
+      .setSize(1)
+      .setVersion(true)
+
+    val verifyProjectResponse = executeESRequest[SearchRequest, SearchResponse, SearchRequestBuilder](verifyProjectRequest)
+
+    if (verifyProjectResponse.getHits.totalHits == 0)
+      throw new FireCloudException(s"project ${projectName.value} not found!")
+
+    val hit = verifyProjectResponse.getHits.getAt(0)
+    val version = hit.getVersion
+    val project = verifyProjectResponse.getHits.getAt(0).getSourceAsString.parseJson.convertTo[TrialProject]
+
+    (version, project)
+  }
+
+  override def getProject(projectName: RawlsBillingProjectName): TrialProject = {
+    val (version, project) = getProjectInternal(projectName)
+    project
+  }
+
+  override def createProject(projectName: RawlsBillingProjectName): TrialProject = {
+    val trialProject = TrialProject(projectName)
+    val insert = client
+      .prepareIndex(indexName, datatype, projectName.value)
+      .setSource(trialProject.toJson.compactPrint, XContentType.JSON)
+      .setCreate(true) // fail the request if the project already exists
+      .setRefreshPolicy(refreshMode)
+
+    executeESRequest[IndexRequest, IndexResponse, IndexRequestBuilder](insert) // will throw error if insert fails
+    trialProject
+  }
+
+  override def verifyProject(projectName: RawlsBillingProjectName, verified: Boolean): TrialProject = {
+    val (version, project) = getProjectInternal(projectName)
+
+    if (project.verified == verified) {
+      project
+    } else {
+      val updatedProject = project.copy(verified = verified)
+      val update = client
+        .prepareUpdate(indexName, datatype, updatedProject.name.value)
+        .setDoc(updatedProject.toJson.compactPrint, XContentType.JSON)
+        .setVersion(version) // guarantee nobody else has updated in the meantime
+        .setRefreshPolicy(refreshMode)
+
+      executeESRequest[UpdateRequest, UpdateResponse, UpdateRequestBuilder](update) // will throw error if update fails
+      updatedProject
+    }
+  }
+
+  override def claimProject(userInfo: WorkbenchUserInfo): TrialProject = {
+    val nextProjectQuery = boolQuery()
+      .must(termQuery("verified", true))
+      .mustNot(existsQuery("user.userSubjectId.keyword"))
+
+    val nextProjectRequest = client
+      .prepareSearch(indexName)
+      .setQuery(nextProjectQuery)
+      .addSort("name.keyword", SortOrder.ASC)
+      .setSize(1)
+      .setVersion(true)
+
+    val nextProjectResponse = executeESRequest[SearchRequest, SearchResponse, SearchRequestBuilder](nextProjectRequest)
+
+    if (nextProjectResponse.getHits.totalHits == 0)
+      throw new FireCloudException("no available projects")
+
+    val hit = nextProjectResponse.getHits.getAt(0)
+    val version = hit.getVersion
+    val project = nextProjectResponse.getHits.getAt(0).getSourceAsString.parseJson.convertTo[TrialProject]
+    assert(project.user.isEmpty)
+
+    val updatedProject = project.copy(user = Some(userInfo))
+    val update = client
+      .prepareUpdate(indexName, datatype, updatedProject.name.value)
+      .setDoc(updatedProject.toJson.compactPrint, XContentType.JSON)
+      .setVersion(version) // guarantee nobody else has updated in the meantime
+      .setRefreshPolicy(refreshMode)
+
+    executeESRequest[UpdateRequest, UpdateResponse, UpdateRequestBuilder](update) // will throw error if update fails
+    updatedProject
+  }
+
+  override def countAvailableProjects: Long = {
+    val countProjectQuery = boolQuery()
+      .must(termQuery("verified", true))
+      .mustNot(existsQuery("user.userSubjectId.keyword"))
+
+    val countProjectRequest = client
+      .prepareSearch(indexName)
+      .setQuery(countProjectQuery)
+      .setSize(0)
+
+    val countProjectResponse = executeESRequest[SearchRequest, SearchResponse, SearchRequestBuilder](countProjectRequest)
+
+    countProjectResponse.getHits.totalHits
+  }
+
+  override def projectReport: Seq[TrialProject] = {
+    val reportProjectQuery = boolQuery()
+      .must(termQuery("verified", true))
+      .must(existsQuery("user.userSubjectId.keyword"))
+
+    val reportProjectRequest = client
+      .prepareSearch(indexName)
+      .setQuery(reportProjectQuery)
+      .addSort("name.keyword", SortOrder.ASC)
+      .setSize(1000)
+
+    val reportProjectResponse = executeESRequest[SearchRequest, SearchResponse, SearchRequestBuilder](reportProjectRequest)
+
+    if (reportProjectResponse.getHits.totalHits == 0)
+      Seq.empty[TrialProject]
+    else
+      reportProjectResponse.getHits.getHits.toSeq map ( _.getSourceAsString.parseJson.convertTo[TrialProject] )
+  }
+
+
+  private def indexExists: Boolean = {
+    executeESRequest[IndicesExistsRequest, IndicesExistsResponse, IndicesExistsRequestBuilder](
+      client.admin.indices.prepareExists(indexName)
+    ).isExists
+  }
+
+  override def status: Future[SubsystemStatus] = {
+    Future(SubsystemStatus(indexExists, None))
+  }
+
+  private def init: Unit = {
+    if (!indexExists)
+      throw new FireCloudException(s"index $indexName does not exist!")
+    if (refreshMode != RefreshPolicy.NONE)
+      logger.warn(s"refresh policy ${refreshMode.getValue} should only be used for testing")
+  }
+
+}

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchTrialDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchTrialDAO.scala
@@ -65,7 +65,7 @@ class ElasticSearchTrialDAO(client: TransportClient, indexName: String, refreshM
     * @param projectName name of the project record to read.
     * @return the project record
     */
-  override def getProject(projectName: RawlsBillingProjectName): TrialProject = {
+  override def getProjectRecord(projectName: RawlsBillingProjectName): TrialProject = {
     val (_, project) = getProjectInternal(projectName)
     project
   }
@@ -77,7 +77,7 @@ class ElasticSearchTrialDAO(client: TransportClient, indexName: String, refreshM
     * @param projectName name of the project to use when creating a record
     * @return the created project record
     */
-  override def createProject(projectName: RawlsBillingProjectName): TrialProject = {
+  override def insertProjectRecord(projectName: RawlsBillingProjectName): TrialProject = {
     val trialProject = TrialProject(projectName)
     val insert = client
       .prepareIndex(indexName, datatype, projectName.value)
@@ -98,7 +98,7 @@ class ElasticSearchTrialDAO(client: TransportClient, indexName: String, refreshM
     * @param verified verified value with which to update the project record
     * @return the updated project record
     */
-  override def verifyProject(projectName: RawlsBillingProjectName, verified: Boolean): TrialProject = {
+  override def setProjectRecordVerified(projectName: RawlsBillingProjectName, verified: Boolean): TrialProject = {
     val (version, project) = getProjectInternal(projectName)
 
     if (project.verified == verified) {
@@ -119,7 +119,7 @@ class ElasticSearchTrialDAO(client: TransportClient, indexName: String, refreshM
     * @param userInfo the user (email and subjectid) with which to update the project record.
     * @return the updated project record
     */
-  override def claimProject(userInfo: WorkbenchUserInfo): TrialProject = {
+  override def claimProjectRecord(userInfo: WorkbenchUserInfo): TrialProject = {
     val nextProjectQuery = boolQuery()
       .must(termQuery("verified", true))
       .mustNot(existsQuery("user.userSubjectId.keyword"))

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/TrialDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/TrialDAO.scala
@@ -13,11 +13,54 @@ trait TrialDAO extends ReportsSubsystemStatus with ElasticSearchDAOSupport {
   override def serviceName:String = TrialDAO.serviceName
   implicit val errorReportSource = ErrorReportSource(TrialDAO.serviceName)
 
+  /**
+    * Read the record for a specified project. Throws an error if record not found.
+    *
+    * @param projectName name of the project record to read.
+    * @return the project record
+    */
   def getProject(projectName: RawlsBillingProjectName): TrialProject
+
+  /**
+    * Create a record for the specified project. Throws error if name
+    * already exists or could not be otherwise created.
+    *
+    * @param projectName name of the project to use when creating a record
+    * @return the created project record
+    */
   def createProject(projectName: RawlsBillingProjectName): TrialProject
+
+  /**
+    * Update the "verified" field for a specified project record. The "verified" field indicates whether
+    * or not the associated billing project was created successfully in Google Cloud. Throws an error if
+    * the record was not found or the record could not be updated.
+    *
+    * @param projectName name of the project record to update
+    * @param verified verified value with which to update the project record
+    * @return the updated project record
+    */
   def verifyProject(projectName: RawlsBillingProjectName, verified: Boolean): TrialProject
+
+  /**
+    * Associates the next-available project record with a specified user. Definition of "next available"
+    * is deferred to impl classes. Throws an error if no project records are available, or if the project
+    * record could not be updated.
+    *
+    * @param userInfo the user (email and subjectid) with which to update the project record.
+    * @return the updated project record
+    */
   def claimProject(userInfo: WorkbenchUserInfo): TrialProject
+
+  /**
+    * Returns a count of available project records. Definition of "available" is deferred to impl classes.
+    * @return count of available project records.
+    */
   def countAvailableProjects: Long
+
+  /**
+    * Returns a list of project records that have associated users.
+    * @return list of project records that have associated users.
+    */
   def projectReport: Seq[TrialProject] // return a list of projects-to-users
 
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/TrialDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/TrialDAO.scala
@@ -1,0 +1,23 @@
+package org.broadinstitute.dsde.firecloud.dataaccess
+
+import org.broadinstitute.dsde.firecloud.model.Trial.TrialProject
+import org.broadinstitute.dsde.firecloud.model.WorkbenchUserInfo
+import org.broadinstitute.dsde.rawls.model.{ErrorReportSource, RawlsBillingProjectName}
+
+object TrialDAO {
+  lazy val serviceName = "TrialDAO"
+}
+
+trait TrialDAO extends ReportsSubsystemStatus with ElasticSearchDAOSupport {
+
+  override def serviceName:String = TrialDAO.serviceName
+  implicit val errorReportSource = ErrorReportSource(TrialDAO.serviceName)
+
+  def getProject(projectName: RawlsBillingProjectName): TrialProject
+  def createProject(projectName: RawlsBillingProjectName): TrialProject
+  def verifyProject(projectName: RawlsBillingProjectName, verified: Boolean): TrialProject
+  def claimProject(userInfo: WorkbenchUserInfo): TrialProject
+  def countAvailableProjects: Long
+  def projectReport: Seq[TrialProject] // return a list of projects-to-users
+
+}

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/TrialDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/TrialDAO.scala
@@ -19,7 +19,7 @@ trait TrialDAO extends ReportsSubsystemStatus with ElasticSearchDAOSupport {
     * @param projectName name of the project record to read.
     * @return the project record
     */
-  def getProject(projectName: RawlsBillingProjectName): TrialProject
+  def getProjectRecord(projectName: RawlsBillingProjectName): TrialProject
 
   /**
     * Create a record for the specified project. Throws error if name
@@ -28,7 +28,7 @@ trait TrialDAO extends ReportsSubsystemStatus with ElasticSearchDAOSupport {
     * @param projectName name of the project to use when creating a record
     * @return the created project record
     */
-  def createProject(projectName: RawlsBillingProjectName): TrialProject
+  def insertProjectRecord(projectName: RawlsBillingProjectName): TrialProject
 
   /**
     * Update the "verified" field for a specified project record. The "verified" field indicates whether
@@ -39,7 +39,7 @@ trait TrialDAO extends ReportsSubsystemStatus with ElasticSearchDAOSupport {
     * @param verified verified value with which to update the project record
     * @return the updated project record
     */
-  def verifyProject(projectName: RawlsBillingProjectName, verified: Boolean): TrialProject
+  def setProjectRecordVerified(projectName: RawlsBillingProjectName, verified: Boolean): TrialProject
 
   /**
     * Associates the next-available project record with a specified user. Definition of "next available"
@@ -49,7 +49,7 @@ trait TrialDAO extends ReportsSubsystemStatus with ElasticSearchDAOSupport {
     * @param userInfo the user (email and subjectid) with which to update the project record.
     * @return the updated project record
     */
-  def claimProject(userInfo: WorkbenchUserInfo): TrialProject
+  def claimProjectRecord(userInfo: WorkbenchUserInfo): TrialProject
 
   /**
     * Returns a count of available project records. Definition of "available" is deferred to impl classes.

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
@@ -7,6 +7,7 @@ import spray.http.StatusCode
 import spray.http.StatusCodes.BadRequest
 import org.broadinstitute.dsde.firecloud.model.MethodRepository._
 import org.broadinstitute.dsde.firecloud.model.Ontology.{ESTermParent, TermParent, TermResource}
+import org.broadinstitute.dsde.firecloud.model.Trial.TrialProject
 import spray.json._
 import spray.routing.{MalformedRequestContentRejection, RejectionHandler}
 import spray.routing.directives.RouteDirectives.complete
@@ -243,6 +244,8 @@ object ModelJsonProtocol extends WorkspaceJsonSupport {
   implicit val impAgoraStatus = jsonFormat2(AgoraStatus)
   implicit val impThurloeStatus = jsonFormat2(ThurloeStatus)
   implicit val impDropwizardHealth = jsonFormat2(DropwizardHealth)
+
+  implicit val impTrialProject = jsonFormat3(TrialProject.apply)
 
   // don't make this implicit! It would be pulled in by anything including ModelJsonProtocol._
   val entityExtractionRejectionHandler = RejectionHandler {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/Trial.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/Trial.scala
@@ -4,6 +4,7 @@ import java.time.Instant
 
 import org.broadinstitute.dsde.firecloud.FireCloudException
 import org.broadinstitute.dsde.firecloud.model.Trial.TrialStates.TrialState
+import org.broadinstitute.dsde.rawls.model.RawlsBillingProjectName
 
 import scala.util.Try
 
@@ -96,6 +97,11 @@ object Trial {
       ) ++ stateKV
     }
 
+  }
+
+  case class TrialProject(name: RawlsBillingProjectName, verified: Boolean, user: Option[WorkbenchUserInfo])
+  object TrialProject {
+    def apply(name: RawlsBillingProjectName) = new TrialProject(name, verified=false, user=None)
   }
 
 }

--- a/src/test/resources/reference.conf
+++ b/src/test/resources/reference.conf
@@ -64,6 +64,7 @@ elasticsearch {
   clusterName = "elasticsearch5a"
   index = "unittest"
   ontologyIndex = "ontology-unittest"
+  trialIndex = "trial-unittest"
   discoverGroupNames = ["all_broad_users","demo_users"]
 }
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/ESIntegrationSupport.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/ESIntegrationSupport.scala
@@ -7,6 +7,7 @@ import org.broadinstitute.dsde.firecloud.FireCloudConfig
 import org.broadinstitute.dsde.firecloud.dataaccess._
 import org.broadinstitute.dsde.firecloud.elastic.ElasticUtils
 import org.broadinstitute.dsde.firecloud.model.LibrarySearchParams
+import org.elasticsearch.action.support.WriteRequest.RefreshPolicy
 import org.elasticsearch.client.transport.TransportClient
 
 import scala.util.{Failure, Success, Try}
@@ -43,6 +44,11 @@ object ESIntegrationSupport extends IntegrationTestConfig {
   lazy val ontologyDAO:OntologyDAO = {
     // use the index name defined in reference.conf, since we execute read-only
     new ElasticSearchOntologyDAO(client, FireCloudConfig.ElasticSearch.ontologyIndexName)
+  }
+
+  lazy val trialDAO:TrialDAO = {
+    // use the temporary index name defined above
+    new ElasticSearchTrialDAO(client, itTestIndexName, RefreshPolicy.IMMEDIATE)
   }
 
   lazy val emptyCriteria = LibrarySearchParams(None,Map.empty[String,Seq[String]],None,Map.empty[String,Int],None,None,None,None)

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/ElasticSearchTrialDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/ElasticSearchTrialDAOSpec.scala
@@ -1,0 +1,138 @@
+package org.broadinstitute.dsde.firecloud.integrationtest
+
+import com.typesafe.scalalogging.LazyLogging
+import org.broadinstitute.dsde.firecloud.FireCloudException
+import org.broadinstitute.dsde.firecloud.integrationtest.ESIntegrationSupport.{searchDAO, trialDAO}
+import org.broadinstitute.dsde.firecloud.model.WorkbenchUserInfo
+import org.broadinstitute.dsde.firecloud.model.Trial.TrialProject
+import org.broadinstitute.dsde.rawls.model.RawlsBillingProjectName
+import org.scalatest.{BeforeAndAfterAll, FreeSpec, Matchers}
+
+class ElasticSearchTrialDAOSpec extends FreeSpec with Matchers with BeforeAndAfterAll with LazyLogging  {
+
+  override def beforeAll = {
+    // using the delete from search dao, because we don't have recreate in trial dao.
+    searchDAO.recreateIndex()
+
+    // set up example data
+    logger.info("indexing fixtures ...")
+    ElasticSearchTrialDAOFixtures.fixtureProjects foreach { project => trialDAO.createProject(project.name)}
+
+    ElasticSearchTrialDAOFixtures.fixtureProjects collect {
+      case project if project.verified => trialDAO.verifyProject(project.name, verified=project.verified)
+    }
+    ElasticSearchTrialDAOFixtures.fixtureProjects collect {
+      case project if project.user.nonEmpty => trialDAO.claimProject(project.user.get)
+    }
+    logger.info("... fixtures indexed.")
+  }
+
+  override def afterAll = {
+    // using the delete from search dao, because we don't have recreate in trial dao.
+    searchDAO.deleteIndex()
+  }
+
+  "ElasticSearchTrialDAO" - {
+    "createProject" - {
+      "should insert a new project" in {
+        val name = RawlsBillingProjectName("garlic")
+        val actual = trialDAO.createProject(name)
+        val expected = TrialProject(name, verified=false, user=None)
+        assertResult(expected) { actual }
+        val expectedCheck = trialDAO.getProject(name)
+        assertResult(expected) { expectedCheck }
+      }
+      "should throw error when inserting an existing project" in {
+        val ex = intercept[FireCloudException] {
+          trialDAO.createProject(RawlsBillingProjectName("endive"))
+        }
+        assert(ex.getMessage == "ElasticSearch request failed")
+      }
+    }
+    "verifyProject" - {
+      "should update a project with a new value for verified" in {
+        val name=RawlsBillingProjectName("endive")
+        trialDAO.verifyProject(name, verified=true)
+        val actual1 = trialDAO.getProject(name)
+        val expected1 = TrialProject(name, verified=true, user=None)
+        assertResult(expected1) { actual1 }
+        trialDAO.verifyProject(name, verified=false)
+        val actual2 = trialDAO.getProject(name)
+        val expected2 = TrialProject(name, verified=false, user=None)
+        assertResult(expected2) { actual2 }
+
+      }
+      "should throw an error if project is not found" in {
+        val ex = intercept[FireCloudException] {
+          trialDAO.verifyProject(RawlsBillingProjectName("habanero"), verified=true)
+        }
+        assert(ex.getMessage == "project habanero not found!")
+      }
+
+    }
+    "claimProject" - {
+      "should claim the first available project by alphabetical order" in {
+        val user = WorkbenchUserInfo("789", "me")
+        val claimed = trialDAO.claimProject(user)
+        val expected = TrialProject(RawlsBillingProjectName("date"), verified=true, user=Some(user))
+        assertResult(expected) { claimed }
+        val claimCheck = trialDAO.getProject(RawlsBillingProjectName("date"))
+        assertResult(expected) { claimCheck }
+      }
+      "should throw an error when no available/verified projects exist" in {
+        // this one should succeed - "fennel" is available
+        val user = WorkbenchUserInfo("101010", "me2")
+        val claimed = trialDAO.claimProject(user)
+        // this one should fail - nothing left
+        val ex = intercept[FireCloudException] {
+          trialDAO.claimProject(user)
+        }
+        assert(ex.getMessage == "no available projects")
+      }
+    }
+    "countAvailableProjects" - {
+      "should return zero when no projects available" in {
+        assertResult(0) { trialDAO.countAvailableProjects }
+      }
+      "should return accurate count of available projects" in {
+        // insert three
+        Seq("orange", "pineapple", "quince") foreach { proj => trialDAO.createProject(RawlsBillingProjectName(proj))}
+        // verify two
+        Seq("orange", "quince") foreach { proj => trialDAO.verifyProject(RawlsBillingProjectName(proj), verified=true)}
+        assertResult(2) { trialDAO.countAvailableProjects }
+      }
+    }
+    "projectReport" - {
+      "should return an accurate report with only verified/claimed projects" in {
+        // unverified/unclaimed projects listed below but commented out for developer clarity
+        val expected = Seq(
+          // TrialProject(RawlsBillingProjectName("apple"), verified=false, None),
+          TrialProject(RawlsBillingProjectName("banana"), verified=true, Some(WorkbenchUserInfo("123", "alice@example.com"))),
+          TrialProject(RawlsBillingProjectName("carrot"), verified=true, Some(WorkbenchUserInfo("456", "bob@example.com"))),
+          TrialProject(RawlsBillingProjectName("date"), verified=true, Some(WorkbenchUserInfo("789", "me"))),
+          // TrialProject(RawlsBillingProjectName("endive"), verified=false, None),
+          TrialProject(RawlsBillingProjectName("fennel"), verified=true, Some(WorkbenchUserInfo("101010", "me2")))
+          // TrialProject(RawlsBillingProjectName("garlic"), verified=false, None),
+          // TrialProject(RawlsBillingProjectName("orange"), verified=true, None),
+          // TrialProject(RawlsBillingProjectName("pineapple"), verified=false, None),
+          // TrialProject(RawlsBillingProjectName("quince"), verified=true, None)
+        )
+        val actual = trialDAO.projectReport
+        assertResult(expected) { actual }
+      }
+    }
+  }
+}
+
+object ElasticSearchTrialDAOFixtures {
+  val fixtureProjects: Seq[TrialProject] = Seq(
+    TrialProject(RawlsBillingProjectName("apple"), verified=false, None),
+    TrialProject(RawlsBillingProjectName("banana"), verified=true, Some(WorkbenchUserInfo("123", "alice@example.com"))),
+    TrialProject(RawlsBillingProjectName("carrot"), verified=true, Some(WorkbenchUserInfo("456", "bob@example.com"))),
+    TrialProject(RawlsBillingProjectName("date"), verified=true, None),
+    TrialProject(RawlsBillingProjectName("endive"), verified=false, None),
+    TrialProject(RawlsBillingProjectName("fennel"), verified=true, None)
+  )
+}
+
+


### PR DESCRIPTION
A dao to manage a pool of free-tier billing projects. Backed by elasticsearch.

Not used anywhere yet - this is prospective coding, trying to get infrastructure in place for when we do start building features.

Will require fc-develop PRs:
broadinstitute/firecloud-develop#843
broadinstitute/firecloud-develop#844
broadinstitute/firecloud-develop#845

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [x] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
