### PR TITLE
GAWB-2944: Increased test coverage for free trial status updates

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -1647,6 +1647,8 @@ paths:
         responses:
           204:
             description: Success (No Content)
+          403:
+            description: Forbidden - You must be a campaign manager to call this endpoint.
           500:
             description: Internal Server Error
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/TrialApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/TrialApiServiceSpec.scala
@@ -194,13 +194,13 @@ final class TrialApiServiceSpec extends BaseServiceSpec with UserApiService with
       }
     }
 
-    "Attempting to terminate a previously enabled user should return NoContent success" in {
+    "Attempting to terminate a previously enabled user should return InternalServerError success" in {
       Post(terminatePath, enabledUserEmails) ~> dummyUserIdHeaders(dummy1User) ~> trialApiServiceRoutes ~> check {
         assertResult(InternalServerError, response.entity.asString) { status }
       }
     }
 
-    "Attempting to terminate a previously disabled user should return NoContent success" in {
+    "Attempting to terminate a previously disabled user should return InternalServerError success" in {
       Post(terminatePath, disabledUserEmails) ~> dummyUserIdHeaders(dummy1User) ~> trialApiServiceRoutes ~> check {
         assertResult(InternalServerError, response.entity.asString) { status }
       }


### PR DESCRIPTION
Added
- positive and negative testing for disabling and terminating users from various states
- negative testing for errors due to unsuccessful Thurloe (get and save) calls

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
