### PR TITLE
stricter startup checks for registration; oauth debugging

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/StartupChecks.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/StartupChecks.scala
@@ -63,11 +63,12 @@ class StartupChecks(app: Application, registerSAs: Boolean = true)
 
   private def manageRegistration(name: String, req: Future[RegistrationInfo]): Future[Boolean] = {
     req map { regInfo =>
-      if (regInfo.enabled.ldap)
+      val fullyRegistered = regInfo.enabled.ldap && regInfo.enabled.allUsersGroup && regInfo.enabled.google
+      if (fullyRegistered)
         logger.info(s"$name is properly registered.")
       else
-        logger.error(s"***    $name is registered but not fully enabled!!    ***")
-      regInfo.enabled.ldap
+        logger.error(s"***    $name is registered but not fully enabled: ${regInfo.enabled}!!    ***")
+      fullyRegistered
     } recover {
       case e: FireCloudExceptionWithErrorReport if e.errorReport.statusCode == Option(StatusCodes.NotFound) =>
         logger.error(s"***    $name is not registered!!    ***")

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/OAuthService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/OAuthService.scala
@@ -84,10 +84,10 @@ class OAuthService(val rawlsDao: RawlsDAO, val thurloeDao: ThurloeDAO)
         val ageDaysCount = Days.daysBetween(tokenDate, DateTime.now).getDays
         ageDaysCount match {
           case x if x < 90 =>
-            logger.debug(s"User's refresh token is $x days old; all good!")
+            logger.debug(s"User ${userInfo.userEmail}'s refresh token is $x days old; all good!")
             RequestComplete(StatusCodes.OK, Map("requiresRefresh" -> false))
           case x =>
-            logger.info(s"User's refresh token is $x days old; requesting a new one.")
+            logger.info(s"User ${userInfo.userEmail}'s refresh token is $x days old; requesting a new one.")
             RequestComplete(StatusCodes.OK, Map("requiresRefresh" -> true))
         }
       case None =>


### PR DESCRIPTION
no jira for this. Make the startup checks for service accounts stricter in what they check.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
