### PR TITLE
(Not yet) Add user to billing project upon enrollment [GAWB-2910]

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/GoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/GoogleServicesDAO.scala
@@ -21,6 +21,7 @@ trait GoogleServicesDAO extends ReportsSubsystemStatus {
 
   def getAdminUserAccessToken: String
   def getTrialBillingManagerAccessToken: String
+  def getTrialBillingManagerEmail: String
   def getBucketObjectAsInputStream(bucketName: String, objectKey: String): InputStream
   def getObjectResourceUrl(bucketName: String, objectKey: String): String
   def getUserProfile(requestContext: RequestContext)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
@@ -112,6 +112,8 @@ object HttpGoogleServicesDAO extends GoogleServicesDAO with FireCloudRequestBuil
     googleCredential.getAccessToken
   }
 
+  def getTrialBillingManagerEmail = trialBillingPemFileClientId
+
   private def getBucketServiceAccountCredential: Credential = {
     new GoogleCredential.Builder()
       .setTransport(httpTransport)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpRawlsDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpRawlsDAO.scala
@@ -182,9 +182,12 @@ class HttpRawlsDAO( implicit val system: ActorSystem, implicit val executionCont
     authedRequestToObject[Seq[RawlsBillingProjectMember]](Get(FireCloudConfig.Rawls.authUrl + s"/billing/$projectId/members"), true)
   }
 
-  override def addUserToBillingProject(projectId: String, role: ProjectRole, email: String)(implicit userToken: WithAccessToken): Future[Boolean] = {
+  override def addUserToBillingProject(projectId: String, role: ProjectRole, email: String)(implicit userToken: WithAccessToken): Future[Unit] = {
     userAuthedRequest(Get(FireCloudConfig.Rawls.authUrl + s"/billing/$projectId/${role.toString}/$email"), true) map { resp =>
-      resp.status.isSuccess
+      resp.status match {
+        case OK => ()
+        case _ => throw new FireCloudExceptionWithErrorReport(FCErrorReport(resp))
+      }
     }
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpRawlsDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpRawlsDAO.scala
@@ -3,7 +3,7 @@ package org.broadinstitute.dsde.firecloud.dataaccess
 import akka.actor.ActorSystem
 import org.broadinstitute.dsde.firecloud.model.ErrorReportExtensions._
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
-import org.broadinstitute.dsde.firecloud.model.Trial.{CreateRawlsBillingProjectFullRequest, RawlsBillingProjectMembership}
+import org.broadinstitute.dsde.firecloud.model.Trial.{CreateRawlsBillingProjectFullRequest, RawlsBillingProjectMember, RawlsBillingProjectMembership}
 import org.broadinstitute.dsde.firecloud.model._
 import org.broadinstitute.dsde.firecloud.utils.RestJsonClient
 import org.broadinstitute.dsde.firecloud.{FireCloudConfig, FireCloudExceptionWithErrorReport}
@@ -19,6 +19,7 @@ import spray.http.{OAuth2BearerToken, StatusCodes, Uri}
 import spray.httpx.SprayJsonSupport._
 import spray.httpx.unmarshalling._
 import spray.json.DefaultJsonProtocol._
+import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol.impRawlsBillingProjectMember
 import spray.json._
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -174,6 +175,10 @@ class HttpRawlsDAO( implicit val system: ActorSystem, implicit val executionCont
         case Left(error) => throw new FireCloudExceptionWithErrorReport(FCErrorReport(resp))
       }
     }
+  }
+
+  override def getProjectMembers(projectId: String)(implicit userToken: WithAccessToken): Future[Seq[RawlsBillingProjectMember]] = {
+    authedRequestToObject[Seq[RawlsBillingProjectMember]](Get(FireCloudConfig.Rawls.authUrl + s"/billing/$projectId/members"), true)
   }
 
   override def status: Future[SubsystemStatus] = {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpRawlsDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpRawlsDAO.scala
@@ -183,7 +183,9 @@ class HttpRawlsDAO( implicit val system: ActorSystem, implicit val executionCont
   }
 
   override def addUserToBillingProject(projectId: String, role: ProjectRole, email: String)(implicit userToken: WithAccessToken): Future[Unit] = {
-    userAuthedRequest(Get(FireCloudConfig.Rawls.authUrl + s"/billing/$projectId/${role.toString}/$email"), true) map { resp =>
+    val url = FireCloudConfig.Rawls.authUrl + s"/billing/$projectId/${role.toString}/${java.net.URLEncoder.encode(email, "UTF-8")}"
+
+    userAuthedRequest(Put(url), true) map { resp =>
       resp.status match {
         case OK => ()
         case _ => throw new FireCloudExceptionWithErrorReport(FCErrorReport(resp))

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpRawlsDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpRawlsDAO.scala
@@ -183,7 +183,7 @@ class HttpRawlsDAO( implicit val system: ActorSystem, implicit val executionCont
   }
 
   override def addUserToBillingProject(projectId: String, role: ProjectRole, email: String)(implicit userToken: WithAccessToken): Future[Boolean] = {
-    val url = FireCloudConfig.Rawls.authUrl + s"/billing/$projectId/${role.toString}/${java.net.URLEncoder.encode(email, "UTF-8")}"
+    val url = editBillingMembershipURL(projectId, role, email)
 
     userAuthedRequest(Put(url), true) map { resp =>
       if (resp.status.isSuccess) {
@@ -192,6 +192,22 @@ class HttpRawlsDAO( implicit val system: ActorSystem, implicit val executionCont
         throw new FireCloudExceptionWithErrorReport(FCErrorReport(resp))
       }
     }
+  }
+
+  override def removeUserFromBillingProject(projectId: String, role: ProjectRole, email: String)(implicit userToken: WithAccessToken): Future[Boolean] = {
+    val url = editBillingMembershipURL(projectId, role, email)
+
+    userAuthedRequest(Delete(url), true) map { resp =>
+      if (resp.status.isSuccess) {
+        true
+      } else {
+        throw new FireCloudExceptionWithErrorReport(FCErrorReport(resp))
+      }
+    }
+  }
+
+  private def editBillingMembershipURL(projectId: String, role: ProjectRole, email: String) = {
+    FireCloudConfig.Rawls.authUrl + s"/billing/$projectId/${role.toString}/${java.net.URLEncoder.encode(email, "UTF-8")}"
   }
 
   override def status: Future[SubsystemStatus] = {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpRawlsDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpRawlsDAO.scala
@@ -20,6 +20,7 @@ import spray.httpx.SprayJsonSupport._
 import spray.httpx.unmarshalling._
 import spray.json.DefaultJsonProtocol._
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol.impRawlsBillingProjectMember
+import org.broadinstitute.dsde.firecloud.model.Trial.ProjectRoles.ProjectRole
 import spray.json._
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -179,6 +180,12 @@ class HttpRawlsDAO( implicit val system: ActorSystem, implicit val executionCont
 
   override def getProjectMembers(projectId: String)(implicit userToken: WithAccessToken): Future[Seq[RawlsBillingProjectMember]] = {
     authedRequestToObject[Seq[RawlsBillingProjectMember]](Get(FireCloudConfig.Rawls.authUrl + s"/billing/$projectId/members"), true)
+  }
+
+  override def addUserToBillingProject(projectId: String, role: ProjectRole, email: String)(implicit userToken: WithAccessToken): Future[Boolean] = {
+    userAuthedRequest(Get(FireCloudConfig.Rawls.authUrl + s"/billing/$projectId/${role.toString}/$email"), true) map { resp =>
+      resp.status.isSuccess
+    }
   }
 
   override def status: Future[SubsystemStatus] = {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpRawlsDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpRawlsDAO.scala
@@ -182,13 +182,14 @@ class HttpRawlsDAO( implicit val system: ActorSystem, implicit val executionCont
     authedRequestToObject[Seq[RawlsBillingProjectMember]](Get(FireCloudConfig.Rawls.authUrl + s"/billing/$projectId/members"), true)
   }
 
-  override def addUserToBillingProject(projectId: String, role: ProjectRole, email: String)(implicit userToken: WithAccessToken): Future[Unit] = {
+  override def addUserToBillingProject(projectId: String, role: ProjectRole, email: String)(implicit userToken: WithAccessToken): Future[Boolean] = {
     val url = FireCloudConfig.Rawls.authUrl + s"/billing/$projectId/${role.toString}/${java.net.URLEncoder.encode(email, "UTF-8")}"
 
     userAuthedRequest(Put(url), true) map { resp =>
-      resp.status match {
-        case OK => ()
-        case _ => throw new FireCloudExceptionWithErrorReport(FCErrorReport(resp))
+      if (resp.status.isSuccess) {
+        true
+      } else {
+        throw new FireCloudExceptionWithErrorReport(FCErrorReport(resp))
       }
     }
   }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/RawlsDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/RawlsDAO.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.dsde.firecloud.dataaccess
 
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.FireCloudConfig
+import org.broadinstitute.dsde.firecloud.model.Trial.ProjectRoles.ProjectRole
 import org.broadinstitute.dsde.firecloud.model.Trial.{RawlsBillingProjectMember, RawlsBillingProjectMembership}
 import org.broadinstitute.dsde.firecloud.model._
 import org.broadinstitute.dsde.rawls.model._
@@ -95,6 +96,8 @@ trait RawlsDAO extends LazyLogging with ReportsSubsystemStatus {
   def getProjects(implicit userToken: WithAccessToken): Future[Seq[RawlsBillingProjectMembership]]
 
   def getProjectMembers(projectId: String)(implicit userToken: WithAccessToken): Future[Seq[RawlsBillingProjectMember]]
+
+  def addUserToBillingProject(projectId: String, role: ProjectRole, email: String)(implicit userToken: WithAccessToken): Future[Boolean]
 
   override def serviceName:String = RawlsDAO.serviceName
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/RawlsDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/RawlsDAO.scala
@@ -99,6 +99,8 @@ trait RawlsDAO extends LazyLogging with ReportsSubsystemStatus {
 
   def addUserToBillingProject(projectId: String, role: ProjectRole, email: String)(implicit userToken: WithAccessToken): Future[Boolean]
 
+  def removeUserFromBillingProject(projectId: String, role: ProjectRole, email: String)(implicit userToken: WithAccessToken): Future[Boolean]
+
   override def serviceName:String = RawlsDAO.serviceName
 
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/RawlsDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/RawlsDAO.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.firecloud.dataaccess
 
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.FireCloudConfig
-import org.broadinstitute.dsde.firecloud.model.Trial.RawlsBillingProjectMembership
+import org.broadinstitute.dsde.firecloud.model.Trial.{RawlsBillingProjectMember, RawlsBillingProjectMembership}
 import org.broadinstitute.dsde.firecloud.model._
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.AttributeUpdateOperation
@@ -93,6 +93,8 @@ trait RawlsDAO extends LazyLogging with ReportsSubsystemStatus {
 
   def createProject(projectName: String, billingAccount: String)(implicit userToken: WithAccessToken): Future[Boolean]
   def getProjects(implicit userToken: WithAccessToken): Future[Seq[RawlsBillingProjectMembership]]
+
+  def getProjectMembers(projectId: String)(implicit userToken: WithAccessToken): Future[Seq[RawlsBillingProjectMember]]
 
   override def serviceName:String = RawlsDAO.serviceName
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/RawlsDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/RawlsDAO.scala
@@ -97,7 +97,7 @@ trait RawlsDAO extends LazyLogging with ReportsSubsystemStatus {
 
   def getProjectMembers(projectId: String)(implicit userToken: WithAccessToken): Future[Seq[RawlsBillingProjectMember]]
 
-  def addUserToBillingProject(projectId: String, role: ProjectRole, email: String)(implicit userToken: WithAccessToken): Future[Boolean]
+  def addUserToBillingProject(projectId: String, role: ProjectRole, email: String)(implicit userToken: WithAccessToken): Future[Unit]
 
   override def serviceName:String = RawlsDAO.serviceName
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/RawlsDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/RawlsDAO.scala
@@ -97,7 +97,7 @@ trait RawlsDAO extends LazyLogging with ReportsSubsystemStatus {
 
   def getProjectMembers(projectId: String)(implicit userToken: WithAccessToken): Future[Seq[RawlsBillingProjectMember]]
 
-  def addUserToBillingProject(projectId: String, role: ProjectRole, email: String)(implicit userToken: WithAccessToken): Future[Unit]
+  def addUserToBillingProject(projectId: String, role: ProjectRole, email: String)(implicit userToken: WithAccessToken): Future[Boolean]
 
   override def serviceName:String = RawlsDAO.serviceName
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
@@ -282,6 +282,9 @@ object ModelJsonProtocol extends WorkspaceJsonSupport {
       case _ => throw new DeserializationException("could not deserialize project role")
     }
   }
+
+  implicit val impRawlsBillingProjectMember = jsonFormat2(RawlsBillingProjectMember)
+
   // END copy/paste from rawls
 
   implicit val impRawlsBillingProjectMembership = jsonFormat4(RawlsBillingProjectMembership)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/Trial.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/Trial.scala
@@ -5,7 +5,7 @@ import java.time.Instant
 import org.broadinstitute.dsde.firecloud.FireCloudException
 import org.broadinstitute.dsde.firecloud.model.Trial.CreationStatuses.CreationStatus
 import org.broadinstitute.dsde.firecloud.model.Trial.TrialStates.TrialState
-import org.broadinstitute.dsde.rawls.model.{RawlsBillingProjectName, RawlsEnumeration}
+import org.broadinstitute.dsde.rawls.model.{RawlsBillingProjectName, RawlsEnumeration, RawlsUserEmail}
 
 import scala.util.Try
 
@@ -155,6 +155,8 @@ object Trial {
   case class CreateRawlsBillingProjectFullRequest(projectName: String, billingAccount: String)
 
   case class RawlsBillingProjectMembership(projectName: RawlsBillingProjectName, role: ProjectRoles.ProjectRole, creationStatus: CreationStatuses.CreationStatus, message: Option[String] = None)
+
+  case class RawlsBillingProjectMember(email: RawlsUserEmail, role: ProjectRoles.ProjectRole)
 
   object CreationStatuses {
     sealed trait CreationStatus extends RawlsEnumeration[CreationStatus] {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/TrialService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/TrialService.scala
@@ -200,36 +200,47 @@ final class TrialService
   }
 
   private def enrollUserInternal(userInfo: UserInfo, status: UserTrialStatus): Future[PerRequestMessage] = {
-    // 1. Update the user's Thurloe profile to indicate Enrolled status
-    thurloeDao.saveTrialStatus(userInfo, enrolledStatusFromStatus(status)) flatMap { _ =>
-      val bpName = "fccredits-hafnium-peach-3794" // TODO: Make this status.billingProjectName when GAWB-2911 lands
 
-      val saToken: WithAccessToken = AccessToken(OAuth2BearerToken(googleDAO.getTrialBillingManagerAccessToken))
+    val bpName = "fccredits-hafnium-peach-3794" // TODO: Make this status.billingProjectName when GAWB-2911 lands
+    val saToken: WithAccessToken = AccessToken(OAuth2BearerToken(googleDAO.getTrialBillingManagerAccessToken))
 
-      // 2. Check that the assigned Billing Project contains exactly one member, the SA we used to create it
-      rawlsDAO.getProjectMembers(projectId = bpName)(userToken = saToken) flatMap { members: Seq[RawlsBillingProjectMember] =>
-        if (members.map(_.email.value) != Seq(HttpGoogleServicesDAO.trialBillingPemFileClientId)) {
-          Future(RequestCompleteWithErrorReport(InternalServerError, s"We could not complete your enrollment due to a problem assigning you to a billing project. (Error 60)"))
-        } else {
-          // 3. Add the user as Owner to the assigned Billing Project
-          rawlsDAO.addUserToBillingProject(bpName, ProjectRoles.Owner, userInfo.userEmail)(userToken = saToken) map { success: Boolean =>
-            if (success) {
-              RequestComplete(NoContent)
-            } else {
-              RequestCompleteWithErrorReport(InternalServerError, "We could not complete your enrollment due to a problem assigning you to a billing project. (Error 70)")
+    // 1. Check that the assigned Billing Project exists and contains exactly one member, the SA we used to create it
+    rawlsDAO.getProjectMembers(projectId = bpName)(userToken = saToken) flatMap { members: Seq[RawlsBillingProjectMember] =>
+      if (members.map(_.email.value) != Seq(HttpGoogleServicesDAO.trialBillingPemFileClientId)) {
+        Future(RequestCompleteWithErrorReport(InternalServerError, s"We could not complete your enrollment because your billing project is missing or unusable. (Error 60)"))
+      } else {
+        // 2. Add the user as Owner to the assigned Billing Project
+        rawlsDAO.addUserToBillingProject(bpName, ProjectRoles.Owner, userInfo.userEmail)(userToken = saToken) flatMap { success: Boolean =>
+          if (success) {
+            // 3. Update the user's Thurloe profile to indicate Enrolled status
+            thurloeDao.saveTrialStatus(userInfo, enrolledStatusFromStatus(status)) map {
+              case Success(_) => RequestComplete(NoContent)
+              case Failure(e) =>
+                RequestCompleteWithErrorReport(InternalServerError, "We could not complete your enrollment due to a problem assigning you to a billing project. (Error 70)")
             }
-          } recover {
-            case e: FireCloudException =>
-              RequestCompleteWithErrorReport(InternalServerError, "We could not complete your enrollment due to a problem assigning you to a billing project. (Error 80)")
-            case _: Throwable => RequestCompleteWithErrorReport(InternalServerError, "We could not complete your enrollment due to an unknown error. (Error 90)")
+          } else {
+            Future(RequestCompleteWithErrorReport(InternalServerError, "We could not complete your enrollment due to a problem assigning you to a billing project. (Error 70)"))
           }
+        } recover {
+          case e: FireCloudException =>
+            RequestCompleteWithErrorReport(InternalServerError, "We could not complete your enrollment due to a problem assigning you to a billing project. (Error 80)")
+          case _: Throwable => RequestCompleteWithErrorReport(InternalServerError, "We could not complete your enrollment due to an unknown error. (Error 90)")
         }
-      } recover {
-        case e: FireCloudExceptionWithErrorReport =>
-        RequestCompleteWithErrorReport(InternalServerError,  s"We could not complete your enrollment: ${e.errorReport.message} (Error 100)")
-        case _: Throwable => RequestCompleteWithErrorReport(InternalServerError, "We could not complete your enrollment due to an unknown error. (Error 110")
       }
+    } recover {
+      case e: FireCloudExceptionWithErrorReport =>
+        RequestCompleteWithErrorReport(InternalServerError,  s"We could not complete your enrollment: ${e.errorReport.message} (Error 100)")
+      case _: Throwable => RequestCompleteWithErrorReport(InternalServerError, "We could not complete your enrollment due to an unknown error. (Error 110")
     }
+
+    // 1. Update the user's Thurloe profile to indicate Enrolled status
+//    thurloeDao.saveTrialStatus(userInfo, enrolledStatusFromStatus(status)) flatMap { _ =>
+//      val bpName = "fccredits-hafnium-peach-3794" // TODO: Make this status.billingProjectName when GAWB-2911 lands
+//
+//      val saToken: WithAccessToken = AccessToken(OAuth2BearerToken(googleDAO.getTrialBillingManagerAccessToken))
+//
+//
+//    }
   }
 
   private def enrolledStatusFromStatus(status: UserTrialStatus): UserTrialStatus = {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/TrialService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/TrialService.scala
@@ -184,7 +184,6 @@ final class TrialService
     // get user's trial status, then check the current state
     thurloeDao.getTrialStatus(userInfo.id, userInfo) flatMap {
       // can't determine the user's trial status; don't enroll
-      case None => Future(RequestCompleteWithErrorReport(BadRequest, "You are not eligible for a free trial. (Error 10)"))
       case Some(status) =>
         status.state match {
           // user already enrolled; don't re-enroll
@@ -196,6 +195,7 @@ final class TrialService
           case Some(TrialStates.Terminated) => Future(RequestCompleteWithErrorReport(BadRequest, "You are not eligible for a free trial. (Error 40)"))
           case None => Future(RequestCompleteWithErrorReport(BadRequest, "You are not eligible for a free trial. (Error 50)"))
         }
+      case _ => Future(RequestCompleteWithErrorReport(BadRequest, "You are not eligible for a free trial. (Error 51)")) // Shouldn't happen
     }
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/TrialService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/TrialService.scala
@@ -215,7 +215,10 @@ final class TrialService
             // 3. Update the user's Thurloe profile to indicate Enrolled status
             thurloeDao.saveTrialStatus(userInfo, enrolledStatusFromStatus(status)) map {
               case Success(_) => RequestComplete(NoContent)
-              case Failure(e) => RequestCompleteWithErrorReport(InternalServerError, s"We could not process your enrollment. (Error 70 - ${e.getMessage})")
+              case Failure(e) => {
+                // TODO: Remove user from billing project on failure? Is this even likely?
+                RequestCompleteWithErrorReport(InternalServerError, s"We could not process your enrollment. (Error 70 - ${e.getMessage})")
+              }
             }
           } else {
             Future(RequestCompleteWithErrorReport(InternalServerError, "We could not process your enrollment. (Error 75 - could not add user to billing project)"))

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/TrialService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/TrialService.scala
@@ -203,7 +203,7 @@ final class TrialService
 
     // 1. Check that the assigned Billing Project exists and contains exactly one member, the SA we used to create it
     rawlsDAO.getProjectMembers(projectId)(saToken) flatMap { members: Seq[RawlsBillingProjectMember] =>
-      if (members.map(_.email.value) != Seq(HttpGoogleServicesDAO.trialBillingPemFileClientId)) {
+      if (members.map(_.email.value) != Seq(googleDAO.getTrialBillingManagerEmail)) {
         Future(RequestCompleteWithErrorReport(InternalServerError, "We could not process your enrollment. (Error 60 - billing project exists but cannot be used)"))
       } else {
         // 2. Add the user as Owner to the assigned Billing Project

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockRawlsDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockRawlsDAO.scala
@@ -371,5 +371,5 @@ class MockRawlsDAO  extends RawlsDAO {
 
   override def getProjectMembers(projectId: String)(implicit userToken: WithAccessToken): Future[Seq[RawlsBillingProjectMember]] = ???
 
-  override def addUserToBillingProject(projectId: String, role: ProjectRole, email: String)(implicit userToken: WithAccessToken): Future[Boolean] = ???
+  override def addUserToBillingProject(projectId: String, role: ProjectRole, email: String)(implicit userToken: WithAccessToken): Future[Unit] = ???
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockRawlsDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockRawlsDAO.scala
@@ -9,6 +9,7 @@ import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.AttributeUp
 import org.joda.time.DateTime
 import spray.http.StatusCodes
 import MockRawlsDAO._
+import org.broadinstitute.dsde.firecloud.model.Trial.ProjectRoles.ProjectRole
 import org.broadinstitute.dsde.firecloud.model.Trial.RawlsBillingProjectMember
 import org.broadinstitute.dsde.workbench.util.health.SubsystemStatus
 
@@ -369,4 +370,6 @@ class MockRawlsDAO  extends RawlsDAO {
   override def getProjects(implicit userToken: WithAccessToken): Future[Seq[Trial.RawlsBillingProjectMembership]] = Future(Seq.empty[Trial.RawlsBillingProjectMembership])
 
   override def getProjectMembers(projectId: String)(implicit userToken: WithAccessToken): Future[Seq[RawlsBillingProjectMember]] = ???
+
+  override def addUserToBillingProject(projectId: String, role: ProjectRole, email: String)(implicit userToken: WithAccessToken): Future[Boolean] = ???
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockRawlsDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockRawlsDAO.scala
@@ -371,5 +371,5 @@ class MockRawlsDAO  extends RawlsDAO {
 
   override def getProjectMembers(projectId: String)(implicit userToken: WithAccessToken): Future[Seq[RawlsBillingProjectMember]] = ???
 
-  override def addUserToBillingProject(projectId: String, role: ProjectRole, email: String)(implicit userToken: WithAccessToken): Future[Unit] = ???
+  override def addUserToBillingProject(projectId: String, role: ProjectRole, email: String)(implicit userToken: WithAccessToken): Future[Boolean] = ???
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockRawlsDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockRawlsDAO.scala
@@ -372,4 +372,6 @@ class MockRawlsDAO  extends RawlsDAO {
   override def getProjectMembers(projectId: String)(implicit userToken: WithAccessToken): Future[Seq[RawlsBillingProjectMember]] = ???
 
   override def addUserToBillingProject(projectId: String, role: ProjectRole, email: String)(implicit userToken: WithAccessToken): Future[Boolean] = ???
+
+  override def removeUserFromBillingProject(projectId: String, role: ProjectRole, email: String)(implicit userToken: WithAccessToken): Future[Boolean] = ???
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockRawlsDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockRawlsDAO.scala
@@ -10,7 +10,7 @@ import org.joda.time.DateTime
 import spray.http.StatusCodes
 import MockRawlsDAO._
 import org.broadinstitute.dsde.firecloud.model.Trial.ProjectRoles.ProjectRole
-import org.broadinstitute.dsde.firecloud.model.Trial.RawlsBillingProjectMember
+import org.broadinstitute.dsde.firecloud.model.Trial.{ProjectRoles, RawlsBillingProjectMember}
 import org.broadinstitute.dsde.workbench.util.health.SubsystemStatus
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -369,9 +369,10 @@ class MockRawlsDAO  extends RawlsDAO {
 
   override def getProjects(implicit userToken: WithAccessToken): Future[Seq[Trial.RawlsBillingProjectMembership]] = Future(Seq.empty[Trial.RawlsBillingProjectMembership])
 
-  override def getProjectMembers(projectId: String)(implicit userToken: WithAccessToken): Future[Seq[RawlsBillingProjectMember]] = ???
+  override def getProjectMembers(projectId: String)(implicit userToken: WithAccessToken): Future[Seq[RawlsBillingProjectMember]] =
+    Future(Seq(Trial.RawlsBillingProjectMember(RawlsUserEmail("mock-trial-billing-mgr-email"), ProjectRoles.Owner)))
 
-  override def addUserToBillingProject(projectId: String, role: ProjectRole, email: String)(implicit userToken: WithAccessToken): Future[Boolean] = ???
+  override def addUserToBillingProject(projectId: String, role: ProjectRole, email: String)(implicit userToken: WithAccessToken): Future[Boolean] = Future(true)
 
-  override def removeUserFromBillingProject(projectId: String, role: ProjectRole, email: String)(implicit userToken: WithAccessToken): Future[Boolean] = ???
+  override def removeUserFromBillingProject(projectId: String, role: ProjectRole, email: String)(implicit userToken: WithAccessToken): Future[Boolean] = Future(true)
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockRawlsDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockRawlsDAO.scala
@@ -9,6 +9,7 @@ import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.AttributeUp
 import org.joda.time.DateTime
 import spray.http.StatusCodes
 import MockRawlsDAO._
+import org.broadinstitute.dsde.firecloud.model.Trial.RawlsBillingProjectMember
 import org.broadinstitute.dsde.workbench.util.health.SubsystemStatus
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -366,4 +367,6 @@ class MockRawlsDAO  extends RawlsDAO {
   override def createProject(projectName: String, billingAccount: String)(implicit userToken: WithAccessToken): Future[Boolean] = Future(false)
 
   override def getProjects(implicit userToken: WithAccessToken): Future[Seq[Trial.RawlsBillingProjectMembership]] = Future(Seq.empty[Trial.RawlsBillingProjectMembership])
+
+  override def getProjectMembers(projectId: String)(implicit userToken: WithAccessToken): Future[Seq[RawlsBillingProjectMember]] = ???
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockGoogleServicesDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockGoogleServicesDAO.scala
@@ -15,7 +15,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 class MockGoogleServicesDAO extends GoogleServicesDAO {
   override def getAdminUserAccessToken: String = ""
   override def getTrialBillingManagerAccessToken: String = ""
-  override def getTrialBillingManagerEmail: String = ""
+  override def getTrialBillingManagerEmail: String = "mock-trial-billing-mgr-email"
   override def getBucketObjectAsInputStream(bucketName: String, objectKey: String): InputStream = {
     objectKey match {
       case "target-whitelist.txt" => new ByteArrayInputStream("firecloud-dev\ntarget-user".getBytes("UTF-8"))

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockGoogleServicesDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockGoogleServicesDAO.scala
@@ -15,6 +15,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 class MockGoogleServicesDAO extends GoogleServicesDAO {
   override def getAdminUserAccessToken: String = ""
   override def getTrialBillingManagerAccessToken: String = ""
+  override def getTrialBillingManagerEmail: String = ""
   override def getBucketObjectAsInputStream(bucketName: String, objectKey: String): InputStream = {
     objectKey match {
       case "target-whitelist.txt" => new ByteArrayInputStream("firecloud-dev\ntarget-user".getBytes("UTF-8"))


### PR DESCRIPTION
This PR enrolls the user and adds them to a hard-coded billing project. (Using the right billing project is TBD as of GAWB-2911.)

<img width="643" alt="screen shot 2017-12-07 at 12 26 41 pm" src="https://user-images.githubusercontent.com/1087943/33728987-45edadc4-db4a-11e7-83a4-073b332ed937.png">

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
