### PR TITLE
GAWB-2511: spreadsheet info

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ThurloeDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ThurloeDAO.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.firecloud.dataaccess
 
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.model.Trial.UserTrialStatus
-import org.broadinstitute.dsde.firecloud.model.{BasicProfile, Profile, UserInfo, WithAccessToken}
+import org.broadinstitute.dsde.firecloud.model.{BasicProfile, Profile, ProfileWrapper, UserInfo, WithAccessToken}
 import org.broadinstitute.dsde.rawls.model.ErrorReportSource
 
 import scala.concurrent.Future
@@ -18,6 +18,8 @@ object ThurloeDAO {
 trait ThurloeDAO extends LazyLogging with ReportsSubsystemStatus {
 
   implicit val errorReportSource = ErrorReportSource(ThurloeDAO.serviceName)
+
+  def getAllKVPs(forUserId: String, callerToken: WithAccessToken): Future[Option[ProfileWrapper]]
 
   def getProfile(userInfo: UserInfo): Future[Option[Profile]]
   def getAllUserValuesForKey(key: String): Future[Map[String, String]]

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockThurloeDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockThurloeDAO.scala
@@ -89,6 +89,10 @@ class MockThurloeDAO extends ThurloeDAO {
       TCGA_AND_TARGET_UNLINKED -> baseProfile
     )
 
+
+  override def getAllKVPs(forUserId: String, callerToken: WithAccessToken): Future[Option[ProfileWrapper]] =
+    Future.successful(None)
+
   override def getProfile(userInfo: UserInfo): Future[Option[Profile]] = {
     val profileWrapper = try {
       Option(Profile(ProfileWrapper(userInfo.id, mockKeyValues(userInfo.id).toList)))

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/TrialApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/TrialApiServiceSpec.scala
@@ -267,7 +267,7 @@ final class TrialApiServiceSpec extends BaseServiceSpec with UserApiService with
           assert(enableResponse(Set(enrolledUser)).contains("Failure: Cannot transition"))
           assert(enableResponse(Set(terminatedUser)).contains("Failure: Cannot transition"))
           assert(enableResponse(Set(dummy1User))
-            .contains("ServerError: ErrorReport(Thurloe,Unable to get user trial status,Some(500 Internal Server Error)"))
+            .contains("ServerError: ErrorReport(Thurloe,Unable to get user KVPs from profile service,Some(500 Internal Server Error)"))
 
           assertResult(OK) {
             status
@@ -288,7 +288,7 @@ final class TrialApiServiceSpec extends BaseServiceSpec with UserApiService with
           assert(disableResponse(Set(terminatedUser)).contains("Failure: Cannot transition"))
           assert(disableResponse(Set(registeredUser)).contains("Failure: Cannot transition"))
           assert(disableResponse(Set(dummy1User))
-            .contains("ServerError: ErrorReport(Thurloe,Unable to get user trial status,Some(500 Internal Server Error)"))
+            .contains("ServerError: ErrorReport(Thurloe,Unable to get user KVPs from profile service,Some(500 Internal Server Error)"))
           assert(disableResponse(Set(dummy2User))
             .contains("ServerError: ErrorReport(Thurloe,Unable to update user profile,Some(500 Internal Server Error)"))
 
@@ -312,7 +312,7 @@ final class TrialApiServiceSpec extends BaseServiceSpec with UserApiService with
           assert(terminateResponse(Set(terminatedUser)) === StatusUpdate.NoChangeRequired.toString)
           assert(terminateResponse(Set(registeredUser)).contains("Failure: Cannot transition"))
           assert(terminateResponse(Set(dummy1User))
-            .contains("ServerError: ErrorReport(Thurloe,Unable to get user trial status,Some(500 Internal Server Error)"))
+            .contains("ServerError: ErrorReport(Thurloe,Unable to get user KVPs from profile service,Some(500 Internal Server Error)"))
 
           assertResult(OK) {
             status

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/TrialApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/TrialApiServiceSpec.scala
@@ -235,7 +235,7 @@ final class TrialApiServiceSpec extends BaseServiceSpec with UserApiService with
           assertResult(OK, response.entity.asString) { status }
           val resp = response.entity.asString
           assert(resp.contains("ServerError:"))
-          assert(resp.contains("Unable to get user trial status"))
+          assert(resp.contains("Unable to get user KVPs from profile service"))
         }
       }
 


### PR DESCRIPTION
I ended up refactoring more code than I expected to!

There's one TODO in the code that the `userAgreedDate` we display in the spreadsheet should be its own value. I'll have to break that out into a separate story, since we are not currently capturing that information.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
