### PR TITLE
GAWB-2948: move the trial/manager/projects route

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/TrialService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/TrialService.scala
@@ -46,12 +46,12 @@ object TrialService {
   }
 
   def constructor(app: Application, projectManager: ActorRef)()(implicit executionContext: ExecutionContext) =
-    new TrialService(app.samDAO, app.thurloeDAO, app.rawlsDAO, app.trialDAO, projectManager)
+    new TrialService(app.samDAO, app.thurloeDAO, app.rawlsDAO, app.trialDAO, app.googleServicesDAO, projectManager)
 }
 
 // TODO: Remove loggers used for development purposes or lower their level
 final class TrialService
-  (val samDao: SamDAO, val thurloeDao: ThurloeDAO, val rawlsDAO: RawlsDAO, val trialDAO: TrialDAO, projectManager: ActorRef)
+  (val samDao: SamDAO, val thurloeDao: ThurloeDAO, val rawlsDAO: RawlsDAO, val trialDAO: TrialDAO, val googleDAO: GoogleServicesDAO, projectManager: ActorRef)
   (implicit protected val executionContext: ExecutionContext)
   extends Actor with PermissionsSupport with SprayJsonSupport with LazyLogging {
 
@@ -222,7 +222,7 @@ final class TrialService
 
   private def verifyProjects: Future[PerRequestMessage] = {
 
-    val saToken:WithAccessToken = AccessToken(OAuth2BearerToken(HttpGoogleServicesDAO.getTrialBillingManagerAccessToken))
+    val saToken:WithAccessToken = AccessToken(OAuth2BearerToken(googleDAO.getTrialBillingManagerAccessToken))
     rawlsDAO.getProjects(saToken) map { projects =>
 
       val projectStatuses:Map[RawlsBillingProjectName, CreationStatus] = projects.map { proj =>

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/trial/ProjectManager.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/trial/ProjectManager.scala
@@ -60,8 +60,12 @@ class ProjectManager(val rawlsDAO: RawlsDAO, val trialDAO: TrialDAO, val googleD
   private def startCreation(count: Int): CreateProjectsResponse = {
     getCurrentStatus match {
       case `idle` =>
-        self ! Create(1, count)
-        CreateProjectsResponse(success = true, count, Some(s"$count projects are queued for creation."))
+        if (count < 1) {
+          CreateProjectsResponse(success = false, count, Some("You must specify a positive number."))
+        } else {
+          self ! Create(1, count)
+          CreateProjectsResponse(success = true, count, Some(s"$count projects are queued for creation."))
+        }
       case x =>
         CreateProjectsResponse(success = false, 0, Some("ProjectManager is already creating projects; don't try to create more!"))
     }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/TrialApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/TrialApiService.scala
@@ -3,9 +3,13 @@ package org.broadinstitute.dsde.firecloud.webservice
 import org.broadinstitute.dsde.firecloud.model.Trial.TrialOperations
 import org.broadinstitute.dsde.firecloud.model.Trial.TrialOperations._
 import org.broadinstitute.dsde.firecloud.model.UserInfo
+import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
+import org.broadinstitute.dsde.firecloud.model._
 import org.broadinstitute.dsde.firecloud.service.TrialService.TrialServiceMessage
 import org.broadinstitute.dsde.firecloud.service.{FireCloudDirectives, PerRequestCreator, TrialService}
 import org.broadinstitute.dsde.firecloud.utils.StandardUserInfoDirectives
+import org.broadinstitute.dsde.rawls.model.ErrorReport
+import spray.http.StatusCodes.BadRequest
 import spray.httpx.SprayJsonSupport
 import spray.json.DefaultJsonProtocol._
 import spray.routing.{HttpService, Route}
@@ -18,13 +22,34 @@ trait TrialApiService extends HttpService with PerRequestCreator with FireCloudD
 
   // TODO: See if it makes sense to use DELETE for terminate, and perhaps PUT for disable
   val trialApiServiceRoutes: Route = {
-    post {
-      path("trial" / "manager" / "enable|disable|terminate".r) { (operation: String) =>
-        requireUserInfo() { managerInfo => // We will need the manager's credentials for authentication downstream
-          entity(as[Seq[String]]) { userEmails => requestContext =>
-              perRequest(requestContext,
-                TrialService.props(trialServiceConstructor),
-                updateUsers(managerInfo, TrialOperations.withName(operation), userEmails))
+    pathPrefix("trial" / "manager") {
+      post {
+        path("enable|disable|terminate".r) { (operation: String) =>
+          requireUserInfo() { managerInfo => // We will need the manager's credentials for authentication downstream
+            entity(as[Seq[String]]) { userEmails => requestContext =>
+                perRequest(requestContext,
+                  TrialService.props(trialServiceConstructor),
+                  updateUsers(managerInfo, TrialOperations.withName(operation), userEmails))
+            }
+          }
+        } ~
+        path("projects") {
+          parameter("count".as[Int] ? 0) { count =>
+            parameter("operation") { op =>
+              requireUserInfo() { userInfo => requestContext =>
+                val message = op.toLowerCase match {
+                  case "create" => Some(TrialService.CreateProjects(userInfo, count))
+                  case "verify" => Some(TrialService.VerifyProjects(userInfo))
+                  case "count" => Some(TrialService.CountProjects(userInfo))
+                  case "report" => Some(TrialService.Report(userInfo))
+                  case _ => None
+                }
+                if (message.nonEmpty)
+                  perRequest(requestContext, TrialService.props(trialServiceConstructor), message.get)
+                else
+                  requestContext.complete(BadRequest, ErrorReport(s"invalid operation '$op'"))
+              }
+            }
           }
         }
       }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/UserApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/UserApiService.scala
@@ -121,28 +121,6 @@ trait UserApiService extends HttpService with PerRequestCreator with FireCloudRe
       }
     } ~
     pathPrefix("api") {
-      // TODO: move to TrialApiService, once that exists
-      path("trial" / "manager" / "projects") {
-        post {
-          parameter("count".as[Int] ? 0) { count =>
-            parameter("operation") { op =>
-              requireUserInfo() { userInfo => requestContext =>
-                val message = op.toLowerCase match {
-                  case "create" => Some(TrialService.CreateProjects(userInfo, count))
-                  case "verify" => Some(TrialService.VerifyProjects(userInfo))
-                  case "count" => Some(TrialService.CountProjects(userInfo))
-                  case "report" => Some(TrialService.Report(userInfo))
-                  case _ => None
-                }
-                if (message.nonEmpty)
-                  perRequest(requestContext, TrialService.props(trialServiceConstructor), message.get)
-                else
-                  requestContext.complete(BadRequest, ErrorReport(s"invalid operation '$op'"))
-              }
-            }
-          }
-        }
-      } ~
       path("profile" / "billing") {
         passthrough(UserApiService.billingUrl, HttpMethods.GET)
       } ~

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/TrialApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/TrialApiServiceSpec.scala
@@ -173,38 +173,38 @@ final class TrialApiServiceSpec extends BaseServiceSpec with UserApiService with
         case Some(c) => s"&count=$c"
         case None => ""
       }
-      s"/api/trial/manager/projects?operation=$operation$countParam"
+      s"/trial/manager/projects?operation=$operation$countParam"
     }
 
     allHttpMethodsExcept(POST) foreach { method =>
       s"should reject ${method.toString} method" in {
-        new RequestBuilder(method)(projectManagementPath("count")) ~> dummyUserIdHeaders(enabledUser) ~> userServiceRoutes ~> check {
+        new RequestBuilder(method)(projectManagementPath("count")) ~> dummyUserIdHeaders(enabledUser) ~> trialApiServiceRoutes ~> check {
           assert(!handled)
         }
       }
     }
     "should return BadRequest for operations other than create, verify, count, and report" in {
-      Post(projectManagementPath("invalid")) ~> dummyUserIdHeaders(enabledUser) ~> userServiceRoutes ~> check {
+      Post(projectManagementPath("invalid")) ~> dummyUserIdHeaders(enabledUser) ~> trialApiServiceRoutes ~> check {
         assertResult(BadRequest) {status}
       }
     }
     "should require a positive count for create" - {
       Seq(0,-1,-50) foreach { neg =>
         s"value tested: $neg" in {
-          Post(projectManagementPath("create", Some(neg))) ~> dummyUserIdHeaders(enabledUser) ~> userServiceRoutes ~> check {
+          Post(projectManagementPath("create", Some(neg))) ~> dummyUserIdHeaders(enabledUser) ~> trialApiServiceRoutes ~> check {
             assertResult(BadRequest) {status}
           }
         }
       }
     }
     "should return Accepted for operation 'create' with a positive count" in {
-      Post(projectManagementPath("create", Some(2))) ~> dummyUserIdHeaders(enabledUser) ~> userServiceRoutes ~> check {
+      Post(projectManagementPath("create", Some(2))) ~> dummyUserIdHeaders(enabledUser) ~> trialApiServiceRoutes ~> check {
         assertResult(Accepted) {status}
       }
     }
     Seq("verify","count","report") foreach { op =>
       s"should return success for operation '$op'" in {
-        Post(projectManagementPath(op)) ~> dummyUserIdHeaders(enabledUser) ~> userServiceRoutes ~> check {
+        Post(projectManagementPath(op)) ~> dummyUserIdHeaders(enabledUser) ~> trialApiServiceRoutes ~> check {
           assert(status.isSuccess)
           assertResult(OK) {status}
         }


### PR DESCRIPTION
now that 2808 and 2909 have both merged, I can move the /api/trial/manager/projects route from UserApiService to TrialApiService. This eliminates a TODO in the code. Also added route tests against the /api/trial/manager/projects route.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
