### PR TITLE
gawb 2947: update exception handling

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpRawlsDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpRawlsDAO.scala
@@ -46,7 +46,7 @@ class HttpRawlsDAO( implicit val system: ActorSystem, implicit val executionCont
     userAuthedRequest(Get(RawlsDAO.groupUrl(groupName)))(userInfo) map { response =>
       response.status match {
         case OK => true
-        case Forbidden => false
+        case NotFound => false
         case _ => throw new FireCloudExceptionWithErrorReport(FCErrorReport(response))
       }
     }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpRawlsDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpRawlsDAO.scala
@@ -46,7 +46,8 @@ class HttpRawlsDAO( implicit val system: ActorSystem, implicit val executionCont
     userAuthedRequest(Get(RawlsDAO.groupUrl(groupName)))(userInfo) map { response =>
       response.status match {
         case OK => true
-        case _ => false
+        case Forbidden => false
+        case _ => throw new FireCloudExceptionWithErrorReport(FCErrorReport(response))
       }
     }
   }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/Trial.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/Trial.scala
@@ -156,13 +156,13 @@ object Trial {
     sealed trait Attempt
 
     case object Success extends Attempt
-    case object Failure extends Attempt
+    case class Failure(msg: String) extends Attempt
     case object NoChangeRequired extends Attempt
     case class ServerError(msg: String) extends Attempt
 
     def toName(status: Attempt): String = status match {
       case Success => "Success"
-      case Failure => "Failure"
+      case Failure(msg) => "Failure: " + msg
       case NoChangeRequired => "NoChangeRequired"
       case ServerError(msg) => "ServerError: " + msg
     }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/TrialService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/TrialService.scala
@@ -144,20 +144,14 @@ final class TrialService
       case None => None
       case Some(status) => status.state
     }
+
     if (innerState.isEmpty || innerState != newState.state) {
-      // TODO throw bad request or invalid state transition exception
-      require(newState.state.nonEmpty, "Cannot transition to an unspecified state")
-      assert(newState.state.get.isAllowedFrom(innerState), s"Cannot transition from $currentState.get.state to $newState.state")
+      if (newState.state.isEmpty || !newState.state.get.isAllowedFrom(innerState))
+        throw new FireCloudException(s"Cannot transition from $currentState.get.state to $newState.state")
       true
     } else {
       false
     }
-  }
-
-  private def getUserSubjectId(userEmail: String): Future[String] = {
-    // TODO: Handle unregistered users which get 404 from Sam causing adminGetUserByEmail to throw
-    // TODO: Handle errors that may come up while querying Sam
-    samDao.adminGetUserByEmail(RawlsUserEmail(userEmail)).map(_.userInfo.userSubjectId)
   }
 
   private def executeStateTransitions(managerInfo: UserInfo, userEmails: Seq[String],
@@ -165,20 +159,34 @@ final class TrialService
                                       transitionPostProcessing: (Attempt, Option[UserTrialStatus], UserTrialStatus) => Unit): Future[PerRequestMessage] = {
     var results: Seq[(String, String)] = Seq()
     userEmails.foreach { userEmail =>
-      val finalStatus = getUserSubjectId(userEmail) flatMap { subId =>
+      val finalStatus = samDao.adminGetUserByEmail(RawlsUserEmail(userEmail)) flatMap { regInfo =>
+        val subId = regInfo.userInfo.userSubjectId
         val userInfo = WorkbenchUserInfo(subId, userEmail)
         thurloeDao.getTrialStatus(subId, managerInfo) flatMap { userTrialStatus =>
           val newStatus = statusTransition(userInfo, userTrialStatus)
-          if (requiresStateTransition(userTrialStatus, newStatus)) {
-            updateTrialStatus(managerInfo, userInfo, newStatus) map { stateResponse =>
-              transitionPostProcessing(stateResponse, userTrialStatus, newStatus)
-              StatusUpdate.toName(stateResponse)
+          try {
+            if (requiresStateTransition(userTrialStatus, newStatus)) {
+              updateTrialStatus(managerInfo, userInfo, newStatus) map { stateResponse =>
+                transitionPostProcessing(stateResponse, userTrialStatus, newStatus)
+                StatusUpdate.toName(stateResponse)
+              }
+            } else {
+              logger.warn(s"The user '${userInfo.userEmail}' is already in the trial state of '$newStatus.newState'. No further action will be taken.")
+              Future.successful(StatusUpdate.toName(StatusUpdate.NoChangeRequired))
             }
-          } else {
-            logger.warn(s"The user '${userInfo.userEmail}' is already in the trial state of '$newStatus.newState'. No further action will be taken.")
-            Future.successful(StatusUpdate.toName(StatusUpdate.NoChangeRequired))
+          } catch {
+            case ex: FireCloudException =>
+              Future.successful(StatusUpdate.toName(StatusUpdate.Failure(ex.getMessage)))
+            case t: Throwable =>
+              StatusUpdate.ServerError(t.getMessage)
+              Future.successful(StatusUpdate.toName(StatusUpdate.ServerError(t.getMessage)))
           }
         }
+      } recoverWith {
+        case e: FireCloudExceptionWithErrorReport if e.errorReport.statusCode.contains(StatusCodes.NotFound) =>
+          Future.successful(StatusUpdate.toName(StatusUpdate.Failure("User not registered")))
+        case ex: Exception =>
+          Future.successful(StatusUpdate.toName(StatusUpdate.ServerError(ex.getMessage)))
       }
       // Use await here so that multiple Futures don't have a conflict when claiming a billing project
       val result = Await.result(finalStatus, scala.concurrent.duration.Duration.Inf)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/TrialService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/TrialService.scala
@@ -178,7 +178,6 @@ final class TrialService
             case ex: FireCloudException =>
               Future.successful(StatusUpdate.toName(StatusUpdate.Failure(ex.getMessage)))
             case t: Throwable =>
-              StatusUpdate.ServerError(t.getMessage)
               Future.successful(StatusUpdate.toName(StatusUpdate.ServerError(t.getMessage)))
           }
         }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/utils/PermissionsSupportSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/utils/PermissionsSupportSpec.scala
@@ -27,10 +27,10 @@ class PermissionsSupportSpec extends PermissionsSupport with FreeSpecLike {
       assert( !Await.result(tryIsGroupMember(UserInfo("", "bob"), "apples"), dur) )
     }
     "should catch and wrap source exceptions" in {
-      val ex = intercept[FireCloudException] {
+      val ex = intercept[FireCloudExceptionWithErrorReport] {
         Await.result(tryIsGroupMember(UserInfo("", "failme"), "anygroup"), Duration.Inf)
       }
-      assert(ex.getMessage == "Unable to query for group membership status.")
+      assert(ex.errorReport.message == "Unable to query for group membership status.")
     }
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/TrialApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/TrialApiServiceSpec.scala
@@ -5,7 +5,7 @@ import java.time.temporal.ChronoUnit
 import com.google.api.client.googleapis.json.{GoogleJsonError, GoogleJsonResponseException}
 import com.google.api.client.http.{HttpHeaders, HttpResponseException}
 import com.google.api.services.sheets.v4.model.ValueRange
-import org.broadinstitute.dsde.firecloud.FireCloudConfig
+import org.broadinstitute.dsde.firecloud.{FireCloudConfig, FireCloudException, FireCloudExceptionWithErrorReport}
 import org.broadinstitute.dsde.firecloud.dataaccess.{HttpSamDAO, HttpThurloeDAO, MockRawlsDAO}
 import org.broadinstitute.dsde.firecloud.mock.{MockGoogleServicesDAO, MockUtils}
 import org.broadinstitute.dsde.firecloud.mock.MockUtils.thurloeServerPort
@@ -16,11 +16,12 @@ import org.broadinstitute.dsde.firecloud.model.{FireCloudKeyValue, ProfileWrappe
 import org.broadinstitute.dsde.firecloud.service.{BaseServiceSpec, TrialService}
 import org.broadinstitute.dsde.firecloud.trial.ProjectManager
 import org.broadinstitute.dsde.firecloud.trial.ProjectManagerSpec.ProjectManagerSpecTrialDAO
-import org.broadinstitute.dsde.rawls.model.{RawlsBillingProjectName, RawlsUserEmail}
+import org.broadinstitute.dsde.rawls.model.{ErrorReport, RawlsBillingProjectName, RawlsUserEmail}
 import org.mockserver.integration.ClientAndServer
 import org.mockserver.integration.ClientAndServer.startClientAndServer
 import org.mockserver.model.HttpRequest.request
 import spray.http.HttpMethods.{POST, PUT}
+import spray.http.StatusCodes
 import spray.http.StatusCodes._
 import spray.json.DefaultJsonProtocol._
 import spray.json._
@@ -221,14 +222,18 @@ final class TrialApiServiceSpec extends BaseServiceSpec with UserApiService with
       "preventing us from getting user trial status should return a server error to the user" in {
         // Utilizes mockThurloeServer
         Post(enablePath, dummy1UserEmails) ~> dummyUserIdHeaders(manager) ~> trialApiServiceRoutes ~> check {
-          assertResult(InternalServerError, response.entity.asString) { status }
+          assertResult(OK, response.entity.asString) { status }
+          val resp = response.entity.asString
+          assert(resp.contains("ServerError:"))
+          assert(resp.contains("Unable to get user trial status"))
         }
       }
 
       "preventing us from saving user trial status should be properly communicated to the user" in {
         // Utilizes localThurloeDao
         Post(disablePath, dummy2UserEmails) ~> dummyUserIdHeaders(manager) ~> trialApiServiceRoutes ~> check {
-          assertResult(InternalServerError, response.entity.asString) { status }
+          assertResult(OK, response.entity.asString) { status }
+          assert(response.entity.asString.contains("ServerError: ErrorReport(Thurloe,Unable to update user profile"))
         }
       }
     }
@@ -284,9 +289,8 @@ final class TrialApiServiceSpec extends BaseServiceSpec with UserApiService with
       expectedFailPaths.foreach { path =>
         s"Attempting $path on ${targetUsers.head} should return InternalServerError failure" in {
           Post(path, targetUsers) ~> dummyUserIdHeaders(manager) ~> trialApiServiceRoutes ~> check {
-            assertResult(InternalServerError, response.entity.asString) {
-              status
-            }
+            assertResult(OK, response.entity.asString) { status }
+            assert(response.entity.asString.contains("Failure: Cannot transition from"))
           }
         }
       }
@@ -458,7 +462,7 @@ final class TrialApiServiceSpec extends BaseServiceSpec with UserApiService with
           Future.successful(Success(()))
         }
         case user @ `dummy2User` => { // Mocking Thurloe status saving failures
-          Future.failed(new InternalError(s"Cannot save trial status for $user"))
+          Future.failed(new FireCloudExceptionWithErrorReport(ErrorReport.apply(StatusCodes.InternalServerError, new FireCloudException(s"Unable to update user profile"))))
         }
         case _ => {
           fail("Should only be updating enabled, disabled or enrolled users")


### PR DESCRIPTION
instead of assert and require, return errors
multi-user requests will only return an overall error code if there is an issue with the permissions of the caller. otherwise any errors will be reported within the body of the response.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
