### PR TITLE
GAWB-2946: cleaner Thurloe DAO method signatures

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpThurloeDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpThurloeDAO.scala
@@ -46,10 +46,27 @@ class HttpThurloeDAO ( implicit val system: ActorSystem, implicit val executionC
     }
   }
 
-  override def saveKeyValues(userInfo: UserInfo, keyValues: Map[String, String]): Future[Try[Unit]] = {
-    val thurloeKeyValues = ThurloeKeyValues(Option(userInfo.getUniqueId), Option(keyValues.map { case (key, value) => FireCloudKeyValue(Option(key), Option(value)) }.toSeq))
+  /**
+    * Save KVPs for myself - the KVPs will be saved to the same user that authenticates the call.
+    * @param userInfo contains the userid for which to save KVPs and that user's auth token
+    * @param keyValues the KVPs to save
+    * @return success/failure of save
+    */
+  override def saveKeyValues(userInfo: UserInfo, keyValues: Map[String, String]): Future[Try[Unit]] =
+    saveKeyValues(userInfo.id, userInfo, keyValues)
+
+  /**
+    * Save KVPs for a different user - the KVPs will be saved to the "forUserId" user,
+    * but the call to Thurloe will be authenticated as the "callerToken" user.
+    *
+    * @param forUserId the userid of the user for which to save KVPs
+    * @param callerToken auth token of the user making the call
+    * @return success/failure of save
+    */
+  override def saveKeyValues(forUserId: String, callerToken: WithAccessToken, keyValues: Map[String, String]): Future[Try[Unit]] = {
+    val thurloeKeyValues = ThurloeKeyValues(Option(forUserId), Option(keyValues.map { case (key, value) => FireCloudKeyValue(Option(key), Option(value)) }.toSeq))
     wrapExceptions {
-      userAuthedRequest(Post(UserApiService.remoteSetKeyURL, thurloeKeyValues), false, true)(userInfo) map { response =>
+      userAuthedRequest(Post(UserApiService.remoteSetKeyURL, thurloeKeyValues), false, true)(callerToken) map { response =>
         if(response.status.isSuccess) Try(())
         else Try(throw new FireCloudException(s"Unable to update user profile"))
       }
@@ -60,10 +77,16 @@ class HttpThurloeDAO ( implicit val system: ActorSystem, implicit val executionC
     val profilePropertyMap = profile.propertyValueMap ++ Map("email" -> userInfo.userEmail)
     saveKeyValues(userInfo, profilePropertyMap).map(_ => ())
   }
-
-  override def getTrialStatus(userInfo: UserInfo): Future[Option[UserTrialStatus]] = {
+  /**
+    * get the UserTrialStatus associated with a specific user.
+    *
+    * @param forUserId the subjectid of the user whose trial status to get
+    * @param callerToken the OAuth token of the person making the API call
+    * @return the trial status for the specified user, or None if trial status could not be determined.
+    */
+  override def getTrialStatus(forUserId: String, callerToken: WithAccessToken): Future[Option[UserTrialStatus]] = {
     wrapExceptions {
-      userAuthedRequest(Get(UserApiService.remoteGetAllURL.format(userInfo.getUniqueId)), false, true)(userInfo) map { response =>
+      userAuthedRequest(Get(UserApiService.remoteGetAllURL.format(forUserId)), false, true)(callerToken) map { response =>
         response.status match {
           case StatusCodes.OK => Some(UserTrialStatus(unmarshal[ProfileWrapper].apply(response)))
           case StatusCodes.NotFound => None
@@ -73,8 +96,17 @@ class HttpThurloeDAO ( implicit val system: ActorSystem, implicit val executionC
     }
   }
 
-  override def saveTrialStatus(userInfo: UserInfo, trialStatus: UserTrialStatus): Future[Try[Unit]] =
-    saveKeyValues(userInfo, UserTrialStatus.toKVPs(trialStatus))
+  /**
+    * set the UserTrialStatus for a specific user
+    *
+    * @param forUserId the subjectid of the user whose trial status to set
+    * @param callerToken the OAuth token of the person making the API call
+    * @param trialStatus the trial status to save for the specified user
+    * @return success/failure of whether or not the status saved correctly
+    */
+  override def saveTrialStatus(forUserId: String, callerToken: WithAccessToken, trialStatus: UserTrialStatus): Future[Try[Unit]] = {
+    saveKeyValues(forUserId, callerToken, UserTrialStatus.toKVPs(trialStatus))
+  }
 
 
   private def wrapExceptions[T](codeBlock: => Future[T]): Future[T] = {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ThurloeDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ThurloeDAO.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.firecloud.dataaccess
 
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.model.Trial.UserTrialStatus
-import org.broadinstitute.dsde.firecloud.model.{BasicProfile, Profile, UserInfo}
+import org.broadinstitute.dsde.firecloud.model.{BasicProfile, Profile, UserInfo, WithAccessToken}
 import org.broadinstitute.dsde.rawls.model.ErrorReportSource
 
 import scala.concurrent.Future
@@ -22,11 +22,44 @@ trait ThurloeDAO extends LazyLogging with ReportsSubsystemStatus {
   def getProfile(userInfo: UserInfo): Future[Option[Profile]]
   def getAllUserValuesForKey(key: String): Future[Map[String, String]]
   def saveProfile(userInfo: UserInfo, profile: BasicProfile): Future[Unit]
+
+  /**
+    * Save KVPs for myself - the KVPs will be saved to the same user that authenticates the call.
+    * @param userInfo contains the userid for which to save KVPs and that user's auth token
+    * @param keyValues the KVPs to save
+    * @return success/failure of save
+    */
   def saveKeyValues(userInfo: UserInfo, keyValues: Map[String, String]): Future[Try[Unit]]
 
+  /**
+    * Save KVPs for a different user - the KVPs will be saved to the "forUserId" user,
+    * but the call to Thurloe will be authenticated as the "callerToken" user.
+    * @param forUserId the userid of the user for which to save KVPs
+    * @param callerToken auth token of the user making the call
+    * @param keyValues the KVPs to save
+    * @return success/failure of save
+    */
+  def saveKeyValues(forUserId: String, callerToken: WithAccessToken, keyValues: Map[String, String]): Future[Try[Unit]]
+
   // methods to work with free-trial objects
-  def getTrialStatus(userInfo: UserInfo): Future[Option[UserTrialStatus]]
-  def saveTrialStatus(userInfo: UserInfo, trialStatus: UserTrialStatus): Future[Try[Unit]]
+  /**
+    * get the UserTrialStatus associated with a specific user.
+    *
+    * @param forUserId the subjectid of the user whose trial status to get
+    * @param callerToken the OAuth token of the person making the API call
+    * @return the trial status for the specified user, or None if trial status could not be determined.
+    */
+  def getTrialStatus(forUserId: String, callerToken: WithAccessToken): Future[Option[UserTrialStatus]]
+
+  /**
+    * set the UserTrialStatus for a specific user
+    *
+    * @param forUserId the subjectid of the user whose trial status to set
+    * @param callerToken the OAuth token of the person making the API call
+    * @param trialStatus the trial status to save for the specified user
+    * @return success/failure of whether or not the status saved correctly
+    */
+  def saveTrialStatus(forUserId: String, callerToken: WithAccessToken, trialStatus: UserTrialStatus): Future[Try[Unit]]
 
 
   override def serviceName:String = ThurloeDAO.serviceName

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockThurloeDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockThurloeDAO.scala
@@ -3,13 +3,13 @@ package org.broadinstitute.dsde.firecloud.dataaccess
 import java.util.NoSuchElementException
 
 import org.broadinstitute.dsde.firecloud.model.Trial.{TrialStates, UserTrialStatus}
-import org.broadinstitute.dsde.firecloud.model.{BasicProfile, FireCloudKeyValue, Profile, ProfileWrapper, Trial, UserInfo}
+import org.broadinstitute.dsde.firecloud.model.{BasicProfile, FireCloudKeyValue, Profile, ProfileWrapper, Trial, UserInfo, WithAccessToken}
 import org.broadinstitute.dsde.firecloud.utils.DateUtils
 import org.broadinstitute.dsde.workbench.util.health.SubsystemStatus
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
-import scala.util.{Success, Try}
+import scala.util.{Failure, Success, Try}
 
 /**
  * Created by mbemis on 10/25/16.
@@ -106,7 +106,13 @@ class MockThurloeDAO extends ThurloeDAO {
     val newKVsForUser = (userInfo.id -> (mockKeyValues(userInfo.id) ++ keyValues.map { case (key, value) => FireCloudKeyValue(Option(key), Option(value))}))
     mockKeyValues = mockKeyValues + newKVsForUser
     Future.successful(Success(()))
+  }
 
+
+  override def saveKeyValues(forUserId: String, callerToken: WithAccessToken, keyValues: Map[String, String]): Future[Try[Unit]] = {
+    val newKVsForUser = (forUserId -> (mockKeyValues(forUserId) ++ keyValues.map { case (key, value) => FireCloudKeyValue(Option(key), Option(value))}))
+    mockKeyValues = mockKeyValues + newKVsForUser
+    Future.successful(Success(()))
   }
 
   override def getAllUserValuesForKey(key: String): Future[Map[String, String]] = {
@@ -124,10 +130,10 @@ class MockThurloeDAO extends ThurloeDAO {
 
   def status: Future[SubsystemStatus] = Future(SubsystemStatus(ok = true, None))
 
-  override def getTrialStatus(userInfo: UserInfo) = Future.successful(Some(
-    UserTrialStatus(userInfo.id, Some(TrialStates.Terminated), 0, 0, 0, 0
+  override def getTrialStatus(forUserId: String, callerToken: WithAccessToken) = Future.successful(Some(
+    UserTrialStatus(forUserId, Some(TrialStates.Terminated), 0, 0, 0, 0
   )))
 
-  override def saveTrialStatus(userInfo: UserInfo, trialStatus: Trial.UserTrialStatus): Future[Try[Unit]] =
+  override def saveTrialStatus(forUserId: String, callerToken: WithAccessToken, trialStatus: UserTrialStatus): Future[Try[Unit]] =
     Future.successful(Success(()))
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/TrialApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/TrialApiServiceSpec.scala
@@ -8,7 +8,7 @@ import org.broadinstitute.dsde.firecloud.mock.MockUtils
 import org.broadinstitute.dsde.firecloud.mock.MockUtils.thurloeServerPort
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol.impProfileWrapper
 import org.broadinstitute.dsde.firecloud.model.Trial.{TrialStates, UserTrialStatus}
-import org.broadinstitute.dsde.firecloud.model.{FireCloudKeyValue, ProfileWrapper, RegistrationInfo, UserInfo, WorkbenchEnabled, WorkbenchUserInfo}
+import org.broadinstitute.dsde.firecloud.model.{FireCloudKeyValue, ProfileWrapper, RegistrationInfo, UserInfo, WithAccessToken, WorkbenchEnabled, WorkbenchUserInfo}
 import org.broadinstitute.dsde.firecloud.service.{BaseServiceSpec, TrialService}
 import org.broadinstitute.dsde.firecloud.trial.ProjectManager
 import org.broadinstitute.dsde.rawls.model.RawlsUserEmail
@@ -213,10 +213,10 @@ final class TrialApiServiceSpec extends BaseServiceSpec with UserApiService with
   }
 
   final class TrialApiServiceSpecThurloeDAO extends HttpThurloeDAO {
-    override def saveTrialStatus(userInfo: UserInfo, trialStatus: UserTrialStatus) = {
+    override def saveTrialStatus(forUserId: String, callerToken: WithAccessToken, trialStatus: UserTrialStatus) = {
       // Note: because HttpThurloeDAO catches exceptions, the assertions here will
       // result in InternalServerErrors instead of appearing nicely in unit test output.
-      userInfo.id match {
+      forUserId match {
         case `enabledUser` =>
           val expectedExpirationDate = trialStatus.enrolledDate.plus(FireCloudConfig.Trial.durationDays, ChronoUnit.DAYS)
 


### PR DESCRIPTION
Thurloe DAO's `getTrialStatus` and `saveTrialStatus` now accept separate arguments for the userid on which to operate and the OAuth token of the user making the call.

In the one instance - inside `TrialService.enrollUser` - where the user making the call is the same as the user being queried - I just specify both arguments. This felt safer than having multiple methods with different argument lists - too easy to confuse and get/set the wrong user.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
