### PR TITLE
GAWB-2959: startup checks

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudServiceActor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudServiceActor.scala
@@ -38,6 +38,8 @@ class FireCloudServiceActor extends HttpServiceActor with FireCloudDirectives
   with TrialApiService
 {
 
+  override lazy val log = LoggerFactory.getLogger(getClass)
+
   implicit val system = context.system
 
   trait ActorRefFactoryContext {
@@ -65,6 +67,9 @@ class FireCloudServiceActor extends HttpServiceActor with FireCloudDirectives
 
   val trialProjectManager = system.actorOf(ProjectManager.props(app.rawlsDAO, app.trialDAO, app.googleServicesDAO), "trial-project-manager")
 
+  // perform startup checks
+  new StartupChecks(app).check
+
   val exportEntitiesByTypeConstructor: (ExportEntitiesByTypeArguments) => ExportEntitiesByTypeActor = ExportEntitiesByTypeActor.constructor(app, materializer)
   val libraryServiceConstructor: (UserInfo) => LibraryService = LibraryService.constructor(app)
   val ontologyServiceConstructor: () => OntologyService = OntologyService.constructor(app)
@@ -88,7 +93,7 @@ class FireCloudServiceActor extends HttpServiceActor with FireCloudDirectives
 
   val healthService = new HealthService with ActorRefFactoryContext
 
-  override lazy val log = LoggerFactory.getLogger(getClass)
+
   val logRequests = mapInnerRoute { route => requestContext =>
     log.debug(requestContext.request.toString)
     route(requestContext)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/StartupChecks.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/StartupChecks.scala
@@ -1,0 +1,69 @@
+package org.broadinstitute.dsde.firecloud
+
+import akka.actor.ActorSystem
+import com.typesafe.scalalogging.LazyLogging
+import org.broadinstitute.dsde.firecloud.model.AccessToken
+import spray.http.StatusCodes
+
+import scala.concurrent.{ExecutionContext, Future}
+
+/**
+  * Encapsulate bootstrap/startup checks into a single class. Note that individual DAOs may
+  * also make their own startup checks, outside of this class.
+  */
+class StartupChecks(app: Application)
+                   (implicit val system: ActorSystem, implicit val executionContext: ExecutionContext)
+                    extends LazyLogging {
+
+  def check: Future[Boolean] = {
+    val checks = Future.sequence(Seq(
+      isAdminSARegistered,
+      isTrialBillingSARegistered
+    ))
+
+    checks map { checkResults =>
+      val hasFailures = checkResults.exists(!_)
+      if (hasFailures) {
+        logger.error(
+          "\n*********************************************************" +
+          "\n*********************************************************" +
+          "\n*********************************************************" +
+          "\n***     BEWARE: AT LEAST ONE STARTUP CHECK FAILED     ***" +
+          "\n***       SEE PREVIOUS LOG MESSAGES FOR DETAILS       ***" +
+          "\n*********************************************************" +
+          "\n*********************************************************" +
+          "\n*********************************************************")
+      } else {
+        logger.info("***    all startup checks succeeded.    ***")
+      }
+      !hasFailures
+    }
+  }
+
+  private def isAdminSARegistered:Future[Boolean] =
+    isServiceAccountRegistered("Admin SA",
+      AccessToken(app.googleServicesDAO.getAdminUserAccessToken))
+
+  private def isTrialBillingSARegistered:Future[Boolean] =
+    isServiceAccountRegistered("Free trial billing SA",
+      AccessToken(app.googleServicesDAO.getTrialBillingManagerAccessToken))
+
+
+  private def isServiceAccountRegistered(name: String, token: AccessToken): Future[Boolean] = {
+    app.samDAO.getRegistrationStatus(implicitly(token)) map { regInfo =>
+      if (regInfo.enabled.ldap)
+        logger.info(s"$name is properly registered.")
+      else
+        logger.error(s"***    $name is registered but not fully enabled!!    ***")
+      regInfo.enabled.ldap
+    } recover {
+      case e: FireCloudExceptionWithErrorReport if e.errorReport.statusCode == Option(StatusCodes.NotFound) =>
+        logger.error(s"***    $name is not registered!!    ***")
+        false
+      case e: Exception =>
+        logger.error(s"***    Error getting registration status for $name: ${e.getMessage}    ***")
+        false
+    }
+  }
+
+}

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/StartupChecks.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/StartupChecks.scala
@@ -72,6 +72,9 @@ class StartupChecks(app: Application, registerSAs: Boolean = true)
       case e: FireCloudExceptionWithErrorReport if e.errorReport.statusCode == Option(StatusCodes.NotFound) =>
         logger.error(s"***    $name is not registered!!    ***")
         false
+      case e: FireCloudExceptionWithErrorReport if e.errorReport.statusCode == Option(StatusCodes.Conflict) =>
+        logger.error(s"***    $name already exists!!    ***")
+        false
       case e: Exception =>
         logger.error(s"***    Error on registration status for $name: ${e.getMessage}    ***")
         false

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/UserInfo.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/UserInfo.scala
@@ -29,6 +29,9 @@ object UserInfo {
 }
 
 case class AccessToken(accessToken: OAuth2BearerToken) extends WithAccessToken
+object AccessToken{
+  def apply(tokenStr: String) = new AccessToken(OAuth2BearerToken(tokenStr))
+}
 
 // response from Google has other fields, but these are the ones we care about
 case class OAuthUser(sub: String, email: String)

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/StartupChecksSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/StartupChecksSpec.scala
@@ -5,7 +5,7 @@ import org.broadinstitute.dsde.firecloud.model.{RegistrationInfo, WithAccessToke
 import org.broadinstitute.dsde.firecloud.service.BaseServiceSpec
 import org.broadinstitute.dsde.rawls.model.ErrorReport
 
-import spray.http.StatusCodes.NotFound
+import spray.http.StatusCodes.{InternalServerError, NotFound}
 
 import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
@@ -23,55 +23,96 @@ class StartupChecksSpec extends BaseServiceSpec {
       "billing SA" -> app.googleServicesDAO.getTrialBillingManagerAccessToken
     )
 
-    "should pass if all SAs are registered" in {
-      val testApp = app.copy(samDAO = new StartupChecksMockSamDAO)
-      val check = Await.result(new StartupChecks(testApp).check, 3.minutes)
-      assert(check)
-    }
+    "When automatic registration of SAs is disabled" - {
 
-    tokens.foreach { case (name, token) =>
-      s"should fail if $name is not ldap-enabled" in {
+      "should pass if all SAs are registered" in {
+        val testApp = app.copy(samDAO = new StartupChecksMockSamDAO)
+        val check = Await.result(new StartupChecks(testApp, registerSAs = false).check, 3.minutes)
+        assert(check)
+      }
+
+      tokens.foreach { case (name, token) =>
+        s"should fail if $name is not ldap-enabled" in {
+          val testApp = app.copy(samDAO = new StartupChecksMockSamDAO(
+            unregisteredTokens = Seq(token)))
+          val check = Await.result(new StartupChecks(testApp, registerSAs = false).check, 3.minutes)
+          assert(!check)
+        }
+      }
+      "should fail if all SAs are not ldap-enabled" in {
         val testApp = app.copy(samDAO = new StartupChecksMockSamDAO(
-          unregisteredTokens = Seq(token)))
-        val check = Await.result(new StartupChecks(testApp).check, 3.minutes)
+          unregisteredTokens = tokens.values.toSeq))
+        val check = Await.result(new StartupChecks(testApp, registerSAs = false).check, 3.minutes)
+        assert(!check)
+      }
+
+      tokens.foreach { case (name, token) =>
+        s"should fail if $name is not registered at all (404)" in {
+          val testApp = app.copy(samDAO = new StartupChecksMockSamDAO(
+            notFounds = Seq(token)))
+          val check = Await.result(new StartupChecks(testApp, registerSAs = false).check, 3.minutes)
+          assert(!check)
+        }
+      }
+      "should fail if all SAs are not registered at all (404)" in {
+        val testApp = app.copy(samDAO = new StartupChecksMockSamDAO(
+          notFounds = tokens.values.toSeq))
+        val check = Await.result(new StartupChecks(testApp, registerSAs = false).check, 3.minutes)
+        assert(!check)
+      }
+
+      tokens.foreach { case (name, token) =>
+        s"should fail if $name returns unexpected error)" in {
+          val testApp = app.copy(samDAO = new StartupChecksMockSamDAO(
+            unexpectedErrors = Seq(token)))
+          val check = Await.result(new StartupChecks(testApp, registerSAs = false).check, 3.minutes)
+          assert(!check)
+        }
+      }
+      "should fail if all SAs return unexpected error" in {
+        val testApp = app.copy(samDAO = new StartupChecksMockSamDAO(
+          unexpectedErrors = tokens.values.toSeq))
+        val check = Await.result(new StartupChecks(testApp, registerSAs = false).check, 3.minutes)
         assert(!check)
       }
     }
-    "should fail if all SAs are not ldap-enabled" in {
-      val testApp = app.copy(samDAO = new StartupChecksMockSamDAO(
-        unregisteredTokens = tokens.values.toSeq))
-      val check = Await.result(new StartupChecks(testApp).check, 3.minutes)
-      assert(!check)
-    }
 
-    tokens.foreach { case (name, token) =>
-      s"should fail if $name is not registered at all (404)" in {
-        val testApp = app.copy(samDAO = new StartupChecksMockSamDAO(
-          notFounds = Seq(token)))
-        val check = Await.result(new StartupChecks(testApp).check, 3.minutes)
-        assert(!check)
+    "When automatic registration of SAs is enabled" - {
+      "should pass when all SAs need to be registered, and succeed" - {
+        val mockDAO = new StartupChecksMockSamDAO(
+          notFounds = Seq(tokens.head._2),
+          unregisteredTokens = tokens.tail.values.toSeq)
+        val testApp = app.copy(samDAO = mockDAO)
+        val check = Await.result(new StartupChecks(testApp, registerSAs = true).check, 3.minutes)
+        assert(check)
+        assertResult(tokens.values.toSet) {mockDAO.newlyRegisteredUsers.toSet}
       }
-    }
-    "should fail if all SAs are not registered at all (404)" in {
-      val testApp = app.copy(samDAO = new StartupChecksMockSamDAO(
-        notFounds = tokens.values.toSeq))
-      val check = Await.result(new StartupChecks(testApp).check, 3.minutes)
-      assert(!check)
-    }
-
-    tokens.foreach { case (name, token) =>
-      s"should fail if $name returns unexpected error)" in {
-        val testApp = app.copy(samDAO = new StartupChecksMockSamDAO(
-          unexpectedErrors = Seq(token)))
-        val check = Await.result(new StartupChecks(testApp).check, 3.minutes)
-        assert(!check)
+      "should pass when only one SA needs to be registered, and succeeds" - {
+        val mockDAO = new StartupChecksMockSamDAO(
+          notFounds = Seq(tokens.head._2))
+        val testApp = app.copy(samDAO = mockDAO)
+        val check = Await.result(new StartupChecks(testApp, registerSAs = true).check, 3.minutes)
+        assert(check)
+        assertResult(Set(tokens.head._2)) {mockDAO.newlyRegisteredUsers.toSet}
       }
-    }
-    "should fail if all SAs return unexpected error" in {
-      val testApp = app.copy(samDAO = new StartupChecksMockSamDAO(
-        unexpectedErrors = tokens.values.toSeq))
-      val check = Await.result(new StartupChecks(testApp).check, 3.minutes)
-      assert(!check)
+      "should fail if automatic registration fails for the single unregistered SA" - {
+        val mockDAO = new StartupChecksMockSamDAO(
+          notFounds = Seq(tokens.head._2),
+          cantRegister = Seq(tokens.head._2))
+        val testApp = app.copy(samDAO = mockDAO)
+        val check = Await.result(new StartupChecks(testApp, registerSAs = true).check, 3.minutes)
+        assert(!check)
+        assert(mockDAO.newlyRegisteredUsers.isEmpty)
+      }
+      "should fail if automatic registration fails for any of the unregistered SAs" - {
+        val mockDAO = new StartupChecksMockSamDAO(
+          notFounds = tokens.values.toSeq,
+          cantRegister = Seq(tokens.head._2))
+        val testApp = app.copy(samDAO = mockDAO)
+        val check = Await.result(new StartupChecks(testApp, registerSAs = true).check, 3.minutes)
+        assert(!check)
+        assertResult(tokens.tail.values.toSet) {mockDAO.newlyRegisteredUsers.toSet}
+      }
     }
 
   }
@@ -79,7 +120,10 @@ class StartupChecksSpec extends BaseServiceSpec {
 
 class StartupChecksMockSamDAO(unregisteredTokens:Seq[String] = Seq.empty[String],
                               notFounds:Seq[String] = Seq.empty[String],
-                              unexpectedErrors:Seq[String] = Seq.empty[String]) extends MockSamDAO {
+                              unexpectedErrors:Seq[String] = Seq.empty[String],
+                              cantRegister:Seq[String] = Seq.empty[String]) extends MockSamDAO {
+
+  var newlyRegisteredUsers = Seq.empty[String]
 
   override def getRegistrationStatus(implicit userInfo: WithAccessToken): Future[RegistrationInfo] = {
     if (notFounds.contains(userInfo.accessToken.token)) {
@@ -93,6 +137,15 @@ class StartupChecksMockSamDAO(unregisteredTokens:Seq[String] = Seq.empty[String]
           WorkbenchUserInfo(userSubjectId = "foo", userEmail = "bar"),
           WorkbenchEnabled(google = true, ldap = isRegistered, allUsersGroup = true)))
       }
+    }
+  }
+
+  override def registerUser(implicit userInfo: WithAccessToken): Future[RegistrationInfo] = {
+    if (cantRegister.contains(userInfo.accessToken.token)) {
+      Future.failed(new FireCloudExceptionWithErrorReport(ErrorReport(InternalServerError, "unit test intentional registration fail")))
+    } else {
+      newlyRegisteredUsers = newlyRegisteredUsers :+ userInfo.accessToken.token
+      super.registerUser
     }
   }
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/StartupChecksSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/StartupChecksSpec.scala
@@ -1,0 +1,98 @@
+package org.broadinstitute.dsde.firecloud
+
+import org.broadinstitute.dsde.firecloud.dataaccess.MockSamDAO
+import org.broadinstitute.dsde.firecloud.model.{RegistrationInfo, WithAccessToken, WorkbenchEnabled, WorkbenchUserInfo}
+import org.broadinstitute.dsde.firecloud.service.BaseServiceSpec
+import org.broadinstitute.dsde.rawls.model.ErrorReport
+
+import spray.http.StatusCodes.NotFound
+
+import scala.concurrent.{Await, Future}
+import scala.concurrent.duration._
+
+class StartupChecksSpec extends BaseServiceSpec {
+
+  // brute-force logging off for the StartupChecks class while running this test
+  org.slf4j.LoggerFactory.getLogger(new StartupChecks(app).getClass)
+    .asInstanceOf[ch.qos.logback.classic.Logger]
+    .setLevel(ch.qos.logback.classic.Level.OFF)
+
+  "Startup checks" - {
+    val tokens = Map(
+      "admin SA" -> app.googleServicesDAO.getAdminUserAccessToken,
+      "billing SA" -> app.googleServicesDAO.getTrialBillingManagerAccessToken
+    )
+
+    "should pass if all SAs are registered" in {
+      val testApp = app.copy(samDAO = new StartupChecksMockSamDAO)
+      val check = Await.result(new StartupChecks(testApp).check, 3.minutes)
+      assert(check)
+    }
+
+    tokens.foreach { case (name, token) =>
+      s"should fail if $name is not ldap-enabled" in {
+        val testApp = app.copy(samDAO = new StartupChecksMockSamDAO(
+          unregisteredTokens = Seq(token)))
+        val check = Await.result(new StartupChecks(testApp).check, 3.minutes)
+        assert(!check)
+      }
+    }
+    "should fail if all SAs are not ldap-enabled" in {
+      val testApp = app.copy(samDAO = new StartupChecksMockSamDAO(
+        unregisteredTokens = tokens.values.toSeq))
+      val check = Await.result(new StartupChecks(testApp).check, 3.minutes)
+      assert(!check)
+    }
+
+    tokens.foreach { case (name, token) =>
+      s"should fail if $name is not registered at all (404)" in {
+        val testApp = app.copy(samDAO = new StartupChecksMockSamDAO(
+          notFounds = Seq(token)))
+        val check = Await.result(new StartupChecks(testApp).check, 3.minutes)
+        assert(!check)
+      }
+    }
+    "should fail if all SAs are not registered at all (404)" in {
+      val testApp = app.copy(samDAO = new StartupChecksMockSamDAO(
+        notFounds = tokens.values.toSeq))
+      val check = Await.result(new StartupChecks(testApp).check, 3.minutes)
+      assert(!check)
+    }
+
+    tokens.foreach { case (name, token) =>
+      s"should fail if $name returns unexpected error)" in {
+        val testApp = app.copy(samDAO = new StartupChecksMockSamDAO(
+          unexpectedErrors = Seq(token)))
+        val check = Await.result(new StartupChecks(testApp).check, 3.minutes)
+        assert(!check)
+      }
+    }
+    "should fail if all SAs return unexpected error" in {
+      val testApp = app.copy(samDAO = new StartupChecksMockSamDAO(
+        unexpectedErrors = tokens.values.toSeq))
+      val check = Await.result(new StartupChecks(testApp).check, 3.minutes)
+      assert(!check)
+    }
+
+  }
+}
+
+class StartupChecksMockSamDAO(unregisteredTokens:Seq[String] = Seq.empty[String],
+                              notFounds:Seq[String] = Seq.empty[String],
+                              unexpectedErrors:Seq[String] = Seq.empty[String]) extends MockSamDAO {
+
+  override def getRegistrationStatus(implicit userInfo: WithAccessToken): Future[RegistrationInfo] = {
+    if (notFounds.contains(userInfo.accessToken.token)) {
+      Future.failed(new FireCloudExceptionWithErrorReport(ErrorReport(NotFound, "unit test intentional failure")))
+    } else {
+      if (unexpectedErrors.contains(userInfo.accessToken.token)) {
+        Future.failed(new Exception("unit test generic error"))
+      } else {
+        val isRegistered = !unregisteredTokens.contains(userInfo.accessToken.token)
+        Future.successful(RegistrationInfo(
+          WorkbenchUserInfo(userSubjectId = "foo", userEmail = "bar"),
+          WorkbenchEnabled(google = true, ldap = isRegistered, allUsersGroup = true)))
+      }
+    }
+  }
+}

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockGoogleServicesDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockGoogleServicesDAO.scala
@@ -13,8 +13,8 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class MockGoogleServicesDAO extends GoogleServicesDAO {
-  override def getAdminUserAccessToken: String = ""
-  override def getTrialBillingManagerAccessToken: String = ""
+  override def getAdminUserAccessToken: String = "adminUserAccessToken"
+  override def getTrialBillingManagerAccessToken: String = "billingManagerAccessToken"
   override def getTrialBillingManagerEmail: String = "mock-trial-billing-mgr-email"
   override def getBucketObjectAsInputStream(bucketName: String, objectKey: String): InputStream = {
     objectKey match {


### PR DESCRIPTION
This adds checks to ensure the free trial service account - and the admin service account - are properly registered in FC. In our shared envs (dev, alpha, staging, prod) I manually registered the free trial SA, so checks should pass; in fiab land, where each env is new, the checks should auto-register the SAs.

This is *not* currently working correctly in my fiab, because orchestration starts before sam, and therefore orch can't register the SAs in sam. If, once my fiab is up and running, I restart orchestration (knowing that sam is up), everything works correctly.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
