### PR TITLE
GAWB-2909: bulk creation of projects under a billing acct

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -1661,7 +1661,7 @@ paths:
           description: |
             operation to perform on projects.
             "Create" will create projects and verify those projects.
-            "Verify" will verify all projects in the pool.
+            "Verify" will verify all unverified projects in the pool.
             "Count" will return the number of projects in various statuses.
             "Report" will return a report of all claimed projects.
           required: true

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -1658,7 +1658,7 @@ paths:
       summary: Manage free trial projects
       parameters:
         - name: operation
-          description: >
+          description: |
             operation to perform on projects.
             "Create" will create projects and verify those projects.
             "Verify" will verify all projects in the pool.

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -1658,7 +1658,9 @@ paths:
       summary: Create free trial projects
       parameters:
         - name: operation
-          description: operation to perform on projects
+          description: |
+            operation to perform on projects. "Create" will create projects and verify those projects.
+            "Verify" will verify all projects in the pool.
           required: true
           in: query
           type: string
@@ -1671,14 +1673,14 @@ paths:
           in: query
           type: number
       responses:
-        204:
-          description: Created
+        200:
+          description: OK; used for verify operation
+        202:
+          description: Accepted; used for create operation
         400:
-          description: firecloud billing user must be an admin of the billing account
+          description: Bad Request. Creation already in progress or incorrect credentials.
         403:
-          description: You must be an admin of the google billing account
-        409:
-          description: project already exists in rawls or google
+          description: You must be a campaign manager to call this endpoint.
         500:
           description: Internal Server Error
 

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -1662,6 +1662,8 @@ paths:
           required: true
           in: query
           type: number
+      produces:
+        - text/plain
       responses:
         204:
           description: Created

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -1654,22 +1654,28 @@ paths:
     post:
       tags:
         - Trial
-      operationId: createTrialProjects
-      summary: Create free trial projects
+      operationId: manageTrialProjects
+      summary: Manage free trial projects
       parameters:
         - name: operation
-          description: |
-            operation to perform on projects. "Create" will create projects and verify those projects.
+          description: >
+            operation to perform on projects.
+            "Create" will create projects and verify those projects.
             "Verify" will verify all projects in the pool.
+            "Count" will return the number of projects in various statuses.
+            "Report" will return a report of all claimed projects.
           required: true
           in: query
           type: string
           enum:
             - create
             - verify
+            - count
+            - report
+          default: count
         - name: count
           description: number of projects to create; only used for create operation
-          required: true
+          required: false
           in: query
           type: number
       responses:

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -1657,13 +1657,19 @@ paths:
       operationId: createTrialProjects
       summary: Create free trial projects
       parameters:
+        - name: operation
+          description: operation to perform on projects
+          required: true
+          in: query
+          type: string
+          enum:
+            - create
+            - verify
         - name: count
-          description: number of projects to create
+          description: number of projects to create; only used for create operation
           required: true
           in: query
           type: number
-      produces:
-        - text/plain
       responses:
         204:
           description: Created
@@ -1675,27 +1681,6 @@ paths:
           description: project already exists in rawls or google
         500:
           description: Internal Server Error
-    put:
-      tags:
-        - Trial
-      operationId: verifyTrialProjects
-      summary: Verify free trial projects
-      description: This is a horrible, horrible use of the PUT verb
-      produces:
-        - text/plain
-        - application/json
-      responses:
-        200:
-          description: Verifications complete
-        400:
-          description: firecloud billing user must be an admin of the billing account
-        403:
-          description: You must be an admin of the google billing account
-        409:
-          description: project already exists in rawls or google
-        500:
-          description: Internal Server Error
-
 
   /version/executionEngine:
     get:

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -1675,6 +1675,27 @@ paths:
           description: project already exists in rawls or google
         500:
           description: Internal Server Error
+    put:
+      tags:
+        - Trial
+      operationId: verifyTrialProjects
+      summary: Verify free trial projects
+      description: This is a horrible, horrible use of the PUT verb
+      produces:
+        - text/plain
+        - application/json
+      responses:
+        200:
+          description: Verifications complete
+        400:
+          description: firecloud billing user must be an admin of the billing account
+        403:
+          description: You must be an admin of the google billing account
+        409:
+          description: project already exists in rawls or google
+        500:
+          description: Internal Server Error
+
 
   /version/executionEngine:
     get:

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -1633,6 +1633,7 @@ paths:
             description: operation to perform on the specified users
             required: true
             in: path
+            type: string
             enum:
               - enable
               - disable
@@ -1648,6 +1649,30 @@ paths:
             description: Success (No Content)
           500:
             description: Internal Server Error
+
+  /api/trial/manager/projects:
+    post:
+      tags:
+        - Trial
+      operationId: createTrialProjects
+      summary: Create free trial projects
+      parameters:
+        - name: count
+          description: number of projects to create
+          required: true
+          in: query
+          type: number
+      responses:
+        204:
+          description: Created
+        400:
+          description: firecloud billing user must be an admin of the billing account
+        403:
+          description: You must be an admin of the google billing account
+        409:
+          description: project already exists in rawls or google
+        500:
+          description: Internal Server Error
 
   /version/executionEngine:
     get:

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/Application.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/Application.scala
@@ -17,7 +17,8 @@ case class Application(agoraDAO: AgoraDAO,
                        rawlsDAO: RawlsDAO,
                        samDAO: SamDAO,
                        searchDAO: SearchDAO,
-                       thurloeDAO: ThurloeDAO) {
+                       thurloeDAO: ThurloeDAO,
+                       trialDAO: TrialDAO) {
 
   def healthMonitorChecks: Map[Subsystem, Future[SubsystemStatus]] = Map(
     Agora -> agoraDAO.status,
@@ -28,6 +29,7 @@ case class Application(agoraDAO: AgoraDAO,
     Rawls -> rawlsDAO.status,
     Sam -> samDAO.status,
     Thurloe -> thurloeDAO.status
+    // TODO: add free-trial index as a monitorable healthcheck
   )
 
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/Application.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/Application.scala
@@ -29,7 +29,7 @@ case class Application(agoraDAO: AgoraDAO,
     Rawls -> rawlsDAO.status,
     Sam -> samDAO.status,
     Thurloe -> thurloeDAO.status
-    // TODO: add free-trial index as a monitorable healthcheck
+    // TODO: add free-trial index as a monitorable healthcheck; requires updates to workbench-libs
   )
 
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
@@ -18,6 +18,8 @@ object FireCloudConfig {
     val pemFileClientId = auth.getString("pemFileClientId")
     val rawlsPemFile = auth.getString("rawlsPemFile")
     val rawlsPemFileClientId = auth.getString("rawlsPemFileClientId")
+    val trialBillingPemFile = auth.getString("trialBillingPemFile")
+    val trialBillingPemFileClientId = auth.getString("trialBillingPemFileClientId")
     val swaggerRealm = auth.getString("swaggerRealm")
   }
 
@@ -167,5 +169,6 @@ object FireCloudConfig {
     private val trial = config.getConfig("trial")
     val durationDays = trial.getInt("durationDays")
     val managerGroup = trial.getString("managerGroup")
+    val billingAccount = trial.getString("billingAccount")
   }
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudServiceActor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudServiceActor.scala
@@ -55,8 +55,9 @@ class FireCloudServiceActor extends HttpServiceActor with FireCloudDirectives
   val ontologyDAO:OntologyDAO = new ElasticSearchOntologyDAO(elasticSearchClient, FireCloudConfig.ElasticSearch.ontologyIndexName)
   val consentDAO:ConsentDAO = new HttpConsentDAO
   val searchDAO:SearchDAO = new ElasticSearchDAO(elasticSearchClient, FireCloudConfig.ElasticSearch.indexName, ontologyDAO)
+  val trialDAO:TrialDAO = new ElasticSearchTrialDAO(elasticSearchClient, FireCloudConfig.ElasticSearch.trialIndexName)
 
-  val app:Application = new Application(agoraDAO, googleServicesDAO, ontologyDAO, consentDAO, rawlsDAO, samDAO, searchDAO, thurloeDAO)
+  val app:Application = new Application(agoraDAO, googleServicesDAO, ontologyDAO, consentDAO, rawlsDAO, samDAO, searchDAO, thurloeDAO, trialDAO)
   val materializer: ActorMaterializer = ActorMaterializer()
 
   val healthMonitorChecks = app.healthMonitorChecks

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudServiceActor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudServiceActor.scala
@@ -63,7 +63,7 @@ class FireCloudServiceActor extends HttpServiceActor with FireCloudDirectives
   val healthMonitor = system.actorOf(HealthMonitor.props(healthMonitorChecks.keySet)( () => healthMonitorChecks ), "health-monitor")
   system.scheduler.schedule(3.seconds, 1.minute, healthMonitor, HealthMonitor.CheckAll)
 
-  val trialProjectManager = system.actorOf(ProjectManager.props(app.rawlsDAO, app.trialDAO), "trial-project-manager")
+  val trialProjectManager = system.actorOf(ProjectManager.props(app.rawlsDAO, app.trialDAO, app.googleServicesDAO), "trial-project-manager")
 
   val exportEntitiesByTypeConstructor: (ExportEntitiesByTypeArguments) => ExportEntitiesByTypeActor = ExportEntitiesByTypeActor.constructor(app, materializer)
   val libraryServiceConstructor: (UserInfo) => LibraryService = LibraryService.constructor(app)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchTrialDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchTrialDAO.scala
@@ -25,22 +25,21 @@ import scala.util.{Failure, Success, Try}
 
 trait TrialQueries {
 
-  val Unverified = termQuery("verified", false)
+  val Unverified:QueryBuilder = termQuery("verified", false)
 
-  val Errored = boolQuery()
+  val Errored:QueryBuilder = boolQuery()
     .must(termQuery("verified", true))
     .must(termQuery("status.keyword", CreationStatuses.Error.toString))
 
-  val Available = boolQuery()
+  val Available:QueryBuilder = boolQuery()
     .must(termQuery("verified", true))
     .must(termQuery("status.keyword", CreationStatuses.Ready.toString))
     .mustNot(existsQuery("user.userSubjectId.keyword"))
 
-  val Claimed = boolQuery()
+  val Claimed:QueryBuilder = boolQuery()
     .must(termQuery("verified", true))
     .must(termQuery("status.keyword", CreationStatuses.Ready.toString))
     .must(existsQuery("user.userSubjectId.keyword"))
-
 }
 
 class ElasticSearchTrialDAO(client: TransportClient, indexName: String, refreshMode: RefreshPolicy = RefreshPolicy.NONE)
@@ -195,7 +194,6 @@ class ElasticSearchTrialDAO(client: TransportClient, indexName: String, refreshM
       Seq.empty[TrialProject]
     else
       unverifiedResponse.getHits.getHits.toSeq map ( _.getSourceAsString.parseJson.convertTo[TrialProject] )
-
   }
 
   /**
@@ -203,17 +201,11 @@ class ElasticSearchTrialDAO(client: TransportClient, indexName: String, refreshM
     * @return counts of project records.
     */
   override def countProjects: Map[String,Long] = {
-    // unverified, errored, available, claimed
-    val unverified = count(Unverified)
-    val errored = count(Errored)
-    val available = count(Available)
-    val claimed = count(Claimed)
-
     Map(
-      "unverified" -> unverified,
-      "errored" -> errored,
-      "available" -> available,
-      "claimed" -> claimed
+      "unverified" -> count(Unverified),
+      "errored" -> count(Errored),
+      "available" -> count(Available),
+      "claimed" -> count(Claimed)
     )
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchTrialDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchTrialDAO.scala
@@ -136,7 +136,7 @@ class ElasticSearchTrialDAO(client: TransportClient, indexName: String, refreshM
   override def claimProjectRecord(userInfo: WorkbenchUserInfo): TrialProject = {
     val nextProjectQuery = boolQuery()
       .must(termQuery("verified", true))
-      .must(termQuery("status.keyword", CreationStatuses.Ready))
+      .must(termQuery("status.keyword", CreationStatuses.Ready.toString))
       .mustNot(existsQuery("user.userSubjectId.keyword"))
 
     // if we find regular race conditions in which multiple users attempt to claim the "next" project,

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchTrialDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchTrialDAO.scala
@@ -72,7 +72,6 @@ class ElasticSearchTrialDAO(client: TransportClient, indexName: String, refreshM
     project
   }
 
-
   /**
     * Check to see if the project record exists.
     *
@@ -82,7 +81,6 @@ class ElasticSearchTrialDAO(client: TransportClient, indexName: String, refreshM
   override def projectRecordExists(projectName: RawlsBillingProjectName): Boolean = {
     Try(getProjectInternal(projectName)).isSuccess
   }
-
 
   /**
     * Create a record for the specified project. Throws error if name
@@ -164,7 +162,6 @@ class ElasticSearchTrialDAO(client: TransportClient, indexName: String, refreshM
     updatedProject
   }
 
-
   /**
     * Returns a list of project records in the pool that are unverified.
     *
@@ -196,6 +193,7 @@ class ElasticSearchTrialDAO(client: TransportClient, indexName: String, refreshM
   override def countAvailableProjects: Long = {
     val countProjectQuery = boolQuery()
       .must(termQuery("verified", true))
+      .must(termQuery("status.keyword", CreationStatuses.Ready.toString))
       .mustNot(existsQuery("user.userSubjectId.keyword"))
 
     val countProjectRequest = client
@@ -215,6 +213,7 @@ class ElasticSearchTrialDAO(client: TransportClient, indexName: String, refreshM
   override def projectReport: Seq[TrialProject] = {
     val reportProjectQuery = boolQuery()
       .must(termQuery("verified", true))
+      .must(termQuery("status.keyword", CreationStatuses.Ready.toString))
       .must(existsQuery("user.userSubjectId.keyword"))
 
     val reportProjectRequest = client
@@ -230,7 +229,6 @@ class ElasticSearchTrialDAO(client: TransportClient, indexName: String, refreshM
     else
       reportProjectResponse.getHits.getHits.toSeq map ( _.getSourceAsString.parseJson.convertTo[TrialProject] )
   }
-
 
   private def indexExists: Boolean = {
     executeESRequest[IndicesExistsRequest, IndicesExistsResponse, IndicesExistsRequestBuilder](

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/GoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/GoogleServicesDAO.scala
@@ -20,6 +20,7 @@ trait GoogleServicesDAO extends ReportsSubsystemStatus {
   implicit val errorReportSource = ErrorReportSource(GoogleServicesDAO.serviceName)
 
   def getAdminUserAccessToken: String
+  def getTrialBillingManagerAccessToken: String
   def getBucketObjectAsInputStream(bucketName: String, objectKey: String): InputStream
   def getObjectResourceUrl(bucketName: String, objectKey: String): String
   def getUserProfile(requestContext: RequestContext)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
@@ -69,7 +69,7 @@ object HttpGoogleServicesDAO extends GoogleServicesDAO with FireCloudRequestBuil
   val authScopes = Seq("profile", "email")
   // the minimal scope to read from GCS
   val storageReadOnly = Seq(StorageScopes.DEVSTORAGE_READ_ONLY)
-  // billing scope for creating projects. We don't have the billing client lib so we hardcode it here.
+  // billing scope for creating projects. We don't have the billing client lib as a dependency so we hardcode it here.
   val billingScope = Seq("https://www.googleapis.com/auth/cloud-billing")
 
   val httpTransport = GoogleNetHttpTransport.newTrustedTransport
@@ -99,11 +99,7 @@ object HttpGoogleServicesDAO extends GoogleServicesDAO with FireCloudRequestBuil
     googleCredential.getAccessToken
   }
 
-  // TODO: use trialBillingPemFileClientId and trialBillingPemFile instead
   def getTrialBillingManagerAccessToken = {
-
-    log.warn(s"*****>>>>>>>>> using client id [$trialBillingPemFileClientId] and pemfile [$trialBillingPemFile]")
-
     val googleCredential = new GoogleCredential.Builder()
       .setTransport(httpTransport)
       .setJsonFactory(jsonFactory)
@@ -113,9 +109,7 @@ object HttpGoogleServicesDAO extends GoogleServicesDAO with FireCloudRequestBuil
       .build()
 
     googleCredential.refreshToken()
-    val accessToken = googleCredential.getAccessToken
-    log.warn(s"*****>>>>>>>>> access token is: $accessToken")
-    accessToken
+    googleCredential.getAccessToken
   }
 
   private def getBucketServiceAccountCredential: Credential = {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
@@ -69,6 +69,8 @@ object HttpGoogleServicesDAO extends GoogleServicesDAO with FireCloudRequestBuil
   val authScopes = Seq("profile", "email")
   // the minimal scope to read from GCS
   val storageReadOnly = Seq(StorageScopes.DEVSTORAGE_READ_ONLY)
+  // billing scope for creating projects. We don't have the billing client lib so we hardcode it here.
+  val billingScope = Seq("https://www.googleapis.com/auth/cloud-billing")
 
   val httpTransport = GoogleNetHttpTransport.newTrustedTransport
   val jsonFactory = JacksonFactory.getDefaultInstance
@@ -78,6 +80,9 @@ object HttpGoogleServicesDAO extends GoogleServicesDAO with FireCloudRequestBuil
 
   val rawlsPemFile = FireCloudConfig.Auth.rawlsPemFile
   val rawlsPemFileClientId = FireCloudConfig.Auth.rawlsPemFileClientId
+
+  val trialBillingPemFile = FireCloudConfig.Auth.trialBillingPemFile
+  val trialBillingPemFileClientId = FireCloudConfig.Auth.trialBillingPemFileClientId
 
   lazy val log = LoggerFactory.getLogger(getClass)
 
@@ -92,6 +97,25 @@ object HttpGoogleServicesDAO extends GoogleServicesDAO with FireCloudRequestBuil
 
     googleCredential.refreshToken()
     googleCredential.getAccessToken
+  }
+
+  // TODO: use trialBillingPemFileClientId and trialBillingPemFile instead
+  def getTrialBillingManagerAccessToken = {
+
+    log.warn(s"*****>>>>>>>>> using client id [$trialBillingPemFileClientId] and pemfile [$trialBillingPemFile]")
+
+    val googleCredential = new GoogleCredential.Builder()
+      .setTransport(httpTransport)
+      .setJsonFactory(jsonFactory)
+      .setServiceAccountId(trialBillingPemFileClientId)
+      .setServiceAccountScopes(authScopes ++ billingScope)
+      .setServiceAccountPrivateKeyFromPemFile(new java.io.File(trialBillingPemFile))
+      .build()
+
+    googleCredential.refreshToken()
+    val accessToken = googleCredential.getAccessToken
+    log.warn(s"*****>>>>>>>>> access token is: $accessToken")
+    accessToken
   }
 
   private def getBucketServiceAccountCredential: Credential = {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpRawlsDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpRawlsDAO.scala
@@ -159,6 +159,16 @@ class HttpRawlsDAO( implicit val system: ActorSystem, implicit val executionCont
     authedRequestToObject[Seq[MethodConfigurationShort]](Get(rawlsWorkspaceMethodConfigsUrl.format(ns, name)), true)
   }
 
+  case class CreateRawlsBillingProjectFullRequest(projectName: String, billingAccount: String)
+  implicit val impCreateRawlsBillingProjectFullRequestFormat = jsonFormat2(CreateRawlsBillingProjectFullRequest)
+  def createProject(projectName: String, billingAccount: String): Future[Boolean] = {
+    val create = CreateRawlsBillingProjectFullRequest(projectName, billingAccount)
+    trialBillingAuthedRequest(Post(FireCloudConfig.Rawls.authUrl + "/billing", create)).map { resp =>
+      logger.warn("response from rawls: " + resp.entity.asString)
+      resp.status.isSuccess
+    }
+  }
+
   override def status: Future[SubsystemStatus] = {
     val rawlsStatus = unAuthedRequestToObject[RawlsStatus](Get(Uri(FireCloudConfig.Rawls.baseUrl).withPath(Uri.Path("/status"))))
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpRawlsDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpRawlsDAO.scala
@@ -161,10 +161,9 @@ class HttpRawlsDAO( implicit val system: ActorSystem, implicit val executionCont
 
   case class CreateRawlsBillingProjectFullRequest(projectName: String, billingAccount: String)
   implicit val impCreateRawlsBillingProjectFullRequestFormat = jsonFormat2(CreateRawlsBillingProjectFullRequest)
-  def createProject(projectName: String, billingAccount: String): Future[Boolean] = {
+  override def createProject(projectName: String, billingAccount: String)(implicit userToken: WithAccessToken): Future[Boolean] = {
     val create = CreateRawlsBillingProjectFullRequest(projectName, billingAccount)
-    trialBillingAuthedRequest(Post(FireCloudConfig.Rawls.authUrl + "/billing", create)).map { resp =>
-      logger.warn("response from rawls: " + resp.entity.asString)
+    userAuthedRequest(Post(FireCloudConfig.Rawls.authUrl + "/billing", create)).map { resp =>
       resp.status.isSuccess
     }
   }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpRawlsDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpRawlsDAO.scala
@@ -3,6 +3,7 @@ package org.broadinstitute.dsde.firecloud.dataaccess
 import akka.actor.ActorSystem
 import org.broadinstitute.dsde.firecloud.model.ErrorReportExtensions._
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
+import org.broadinstitute.dsde.firecloud.model.Trial.RawlsBillingProjectMembership
 import org.broadinstitute.dsde.firecloud.model._
 import org.broadinstitute.dsde.firecloud.utils.RestJsonClient
 import org.broadinstitute.dsde.firecloud.{FireCloudConfig, FireCloudExceptionWithErrorReport}
@@ -165,6 +166,16 @@ class HttpRawlsDAO( implicit val system: ActorSystem, implicit val executionCont
     val create = CreateRawlsBillingProjectFullRequest(projectName, billingAccount)
     userAuthedRequest(Post(FireCloudConfig.Rawls.authUrl + "/billing", create)).map { resp =>
       resp.status.isSuccess
+    }
+  }
+
+
+  override def getProjects(implicit userToken: WithAccessToken): Future[Seq[RawlsBillingProjectMembership]] = {
+    userAuthedRequest(Get(FireCloudConfig.Rawls.authUrl + "/user/billing")).map { resp =>
+      resp.entity.as[Seq[RawlsBillingProjectMembership]] match {
+        case Right(obj) => obj
+        case Left(error) => throw new FireCloudExceptionWithErrorReport(FCErrorReport(resp))
+      }
     }
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpRawlsDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpRawlsDAO.scala
@@ -3,7 +3,7 @@ package org.broadinstitute.dsde.firecloud.dataaccess
 import akka.actor.ActorSystem
 import org.broadinstitute.dsde.firecloud.model.ErrorReportExtensions._
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
-import org.broadinstitute.dsde.firecloud.model.Trial.RawlsBillingProjectMembership
+import org.broadinstitute.dsde.firecloud.model.Trial.{CreateRawlsBillingProjectFullRequest, RawlsBillingProjectMembership}
 import org.broadinstitute.dsde.firecloud.model._
 import org.broadinstitute.dsde.firecloud.utils.RestJsonClient
 import org.broadinstitute.dsde.firecloud.{FireCloudConfig, FireCloudExceptionWithErrorReport}
@@ -160,15 +160,12 @@ class HttpRawlsDAO( implicit val system: ActorSystem, implicit val executionCont
     authedRequestToObject[Seq[MethodConfigurationShort]](Get(rawlsWorkspaceMethodConfigsUrl.format(ns, name)), true)
   }
 
-  case class CreateRawlsBillingProjectFullRequest(projectName: String, billingAccount: String)
-  implicit val impCreateRawlsBillingProjectFullRequestFormat = jsonFormat2(CreateRawlsBillingProjectFullRequest)
   override def createProject(projectName: String, billingAccount: String)(implicit userToken: WithAccessToken): Future[Boolean] = {
     val create = CreateRawlsBillingProjectFullRequest(projectName, billingAccount)
     userAuthedRequest(Post(FireCloudConfig.Rawls.authUrl + "/billing", create)).map { resp =>
       resp.status.isSuccess
     }
   }
-
 
   override def getProjects(implicit userToken: WithAccessToken): Future[Seq[RawlsBillingProjectMembership]] = {
     userAuthedRequest(Get(FireCloudConfig.Rawls.authUrl + "/user/billing")).map { resp =>

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/RawlsDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/RawlsDAO.scala
@@ -90,6 +90,8 @@ trait RawlsDAO extends LazyLogging with ReportsSubsystemStatus {
 
   def deleteWorkspace(workspaceNamespace: String, workspaceName: String)(implicit userToken: WithAccessToken): Future[WorkspaceDeleteResponse]
 
+  def createProject(projectName: String, billingAccount: String)(implicit userToken: WithAccessToken): Future[Boolean]
+
   override def serviceName:String = RawlsDAO.serviceName
 
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/RawlsDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/RawlsDAO.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.dsde.firecloud.dataaccess
 
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.FireCloudConfig
+import org.broadinstitute.dsde.firecloud.model.Trial.RawlsBillingProjectMembership
 import org.broadinstitute.dsde.firecloud.model._
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.AttributeUpdateOperation
@@ -91,6 +92,7 @@ trait RawlsDAO extends LazyLogging with ReportsSubsystemStatus {
   def deleteWorkspace(workspaceNamespace: String, workspaceName: String)(implicit userToken: WithAccessToken): Future[WorkspaceDeleteResponse]
 
   def createProject(projectName: String, billingAccount: String)(implicit userToken: WithAccessToken): Future[Boolean]
+  def getProjects(implicit userToken: WithAccessToken): Future[Seq[RawlsBillingProjectMembership]]
 
   override def serviceName:String = RawlsDAO.serviceName
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/TrialDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/TrialDAO.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.firecloud.dataaccess
 
+import org.broadinstitute.dsde.firecloud.model.Trial.CreationStatuses.CreationStatus
 import org.broadinstitute.dsde.firecloud.model.Trial.TrialProject
 import org.broadinstitute.dsde.firecloud.model.WorkbenchUserInfo
 import org.broadinstitute.dsde.rawls.model.{ErrorReportSource, RawlsBillingProjectName}
@@ -22,6 +23,14 @@ trait TrialDAO extends ReportsSubsystemStatus with ElasticSearchDAOSupport {
   def getProjectRecord(projectName: RawlsBillingProjectName): TrialProject
 
   /**
+    * Check to see if the project record exists.
+    *
+    * @param projectName name of the project record to read.
+    * @return whether or not the project record exists
+    */
+  def projectRecordExists(projectName: RawlsBillingProjectName): Boolean
+
+  /**
     * Create a record for the specified project. Throws error if name
     * already exists or could not be otherwise created.
     *
@@ -39,7 +48,7 @@ trait TrialDAO extends ReportsSubsystemStatus with ElasticSearchDAOSupport {
     * @param verified verified value with which to update the project record
     * @return the updated project record
     */
-  def setProjectRecordVerified(projectName: RawlsBillingProjectName, verified: Boolean): TrialProject
+  def setProjectRecordVerified(projectName: RawlsBillingProjectName, verified: Boolean, status: CreationStatus): TrialProject
 
   /**
     * Associates the next-available project record with a specified user. Definition of "next available"
@@ -50,6 +59,12 @@ trait TrialDAO extends ReportsSubsystemStatus with ElasticSearchDAOSupport {
     * @return the updated project record
     */
   def claimProjectRecord(userInfo: WorkbenchUserInfo): TrialProject
+
+  /**
+    * Returns a list of project records in the pool that are unverified.
+    * @return list of project records in the pool that are unverified.
+    */
+  def listUnverifiedProjects: Seq[TrialProject]
 
   /**
     * Returns a count of available project records. Definition of "available" is deferred to impl classes.

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/TrialDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/TrialDAO.scala
@@ -67,10 +67,10 @@ trait TrialDAO extends ReportsSubsystemStatus with ElasticSearchDAOSupport {
   def listUnverifiedProjects: Seq[TrialProject]
 
   /**
-    * Returns a count of available project records. Definition of "available" is deferred to impl classes.
-    * @return count of available project records.
+    * Returns a counts of project records by status.
+    * @return counts of project records.
     */
-  def countAvailableProjects: Long
+  def countProjects: Map[String,Long]
 
   /**
     * Returns a list of project records that have associated users.

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
@@ -265,7 +265,6 @@ object ModelJsonProtocol extends WorkspaceJsonSupport {
 
 
   // following are horribly copied-and-pasted from rawls core, since they're not available as shared models
-
   implicit object ProjectStatusFormat extends RootJsonFormat[CreationStatuses.CreationStatus] {
     override def write(obj: CreationStatuses.CreationStatus): JsValue = JsString(obj.toString)
 
@@ -283,6 +282,7 @@ object ModelJsonProtocol extends WorkspaceJsonSupport {
       case _ => throw new DeserializationException("could not deserialize project role")
     }
   }
+  // END copy/paste from rawls
 
   implicit val impRawlsBillingProjectMembership = jsonFormat4(RawlsBillingProjectMembership)
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
@@ -289,4 +289,7 @@ object ModelJsonProtocol extends WorkspaceJsonSupport {
   implicit val impTrialProject = jsonFormat4(TrialProject.apply)
   implicit val impCreateProjectsResponse = jsonFormat3(CreateProjectsResponse)
 
+  implicit val impCreateRawlsBillingProjectFullRequestFormat = jsonFormat2(CreateRawlsBillingProjectFullRequest)
+
+
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
@@ -8,7 +8,7 @@ import spray.http.StatusCodes.BadRequest
 import org.broadinstitute.dsde.firecloud.model.MethodRepository._
 import org.broadinstitute.dsde.firecloud.model.Ontology.{ESTermParent, TermParent, TermResource}
 import org.broadinstitute.dsde.firecloud.model.Trial.ProjectRoles.ProjectRole
-import org.broadinstitute.dsde.firecloud.model.Trial.{CreationStatuses, ProjectRoles, RawlsBillingProjectMembership, TrialProject}
+import org.broadinstitute.dsde.firecloud.model.Trial._
 import spray.json._
 import spray.routing.{MalformedRequestContentRejection, RejectionHandler}
 import spray.routing.directives.RouteDirectives.complete
@@ -287,5 +287,6 @@ object ModelJsonProtocol extends WorkspaceJsonSupport {
   implicit val impRawlsBillingProjectMembership = jsonFormat4(RawlsBillingProjectMembership)
 
   implicit val impTrialProject = jsonFormat4(TrialProject.apply)
+  implicit val impCreateProjectsResponse = jsonFormat3(CreateProjectsResponse)
 
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
@@ -7,7 +7,8 @@ import spray.http.StatusCode
 import spray.http.StatusCodes.BadRequest
 import org.broadinstitute.dsde.firecloud.model.MethodRepository._
 import org.broadinstitute.dsde.firecloud.model.Ontology.{ESTermParent, TermParent, TermResource}
-import org.broadinstitute.dsde.firecloud.model.Trial.TrialProject
+import org.broadinstitute.dsde.firecloud.model.Trial.ProjectRoles.ProjectRole
+import org.broadinstitute.dsde.firecloud.model.Trial.{CreationStatuses, ProjectRoles, RawlsBillingProjectMembership, TrialProject}
 import spray.json._
 import spray.routing.{MalformedRequestContentRejection, RejectionHandler}
 import spray.routing.directives.RouteDirectives.complete
@@ -245,7 +246,7 @@ object ModelJsonProtocol extends WorkspaceJsonSupport {
   implicit val impThurloeStatus = jsonFormat2(ThurloeStatus)
   implicit val impDropwizardHealth = jsonFormat2(DropwizardHealth)
 
-  implicit val impTrialProject = jsonFormat3(TrialProject.apply)
+
 
   // don't make this implicit! It would be pulled in by anything including ModelJsonProtocol._
   val entityExtractionRejectionHandler = RejectionHandler {
@@ -260,5 +261,31 @@ object ModelJsonProtocol extends WorkspaceJsonSupport {
     def write(either: Either[A, B]) = format.write(either)
     def read(value: JsValue) = format.read(value)
   }
+
+
+
+  // following are horribly copied-and-pasted from rawls core, since they're not available as shared models
+
+  implicit object ProjectStatusFormat extends RootJsonFormat[CreationStatuses.CreationStatus] {
+    override def write(obj: CreationStatuses.CreationStatus): JsValue = JsString(obj.toString)
+
+    override def read(json: JsValue): CreationStatuses.CreationStatus = json match {
+      case JsString(name) => CreationStatuses.withName(name)
+      case _ => throw new DeserializationException("could not deserialize project status")
+    }
+  }
+
+  implicit object ProjectRoleFormat extends RootJsonFormat[ProjectRole] {
+    override def write(obj: ProjectRole): JsValue = JsString(obj.toString)
+
+    override def read(json: JsValue): ProjectRole = json match {
+      case JsString(name) => ProjectRoles.withName(name)
+      case _ => throw new DeserializationException("could not deserialize project role")
+    }
+  }
+
+  implicit val impRawlsBillingProjectMembership = jsonFormat4(RawlsBillingProjectMembership)
+
+  implicit val impTrialProject = jsonFormat4(TrialProject.apply)
 
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/Trial.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/Trial.scala
@@ -3,8 +3,10 @@ package org.broadinstitute.dsde.firecloud.model
 import java.time.Instant
 
 import org.broadinstitute.dsde.firecloud.FireCloudException
+import org.broadinstitute.dsde.firecloud.model.Trial.CreationStatuses.CreationStatus
 import org.broadinstitute.dsde.firecloud.model.Trial.TrialStates.TrialState
-import org.broadinstitute.dsde.rawls.model.RawlsBillingProjectName
+import org.broadinstitute.dsde.rawls.RawlsException
+import org.broadinstitute.dsde.rawls.model.{RawlsBillingProjectName, RawlsEnumeration}
 
 import scala.util.Try
 
@@ -135,10 +137,11 @@ object Trial {
 
   }
 
-  case class TrialProject(name: RawlsBillingProjectName, verified: Boolean, user: Option[WorkbenchUserInfo])
+  case class TrialProject(name: RawlsBillingProjectName, verified: Boolean, user: Option[WorkbenchUserInfo], status: Option[CreationStatus])
   object TrialProject {
-    def apply(name: RawlsBillingProjectName) = new TrialProject(name, verified=false, user=None)
+    def apply(name: RawlsBillingProjectName) = new TrialProject(name, verified=false, user=None, status=None)
   }
+
 
   object StatusUpdate {
     sealed trait Attempt
@@ -146,5 +149,61 @@ object Trial {
     case object Success extends Attempt
     case object Failure extends Attempt
     case class ServerError(msg: String) extends Attempt
+  }
+
+  // following are horribly copied-and-pasted from rawls core, since they're not available as shared models
+
+  case class RawlsBillingProjectMembership(projectName: RawlsBillingProjectName, role: ProjectRoles.ProjectRole, creationStatus: CreationStatuses.CreationStatus, message: Option[String] = None)
+
+  object CreationStatuses {
+    sealed trait CreationStatus extends RawlsEnumeration[CreationStatus] {
+      override def toString = toName(this)
+
+      override def withName(name: String): CreationStatus = CreationStatuses.withName(name)
+    }
+
+    def toName(status: CreationStatus): String = status match {
+      case Creating => "Creating"
+      case Ready => "Ready"
+      case Error => "Error"
+    }
+
+    def withName(name: String): CreationStatus = name.toLowerCase match {
+      case "creating" => Creating
+      case "ready" => Ready
+      case "error" => Error
+      case _ => throw new FireCloudException(s"invalid CreationStatus [${name}]")
+    }
+
+    case object Creating extends CreationStatus
+    case object Ready extends CreationStatus
+    case object Error extends CreationStatus
+
+    val all: Set[CreationStatus] = Set(Creating, Ready, Error)
+    val terminal: Set[CreationStatus] = Set(Ready, Error)
+  }
+
+  object ProjectRoles {
+    sealed trait ProjectRole extends RawlsEnumeration[ProjectRole] {
+      override def toString = toName(this)
+
+      override def withName(name: String): ProjectRole = ProjectRoles.withName(name)
+    }
+
+    def toName(role: ProjectRole): String = role match {
+      case Owner => "Owner"
+      case User => "User"
+    }
+
+    def withName(name: String): ProjectRole = name.toLowerCase match {
+      case "owner" => Owner
+      case "user" => User
+      case _ => throw new FireCloudException(s"invalid ProjectRole [${name}]")
+    }
+
+    case object Owner extends ProjectRole
+    case object User extends ProjectRole
+
+    val all: Set[ProjectRole] = Set(Owner, User)
   }
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/Trial.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/Trial.scala
@@ -153,6 +153,8 @@ object Trial {
   case class CreateProjectsResponse(success: Boolean, count: Int, message: Option[String])
 
   // following are horribly copied-and-pasted from rawls core, since they're not available as shared models
+  case class CreateRawlsBillingProjectFullRequest(projectName: String, billingAccount: String)
+
   case class RawlsBillingProjectMembership(projectName: RawlsBillingProjectName, role: ProjectRoles.ProjectRole, creationStatus: CreationStatuses.CreationStatus, message: Option[String] = None)
 
   object CreationStatuses {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/Trial.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/Trial.scala
@@ -208,4 +208,5 @@ object Trial {
 
     val all: Set[ProjectRole] = Set(Owner, User)
   }
+  // END copy/paste from rawls
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/Trial.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/Trial.scala
@@ -5,7 +5,6 @@ import java.time.Instant
 import org.broadinstitute.dsde.firecloud.FireCloudException
 import org.broadinstitute.dsde.firecloud.model.Trial.CreationStatuses.CreationStatus
 import org.broadinstitute.dsde.firecloud.model.Trial.TrialStates.TrialState
-import org.broadinstitute.dsde.rawls.RawlsException
 import org.broadinstitute.dsde.rawls.model.{RawlsBillingProjectName, RawlsEnumeration}
 
 import scala.util.Try

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/Trial.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/Trial.scala
@@ -142,7 +142,6 @@ object Trial {
     def apply(name: RawlsBillingProjectName) = new TrialProject(name, verified=false, user=None, status=None)
   }
 
-
   object StatusUpdate {
     sealed trait Attempt
 
@@ -151,8 +150,9 @@ object Trial {
     case class ServerError(msg: String) extends Attempt
   }
 
-  // following are horribly copied-and-pasted from rawls core, since they're not available as shared models
+  case class CreateProjectsResponse(success: Boolean, count: Int, message: Option[String])
 
+  // following are horribly copied-and-pasted from rawls core, since they're not available as shared models
   case class RawlsBillingProjectMembership(projectName: RawlsBillingProjectName, role: ProjectRoles.ProjectRole, creationStatus: CreationStatuses.CreationStatus, message: Option[String] = None)
 
   object CreationStatuses {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/FireCloudRequestBuilding.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/FireCloudRequestBuilding.scala
@@ -46,6 +46,8 @@ trait FireCloudRequestBuilding extends spray.httpx.RequestBuilding {
   // with great power comes great responsibility!
   def addAdminCredentials = addCredentials(OAuth2BearerToken(HttpGoogleServicesDAO.getAdminUserAccessToken))
 
+  def addTrialBillingCredentials = addCredentials(OAuth2BearerToken(HttpGoogleServicesDAO.getTrialBillingManagerAccessToken))
+
   def addFireCloudCredentials = addHeader(fireCloudHeader)
 
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/FireCloudRequestBuilding.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/FireCloudRequestBuilding.scala
@@ -46,8 +46,6 @@ trait FireCloudRequestBuilding extends spray.httpx.RequestBuilding {
   // with great power comes great responsibility!
   def addAdminCredentials = addCredentials(OAuth2BearerToken(HttpGoogleServicesDAO.getAdminUserAccessToken))
 
-  def addTrialBillingCredentials = addCredentials(OAuth2BearerToken(HttpGoogleServicesDAO.getTrialBillingManagerAccessToken))
-
   def addFireCloudCredentials = addHeader(fireCloudHeader)
 
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/TrialService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/TrialService.scala
@@ -15,33 +15,46 @@ import org.broadinstitute.dsde.firecloud.service.PerRequest.{PerRequestMessage, 
 import org.broadinstitute.dsde.firecloud.service.TrialService._
 import org.broadinstitute.dsde.firecloud.utils.PermissionsSupport
 import org.broadinstitute.dsde.rawls.model.RawlsUserEmail
+import org.broadinstitute.dsde.firecloud.{Application, FireCloudConfig, FireCloudException, FireCloudExceptionWithErrorReport}
+import org.broadinstitute.dsde.firecloud.dataaccess._
+import org.broadinstitute.dsde.firecloud.model.Trial.{TrialStates, UserTrialStatus}
+import org.broadinstitute.dsde.firecloud.model.{BasicProfile, Profile, RegistrationInfo, RequestCompleteWithErrorReport, UserInfo, WorkbenchEnabled, WorkbenchUserInfo}
+import org.broadinstitute.dsde.firecloud.service.PerRequest.{PerRequestMessage, RequestComplete}
+import org.broadinstitute.dsde.firecloud.trial.ProjectNamer
+import org.broadinstitute.dsde.firecloud.utils.PermissionsSupport
+import org.broadinstitute.dsde.rawls.model.RawlsBillingProjectName
+import spray.http.{OAuth2BearerToken, StatusCodes}
 import spray.http.StatusCodes._
 import spray.httpx.SprayJsonSupport
 import spray.json.DefaultJsonProtocol._
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
+import scala.util.Try
 
 // TODO: Contain userEmail in value class for stronger type safety without incurring performance penalty
 object TrialService {
   sealed trait TrialServiceMessage
+
   case class EnableUsers(managerInfo: UserInfo, userEmails: Seq[String]) extends TrialServiceMessage
   case class DisableUsers(managerInfo: UserInfo, userEmails: Seq[String]) extends TrialServiceMessage
   case class EnrollUser(managerInfo: UserInfo) extends TrialServiceMessage
   case class TerminateUsers(managerInfo: UserInfo, userEmails: Seq[String]) extends TrialServiceMessage
+  case class CreateProjects(userInfo:UserInfo, count:Int) extends TrialServiceMessage
 
   def props(service: () => TrialService): Props = {
     Props(service())
   }
 
   def constructor(app: Application)()(implicit executionContext: ExecutionContext) =
-    new TrialService(app.rawlsDAO, app.samDAO, app.thurloeDAO)
+    new TrialService(app.samDAO, app.thurloeDAO, app.rawlsDAO, app.trialDAO)
 }
 
 // TODO: Remove loggers used for development purposes or lower their level
-final class TrialService(val rawlsDAO: RawlsDAO, val samDao: SamDAO, val thurloeDao: ThurloeDAO)
-                        (implicit protected val executionContext: ExecutionContext)
-  extends Actor with LazyLogging with SprayJsonSupport with PermissionsSupport {
+final class TrialService
+  (val samDao: SamDAO, val thurloeDao: ThurloeDAO, val rawlsDAO: RawlsDAO, val trialDAO: TrialDAO)
+  (implicit protected val executionContext: ExecutionContext)
+  extends Actor with PermissionsSupport with SprayJsonSupport with LazyLogging {
 
   override def receive = {
     case EnableUsers(managerInfo, userEmails) =>
@@ -52,6 +65,9 @@ final class TrialService(val rawlsDAO: RawlsDAO, val samDao: SamDAO, val thurloe
       enrollUser(userInfo) pipeTo sender
     case TerminateUsers(managerInfo, userEmails) =>
       asTrialCampaignManager(terminateUsers(managerInfo, userEmails))(managerInfo) pipeTo sender
+    case CreateProjects(userInfo, count) => asTrialCampaignManager {
+      createProjects(count)
+    }(userInfo) pipeTo sender
   }
 
   private def enableUsers(managerInfo: UserInfo, userEmails: Seq[String]): Future[PerRequestMessage] = {
@@ -192,5 +208,87 @@ final class TrialService(val rawlsDAO: RawlsDAO, val samDao: SamDAO, val thurloe
       }
     }
   }
+
+  private def createProjects(count: Int): Future[PerRequestMessage] = {
+    // TODO: loop over {count} times
+
+    ProjectNamer.exampleNames
+    throw new FireCloudException("stop here")
+
+//    ProjectNamer.trimLists
+//    throw new FireCloudException("stop here")
+
+//    val saToken = HttpGoogleServicesDAO.getTrialBillingManagerAccessToken
+//
+//    val saInfo:UserInfo = new UserInfo("free-trial-billing-manager@broad-dsde-dev.iam.gserviceaccount.com", OAuth2BearerToken(saToken), 12345, "110709330359854943358")
+//
+//    // temp: register SA
+//    val saProfile = BasicProfile(
+//      firstName = "FreeTrial",
+//      lastName = "BillingManager",
+//      title = "Free Trial Billing Manager Service Account",
+//      contactEmail = Option("billing@firecloud.org"),
+//      institute = "Broad Institute",
+//      institutionalProgram = "DSP",
+//      programLocationCity = "Cambridge",
+//      programLocationState = "MA",
+//      programLocationCountry = "USA",
+//      pi = "Broad Institute",
+//      nonProfitStatus = "true")
+//    val registrationInfo: RegistrationInfo = scala.concurrent.Await.result(createUpdateProfile(saInfo, saProfile), scala.concurrent.duration.Duration.Inf)
+//    logger.warn(s" ############# registration result: " + registrationInfo)
+
+    // generate a unique project name
+    def verifyUniqueProjectName(seed: String): String = {
+      var sanityCheck = 1
+      Try(trialDAO.insertProjectRecord(RawlsBillingProjectName(seed))) match {
+        case scala.util.Success(project) =>
+          logger.warn(s"created unique project name in $sanityCheck attempts.")
+          project.name.value
+        case scala.util.Failure(f) =>
+          sanityCheck += 1
+          if (sanityCheck > 100) throw new FireCloudException(s"Could not generate a unique project name after $sanityCheck tries")
+          verifyUniqueProjectName(ProjectNamer.randomName)
+      }
+    }
+
+    val projectName = verifyUniqueProjectName(ProjectNamer.randomName)
+//    val billingAcct = "billingAccounts/00708C-45D19D-27AAFA"
+    val billingAcct = FireCloudConfig.Trial.billingAccount
+
+    logger.warn(s"creating name '$projectName' ...")
+
+
+    // create project via rawls
+    rawlsDAO.asInstanceOf[HttpRawlsDAO].createProject(projectName, billingAcct) map { createSuccess =>
+      RequestComplete(StatusCodes.EnhanceYourCalm)
+    }
+
+  }
+
+
+  private def createUpdateProfile(userInfo: UserInfo, basicProfile: BasicProfile): Future[RegistrationInfo] = {
+    for {
+      _ <- thurloeDao.saveProfile(userInfo, basicProfile)
+      _ <- thurloeDao.saveKeyValues(
+        userInfo, Map("isRegistrationComplete" -> Profile.currentVersion.toString)
+      )
+      isRegistered <- samDao.getRegistrationStatus(userInfo) recover {
+        case e: FireCloudExceptionWithErrorReport if e.errorReport.statusCode == Option(StatusCodes.NotFound) =>
+          RegistrationInfo(WorkbenchUserInfo(userInfo.id, userInfo.userEmail), WorkbenchEnabled(false, false, false))
+      }
+      userStatus <- if (!isRegistered.enabled.google || !isRegistered.enabled.ldap) {
+        for {
+          registrationInfo <- samDao.registerUser(userInfo)
+          _ <- rawlsDAO.registerUser(userInfo) //This call to rawls handles leftover registration pieces (welcome email and pending workspace access)
+        } yield registrationInfo
+      } else Future.successful(isRegistered)
+    } yield {
+      userStatus
+    }
+  }
 }
+
+
+
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/TrialService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/TrialService.scala
@@ -249,7 +249,7 @@ final class TrialService
             logger.warn(s"project ${unv.name.value} errored, so we have to give up on it.")
             trialDAO.setProjectRecordVerified(unv.name, verified=true, status = CreationStatuses.Error)
           case Some(CreationStatuses.Ready) =>
-            trialDAO.setProjectRecordVerified(unv.name, verified=true, status = CreationStatuses.Error)
+            trialDAO.setProjectRecordVerified(unv.name, verified=true, status = CreationStatuses.Ready)
           case None =>
             logger.warn(s"project ${unv.name.value} exists in pool but not found via Rawls!")
         }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/TrialService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/TrialService.scala
@@ -7,37 +7,26 @@ import akka.actor.{Actor, ActorRef, Props}
 import akka.pattern._
 import akka.util.Timeout
 import com.typesafe.scalalogging.LazyLogging
-import org.broadinstitute.dsde.firecloud.{Application, FireCloudConfig}
-import org.broadinstitute.dsde.firecloud.dataaccess.{RawlsDAO, SamDAO, ThurloeDAO}
-import org.broadinstitute.dsde.firecloud.model.Trial.TrialStates.{Disabled, Enabled, Terminated, TrialState}
-import org.broadinstitute.dsde.firecloud.model.Trial.{StatusUpdate, TrialStates, UserTrialStatus}
-import org.broadinstitute.dsde.firecloud.model.{RequestCompleteWithErrorReport, UserInfo, WorkbenchUserInfo}
-import org.broadinstitute.dsde.firecloud.service.PerRequest.{PerRequestMessage, RequestComplete}
-import org.broadinstitute.dsde.firecloud.service.TrialService._
-import org.broadinstitute.dsde.firecloud.utils.PermissionsSupport
-import org.broadinstitute.dsde.rawls.model.RawlsUserEmail
-import org.broadinstitute.dsde.firecloud.{Application, FireCloudConfig, FireCloudException, FireCloudExceptionWithErrorReport}
-import org.broadinstitute.dsde.firecloud.{Application, FireCloudConfig, FireCloudException}
-import org.broadinstitute.dsde.firecloud.dataaccess._
-import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol.{impCreateProjectsResponse, impTrialProject}
+import org.broadinstitute.dsde.firecloud.dataaccess.{RawlsDAO, SamDAO, ThurloeDAO, _}
 import org.broadinstitute.dsde.firecloud.model.Trial.CreationStatuses.CreationStatus
-import org.broadinstitute.dsde.firecloud.model.Trial._
-import org.broadinstitute.dsde.firecloud.model.{AccessToken, RequestCompleteWithErrorReport, UserInfo, WithAccessToken}
+import org.broadinstitute.dsde.firecloud.model.Trial.TrialStates.{Disabled, Enabled, Terminated}
+import org.broadinstitute.dsde.firecloud.model.Trial.{StatusUpdate, TrialStates, UserTrialStatus, _}
+import org.broadinstitute.dsde.firecloud.model.{AccessToken, RequestCompleteWithErrorReport, UserInfo, WithAccessToken, WorkbenchUserInfo}
+import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol.{impCreateProjectsResponse, impTrialProject}
 import org.broadinstitute.dsde.firecloud.service.PerRequest.{PerRequestMessage, RequestComplete}
 import org.broadinstitute.dsde.firecloud.service.TrialService._
 import org.broadinstitute.dsde.firecloud.trial.ProjectManager.StartCreation
 import org.broadinstitute.dsde.firecloud.utils.PermissionsSupport
-import org.broadinstitute.dsde.rawls.model.RawlsBillingProjectName
-import spray.http.{OAuth2BearerToken, StatusCodes}
+import org.broadinstitute.dsde.firecloud.{Application, FireCloudConfig, FireCloudException}
+import org.broadinstitute.dsde.rawls.model.{RawlsBillingProjectName, RawlsUserEmail}
 import spray.http.StatusCodes._
+import spray.http.{OAuth2BearerToken, StatusCodes}
 import spray.httpx.SprayJsonSupport
-import spray.json._
 import spray.json.DefaultJsonProtocol._
 
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
-import scala.util.Try
 
 // TODO: Contain userEmail in value class for stronger type safety without incurring performance penalty
 object TrialService {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/TrialService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/TrialService.scala
@@ -17,6 +17,7 @@ import org.broadinstitute.dsde.firecloud.service.TrialService._
 import org.broadinstitute.dsde.firecloud.utils.PermissionsSupport
 import org.broadinstitute.dsde.rawls.model.RawlsUserEmail
 import org.broadinstitute.dsde.firecloud.{Application, FireCloudConfig, FireCloudException, FireCloudExceptionWithErrorReport}
+import org.broadinstitute.dsde.firecloud.{Application, FireCloudConfig, FireCloudException}
 import org.broadinstitute.dsde.firecloud.dataaccess._
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol.{impCreateProjectsResponse, impTrialProject}
 import org.broadinstitute.dsde.firecloud.model.Trial.CreationStatuses.CreationStatus
@@ -78,6 +79,7 @@ final class TrialService
     case VerifyProjects(userInfo) => asTrialCampaignManager {verifyProjects}(userInfo) pipeTo sender
     case CountProjects(userInfo) => asTrialCampaignManager {countProjects}(userInfo) pipeTo sender
     case Report(userInfo) => asTrialCampaignManager {projectReport}(userInfo) pipeTo sender
+    case x => throw new FireCloudException("unrecognized message: " + x.toString)
   }
 
   private def enableUsers(managerInfo: UserInfo, userEmails: Seq[String]): Future[PerRequestMessage] = {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/trial/ProjectManager.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/trial/ProjectManager.scala
@@ -1,0 +1,149 @@
+package org.broadinstitute.dsde.firecloud.trial
+
+import akka.actor.{Actor, Props}
+import com.typesafe.scalalogging.LazyLogging
+import org.broadinstitute.dsde.firecloud.FireCloudConfig
+import org.broadinstitute.dsde.firecloud.dataaccess.{HttpGoogleServicesDAO, RawlsDAO, TrialDAO}
+import org.broadinstitute.dsde.firecloud.model.Trial.{CreateProjectsResponse, CreationStatuses}
+import org.broadinstitute.dsde.firecloud.model.{AccessToken, WithAccessToken}
+import org.broadinstitute.dsde.firecloud.trial.ProjectManager.{Create, StartCreation, Verify}
+import org.broadinstitute.dsde.rawls.model.RawlsBillingProjectName
+import spray.http.OAuth2BearerToken
+
+import scala.concurrent.duration._
+import scala.util.Try
+
+object ProjectManager {
+
+  val DefaultCreateDelay = 2.minutes // pause between creating projects to avoid triggering Google quotas
+  val DefaultVerifyDelay = 3.minutes // pause between creating a project and verifying it, to allow Google to finish creation
+
+  sealed trait ProjectManagerMessage
+  case class StartCreation(count: Int) extends ProjectManagerMessage
+  case class Create(current: Int, target: Int) extends ProjectManagerMessage
+  case class Verify(projectName: String) extends ProjectManagerMessage
+
+  def props(rawlsDAO: RawlsDAO, trialDAO: TrialDAO,
+            createDelay: FiniteDuration = DefaultCreateDelay, verifyDelay: FiniteDuration = DefaultVerifyDelay): Props =
+    Props(new ProjectManager(rawlsDAO, trialDAO, createDelay, verifyDelay))
+}
+
+/**
+  * Actor to manage creation of free trial billing projects
+  *
+  * @param rawlsDAO dao for rawls
+  * @param trialDAO dao for the trial pool
+  * @param createDelay pause between creating projects to avoid triggering Google quotas
+  * @param verifyDelay pause between creating a project and verifying it, to allow Google to finish creation
+  */
+class ProjectManager(val rawlsDAO: RawlsDAO, val trialDAO: TrialDAO, val createDelay: FiniteDuration, val verifyDelay: FiniteDuration)
+  extends Actor with LazyLogging {
+
+  import context.dispatcher
+
+  val billingAcct = FireCloudConfig.Trial.billingAccount
+
+  // these should probably be an enum or the like
+  val idle = "idle"
+  val creating = "creating"
+
+  var currentStatus = idle
+
+  override def receive: Receive = {
+    case StartCreation(count: Int) => sender ! startCreation(count)
+    case Create(current: Int, target: Int) => sender ! create(current, target)
+    case Verify(projectName: String) => verify(projectName)
+  }
+
+  private def startCreation(count: Int): CreateProjectsResponse = {
+    getCurrentStatus match {
+      case `idle` =>
+        self ! Create(1, count)
+        CreateProjectsResponse(success = true, count, Some(s"$count projects are queued for creation."))
+      case x =>
+        CreateProjectsResponse(success = false, 0, Some("ProjectManager is already creating projects; don't try to create more!"))
+    }
+  }
+
+  private def create(current: Int, target: Int) = {
+    if (current > target) {
+      setCurrentStatus(idle)
+      logger.info("project creation requests complete.")
+      // don't stop the actor, because we are likely still verifying
+    } else {
+      setCurrentStatus(s"$creating: $current / $target")
+      logger.info(s"project creation cycle: $getCurrentStatus")
+
+      // generate a unique project name
+      val uniqueProjectName = verifyUniqueProjectName(ProjectNamer.randomName, 1)
+
+      uniqueProjectName map { projectName =>
+        logger.info(s"creating name <$projectName> via rawls ...")
+        // create project via rawls, after sudoing to the trial billing manager
+        val saToken:WithAccessToken = AccessToken(OAuth2BearerToken(HttpGoogleServicesDAO.getTrialBillingManagerAccessToken))
+        rawlsDAO.createProject(projectName, billingAcct)(saToken) map { createSuccess =>
+          if (createSuccess) {
+            logger.info(s"rawls acknowledged create request for <$projectName>.")
+            // schedule a verify for the project we just created
+            context.system.scheduler.scheduleOnce(verifyDelay, self, Verify(projectName))
+          } else {
+            logger.warn(s"rawls reports error when creating <$projectName>.")
+          }
+        }
+        // schedule the next creation
+        context.system.scheduler.scheduleOnce(createDelay, self, Create(current+1, target))
+      }
+    }
+  }
+
+  private def verify(projectName: String) = {
+    logger.info(s"verifying project <$projectName> ...")
+    val rawlsName = RawlsBillingProjectName(projectName)
+    val saToken:WithAccessToken = AccessToken(OAuth2BearerToken(HttpGoogleServicesDAO.getTrialBillingManagerAccessToken))
+    // as the trial billing manager, get the list of all projects I own (no API to get a single project)
+    rawlsDAO.getProjects(saToken) map { projects =>
+      projects.find(p => p.projectName == rawlsName) match {
+        case None => // project doesn't exist in rawls. This shouldn't happen.
+          logger.warn(s"Project <$projectName> was created in rawls but not returned by rawls. Calling it an error.")
+          trialDAO.setProjectRecordVerified(rawlsName, verified = true, status = CreationStatuses.Error)
+        case Some(proj) =>
+          proj.creationStatus match {
+            case CreationStatuses.Creating =>
+              logger.info(s"Project <$projectName> still creating; will retry verification.")
+              context.system.scheduler.scheduleOnce(verifyDelay, self, Verify(projectName))
+            case CreationStatuses.Ready =>
+              logger.info(s"Project <$projectName> verified as ready!")
+              trialDAO.setProjectRecordVerified(rawlsName, verified = true, status = CreationStatuses.Ready)
+            case CreationStatuses.Error =>
+              logger.warn(s"Project <$projectName> errored during creation: ${proj.message}")
+              trialDAO.setProjectRecordVerified(rawlsName, verified = true, status = CreationStatuses.Error)
+          }
+      }
+    } recover {
+      case t:Throwable =>
+        logger.warn(s"Error checking status on <$projectName>: ${t.getMessage}")
+        context.system.scheduler.scheduleOnce(verifyDelay, self, Verify(projectName))
+    }
+  }
+
+  private def verifyUniqueProjectName(name: String, currentAttempt: Int): Option[String] = {
+    val sanityLimit = 100
+    Try(trialDAO.insertProjectRecord(RawlsBillingProjectName(name))) match {
+      case scala.util.Success(project) =>
+        logger.debug(s"found unique project name in $currentAttempt attempt(s); recorded in pool.")
+        Some(project.name.value)
+      case scala.util.Failure(f) =>
+        if (currentAttempt > sanityLimit) {
+          logger.error(s"Could not generate a unique project name after $currentAttempt tries: ${f.getMessage}")
+          None
+        } else {
+          verifyUniqueProjectName(ProjectNamer.randomName, currentAttempt+1)
+        }
+    }
+  }
+
+  private def setCurrentStatus(status: String) = currentStatus = status
+  private def getCurrentStatus = currentStatus
+
+}
+

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/trial/ProjectNamer.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/trial/ProjectNamer.scala
@@ -4,43 +4,11 @@ import scala.util.Random.nextInt
 
 object ProjectNamer {
 
-//  private final val elements = List("Hydrogen", "Helium", "Lithium", "Beryllium", "Boron", "Carbon", "Nitrogen", "Oxygen",
-//    "Fluorine", "Neon", "Sodium", "Magnesium", "Aluminium", "Silicon", "Phosphorus", "Sulfur", "Chlorine", "Argon", "Potassium",
-//    "Calcium", "Scandium", "Titanium", "Vanadium", "Chromium", "Manganese", "Iron", "Cobalt", "Nickel", "Copper", "Zinc",
-//    "Gallium", "Germanium", "Arsenic", "Selenium", "Bromine", "Krypton", "Rubidium", "Strontium", "Yttrium", "Zirconium",
-//    "Niobium", "Molybdenum", "Technetium", "Ruthenium", "Rhodium", "Palladium", "Silver", "Cadmium", "Indium", "Tin",
-//    "Antimony", "Tellurium", "Iodine", "Xenon", "Caesium", "Barium", "Lanthanum", "Cerium", "Praseodymium", "Neodymium",
-//    "Promethium", "Samarium", "Europium", "Gadolinium", "Terbium", "Dysprosium", "Holmium", "Erbium", "Thulium", "Ytterbium",
-//    "Lutetium", "Hafnium", "Tantalum", "Tungsten", "Rhenium", "Osmium", "Iridium", "Platinum", "Gold", "Mercury", "Thallium",
-//    "Lead", "Bismuth", "Polonium", "Astatine", "Radon", "Francium", "Radium", "Actinium", "Thorium", "Protactinium", "Uranium",
-//    "Neptunium", "Plutonium", "Americium", "Curium", "Berkelium", "Californium", "Einsteinium", "Fermium", "Mendelevium",
-//    "Nobelium", "Lawrencium", "Rutherfordium", "Dubnium", "Seaborgium", "Bohrium", "Hassium", "Meitnerium", "Darmstadtium",
-//    "Roentgenium", "Copernicium", "Nihonium", "Flerovium", "Moscovium", "Livermorium", "Tennessine", "Oganesson")
-
   private final val elements = List("Helium", "Lithium", "Boron", "Carbon", "Oxygen", "Neon", "Sodium", "Silicon",
     "Sulfur", "Argon", "Calcium", "Iron", "Cobalt", "Nickel", "Copper", "Zinc", "Gallium", "Arsenic", "Bromine", "Krypton",
     "Yttrium", "Niobium", "Rhodium", "Silver", "Cadmium", "Indium", "Tin", "Iodine", "Xenon", "Caesium", "Barium", "Cerium",
     "Terbium", "Holmium", "Erbium", "Thulium", "Hafnium", "Rhenium", "Osmium", "Iridium", "Gold", "Mercury", "Lead", "Bismuth",
     "Radon", "Radium", "Thorium", "Uranium", "Curium", "Fermium", "Dubnium", "Bohrium", "Hassium")
-
-//  private final val colors = List( "Alizarin", "Amaranth", "Amber", "Amethyst", "Apricot", "Aqua", "Aquamarine", "Asparagus",
-//    "Auburn", "Azure", "Beige", "Bistre", "Black", "Blue", "Blue Green", "Blue Violet", "Bondi Blue", "Brass", "Bronze",
-//    "Brown", "Buff", "Burgundy", "Burnt Orange", "Burnt Sienna", "Burnt Umber", "Camouflage Green", "Caput Mortuum",
-//    "Cardinal", "Carmine", "Carrot orange", "Celadon", "Cerise", "Cerulean", "Champagne", "Charcoal", "Chartreuse",
-//    "Cherry Blossom Pink", "Chestnut", "Chocolate", "Cinnabar", "Cinnamon", "Cobalt", "Copper", "Coral", "Corn", "Cornflower",
-//    "Cream", "Crimson", "Cyan", "Dandelion", "Denim", "Ecru", "Eggplant", "Emerald", "Falu red", "Fern green", "Firebrick",
-//    "Flax", "Forest green", "French Rose", "Fuchsia", "Gamboge", "Gold", "Goldenrod", "Green", "Grey", "Han Purple",
-//    "Harlequin", "Heliotrope", "Hollywood Cerise", "Indigo", "Ivory", "Jade", "Kelly green", "Khaki", "Lavender", "Lawn green",
-//    "Lemon", "Lemon chiffon", "Lilac", "Lime", "Lime green", "Linen", "Magenta", "Magnolia", "Malachite", "Maroon", "Mauve",
-//    "Midnight Blue", "Mint green", "Misty rose", "Moss green", "Mustard", "Myrtle", "Navajo white", "Navy Blue", "Ochre",
-//    "Office green", "Olive", "Olivine", "Orange", "Orchid", "Papaya whip", "Peach", "Pear", "Periwinkle", "Persimmon",
-//    "Pine Green", "Pink", "Platinum", "Plum", "Powder blue", "Prussian blue", "Psychedelic purple", "Puce", "Pumpkin",
-//    "Purple", "Quartz Grey", "Raw umber", "Razzmatazz", "Red", "Robin egg blue", "Rose", "Royal blue", "Royal purple",
-//    "Ruby", "Russet", "Rust", "Safety orange", "Saffron", "Salmon", "Sandy brown", "Sangria", "Sapphire", "Scarlet",
-//    "School bus yellow", "Sea Green", "Seashell", "Sepia", "Shamrock green", "Shocking Pink", "Silver", "Sky Blue", "Slate grey",
-//    "Smalt", "Spring bud", "Spring green", "Steel blue", "Tan", "Tangerine", "Taupe", "Teal", "Tawny", "Terra cotta",
-//    "Thistle", "Titanium White", "Tomato", "Turquoise", "Tyrian purple", "Ultramarine", "Van Dyke Brown", "Vermilion", "Violet",
-//    "Viridian", "Wheat", "White", "Wisteria", "Xanthic", "Yellow", "Zucchini")
 
   private final val colors = List("Amber", "Apricot", "Aqua", "Auburn", "Azure", "Beige", "Bistre", "Black", "Blue",
     "Brass", "Bronze", "Brown", "Buff", "Carmine", "Celadon", "Cerise", "Cobalt", "Copper", "Coral", "Corn", "Cream",

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/trial/ProjectNamer.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/trial/ProjectNamer.scala
@@ -29,19 +29,4 @@ object ProjectNamer {
     s"$prefix-$element-$color-$suffix".replace(" ", "-").toLowerCase
   }
 
-  def trimLists = {
-    val shortElements = elements.collect {
-      case s if s.length <= 7 => s
-    }
-    val shortColor = colors.collect {
-      case s if s.length <= 7 => s
-    }
-
-    println(shortElements)
-    println(shortColor)
-  }
-
-  def exampleNames = 1 to 10 foreach (_ => println(randomName))
-
-
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/trial/ProjectNamer.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/trial/ProjectNamer.scala
@@ -1,0 +1,79 @@
+package org.broadinstitute.dsde.firecloud.trial
+
+import scala.util.Random.nextInt
+
+object ProjectNamer {
+
+//  private final val elements = List("Hydrogen", "Helium", "Lithium", "Beryllium", "Boron", "Carbon", "Nitrogen", "Oxygen",
+//    "Fluorine", "Neon", "Sodium", "Magnesium", "Aluminium", "Silicon", "Phosphorus", "Sulfur", "Chlorine", "Argon", "Potassium",
+//    "Calcium", "Scandium", "Titanium", "Vanadium", "Chromium", "Manganese", "Iron", "Cobalt", "Nickel", "Copper", "Zinc",
+//    "Gallium", "Germanium", "Arsenic", "Selenium", "Bromine", "Krypton", "Rubidium", "Strontium", "Yttrium", "Zirconium",
+//    "Niobium", "Molybdenum", "Technetium", "Ruthenium", "Rhodium", "Palladium", "Silver", "Cadmium", "Indium", "Tin",
+//    "Antimony", "Tellurium", "Iodine", "Xenon", "Caesium", "Barium", "Lanthanum", "Cerium", "Praseodymium", "Neodymium",
+//    "Promethium", "Samarium", "Europium", "Gadolinium", "Terbium", "Dysprosium", "Holmium", "Erbium", "Thulium", "Ytterbium",
+//    "Lutetium", "Hafnium", "Tantalum", "Tungsten", "Rhenium", "Osmium", "Iridium", "Platinum", "Gold", "Mercury", "Thallium",
+//    "Lead", "Bismuth", "Polonium", "Astatine", "Radon", "Francium", "Radium", "Actinium", "Thorium", "Protactinium", "Uranium",
+//    "Neptunium", "Plutonium", "Americium", "Curium", "Berkelium", "Californium", "Einsteinium", "Fermium", "Mendelevium",
+//    "Nobelium", "Lawrencium", "Rutherfordium", "Dubnium", "Seaborgium", "Bohrium", "Hassium", "Meitnerium", "Darmstadtium",
+//    "Roentgenium", "Copernicium", "Nihonium", "Flerovium", "Moscovium", "Livermorium", "Tennessine", "Oganesson")
+
+  private final val elements = List("Helium", "Lithium", "Boron", "Carbon", "Oxygen", "Neon", "Sodium", "Silicon",
+    "Sulfur", "Argon", "Calcium", "Iron", "Cobalt", "Nickel", "Copper", "Zinc", "Gallium", "Arsenic", "Bromine", "Krypton",
+    "Yttrium", "Niobium", "Rhodium", "Silver", "Cadmium", "Indium", "Tin", "Iodine", "Xenon", "Caesium", "Barium", "Cerium",
+    "Terbium", "Holmium", "Erbium", "Thulium", "Hafnium", "Rhenium", "Osmium", "Iridium", "Gold", "Mercury", "Lead", "Bismuth",
+    "Radon", "Radium", "Thorium", "Uranium", "Curium", "Fermium", "Dubnium", "Bohrium", "Hassium")
+
+//  private final val colors = List( "Alizarin", "Amaranth", "Amber", "Amethyst", "Apricot", "Aqua", "Aquamarine", "Asparagus",
+//    "Auburn", "Azure", "Beige", "Bistre", "Black", "Blue", "Blue Green", "Blue Violet", "Bondi Blue", "Brass", "Bronze",
+//    "Brown", "Buff", "Burgundy", "Burnt Orange", "Burnt Sienna", "Burnt Umber", "Camouflage Green", "Caput Mortuum",
+//    "Cardinal", "Carmine", "Carrot orange", "Celadon", "Cerise", "Cerulean", "Champagne", "Charcoal", "Chartreuse",
+//    "Cherry Blossom Pink", "Chestnut", "Chocolate", "Cinnabar", "Cinnamon", "Cobalt", "Copper", "Coral", "Corn", "Cornflower",
+//    "Cream", "Crimson", "Cyan", "Dandelion", "Denim", "Ecru", "Eggplant", "Emerald", "Falu red", "Fern green", "Firebrick",
+//    "Flax", "Forest green", "French Rose", "Fuchsia", "Gamboge", "Gold", "Goldenrod", "Green", "Grey", "Han Purple",
+//    "Harlequin", "Heliotrope", "Hollywood Cerise", "Indigo", "Ivory", "Jade", "Kelly green", "Khaki", "Lavender", "Lawn green",
+//    "Lemon", "Lemon chiffon", "Lilac", "Lime", "Lime green", "Linen", "Magenta", "Magnolia", "Malachite", "Maroon", "Mauve",
+//    "Midnight Blue", "Mint green", "Misty rose", "Moss green", "Mustard", "Myrtle", "Navajo white", "Navy Blue", "Ochre",
+//    "Office green", "Olive", "Olivine", "Orange", "Orchid", "Papaya whip", "Peach", "Pear", "Periwinkle", "Persimmon",
+//    "Pine Green", "Pink", "Platinum", "Plum", "Powder blue", "Prussian blue", "Psychedelic purple", "Puce", "Pumpkin",
+//    "Purple", "Quartz Grey", "Raw umber", "Razzmatazz", "Red", "Robin egg blue", "Rose", "Royal blue", "Royal purple",
+//    "Ruby", "Russet", "Rust", "Safety orange", "Saffron", "Salmon", "Sandy brown", "Sangria", "Sapphire", "Scarlet",
+//    "School bus yellow", "Sea Green", "Seashell", "Sepia", "Shamrock green", "Shocking Pink", "Silver", "Sky Blue", "Slate grey",
+//    "Smalt", "Spring bud", "Spring green", "Steel blue", "Tan", "Tangerine", "Taupe", "Teal", "Tawny", "Terra cotta",
+//    "Thistle", "Titanium White", "Tomato", "Turquoise", "Tyrian purple", "Ultramarine", "Van Dyke Brown", "Vermilion", "Violet",
+//    "Viridian", "Wheat", "White", "Wisteria", "Xanthic", "Yellow", "Zucchini")
+
+  private final val colors = List("Amber", "Apricot", "Aqua", "Auburn", "Azure", "Beige", "Bistre", "Black", "Blue",
+    "Brass", "Bronze", "Brown", "Buff", "Carmine", "Celadon", "Cerise", "Cobalt", "Copper", "Coral", "Corn", "Cream",
+    "Crimson", "Cyan", "Denim", "Ecru", "Emerald", "Flax", "Fuchsia", "Gamboge", "Gold", "Green", "Grey", "Indigo", "Ivory",
+    "Jade", "Khaki", "Lemon", "Lilac", "Lime", "Linen", "Magenta", "Maroon", "Mauve", "Mustard", "Myrtle", "Ochre", "Olive",
+    "Olivine", "Orange", "Orchid", "Peach", "Pear", "Pink", "Plum", "Puce", "Pumpkin", "Purple", "Red", "Rose", "Ruby",
+    "Russet", "Rust", "Saffron", "Salmon", "Sangria", "Scarlet", "Sepia", "Silver", "Smalt", "Tan", "Taupe", "Teal", "Tawny",
+    "Thistle", "Tomato", "Violet", "Wheat", "White", "Xanthic", "Yellow")
+
+  private final val ra:Range = Range(1000, 9999)
+
+  private final val prefix = "FCcredits"
+
+  def randomName:String = {
+    val color = colors.apply(nextInt(colors.size))
+    val element = elements.apply(nextInt(elements.size))
+    val suffix = ra.head + nextInt(ra.end - ra.head)
+    s"$prefix-$element-$color-$suffix".replace(" ", "-").toLowerCase
+  }
+
+  def trimLists = {
+    val shortElements = elements.collect {
+      case s if s.length <= 7 => s
+    }
+    val shortColor = colors.collect {
+      case s if s.length <= 7 => s
+    }
+
+    println(shortElements)
+    println(shortColor)
+  }
+
+  def exampleNames = 1 to 10 foreach (_ => println(randomName))
+
+
+}

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/utils/RestJsonClient.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/utils/RestJsonClient.scala
@@ -40,9 +40,6 @@ trait RestJsonClient extends FireCloudRequestBuilding with PerformanceLogging {
                          connector: Option[ActorRef] = None, label: Option[String] = None): Future[HttpResponse] =
     doRequest(Option(addAdminCredentials))(req, compressed, useFireCloudHeader, connector, label)
 
-  def trialBillingAuthedRequest(req: HttpRequest, compressed: Boolean = false, useFireCloudHeader: Boolean = false, connector: Option[ActorRef] = None, label: Option[String] = None): Future[HttpResponse] =
-    doRequest(Option(addTrialBillingCredentials))(req, compressed, useFireCloudHeader, connector, label)
-
   private def doRequest(addCreds: Option[RequestTransformer])(req: HttpRequest, compressed: Boolean = false, useFireCloudHeader: Boolean = false,
                                                               connector: Option[ActorRef] = None, label: Option[String] = None): Future[HttpResponse] = {
     val sr = if (connector.isDefined) {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/utils/RestJsonClient.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/utils/RestJsonClient.scala
@@ -40,6 +40,9 @@ trait RestJsonClient extends FireCloudRequestBuilding with PerformanceLogging {
                          connector: Option[ActorRef] = None, label: Option[String] = None): Future[HttpResponse] =
     doRequest(Option(addAdminCredentials))(req, compressed, useFireCloudHeader, connector, label)
 
+  def trialBillingAuthedRequest(req: HttpRequest, compressed: Boolean = false, useFireCloudHeader: Boolean = false, connector: Option[ActorRef] = None, label: Option[String] = None): Future[HttpResponse] =
+    doRequest(Option(addTrialBillingCredentials))(req, compressed, useFireCloudHeader, connector, label)
+
   private def doRequest(addCreds: Option[RequestTransformer])(req: HttpRequest, compressed: Boolean = false, useFireCloudHeader: Boolean = false,
                                                               connector: Option[ActorRef] = None, label: Option[String] = None): Future[HttpResponse] = {
     val sr = if (connector.isDefined) {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/UserApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/UserApiService.scala
@@ -121,6 +121,15 @@ trait UserApiService extends HttpService with PerRequestCreator with FireCloudRe
       }
     } ~
     pathPrefix("api") {
+      path("trial" / "manager" / "projects") {
+        parameter("count".as[Int]) { count =>
+          requireUserInfo() { userInfo => requestContext =>
+            perRequest(requestContext, TrialService.props(trialServiceConstructor),
+              TrialService.CreateProjects(userInfo, count)
+            )
+          }
+        }
+      } ~
       path("profile" / "billing") {
         passthrough(UserApiService.billingUrl, HttpMethods.GET)
       } ~

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/UserApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/UserApiService.scala
@@ -128,13 +128,16 @@ trait UserApiService extends HttpService with PerRequestCreator with FireCloudRe
             parameter("operation") { op =>
               requireUserInfo() { userInfo => requestContext =>
                 val message = op.toLowerCase match {
-                  case "create" => TrialService.CreateProjects(userInfo, count)
-                  case "verify" => TrialService.VerifyProjects(userInfo)
-                  case "count" => TrialService.CountProjects(userInfo)
-                  case "report" => TrialService.Report(userInfo)
-                  case _ => requestContext.complete(spray.http.StatusCodes.BadRequest)
+                  case "create" => Some(TrialService.CreateProjects(userInfo, count))
+                  case "verify" => Some(TrialService.VerifyProjects(userInfo))
+                  case "count" => Some(TrialService.CountProjects(userInfo))
+                  case "report" => Some(TrialService.Report(userInfo))
+                  case _ => None
                 }
-                perRequest(requestContext, TrialService.props(trialServiceConstructor), message)
+                if (message.nonEmpty)
+                  perRequest(requestContext, TrialService.props(trialServiceConstructor), message)
+                else
+                  requestContext.complete(BadRequest, ErrorReport(s"invalid operation '$op'"))
               }
             }
           }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/UserApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/UserApiService.scala
@@ -124,12 +124,14 @@ trait UserApiService extends HttpService with PerRequestCreator with FireCloudRe
       // TODO: move to TrialApiService, once that exists
       path("trial" / "manager" / "projects") {
         post {
-          parameter("count".as[Int]) { count =>
+          parameter("count".as[Int] ? 0) { count =>
             parameter("operation") { op =>
               requireUserInfo() { userInfo => requestContext =>
                 val message = op.toLowerCase match {
                   case "create" => TrialService.CreateProjects(userInfo, count)
-                  case "verify" => TrialService.VerifyProjects
+                  case "verify" => TrialService.VerifyProjects(userInfo)
+                  case "count" => TrialService.CountProjects(userInfo)
+                  case "report" => TrialService.Report(userInfo)
                 }
                 perRequest(requestContext, TrialService.props(trialServiceConstructor), message)
               }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/UserApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/UserApiService.scala
@@ -135,7 +135,7 @@ trait UserApiService extends HttpService with PerRequestCreator with FireCloudRe
                   case _ => None
                 }
                 if (message.nonEmpty)
-                  perRequest(requestContext, TrialService.props(trialServiceConstructor), message)
+                  perRequest(requestContext, TrialService.props(trialServiceConstructor), message.get)
                 else
                   requestContext.complete(BadRequest, ErrorReport(s"invalid operation '$op'"))
               }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/UserApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/UserApiService.scala
@@ -122,10 +122,19 @@ trait UserApiService extends HttpService with PerRequestCreator with FireCloudRe
     } ~
     pathPrefix("api") {
       path("trial" / "manager" / "projects") {
-        parameter("count".as[Int]) { count =>
+        post {
+          parameter("count".as[Int]) { count =>
+            requireUserInfo() { userInfo => requestContext =>
+              perRequest(requestContext, TrialService.props(trialServiceConstructor),
+                TrialService.CreateProjects(userInfo, count)
+              )
+            }
+          }
+        } ~
+        put {
           requireUserInfo() { userInfo => requestContext =>
             perRequest(requestContext, TrialService.props(trialServiceConstructor),
-              TrialService.CreateProjects(userInfo, count)
+              TrialService.VerifyProjects(userInfo)
             )
           }
         }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/UserApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/UserApiService.scala
@@ -121,13 +121,18 @@ trait UserApiService extends HttpService with PerRequestCreator with FireCloudRe
       }
     } ~
     pathPrefix("api") {
+      // TODO: move to TrialApiService, once that exists
       path("trial" / "manager" / "projects") {
         post {
           parameter("count".as[Int]) { count =>
-            requireUserInfo() { userInfo => requestContext =>
-              perRequest(requestContext, TrialService.props(trialServiceConstructor),
-                TrialService.CreateProjects(userInfo, count)
-              )
+            parameter("operation") { op =>
+              requireUserInfo() { userInfo => requestContext =>
+                val message = op.toLowerCase match {
+                  case "create" => TrialService.CreateProjects(userInfo, count)
+                  case "verify" => TrialService.VerifyProjects
+                }
+                perRequest(requestContext, TrialService.props(trialServiceConstructor), message)
+              }
             }
           }
         } ~

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/UserApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/UserApiService.scala
@@ -132,17 +132,11 @@ trait UserApiService extends HttpService with PerRequestCreator with FireCloudRe
                   case "verify" => TrialService.VerifyProjects(userInfo)
                   case "count" => TrialService.CountProjects(userInfo)
                   case "report" => TrialService.Report(userInfo)
+                  case _ => requestContext.complete(spray.http.StatusCodes.BadRequest)
                 }
                 perRequest(requestContext, TrialService.props(trialServiceConstructor), message)
               }
             }
-          }
-        } ~
-        put {
-          requireUserInfo() { userInfo => requestContext =>
-            perRequest(requestContext, TrialService.props(trialServiceConstructor),
-              TrialService.VerifyProjects(userInfo)
-            )
           }
         }
       } ~

--- a/src/test/resources/reference.conf
+++ b/src/test/resources/reference.conf
@@ -11,6 +11,9 @@ auth {
   pemFileClientId = "dummy"
   rawlsPemFile = "/dev/null"
   rawlsPemFileClientId = "dummy"
+  trialBillingPemFile = "/dev/null"
+  trialBillingPemFileClientId = "dummy"
+
   swaggerRealm = "broad-dsde-dev"
 }
 
@@ -76,6 +79,7 @@ duos {
 trial {
   durationDays = 60
   managerGroup = "trial_managers"
+  billingAccount = "billingAccounts/dummy"
 }
 
 # these are the settings currently used at runtime; copy them here

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockRawlsDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockRawlsDAO.scala
@@ -362,4 +362,6 @@ class MockRawlsDAO  extends RawlsDAO {
   def deleteWorkspace(workspaceNamespace: String, workspaceName: String)(implicit userToken: WithAccessToken): Future[WorkspaceDeleteResponse] = {
     Future.successful(WorkspaceDeleteResponse(Some("Your Google bucket 'bucketId' will be deleted within 24h.")))
   }
+
+  override def createProject(projectName: String, billingAccount: String)(implicit userToken: WithAccessToken): Future[Boolean] = Future(false)
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockRawlsDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockRawlsDAO.scala
@@ -364,4 +364,6 @@ class MockRawlsDAO  extends RawlsDAO {
   }
 
   override def createProject(projectName: String, billingAccount: String)(implicit userToken: WithAccessToken): Future[Boolean] = Future(false)
+
+  override def getProjects(implicit userToken: WithAccessToken): Future[Seq[Trial.RawlsBillingProjectMembership]] = Future(Seq.empty[Trial.RawlsBillingProjectMembership])
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockTrialDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockTrialDAO.scala
@@ -1,0 +1,64 @@
+package org.broadinstitute.dsde.firecloud.dataaccess
+import org.broadinstitute.dsde.firecloud.model.Trial.TrialProject
+import org.broadinstitute.dsde.firecloud.model.{Trial, WorkbenchUserInfo}
+import org.broadinstitute.dsde.rawls.model.RawlsBillingProjectName
+import org.broadinstitute.dsde.workbench.util.health.SubsystemStatus
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class MockTrialDAO extends TrialDAO {
+  /**
+    * Read the record for a specified project. Throws an error if record not found.
+    *
+    * @param projectName name of the project record to read.
+    * @return the project record
+    */
+  override def getProjectRecord(projectName: RawlsBillingProjectName): Trial.TrialProject = throw new Exception("unit test intentional exception")
+
+  /**
+    * Create a record for the specified project. Throws error if name
+    * already exists or could not be otherwise created.
+    *
+    * @param projectName name of the project to use when creating a record
+    * @return the created project record
+    */
+  override def insertProjectRecord(projectName: RawlsBillingProjectName): Trial.TrialProject = throw new Exception("unit test intentional exception")
+
+  /**
+    * Update the "verified" field for a specified project record. The "verified" field indicates whether
+    * or not the associated billing project was created successfully in Google Cloud. Throws an error if
+    * the record was not found or the record could not be updated.
+    *
+    * @param projectName name of the project record to update
+    * @param verified    verified value with which to update the project record
+    * @return the updated project record
+    */
+  override def setProjectRecordVerified(projectName: RawlsBillingProjectName, verified: Boolean): Trial.TrialProject = throw new Exception("unit test intentional exception")
+
+  /**
+    * Associates the next-available project record with a specified user. Definition of "next available"
+    * is deferred to impl classes. Throws an error if no project records are available, or if the project
+    * record could not be updated.
+    *
+    * @param userInfo the user (email and subjectid) with which to update the project record.
+    * @return the updated project record
+    */
+  override def claimProjectRecord(userInfo: WorkbenchUserInfo): Trial.TrialProject = throw new Exception("unit test intentional exception")
+
+  /**
+    * Returns a count of available project records. Definition of "available" is deferred to impl classes.
+    *
+    * @return count of available project records.
+    */
+  override def countAvailableProjects: Long = 0
+
+  /**
+    * Returns a list of project records that have associated users.
+    *
+    * @return list of project records that have associated users.
+    */
+override def projectReport: Seq[Trial.TrialProject] = Seq.empty[TrialProject]
+
+  override def status: Future[SubsystemStatus] = Future(SubsystemStatus(ok = true, None))
+}

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockTrialDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockTrialDAO.scala
@@ -1,4 +1,5 @@
 package org.broadinstitute.dsde.firecloud.dataaccess
+import org.broadinstitute.dsde.firecloud.model.Trial.CreationStatuses.CreationStatus
 import org.broadinstitute.dsde.firecloud.model.Trial.TrialProject
 import org.broadinstitute.dsde.firecloud.model.{Trial, WorkbenchUserInfo}
 import org.broadinstitute.dsde.rawls.model.RawlsBillingProjectName
@@ -15,6 +16,15 @@ class MockTrialDAO extends TrialDAO {
     * @return the project record
     */
   override def getProjectRecord(projectName: RawlsBillingProjectName): Trial.TrialProject = throw new Exception("unit test intentional exception")
+
+
+  /**
+    * Check to see if the project record exists.
+    *
+    * @param projectName name of the project record to read.
+    * @return whether or not the project record exists
+    */
+  override def projectRecordExists(projectName: RawlsBillingProjectName): Boolean = false
 
   /**
     * Create a record for the specified project. Throws error if name
@@ -34,7 +44,7 @@ class MockTrialDAO extends TrialDAO {
     * @param verified    verified value with which to update the project record
     * @return the updated project record
     */
-  override def setProjectRecordVerified(projectName: RawlsBillingProjectName, verified: Boolean): Trial.TrialProject = throw new Exception("unit test intentional exception")
+  override def setProjectRecordVerified(projectName: RawlsBillingProjectName, verified: Boolean, status: CreationStatus): Trial.TrialProject = throw new Exception("unit test intentional exception")
 
   /**
     * Associates the next-available project record with a specified user. Definition of "next available"
@@ -45,6 +55,14 @@ class MockTrialDAO extends TrialDAO {
     * @return the updated project record
     */
   override def claimProjectRecord(userInfo: WorkbenchUserInfo): Trial.TrialProject = throw new Exception("unit test intentional exception")
+
+
+  /**
+    * Returns a list of project records in the pool that are unverified.
+    *
+    * @return list of project records in the pool that are unverified.
+    */
+  override def listUnverifiedProjects: Seq[TrialProject] = Seq.empty[TrialProject]
 
   /**
     * Returns a count of available project records. Definition of "available" is deferred to impl classes.

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockTrialDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockTrialDAO.scala
@@ -75,7 +75,7 @@ class MockTrialDAO extends TrialDAO {
     *
     * @return list of project records that have associated users.
     */
-override def projectReport: Seq[Trial.TrialProject] = Seq.empty[TrialProject]
+  override def projectReport: Seq[Trial.TrialProject] = Seq.empty[TrialProject]
 
   override def status: Future[SubsystemStatus] = Future(SubsystemStatus(ok = true, None))
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockTrialDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockTrialDAO.scala
@@ -65,11 +65,10 @@ class MockTrialDAO extends TrialDAO {
   override def listUnverifiedProjects: Seq[TrialProject] = Seq.empty[TrialProject]
 
   /**
-    * Returns a count of available project records. Definition of "available" is deferred to impl classes.
-    *
-    * @return count of available project records.
+    * Returns a counts of project records by status.
+    * @return counts of project records.
     */
-  override def countAvailableProjects: Long = 0
+  override def countProjects: Map[String,Long] = Map.empty[String,Long]
 
   /**
     * Returns a list of project records that have associated users.

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/ElasticSearchTrialDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/ElasticSearchTrialDAOSpec.scala
@@ -95,14 +95,14 @@ class ElasticSearchTrialDAOSpec extends FreeSpec with Matchers with BeforeAndAft
     }
     "countAvailableProjects" - {
       "should return zero when no projects available" in {
-        assertResult(0) { trialDAO.countAvailableProjects }
+        assertResult(Some(0)) { trialDAO.countProjects.get("available") }
       }
       "should return accurate count of available projects" in {
         // insert three
         Seq("orange", "pineapple", "quince") foreach { proj => trialDAO.insertProjectRecord(RawlsBillingProjectName(proj))}
         // verify two
         Seq("orange", "quince") foreach { proj => trialDAO.setProjectRecordVerified(RawlsBillingProjectName(proj), verified=true, status=Ready)}
-        assertResult(2) { trialDAO.countAvailableProjects }
+        assertResult(Some(2)) { trialDAO.countProjects.get("available") }
       }
     }
     "projectReport" - {

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/ElasticSearchTrialDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/ElasticSearchTrialDAOSpec.scala
@@ -4,6 +4,7 @@ import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.FireCloudException
 import org.broadinstitute.dsde.firecloud.dataaccess.ElasticSearchTrialDAO
 import org.broadinstitute.dsde.firecloud.integrationtest.ESIntegrationSupport.{searchDAO, trialDAO}
+import org.broadinstitute.dsde.firecloud.model.Trial.CreationStatuses._
 import org.broadinstitute.dsde.firecloud.model.WorkbenchUserInfo
 import org.broadinstitute.dsde.firecloud.model.Trial.TrialProject
 import org.broadinstitute.dsde.rawls.model.RawlsBillingProjectName
@@ -20,7 +21,7 @@ class ElasticSearchTrialDAOSpec extends FreeSpec with Matchers with BeforeAndAft
     ElasticSearchTrialDAOFixtures.fixtureProjects foreach { project => trialDAO.insertProjectRecord(project.name)}
 
     ElasticSearchTrialDAOFixtures.fixtureProjects collect {
-      case project if project.verified => trialDAO.setProjectRecordVerified(project.name, verified=project.verified)
+      case project if project.verified => trialDAO.setProjectRecordVerified(project.name, verified=project.verified, status=Ready)
     }
     ElasticSearchTrialDAOFixtures.fixtureProjects collect {
       case project if project.user.nonEmpty => trialDAO.claimProjectRecord(project.user.get)
@@ -38,7 +39,7 @@ class ElasticSearchTrialDAOSpec extends FreeSpec with Matchers with BeforeAndAft
       "should insert a new project" in {
         val name = RawlsBillingProjectName("garlic")
         val actual = trialDAO.insertProjectRecord(name)
-        val expected = TrialProject(name, verified=false, user=None)
+        val expected = TrialProject(name, verified=false, user=None, status=None)
         assertResult(expected) { actual }
         val expectedCheck = trialDAO.getProjectRecord(name)
         assertResult(expected) { expectedCheck }
@@ -54,19 +55,19 @@ class ElasticSearchTrialDAOSpec extends FreeSpec with Matchers with BeforeAndAft
     "verifyProject" - {
       "should update a project with a new value for verified" in {
         val name=RawlsBillingProjectName("endive")
-        trialDAO.setProjectRecordVerified(name, verified=true)
+        trialDAO.setProjectRecordVerified(name, verified=true, status=Ready)
         val actual1 = trialDAO.getProjectRecord(name)
-        val expected1 = TrialProject(name, verified=true, user=None)
+        val expected1 = TrialProject(name, verified=true, user=None, status=Some(Ready))
         assertResult(expected1) { actual1 }
-        trialDAO.setProjectRecordVerified(name, verified=false)
+        trialDAO.setProjectRecordVerified(name, verified=false, status=Creating)
         val actual2 = trialDAO.getProjectRecord(name)
-        val expected2 = TrialProject(name, verified=false, user=None)
+        val expected2 = TrialProject(name, verified=false, user=None, status=Some(Creating))
         assertResult(expected2) { actual2 }
 
       }
       "should throw an error if project is not found" in {
         val ex = intercept[FireCloudException] {
-          trialDAO.setProjectRecordVerified(RawlsBillingProjectName("habanero"), verified=true)
+          trialDAO.setProjectRecordVerified(RawlsBillingProjectName("habanero"), verified=true, status=Ready)
         }
         assert(ex.getMessage == "project habanero not found!")
       }
@@ -76,7 +77,7 @@ class ElasticSearchTrialDAOSpec extends FreeSpec with Matchers with BeforeAndAft
       "should claim the first available project by alphabetical order" in {
         val user = WorkbenchUserInfo("789", "me")
         val claimed = trialDAO.claimProjectRecord(user)
-        val expected = TrialProject(RawlsBillingProjectName("date"), verified=true, user=Some(user))
+        val expected = TrialProject(RawlsBillingProjectName("date"), verified=true, user=Some(user), status=Some(Ready))
         assertResult(expected) { claimed }
         val claimCheck = trialDAO.getProjectRecord(RawlsBillingProjectName("date"))
         assertResult(expected) { claimCheck }
@@ -100,7 +101,7 @@ class ElasticSearchTrialDAOSpec extends FreeSpec with Matchers with BeforeAndAft
         // insert three
         Seq("orange", "pineapple", "quince") foreach { proj => trialDAO.insertProjectRecord(RawlsBillingProjectName(proj))}
         // verify two
-        Seq("orange", "quince") foreach { proj => trialDAO.setProjectRecordVerified(RawlsBillingProjectName(proj), verified=true)}
+        Seq("orange", "quince") foreach { proj => trialDAO.setProjectRecordVerified(RawlsBillingProjectName(proj), verified=true, status=Ready)}
         assertResult(2) { trialDAO.countAvailableProjects }
       }
     }
@@ -109,11 +110,11 @@ class ElasticSearchTrialDAOSpec extends FreeSpec with Matchers with BeforeAndAft
         // unverified/unclaimed projects listed below but commented out for developer clarity
         val expected = Seq(
           // TrialProject(RawlsBillingProjectName("apple"), verified=false, None),
-          TrialProject(RawlsBillingProjectName("banana"), verified=true, Some(WorkbenchUserInfo("123", "alice@example.com"))),
-          TrialProject(RawlsBillingProjectName("carrot"), verified=true, Some(WorkbenchUserInfo("456", "bob@example.com"))),
-          TrialProject(RawlsBillingProjectName("date"), verified=true, Some(WorkbenchUserInfo("789", "me"))),
+          TrialProject(RawlsBillingProjectName("banana"), verified=true, Some(WorkbenchUserInfo("123", "alice@example.com")), Some(Ready)),
+          TrialProject(RawlsBillingProjectName("carrot"), verified=true, Some(WorkbenchUserInfo("456", "bob@example.com")), Some(Ready)),
+          TrialProject(RawlsBillingProjectName("date"), verified=true, Some(WorkbenchUserInfo("789", "me")), Some(Ready)),
           // TrialProject(RawlsBillingProjectName("endive"), verified=false, None),
-          TrialProject(RawlsBillingProjectName("fennel"), verified=true, Some(WorkbenchUserInfo("101010", "me2")))
+          TrialProject(RawlsBillingProjectName("fennel"), verified=true, Some(WorkbenchUserInfo("101010", "me2")), Some(Ready))
           // TrialProject(RawlsBillingProjectName("garlic"), verified=false, None),
           // TrialProject(RawlsBillingProjectName("orange"), verified=true, None),
           // TrialProject(RawlsBillingProjectName("pineapple"), verified=false, None),
@@ -140,7 +141,7 @@ class ElasticSearchTrialDAOSpec extends FreeSpec with Matchers with BeforeAndAft
         assert(project.name == name)
 
         // verify the project - this will increment the version in ES from 1 to 2
-        trialDAO.setProjectRecordVerified(name, verified=true)
+        trialDAO.setProjectRecordVerified(name, verified=true, status=Ready)
         val (newVersion, newProject) = esTrialDAO.getProjectInternal(name)
         assert(newVersion == 2)
         assert(newProject.name == name)
@@ -165,12 +166,12 @@ class ElasticSearchTrialDAOSpec extends FreeSpec with Matchers with BeforeAndAft
 
 object ElasticSearchTrialDAOFixtures {
   val fixtureProjects: Seq[TrialProject] = Seq(
-    TrialProject(RawlsBillingProjectName("apple"), verified=false, None),
-    TrialProject(RawlsBillingProjectName("banana"), verified=true, Some(WorkbenchUserInfo("123", "alice@example.com"))),
-    TrialProject(RawlsBillingProjectName("carrot"), verified=true, Some(WorkbenchUserInfo("456", "bob@example.com"))),
-    TrialProject(RawlsBillingProjectName("date"), verified=true, None),
-    TrialProject(RawlsBillingProjectName("endive"), verified=false, None),
-    TrialProject(RawlsBillingProjectName("fennel"), verified=true, None)
+    TrialProject(RawlsBillingProjectName("apple"), verified=false, None, None),
+    TrialProject(RawlsBillingProjectName("banana"), verified=true, Some(WorkbenchUserInfo("123", "alice@example.com")), Some(Ready)),
+    TrialProject(RawlsBillingProjectName("carrot"), verified=true, Some(WorkbenchUserInfo("456", "bob@example.com")), Some(Ready)),
+    TrialProject(RawlsBillingProjectName("date"), verified=true, None, None),
+    TrialProject(RawlsBillingProjectName("endive"), verified=false, None, None),
+    TrialProject(RawlsBillingProjectName("fennel"), verified=true, None, None)
   )
 }
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockGoogleServicesDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockGoogleServicesDAO.scala
@@ -14,6 +14,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 class MockGoogleServicesDAO extends GoogleServicesDAO {
   override def getAdminUserAccessToken: String = ""
+  override def getTrialBillingManagerAccessToken: String = ""
   override def getBucketObjectAsInputStream(bucketName: String, objectKey: String): InputStream = {
     objectKey match {
       case "target-whitelist.txt" => new ByteArrayInputStream("firecloud-dev\ntarget-user".getBytes("UTF-8"))

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/ApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/ApiServiceSpec.scala
@@ -32,11 +32,12 @@ trait ApiServiceSpec extends FlatSpec with Matchers with HttpService with Scalat
     val samDao: MockSamDAO
     val searchDao: MockSearchDAO
     val thurloeDao: MockThurloeDAO
+    val trialDao: MockTrialDAO
 
     def actorRefFactory = system
 
     val nihServiceConstructor = NihService.constructor(
-      new Application(agoraDao, googleDao, ontologyDao, consentDao, rawlsDao, samDao, searchDao, thurloeDao)
+      new Application(agoraDao, googleDao, ontologyDao, consentDao, rawlsDao, samDao, searchDao, thurloeDao, trialDao)
     )_
 
   }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/BaseServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/BaseServiceSpec.scala
@@ -15,8 +15,9 @@ class BaseServiceSpec extends ServiceSpec with BeforeAndAfter {
   val samDao:MockSamDAO = new MockSamDAO
   val searchDao:MockSearchDAO = new MockSearchDAO
   val thurloeDao:MockThurloeDAO = new MockThurloeDAO
+  val trialDao:MockTrialDAO = new MockTrialDAO
 
   val app:Application =
-    new Application(agoraDao, googleServicesDao, ontologyDao, consentDao, rawlsDao, samDao, searchDao, thurloeDao)
+    new Application(agoraDao, googleServicesDao, ontologyDao, consentDao, rawlsDao, samDao, searchDao, thurloeDao, trialDao)
 
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/NihApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/NihApiServiceSpec.scala
@@ -26,10 +26,10 @@ class NihApiServiceSpec extends ApiServiceSpec {
   //JWT for NIH username "not-on-whitelist" (don't ever add this to the mock whitelists in MockGoogleServicesDAO.scala)
   val validJwtNotOnWhitelist = JWTWrapper("eyJhbGciOiJIUzI1NiJ9.bm90LW9uLXdoaXRlbGlzdA.DayvfECuGAQsXx-MEwXiuQyq86Eqc3Lmn46_9BGs6t0")
 
-  case class TestApiService(agoraDao: MockAgoraDAO, googleDao: MockGoogleServicesDAO, ontologyDao: MockOntologyDAO, consentDao: MockConsentDAO, rawlsDao: MockRawlsDAO, samDao: MockSamDAO, searchDao: MockSearchDAO, thurloeDao: MockThurloeDAO)(implicit val executionContext: ExecutionContext) extends ApiServices
+  case class TestApiService(agoraDao: MockAgoraDAO, googleDao: MockGoogleServicesDAO, ontologyDao: MockOntologyDAO, consentDao: MockConsentDAO, rawlsDao: MockRawlsDAO, samDao: MockSamDAO, searchDao: MockSearchDAO, thurloeDao: MockThurloeDAO, trialDao: MockTrialDAO)(implicit val executionContext: ExecutionContext) extends ApiServices
 
   def withDefaultApiServices[T](testCode: TestApiService => T): T = {
-    val apiService = new TestApiService(new MockAgoraDAO, new MockGoogleServicesDAO, new MockOntologyDAO, new MockConsentDAO, new MockRawlsDAO, new MockSamDAO, new MockSearchDAO, new MockThurloeDAO)
+    val apiService = new TestApiService(new MockAgoraDAO, new MockGoogleServicesDAO, new MockOntologyDAO, new MockConsentDAO, new MockRawlsDAO, new MockSamDAO, new MockSearchDAO, new MockThurloeDAO, new MockTrialDAO)
     testCode(apiService)
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/UserApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/UserApiServiceSpec.scala
@@ -5,6 +5,7 @@ import org.broadinstitute.dsde.firecloud.mock.MockUtils
 import org.broadinstitute.dsde.firecloud.mock.MockUtils._
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
 import org.broadinstitute.dsde.firecloud.model._
+import org.broadinstitute.dsde.firecloud.trial.ProjectManager
 import org.broadinstitute.dsde.firecloud.webservice.{RegisterApiService, UserApiService}
 import org.mockserver.integration.ClientAndServer
 import org.mockserver.integration.ClientAndServer._
@@ -17,8 +18,11 @@ import spray.json.DefaultJsonProtocol._
 class UserApiServiceSpec extends BaseServiceSpec with RegisterApiService with UserApiService {
 
   def actorRefFactory = system
+
+  val trialProjectManager = system.actorOf(ProjectManager.props(app.rawlsDAO, app.trialDAO), "trial-project-manager")
+
   val registerServiceConstructor:() => RegisterService = RegisterService.constructor(app)
-  val trialServiceConstructor:() => TrialService = TrialService.constructor(app)
+  val trialServiceConstructor:() => TrialService = TrialService.constructor(app, trialProjectManager)
   var workspaceServer: ClientAndServer = _
   var profileServer: ClientAndServer = _
   var samServer: ClientAndServer = _

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/UserApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/UserApiServiceSpec.scala
@@ -19,7 +19,7 @@ class UserApiServiceSpec extends BaseServiceSpec with RegisterApiService with Us
 
   def actorRefFactory = system
 
-  val trialProjectManager = system.actorOf(ProjectManager.props(app.rawlsDAO, app.trialDAO), "trial-project-manager")
+  val trialProjectManager = system.actorOf(ProjectManager.props(app.rawlsDAO, app.trialDAO, app.googleServicesDAO), "trial-project-manager")
 
   val registerServiceConstructor:() => RegisterService = RegisterService.constructor(app)
   val trialServiceConstructor:() => TrialService = TrialService.constructor(app, trialProjectManager)

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceServiceSpec.scala
@@ -15,7 +15,7 @@ import scala.concurrent.duration._
 
 class WorkspaceServiceSpec extends BaseServiceSpec with BeforeAndAfterEach {
 
-  val customApp = Application(agoraDao, googleServicesDao, ontologyDao, consentDao, new MockRawlsDeleteWSDAO(), samDao, new MockSearchDeleteWSDAO(), thurloeDao)
+  val customApp = Application(agoraDao, googleServicesDao, ontologyDao, consentDao, new MockRawlsDeleteWSDAO(), samDao, new MockSearchDeleteWSDAO(), thurloeDao, trialDao)
 
   val workspaceServiceConstructor: (WithAccessToken) => WorkspaceService = WorkspaceService.constructor(customApp)
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/trial/ProjectManagerSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/trial/ProjectManagerSpec.scala
@@ -1,0 +1,268 @@
+package org.broadinstitute.dsde.firecloud.trial
+
+import akka.actor.{ActorRef, ActorSystem}
+import akka.testkit.TestKit
+import akka.util.Timeout
+import org.broadinstitute.dsde.firecloud.dataaccess._
+import org.scalatest.{BeforeAndAfterAll, FreeSpecLike}
+import org.broadinstitute.dsde.firecloud.FireCloudException
+import org.broadinstitute.dsde.firecloud.mock.MockGoogleServicesDAO
+import org.broadinstitute.dsde.firecloud.model.{Trial, WithAccessToken, WorkbenchUserInfo}
+import org.broadinstitute.dsde.firecloud.model.Trial.{CreationStatuses, ProjectRoles, RawlsBillingProjectMembership, TrialProject}
+import org.broadinstitute.dsde.firecloud.trial.ProjectManager._
+import org.broadinstitute.dsde.rawls.model.RawlsBillingProjectName
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+class ProjectManagerSpec extends TestKit(ActorSystem("ProjectManagerSpec")) with FreeSpecLike with BeforeAndAfterAll {
+
+
+  override def afterAll {
+    TestKit.shutdownActorSystem(system)
+  }
+
+  implicit val askTimeout = Timeout(5.seconds) // timeout for getting a response from the ProjectManager actor
+  val testTimeout = 3.seconds // timeout for a test to succeed or fail when using awaitCond/awaitAssert
+  val testInterval = 150.millis // interval on which to repeatedly re-check a test when using awaitCond/awaitAssert
+
+  val rawlsDAO = new ProjectManagerSpecRawlsDAO
+  val trialDAO = new ProjectManagerSpecTrialDAO
+  val googleDAO = new MockGoogleServicesDAO
+
+  /*
+    call stack for project manager:
+      - trialDAO.insertProjectRecord
+      - rawlsDAO.createProject
+      - rawlsDAO.getProjects
+      - trialDAO.setProjectRecordVerified
+   */
+
+  "ProjectManager actor, when creating projects" -{
+    "should insert a record" in {
+      val (pm, rawlsDAO, trialDAO, googleDAO) = initTestState()
+      pm ! StartCreation(1)
+      awaitCond(trialDAO.insertCount == 1, testTimeout, testInterval)
+      system.stop(pm)
+    }
+    "should insert multiple records" in {
+      val (pm, rawlsDAO, trialDAO, googleDAO) = initTestState()
+      pm ! StartCreation(5)
+      awaitCond(trialDAO.insertCount == 5, testTimeout, testInterval)
+      system.stop(pm)
+    }
+    "multiple inserted records should all be unique" in {
+      val (pm, rawlsDAO, trialDAO, googleDAO) = initTestState()
+      pm ! StartCreation(5)
+      awaitCond(insertedProjects.map(_.name).distinct.size == 5, testTimeout, testInterval)
+      system.stop(pm)
+    }
+
+    "should impose a delay between multiple project creations" in {
+      // with a createDelay of 5 seconds, creating 5 project should take at least 25 seconds
+      // previous test proves that we can create 5 projects (in the mocks!) within 3 seconds
+      val (pm, rawlsDAO, trialDAO, googleDAO) = initTestState(createDelay = 5.seconds)
+      pm ! StartCreation(5)
+      Thread.sleep(3000)
+      assert(trialDAO.insertCount < 5)
+      system.stop(pm)
+    }
+
+    "should trigger project creation in rawls" in {
+      val (pm, rawlsDAO, trialDAO, googleDAO) = initTestState()
+      pm ! StartCreation(5)
+      awaitCond(trialDAO.insertCount == 5, testTimeout, testInterval)
+      awaitCond(rawlsDAO.createCount == 5, testTimeout, testInterval)
+      system.stop(pm)
+    }
+
+    "should trigger verification of inserted records" in {
+      val (pm, rawlsDAO, trialDAO, googleDAO) = initTestState()
+      pm ! StartCreation(5)
+      awaitCond(trialDAO.insertCount == 5 && insertedProjects.map(_.name).toSet == verifiedProjects.map(_.name).toSet, testTimeout, testInterval)
+      system.stop(pm)
+    }
+    "should impose a delay between project creation and verification" in {
+      // with a verify delay of 5 seconds and a sleep of 3, we should see no verifications.
+      // previous test proves that verifications are triggered correctly, this test checks the delay.
+      val (pm, rawlsDAO, trialDAO, googleDAO) = initTestState(verifyDelay = 5.seconds)
+      pm ! StartCreation(5)
+      Thread.sleep(3000)
+      assert(trialDAO.verifiedCount == 0)
+      system.stop(pm)
+    }
+    "should only verify a project once if it verifies on the first try" in {
+      // we use the rawls getProjects() call as a proxy for verification - in ProjectManager,
+      // getProjects() is only called within the verify handler.
+      val (pm, rawlsDAO, trialDAO, googleDAO) = initTestState()
+      pm ! StartCreation(1)
+      Thread.sleep(3000)
+      // under normal conditions, verification succeeds and only executes once.
+      assert(rawlsGetProjectsCallCount == 1)
+      system.stop(pm)
+    }
+    "should re-verify a project if it is still creating" in {
+      // we use the rawls getProjects() call as a proxy for verification - in ProjectManager,
+      // getProjects() is only called within the verify handler.
+      val (pm, rawlsDAO, trialDAO, googleDAO) = initTestState(mockRawlsDAO = new StillCreatingProjectsRawlsDAO)
+      pm ! StartCreation(1)
+      Thread.sleep(3000)
+      // if projects are still creating, and we have zero verification delay, rawlsGetProjectsCallCount should
+      // be much much higher than 1.
+      assert(rawlsGetProjectsCallCount > 1 && verifiedProjects.isEmpty)
+      system.stop(pm)
+    }
+    "should mark projects as error during verification if they failed to create" in {
+      val (pm, rawlsDAO, trialDAO, googleDAO) = initTestState(mockRawlsDAO = new BadGetProjectsRawlsDAO)
+      pm ! StartCreation(3)
+      awaitCond(trialDAO.insertCount == 3, testTimeout, testInterval)
+      awaitCond(trialDAO.verifiedCount == 3 && verifiedProjects.forall(p => p.verified && p.status.contains(CreationStatuses.Error)), testTimeout, testInterval)
+      system.stop(pm)
+    }
+    "should mark projects as error during verification if they are not returned by Rawls" in {
+      val (pm, rawlsDAO, trialDAO, googleDAO) = initTestState(mockRawlsDAO = new MissingGetProjectsRawlsDAO)
+      pm ! StartCreation(3)
+      awaitCond(trialDAO.insertCount == 3, testTimeout, testInterval)
+      awaitCond(trialDAO.verifiedCount == 3 && verifiedProjects.forall(p => p.verified && p.status.contains(CreationStatuses.Error)), testTimeout, testInterval)
+      system.stop(pm)
+    }
+
+  }
+
+
+  private def initTestState(mockRawlsDAO: ProjectManagerSpecRawlsDAO = new ProjectManagerSpecRawlsDAO,
+                            mockTrialDAO: ProjectManagerSpecTrialDAO = new ProjectManagerSpecTrialDAO,
+                            mockGoogleDAO: ProjectManagerSpecMockGoogleServicesDAO = new ProjectManagerSpecMockGoogleServicesDAO,
+                            createDelay: FiniteDuration = Duration.Zero,
+                            verifyDelay: FiniteDuration = Duration.Zero):
+    (ActorRef, ProjectManagerSpecRawlsDAO, ProjectManagerSpecTrialDAO, ProjectManagerSpecMockGoogleServicesDAO) = {
+
+    initVars
+
+    // start a project manager, with zero delays for creating projects and verifying projects
+    val pm = system.actorOf(
+      ProjectManager.props(mockRawlsDAO, mockTrialDAO, mockGoogleDAO, createDelay, verifyDelay),
+      java.util.UUID.randomUUID().toString)
+
+    (pm, mockRawlsDAO, mockTrialDAO, mockGoogleDAO)
+  }
+
+
+  // ****************************************************
+  // mutable shared state variables used by the mock DAOs
+  var insertedProjects = Seq.empty[TrialProject]
+  var verifiedProjects = Seq.empty[TrialProject]
+  var rawlsGetProjectsCallCount = 0
+  var rawlsCreatedProjects = Seq.empty[String]
+  // ****************************************************
+
+  private def initVars = {
+    insertedProjects = Seq.empty[TrialProject]
+    verifiedProjects = Seq.empty[TrialProject]
+    rawlsGetProjectsCallCount = 0
+    rawlsCreatedProjects = Seq.empty[String]
+  }
+
+  /**
+    * Trial DAO with test instrumentation
+    */
+  class ProjectManagerSpecTrialDAO extends MockTrialDAO {
+
+    def insertCount = insertedProjects.size
+    def verifiedCount = verifiedProjects.size
+
+    override def insertProjectRecord(projectName: RawlsBillingProjectName): TrialProject = {
+      if (insertedProjects.exists(p => p.name == projectName)) {
+        throw new FireCloudException("ProjectManagerSpecTrialDAO says not unique")
+      } else {
+        val insertedProject = TrialProject(projectName)
+        insertedProjects = insertedProjects :+ insertedProject
+        insertedProject
+      }
+    }
+
+    override def getProjectRecord(projectName: RawlsBillingProjectName): TrialProject = insertedProjects.reverse.head
+
+    override def projectRecordExists(projectName: RawlsBillingProjectName): Boolean = true
+
+    override def setProjectRecordVerified(projectName: RawlsBillingProjectName, verified: Boolean, status: CreationStatuses.CreationStatus): TrialProject = {
+      val verifiedProject = TrialProject(projectName, verified, None, Some(status))
+      verifiedProjects = verifiedProjects :+ verifiedProject
+      verifiedProject
+    }
+
+    override def claimProjectRecord(userInfo: WorkbenchUserInfo): TrialProject =
+      TrialProject(RawlsBillingProjectName("unittest"))
+
+    override def listUnverifiedProjects: Seq[TrialProject] = Seq.empty[TrialProject]
+
+    override def countProjects: Map[String, Long] = Map.empty[String,Long]
+
+    override def projectReport: Seq[TrialProject] = Seq.empty[TrialProject]
+  }
+
+  /**
+    * Rawls dao with test instrumentation
+    */
+  class ProjectManagerSpecRawlsDAO extends MockRawlsDAO {
+
+    def createCount = rawlsCreatedProjects.size
+
+    override def createProject(projectName: String, billingAccount: String)(implicit userToken: WithAccessToken): Future[Boolean] = {
+      rawlsCreatedProjects = rawlsCreatedProjects :+ projectName
+      Future.successful(true)
+    }
+
+    override def getProjects(implicit userToken: WithAccessToken): Future[Seq[Trial.RawlsBillingProjectMembership]] = {
+      rawlsGetProjectsCallCount = rawlsGetProjectsCallCount + 1
+      val projects = rawlsCreatedProjects map { name =>
+        RawlsBillingProjectMembership(RawlsBillingProjectName(name), ProjectRoles.Owner, CreationStatuses.Ready, None)
+      }
+      Future.successful(projects)
+    }
+  }
+
+  /**
+    * Rawls dao that fails to return projects in the getProjects query
+    */
+  class MissingGetProjectsRawlsDAO extends ProjectManagerSpecRawlsDAO {
+    override def getProjects(implicit userToken: WithAccessToken): Future[Seq[Trial.RawlsBillingProjectMembership]] = {
+      rawlsGetProjectsCallCount = rawlsGetProjectsCallCount + 1
+      Future.successful(Seq.empty[RawlsBillingProjectMembership])
+    }
+  }
+
+  /**
+    * Rawls dao that says that projects failed to create in Google land
+    */
+  class BadGetProjectsRawlsDAO extends ProjectManagerSpecRawlsDAO {
+    override def getProjects(implicit userToken: WithAccessToken): Future[Seq[Trial.RawlsBillingProjectMembership]] = {
+      rawlsGetProjectsCallCount = rawlsGetProjectsCallCount + 1
+      val projects = rawlsCreatedProjects map { name =>
+        RawlsBillingProjectMembership(RawlsBillingProjectName(name), ProjectRoles.Owner, CreationStatuses.Error, Some("unit test creation error"))
+      }
+      Future.successful(projects)
+    }
+  }
+
+  /**
+    * Rawls dao that says that projects are still creating in Google land
+    */
+  class StillCreatingProjectsRawlsDAO extends ProjectManagerSpecRawlsDAO {
+    override def getProjects(implicit userToken: WithAccessToken): Future[Seq[Trial.RawlsBillingProjectMembership]] = {
+      rawlsGetProjectsCallCount = rawlsGetProjectsCallCount + 1
+      val projects = rawlsCreatedProjects map { name =>
+        RawlsBillingProjectMembership(RawlsBillingProjectName(name), ProjectRoles.Owner, CreationStatuses.Creating, None)
+      }
+      Future.successful(projects)
+    }
+  }
+
+  class ProjectManagerSpecMockGoogleServicesDAO extends MockGoogleServicesDAO
+
+}
+
+
+
+
+

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/trial/ProjectNamerSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/trial/ProjectNamerSpec.scala
@@ -1,0 +1,19 @@
+package org.broadinstitute.dsde.firecloud.trial
+
+import org.scalatest.FreeSpec
+
+class ProjectNamerSpec extends FreeSpec {
+
+  "ProjectNamer" - {
+    "should always be 6-30 chars, start with a letter, and lower case alphanumeric or hyphen" in {
+      // project namer generates random names, so loop over the checks. This test can generate false positives if the
+      // randomization is truly skewed AND the logic being tested is incorrect.
+      1 to 5000 foreach { _ =>
+        val name = ProjectNamer.randomName
+        assert(name.length >= 6, s"'$name' is not at least 6 chars")
+        assert(name.length <= 30, s"'$name' is not 30 chars or less")
+        assert(name.matches("[a-z][a-z0-9\\-]+"), s"'$name' does not start with a letter or is not alphanumeric or hyphen")
+      }
+    }
+  }
+}

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/TrialApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/TrialApiServiceSpec.scala
@@ -32,10 +32,11 @@ final class TrialApiServiceSpec extends BaseServiceSpec with UserApiService with
   // but it is tested here since it is used for the trial feature.
 
   def actorRefFactory = system
+
   val localThurloeDao = new TrialApiServiceSpecThurloeDAO
   val localSamDao = new TrialApiServiceSpecSamDAO
 
-  val trialProjectManager = system.actorOf(ProjectManager.props(app.rawlsDAO, app.trialDAO), "trial-project-manager")
+  val trialProjectManager = system.actorOf(ProjectManager.props(app.rawlsDAO, app.trialDAO, app.googleServicesDAO), "trial-project-manager")
   val trialServiceConstructor:() => TrialService = TrialService.constructor(app.copy(thurloeDAO = localThurloeDao, samDAO = localSamDao), trialProjectManager)
 
   var profileServer: ClientAndServer = _

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/TrialApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/TrialApiServiceSpec.scala
@@ -6,19 +6,17 @@ import org.broadinstitute.dsde.firecloud.FireCloudConfig
 import org.broadinstitute.dsde.firecloud.dataaccess.{HttpSamDAO, HttpThurloeDAO}
 import org.broadinstitute.dsde.firecloud.mock.MockUtils
 import org.broadinstitute.dsde.firecloud.mock.MockUtils.thurloeServerPort
-import org.broadinstitute.dsde.firecloud.model.{FireCloudKeyValue, ProfileWrapper, RegistrationInfo, UserInfo, WorkbenchEnabled, WorkbenchUserInfo}
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol.impProfileWrapper
 import org.broadinstitute.dsde.firecloud.model.Trial.{TrialStates, UserTrialStatus}
+import org.broadinstitute.dsde.firecloud.model.{FireCloudKeyValue, ProfileWrapper, RegistrationInfo, UserInfo, WorkbenchEnabled, WorkbenchUserInfo}
 import org.broadinstitute.dsde.firecloud.service.{BaseServiceSpec, TrialService}
+import org.broadinstitute.dsde.firecloud.trial.ProjectManager
 import org.broadinstitute.dsde.rawls.model.RawlsUserEmail
 import org.mockserver.integration.ClientAndServer
 import org.mockserver.integration.ClientAndServer.startClientAndServer
 import org.mockserver.model.HttpRequest.request
-import spray.http.StatusCodes.{BadRequest, NoContent, OK}
-import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol.impProfileWrapper
-import org.broadinstitute.dsde.firecloud.model.Trial.{TrialStates, UserTrialStatus}
-import org.broadinstitute.dsde.firecloud.trial.ProjectManager
 import spray.http.HttpMethods.POST
+import spray.http.StatusCodes.{BadRequest, NoContent, OK}
 import spray.json.DefaultJsonProtocol._
 import spray.json._
 
@@ -32,7 +30,6 @@ final class TrialApiServiceSpec extends BaseServiceSpec with UserApiService with
   // but it is tested here since it is used for the trial feature.
 
   def actorRefFactory = system
-
   val localThurloeDao = new TrialApiServiceSpecThurloeDAO
   val localSamDao = new TrialApiServiceSpecSamDAO
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/TrialApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/TrialApiServiceSpec.scala
@@ -15,6 +15,9 @@ import org.mockserver.integration.ClientAndServer
 import org.mockserver.integration.ClientAndServer.startClientAndServer
 import org.mockserver.model.HttpRequest.request
 import spray.http.StatusCodes.{BadRequest, NoContent, OK}
+import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol.impProfileWrapper
+import org.broadinstitute.dsde.firecloud.model.Trial.{TrialStates, UserTrialStatus}
+import org.broadinstitute.dsde.firecloud.trial.ProjectManager
 import spray.http.HttpMethods.POST
 import spray.json.DefaultJsonProtocol._
 import spray.json._
@@ -31,8 +34,9 @@ final class TrialApiServiceSpec extends BaseServiceSpec with UserApiService with
   def actorRefFactory = system
   val localThurloeDao = new TrialApiServiceSpecThurloeDAO
   val localSamDao = new TrialApiServiceSpecSamDAO
-  val trialServiceConstructor:() => TrialService =
-    TrialService.constructor(app.copy(thurloeDAO = localThurloeDao, samDAO = localSamDao))
+
+  val trialProjectManager = system.actorOf(ProjectManager.props(app.rawlsDAO, app.trialDAO), "trial-project-manager")
+  val trialServiceConstructor:() => TrialService = TrialService.constructor(app.copy(thurloeDAO = localThurloeDao, samDAO = localSamDao), trialProjectManager)
 
   var profileServer: ClientAndServer = _
 


### PR DESCRIPTION
See https://docs.google.com/a/broadinstitute.org/document/d/1Yp4ljrYyh7pw6Bcv_zkV3uBUymvF7Rnkx5LAhVS0BBI/edit?usp=sharing for high-ish level documentation of how this works.

This doesn't have tests yet, so it is incomplete. Opening now to get as much feedback as possible. My primary objective was to get projects created in the dev env to unblock other stories; my secondary objective was to productionize this code so it can be run again in prod once we have the appropriate billing account. I accomplished the first, and am now working on the second.

The commit history on this PR is a mess - sorry about that! You'll have to review it as a whole.

Requires
broadinstitute/firecloud-develop#856
broadinstitute/firecloud-develop#857
broadinstitute/firecloud-develop#858

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
