### PR TITLE
GAWB-2965: update Jackson and Scala versions

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,14 +3,14 @@ import sbt._
 object Dependencies {
   val akkaV = "2.4.19"
   val sprayV = "1.3.4"
-  val jacksonV = "2.8.8"
+  val jacksonV = "2.8.10"
      // note that jackson-databind overrides this below! 2.8.8.1 is not released for core or annotations.
 
   val rootDependencies = Seq(
     // proactively pull in latest versions of Jackson libs, instead of relying on the versions
     // specified as transitive dependencies, due to OWASP DependencyCheck warnings for earlier versions.
     "com.fasterxml.jackson.core"     % "jackson-annotations" % jacksonV,
-    "com.fasterxml.jackson.core"     % "jackson-databind"    % "2.8.8.1",
+    "com.fasterxml.jackson.core"     % "jackson-databind"    % jacksonV,
     "com.fasterxml.jackson.core"     % "jackson-core"        % jacksonV,
 
     "org.apache.logging.log4j"       % "log4j-api"           % "2.8.2", // elasticsearch requires log4j ...

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -39,7 +39,7 @@ object Settings {
   val commonSettings =
     commonBuildSettings ++ commonAssemblySettings ++ commonTestSettings ++ List(
     organization  := "org.broadinstitute.dsde.firecloud",
-    scalaVersion  := "2.11.8",
+    scalaVersion  := "2.11.12",
     resolvers ++= commonResolvers,
     scalacOptions ++= commonCompilerSettings
   )


### PR DESCRIPTION
update Jackson and Scala versions based on SourceClear recommendations.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
