### PR TITLE
GAWB-2964: make sure health monitor repeats its checks

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/Application.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/Application.scala
@@ -20,7 +20,7 @@ case class Application(agoraDAO: AgoraDAO,
                        thurloeDAO: ThurloeDAO,
                        trialDAO: TrialDAO) {
 
-  def healthMonitorChecks: Map[Subsystem, Future[SubsystemStatus]] = Map(
+  def healthMonitorChecks: () => Map[Subsystem, Future[SubsystemStatus]] = () => Map(
     Agora -> agoraDAO.status,
     Consent -> consentDAO.status,
     GoogleBuckets -> googleServicesDAO.status,

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudServiceActor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudServiceActor.scala
@@ -60,7 +60,7 @@ class FireCloudServiceActor extends HttpServiceActor with FireCloudDirectives
   val materializer: ActorMaterializer = ActorMaterializer()
 
   val healthMonitorChecks = app.healthMonitorChecks
-  val healthMonitor = system.actorOf(HealthMonitor.props(healthMonitorChecks().keySet)( healthMonitorChecks ), "healt-monitor")
+  val healthMonitor = system.actorOf(HealthMonitor.props(healthMonitorChecks().keySet)( healthMonitorChecks ), "health-monitor")
   system.scheduler.schedule(3.seconds, 1.minute, healthMonitor, HealthMonitor.CheckAll)
 
   val trialProjectManager = system.actorOf(ProjectManager.props(app.rawlsDAO, app.trialDAO, app.googleServicesDAO), "trial-project-manager")

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudServiceActor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudServiceActor.scala
@@ -36,7 +36,7 @@ class FireCloudServiceActor extends HttpServiceActor with FireCloudDirectives
   with Ga4ghApiService
   with UserApiService
   with TrialApiService
-  {
+{
 
   implicit val system = context.system
 
@@ -60,7 +60,7 @@ class FireCloudServiceActor extends HttpServiceActor with FireCloudDirectives
   val materializer: ActorMaterializer = ActorMaterializer()
 
   val healthMonitorChecks = app.healthMonitorChecks
-  val healthMonitor = system.actorOf(HealthMonitor.props(healthMonitorChecks.keySet)( () => healthMonitorChecks ), "health-monitor")
+  val healthMonitor = system.actorOf(HealthMonitor.props(healthMonitorChecks().keySet)( healthMonitorChecks ), "healt-monitor")
   system.scheduler.schedule(3.seconds, 1.minute, healthMonitor, HealthMonitor.CheckAll)
 
   val trialProjectManager = system.actorOf(ProjectManager.props(app.rawlsDAO, app.trialDAO, app.googleServicesDAO), "trial-project-manager")

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/StatusApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/StatusApiServiceSpec.scala
@@ -20,7 +20,7 @@ class StatusApiServiceSpec extends BaseServiceSpec with StatusApiService {
   def actorRefFactory = system
 
   val healthMonitorChecks = app.healthMonitorChecks
-  val healthMonitor = system.actorOf(HealthMonitor.props(healthMonitorChecks.keySet)( () => healthMonitorChecks ), "health-monitor")
+  val healthMonitor = system.actorOf(HealthMonitor.props(healthMonitorChecks().keySet)( healthMonitorChecks ), "health-monitor")
   val monitorSchedule = system.scheduler.schedule(Duration.Zero, 1.second, healthMonitor, HealthMonitor.CheckAll)
 
   override def beforeAll = {


### PR DESCRIPTION
Found while debugging a problem with Thurloe in dev ... during that session, we noticed that orchestration's status never went red, and continued to show Thurloe as up. Then through code inspection, realized that the set of health checks we were passing into the health monitor were resolved the first time they were checked, and then never again.

End result is that orch's status wasn't updating over time.

Tested by running a local orch and a local agora, switched agora on and off and watched orch's status update correctly.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
