### PR TITLE
GAWB-2986: use caller token for reindexing, add logging

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/RawlsDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/RawlsDAO.scala
@@ -64,7 +64,8 @@ trait RawlsDAO extends LazyLogging with ReportsSubsystemStatus {
 
   def updateLibraryAttributes(ns: String, name: String, attributeOperations: Seq[AttributeUpdateOperation])(implicit userToken: WithAccessToken): Future[Workspace]
 
-  def getAllLibraryPublishedWorkspaces: Future[Seq[Workspace]]
+  // you must be an admin to execute this method
+  def getAllLibraryPublishedWorkspaces(implicit userToken: WithAccessToken): Future[Seq[Workspace]]
 
   def getWorkspaceACL(ns: String, name: String)(implicit userToken: WithAccessToken): Future[WorkspaceACL]
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockRawlsDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockRawlsDAO.scala
@@ -274,7 +274,7 @@ class MockRawlsDAO  extends RawlsDAO {
     Future.successful((newWorkspace))
   }
 
-  override def getAllLibraryPublishedWorkspaces: Future[Seq[Workspace]] = Future.successful(Seq.empty[Workspace])
+  override def getAllLibraryPublishedWorkspaces(implicit userToken: WithAccessToken): Future[Seq[Workspace]] = Future.successful(Seq.empty[Workspace])
 
   override def getWorkspaceACL(ns: String, name: String)(implicit userToken: WithAccessToken) =
     Future.successful(WorkspaceACL(Map.empty[String, AccessEntry]))


### PR DESCRIPTION
In Library's reindex-all operation, we [require](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/src/main/scala/org/broadinstitute/dsde/firecloud/service/LibraryService.scala#L73) the caller to be a FireCloud admin. But in the call from orch to rawls, we generate a new access token, using an admin service account. Since the original caller is already an admin, we could/should just use the caller's token.

I've also added some extra logging to reindex-all failures to help out in the future.

I tested by:
* performing a successful reindex as admin
* attempting reindex as non-admin and being rejected
* manually modifying the `rawlsAdminWorkspaces` url in `HttpRawlsDAO` to force errors when running locally, and seeing that my new logging statements are properly logged

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
