### PR TITLE
GAWB-2934: Added passthrough for sam's proxyGroup endpoint.

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -3550,6 +3550,30 @@ paths:
         503:
           description: Service Unavailable. Could not reach underlying services to determine user status.
 
+  /api/proxyGroup/{email}:
+    get:
+      tags:
+        - Profile
+      operationId: getProxyGroup
+      summary: Returns the proxy group email for the current user
+      parameters:
+        - in: path
+          description: User email whose proxy group to retrieve
+          name: email
+          required: true
+          type: string
+      responses:
+        200:
+          description: 'user proxy group'
+          schema:
+            type: string
+        404:
+          description: 'user not found'
+        500:
+          description: Internal Error
+          schema:
+            $ref: '#/definitions/ErrorReport'
+
   /register:
     get:
       tags:

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/UserApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/UserApiService.scala
@@ -55,6 +55,7 @@ object UserApiService {
   def rawlsGroupRequestAccessPath(group: String) = rawlsGroupPath(group) + "/requestAccess"
   def rawlsGroupRequestAccessUrl(group: String) = FireCloudConfig.Rawls.baseUrl + rawlsGroupRequestAccessPath(group)
 
+  def samUserProxyGroupURL(email: String) = FireCloudConfig.Sam.baseUrl + s"/api/google/user/proxyGroup/$email"
 }
 
 // TODO: this should use UserInfoDirectives, not StandardUserInfoDirectives. That would require a refactoring
@@ -180,6 +181,11 @@ trait UserApiService extends HttpService with PerRequestCreator with FireCloudRe
               passthrough(UserApiService.rawlsGroupMemberUrl(groupName, role, email), HttpMethods.DELETE)
             }
           }
+        }
+      }
+      pathPrefix("proxyGroup") {
+        path(Segment) { email =>
+          passthrough(UserApiService.samUserProxyGroupURL(email), HttpMethods.GET)
         }
       }
     } ~

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/UserApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/UserApiService.scala
@@ -55,7 +55,8 @@ object UserApiService {
   def rawlsGroupRequestAccessPath(group: String) = rawlsGroupPath(group) + "/requestAccess"
   def rawlsGroupRequestAccessUrl(group: String) = FireCloudConfig.Rawls.baseUrl + rawlsGroupRequestAccessPath(group)
 
-  def samUserProxyGroupURL(email: String) = FireCloudConfig.Sam.baseUrl + s"/api/google/user/proxyGroup/$email"
+  def samUserProxyGroupPath(email: String) = s"/api/google/user/proxyGroup/$email"
+  def samUserProxyGroupURL(email: String) = FireCloudConfig.Sam.baseUrl + samUserProxyGroupPath(email)
 }
 
 // TODO: this should use UserInfoDirectives, not StandardUserInfoDirectives. That would require a refactoring
@@ -182,7 +183,7 @@ trait UserApiService extends HttpService with PerRequestCreator with FireCloudRe
             }
           }
         }
-      }
+      } ~
       pathPrefix("proxyGroup") {
         path(Segment) { email =>
           passthrough(UserApiService.samUserProxyGroupURL(email), HttpMethods.GET)

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/UserApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/UserApiServiceSpec.scala
@@ -147,6 +147,13 @@ class UserApiServiceSpec extends BaseServiceSpec with RegisterApiService with Us
           .withHeaders(MockUtils.header).withBody(userStatus).withStatusCode(OK.intValue)
       )
 
+    samServer
+      .when(request.withMethod("GET").withPath(UserApiService.samUserProxyGroupPath("test@test.test")))
+      .respond(
+        org.mockserver.model.HttpResponse.response()
+          .withHeaders(MockUtils.header).withStatusCode(OK.intValue)
+      )
+
     profileServer = startClientAndServer(thurloeServerPort)
     // Generate a mock response for all combinations of profile properties
     // to ensure that all posts to any combination will yield a successful response.
@@ -314,6 +321,21 @@ class UserApiServiceSpec extends BaseServiceSpec with RegisterApiService with Us
       }
     }
 
+    "when GET-ing proxy group" - {
+      "OK response is returned for valid user" in {
+        Get("/api/proxyGroup/test@test.test") ~>
+          dummyUserIdHeaders(uniqueId) ~> sealRoute(userServiceRoutes) ~> check {
+          status should equal(OK)
+        }
+      }
+
+      "NotFound response is returned for invalid user" in {
+        Get("/api/proxyGroup/test@not.found") ~>
+          dummyUserIdHeaders(uniqueId) ~> sealRoute(userServiceRoutes) ~> check {
+          status should equal(NotFound)
+        }
+      }
+    }
   }
 
   "UserService Edge Cases" - {


### PR DESCRIPTION
Ended up just adding the passthrough because, in sam, the proxy group is currently an implementation detail in the Google cloud extension support and, therefore, seemed incorrect to add to `UserInfo`. I think we should either decide to include cloud extension info in `UserInfo` or make an overall cloud extension user info endpoint that the proxy group can be included in. This passthrough will work until we're ready to make that decision.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
