### PR TITLE
GAWB-3062: Ability to finalize free trial user status

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -1619,12 +1619,12 @@ paths:
         - Profile
       operationId: userTrial
       summary: Enroll or Finalize yourself in FireCloud free trial
+      description: |
+        * **Enroll:** starts an enabled user's trial and adds them to a billing project.
+        * **Finalize:** concludes a terminated user's trial progress.
       parameters:
         - name: operation
-          description: |
-            operation to perform on projects.
-            "Enroll" will create projects and verify those projects.
-            "Finalize" will verify all unverified projects in the pool.
+          description: operation user can perform
           required: false
           in: query
           type: string

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -1617,11 +1617,26 @@ paths:
     post:
       tags:
         - Profile
-      operationId: enrollTrial
-      summary: Enroll yourself in FireCloud free trial
+      operationId: userTrial
+      summary: Enroll or Finalize yourself in FireCloud free trial
+      parameters:
+        - name: operation
+          description: |
+            operation to perform on projects.
+            "Enroll" will create projects and verify those projects.
+            "Finalize" will verify all unverified projects in the pool.
+          required: false
+          in: query
+          type: string
+          enum:
+            - enroll
+            - finalize
+          default: enroll
       responses:
         204:
           description: Success (No Content)
+        400:
+          description: Bad Request; invalid operation
         403:
           description: Forbidden; user must agree to terms to be enrolled
         500:

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/Trial.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/Trial.scala
@@ -40,7 +40,7 @@ object Trial {
       def isAllowedFromNone: Boolean = false
     }
 
-    val allStates = Seq(Disabled, Enabled, Enrolled, Terminated)
+    val allStates = Seq(Disabled, Enabled, Enrolled, Terminated, Finalized)
 
     def withName(name: String): TrialState = {
       name match {
@@ -58,6 +58,7 @@ object Trial {
         case Enabled => "Enabled"
         case Enrolled => "Enrolled"
         case Terminated => "Terminated"
+        case Finalized => "Finalized"
         case _ => throw new FireCloudException(s"invalid TrialState [${state.getClass.getName}]")
       }
     }
@@ -74,6 +75,9 @@ object Trial {
     }
     case object Terminated extends TrialState {
       override def isAllowedFromState(previous: TrialState): Boolean = previous == Enrolled
+    }
+    case object Finalized extends TrialState {
+      override def isAllowedFromState(previous: TrialState): Boolean = previous == Terminated
     }
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/Trial.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/Trial.scala
@@ -40,8 +40,6 @@ object Trial {
       def isAllowedFromNone: Boolean = false
     }
 
-    val allStates = Seq(Disabled, Enabled, Enrolled, Terminated, Finalized)
-
     def withName(name: String): TrialState = {
       name match {
         case "Disabled" => Disabled

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/Trial.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/Trial.scala
@@ -78,7 +78,7 @@ object Trial {
       override def isAllowedFromState(previous: TrialState): Boolean = previous == Enrolled
     }
     case object Finalized extends TrialState {
-      override def isAllowedFromState(previous: TrialState): Boolean = previous == Terminated
+      override def isAllowedFromState(previous: TrialState): Boolean = previous == Terminated || previous == Finalized
     }
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/Trial.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/Trial.scala
@@ -48,6 +48,7 @@ object Trial {
         case "Enabled" => Enabled
         case "Enrolled" => Enrolled
         case "Terminated" => Terminated
+        case "Finalized" => Finalized
         case _ => throw new FireCloudException(s"invalid TrialState [$name]")
       }
     }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/TrialService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/TrialService.scala
@@ -330,7 +330,7 @@ final class TrialService
     import TrialStates._
 
     // Get user's trial status, check and update the current state if it's a valid transition
-    // NB: We are being lenient and are not complaining when a user was already terminated previously
+    // NB: We are being lenient and are not complaining when a user was already 'finalized' previously
     thurloeDao.getTrialStatus(userInfo.id, userInfo) flatMap { status =>
       if (Finalized.isAllowedFrom(status.state)) {
         thurloeDao.saveTrialStatus (userInfo.id, userInfo, status.copy (state = Some (Finalized) ) ) flatMap {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/TrialService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/TrialService.scala
@@ -41,6 +41,7 @@ object TrialService {
   case class DisableUsers(managerInfo: UserInfo, userEmails: Seq[String]) extends TrialServiceMessage
   case class EnrollUser(managerInfo: UserInfo) extends TrialServiceMessage
   case class TerminateUsers(managerInfo: UserInfo, userEmails: Seq[String]) extends TrialServiceMessage
+  case class FinalizeUser(managerInfo: UserInfo) extends TrialServiceMessage
   case class CreateProjects(userInfo:UserInfo, count:Int) extends TrialServiceMessage
   case class VerifyProjects(userInfo:UserInfo) extends TrialServiceMessage
   case class CountProjects(userInfo:UserInfo) extends TrialServiceMessage
@@ -72,6 +73,8 @@ final class TrialService
       enrollUser(userInfo) pipeTo sender
     case TerminateUsers(managerInfo, userEmails) =>
       asTrialCampaignManager(terminateUsers(managerInfo, userEmails))(managerInfo) pipeTo sender
+    case FinalizeUser(userInfo) =>
+      finalizeUser(userInfo) pipeTo sender
     case CreateProjects(userInfo, count) => asTrialCampaignManager {createProjects(count)}(userInfo) pipeTo sender
     case VerifyProjects(userInfo) => asTrialCampaignManager {verifyProjects}(userInfo) pipeTo sender
     case CountProjects(userInfo) => asTrialCampaignManager {countProjects}(userInfo) pipeTo sender
@@ -320,6 +323,10 @@ final class TrialService
       enrolledDate = now,
       expirationDate = expirationDate
     )
+  }
+
+  private def finalizeUser(userInfo: UserInfo): Future[PerRequestMessage] = {
+    Future(RequestCompleteWithErrorReport(StatusCodes.EnhanceYourCalm, "Finalizing user..."))
   }
 
   private def createProjects(count: Int): Future[PerRequestMessage] = {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/TrialService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/TrialService.scala
@@ -253,8 +253,8 @@ final class TrialService
           // user in some other state; don't enroll
           case Some(TrialStates.Disabled) => Future(RequestCompleteWithErrorReport(BadRequest, "You are not eligible for a free trial. (Error 30)"))
           case Some(TrialStates.Terminated) => Future(RequestCompleteWithErrorReport(BadRequest, "You are not eligible for a free trial. (Error 40)"))
-          case Some(TrialStates.Finalized) => Future(RequestCompleteWithErrorReport(BadRequest, "You are not eligible for a free trial. (Error 50)"))
-          case _ => Future(RequestCompleteWithErrorReport(BadRequest, "You are not eligible for a free trial. (Error 60)"))
+          case Some(TrialStates.Finalized) => Future(RequestCompleteWithErrorReport(BadRequest, "You are not eligible for a free trial. (Error 45)"))
+          case _ => Future(RequestCompleteWithErrorReport(BadRequest, "You are not eligible for a free trial. (Error 50)"))
         }
     }
   }
@@ -341,7 +341,7 @@ final class TrialService
           }
         // user in some other state; can't finalize
         case _ =>
-          val errMsg = "Your free trial should have been terminated to be finalized."
+          val errMsg = "Your free trial should have been terminated first."
           Future(RequestCompleteWithErrorReport(BadRequest, errMsg))
       }
     }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/TrialService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/TrialService.scala
@@ -253,7 +253,8 @@ final class TrialService
           // user in some other state; don't enroll
           case Some(TrialStates.Disabled) => Future(RequestCompleteWithErrorReport(BadRequest, "You are not eligible for a free trial. (Error 30)"))
           case Some(TrialStates.Terminated) => Future(RequestCompleteWithErrorReport(BadRequest, "You are not eligible for a free trial. (Error 40)"))
-          case _ => Future(RequestCompleteWithErrorReport(BadRequest, "You are not eligible for a free trial. (Error 50)"))
+          case Some(TrialStates.Finalized) => Future(RequestCompleteWithErrorReport(BadRequest, "You are not eligible for a free trial. (Error 50)"))
+          case _ => Future(RequestCompleteWithErrorReport(BadRequest, "You are not eligible for a free trial. (Error 60)"))
         }
     }
   }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/UserApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/UserApiService.scala
@@ -143,9 +143,9 @@ trait UserApiService extends HttpService with PerRequestCreator with FireCloudRe
                 }
 
                 if (operation.nonEmpty)
-                  perRequest (requestContext, TrialService.props(trialServiceConstructor), operation.get)
+                  perRequest(requestContext, TrialService.props(trialServiceConstructor), operation.get)
                 else
-                  requestContext.complete(BadRequest, ErrorReport(s"invalid operation '$op'"))
+                  requestContext.complete(BadRequest, ErrorReport(s"Invalid operation '$op'"))
               }
             }
           }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/model/TrialSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/model/TrialSpec.scala
@@ -1,10 +1,12 @@
 package org.broadinstitute.dsde.firecloud.model
 
 import org.broadinstitute.dsde.firecloud.FireCloudException
+import org.broadinstitute.dsde.firecloud.model.Trial.TrialStates._
 import org.broadinstitute.dsde.firecloud.model.Trial.{TrialStates, UserTrialStatus}
 import org.scalatest.FreeSpec
 
 class TrialSpec extends FreeSpec  {
+  val allTrialStates = Seq(Disabled, Enabled, Enrolled, Terminated, Finalized)
 
   "TrialStates" - {
     "should create from known strings" in {
@@ -39,7 +41,7 @@ class TrialSpec extends FreeSpec  {
         assert(testState.isAllowedFrom(Some(TrialStates.Enabled)))
       }
       "should disallow from anything other than Enabled" - {
-        (TrialStates.allStates.toSet - TrialStates.Enabled) foreach { state =>
+        (allTrialStates.toSet - TrialStates.Enabled) foreach { state =>
           s"${state.toString}" in {
             assert(!testState.isAllowedFrom(Some(state)))
           }
@@ -55,7 +57,7 @@ class TrialSpec extends FreeSpec  {
         assert(testState.isAllowedFrom(Some(TrialStates.Disabled)))
       }
       "should disallow from anything other than Disabled" - {
-        (TrialStates.allStates.toSet - TrialStates.Disabled) foreach { state =>
+        (allTrialStates.toSet - TrialStates.Disabled) foreach { state =>
           s"${state.toString}" in {
             assert(!testState.isAllowedFrom(Some(state)))
           }
@@ -71,7 +73,7 @@ class TrialSpec extends FreeSpec  {
         assert(testState.isAllowedFrom(Some(TrialStates.Enabled)))
       }
       "should disallow from anything other than Enabled" - {
-        (TrialStates.allStates.toSet - TrialStates.Enabled) foreach { state =>
+        (allTrialStates.toSet - TrialStates.Enabled) foreach { state =>
           s"${state.toString}" in {
             assert(!testState.isAllowedFrom(Some(state)))
           }
@@ -87,7 +89,7 @@ class TrialSpec extends FreeSpec  {
         assert(testState.isAllowedFrom(Some(TrialStates.Enrolled)))
       }
       "should disallow from anything other than Enrolled" - {
-        (TrialStates.allStates.toSet - TrialStates.Enrolled) foreach { state =>
+        (allTrialStates.toSet - TrialStates.Enrolled) foreach { state =>
           s"${state.toString}" in {
             assert(!testState.isAllowedFrom(Some(state)))
           }
@@ -106,7 +108,7 @@ class TrialSpec extends FreeSpec  {
         assert(testState.isAllowedFrom(Some(TrialStates.Finalized)))
       }
       "should disallow from anything other than Terminated or Finalized" - {
-        (TrialStates.allStates.toSet -- Set(TrialStates.Terminated, TrialStates.Finalized)) foreach { state =>
+        (allTrialStates.toSet -- Set(TrialStates.Terminated, TrialStates.Finalized)) foreach { state =>
           s"${state.toString}" in {
             assert(!testState.isAllowedFrom(Some(state)))
           }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/model/TrialSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/model/TrialSpec.scala
@@ -11,6 +11,7 @@ class TrialSpec extends FreeSpec  {
       assertResult(TrialStates.Enabled) { TrialStates.withName("Enabled") }
       assertResult(TrialStates.Enrolled) { TrialStates.withName("Enrolled") }
       assertResult(TrialStates.Terminated) { TrialStates.withName("Terminated") }
+      assertResult(TrialStates.Finalized) { TrialStates.withName("Finalized") }
     }
     "should error from unknown strings" in {
       intercept[FireCloudException] {
@@ -27,6 +28,7 @@ class TrialSpec extends FreeSpec  {
       assertResult("Enabled") { TrialStates.Enabled.toString }
       assertResult("Enrolled") { TrialStates.Enrolled.toString }
       assertResult("Terminated") { TrialStates.Terminated.toString }
+      assertResult("Finalized") { TrialStates.Finalized.toString }
     }
     "the Disabled state" - {
       val testState = TrialStates.Disabled
@@ -86,6 +88,25 @@ class TrialSpec extends FreeSpec  {
       }
       "should disallow from anything other than Enrolled" - {
         (TrialStates.allStates.toSet - TrialStates.Enrolled) foreach { state =>
+          s"${state.toString}" in {
+            assert(!testState.isAllowedFrom(Some(state)))
+          }
+        }
+      }
+    }
+    "the Finalized state" - {
+      val testState = TrialStates.Finalized
+      "should not allow from None" in {
+        assert(!testState.isAllowedFrom(None))
+      }
+      "should allow from Terminated" in {
+        assert(testState.isAllowedFrom(Some(TrialStates.Terminated)))
+      }
+      "should allow from Finalized" in {
+        assert(testState.isAllowedFrom(Some(TrialStates.Finalized)))
+      }
+      "should disallow from anything other than Terminated or Finalized" - {
+        (TrialStates.allStates.toSet -- Set(TrialStates.Terminated, TrialStates.Finalized)) foreach { state =>
           s"${state.toString}" in {
             assert(!testState.isAllowedFrom(Some(state)))
           }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/TrialApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/TrialApiServiceSpec.scala
@@ -166,7 +166,7 @@ final class TrialApiServiceSpec extends BaseServiceSpec with UserApiService with
         }
       }
 
-      s"enrollment as an enabled user that agreed to terms via $enrollPath" - {
+      s"enrollment via $enrollPath as an enabled user that agreed to terms " - {
         "should be NoContent success" in {
           Post(enrollPath) ~> dummyUserIdHeaders(enabledUser) ~> userServiceRoutes ~> check {
             assertResult(NoContent, response.entity.asString) {

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/TrialApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/TrialApiServiceSpec.scala
@@ -144,9 +144,8 @@ final class TrialApiServiceSpec extends BaseServiceSpec with UserApiService with
     }
 
     val trialPathBase = "/api/profile/trial"
+
     val enrollPaths = Seq(trialPathBase, s"$trialPathBase?operation=enroll")
-    val finalizePath = s"$trialPathBase?operation=finalize"
-    val invalidPaths = Seq(s"$trialPathBase?operation=", s"$trialPathBase?operation=invalid")
 
     enrollPaths foreach { enrollPath =>
       s"enrollment endpoint $enrollPath" - {
@@ -205,6 +204,8 @@ final class TrialApiServiceSpec extends BaseServiceSpec with UserApiService with
       }
     }
 
+    val finalizePath = s"$trialPathBase?operation=finalize"
+
     s"finalization endpoint $finalizePath" - {
       allHttpMethodsExcept(POST) foreach { method =>
         s"should reject ${method.toString} method" in {
@@ -235,9 +236,18 @@ final class TrialApiServiceSpec extends BaseServiceSpec with UserApiService with
         }
       }
     }
+
+    val invalidPaths = Seq(s"$trialPathBase?operation=", s"$trialPathBase?operation=invalid")
+
+    invalidPaths foreach { path =>
+      s"invalid operations via $path should be a BadRequest" in {
+        Post(finalizePath) ~> dummyUserIdHeaders(enabledUser) ~> userServiceRoutes ~> check {
+          status should equal(BadRequest)
+        }
+      }
+    }
   }
 
-  // TODO: Keep track of and check all users whose statuses are updated when multi-user updates are supported
   "Campaign manager user enable/disable/terminate endpoint" - {
     val enablePath    = "/trial/manager/enable"
     val disablePath   = "/trial/manager/disable"
@@ -248,10 +258,8 @@ final class TrialApiServiceSpec extends BaseServiceSpec with UserApiService with
     val dummy2UserEmails = Seq(dummy2User)
     val disabledUserEmails = Seq(disabledUser)
     val enabledUserEmails = Seq(enabledUser)
-    val enabledButNotAgreedUserEmails = Seq(enabledButNotAgreedUser)
     val enrolledUserEmails = Seq(enrolledUser)
     val terminatedUserEmails = Seq(terminatedUser)
-    val finalizedUserEmails = Seq(finalizedUser)
     val registeredUserEmails = Seq(registeredUser)
     val nonRegisteredUserEmails = Seq(unregisteredUser)
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/TrialApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/TrialApiServiceSpec.scala
@@ -251,6 +251,7 @@ final class TrialApiServiceSpec extends BaseServiceSpec with UserApiService with
     val enabledButNotAgreedUserEmails = Seq(enabledButNotAgreedUser)
     val enrolledUserEmails = Seq(enrolledUser)
     val terminatedUserEmails = Seq(terminatedUser)
+    val finalizedUserEmails = Seq(finalizedUser)
     val registeredUserEmails = Seq(registeredUser)
     val nonRegisteredUserEmails = Seq(unregisteredUser)
 
@@ -296,8 +297,8 @@ final class TrialApiServiceSpec extends BaseServiceSpec with UserApiService with
 
     "Multi-User Status Updates" - {
       "Attempting to enable multiple users in various states should return a map of status lists" in {
-        val assortmentOfUserEmails =
-          Seq(disabledUser, enabledUser, enrolledUser, terminatedUser, registeredUser, dummy1User, dummy2User)
+        val assortmentOfUserEmails = Seq(disabledUser, enabledUser, enrolledUser, terminatedUser,
+            finalizedUser, registeredUser, dummy1User, dummy2User)
 
         Post(enablePath, assortmentOfUserEmails) ~> dummyUserIdHeaders(manager) ~> trialApiServiceRoutes ~> check {
           val enableResponse = responseAs[Map[String, Set[String]]].map(_.swap)
@@ -306,6 +307,7 @@ final class TrialApiServiceSpec extends BaseServiceSpec with UserApiService with
           assert(enableResponse(Set(disabledUser, registeredUser)) === StatusUpdate.Success.toString)
           assert(enableResponse(Set(enrolledUser)).contains("Failure: Cannot transition"))
           assert(enableResponse(Set(terminatedUser)).contains("Failure: Cannot transition"))
+          assert(enableResponse(Set(finalizedUser)).contains("Failure: Cannot transition"))
           assert(enableResponse(Set(dummy1User))
             .contains("ServerError: ErrorReport(Thurloe,Unable to get user KVPs from profile service,Some(500 Internal Server Error)"))
 
@@ -316,8 +318,8 @@ final class TrialApiServiceSpec extends BaseServiceSpec with UserApiService with
       }
 
       "Attempting to disable multiple users in various states should return a map of status lists" in {
-        val assortmentOfUserEmails =
-          Seq(disabledUser, enabledUser, enrolledUser, terminatedUser, registeredUser, dummy1User, dummy2User)
+        val assortmentOfUserEmails = Seq(disabledUser, enabledUser, enrolledUser, terminatedUser,
+            finalizedUser, registeredUser, dummy1User, dummy2User)
 
         Post(disablePath, assortmentOfUserEmails) ~> dummyUserIdHeaders(manager) ~> trialApiServiceRoutes ~> check {
           val disableResponse = responseAs[Map[String, Set[String]]].map(_.swap)
@@ -326,6 +328,7 @@ final class TrialApiServiceSpec extends BaseServiceSpec with UserApiService with
           assert(disableResponse(Set(disabledUser)) === StatusUpdate.NoChangeRequired.toString)
           assert(disableResponse(Set(enrolledUser)).contains("Failure: Cannot transition"))
           assert(disableResponse(Set(terminatedUser)).contains("Failure: Cannot transition"))
+          assert(disableResponse(Set(finalizedUser)).contains("Failure: Cannot transition"))
           assert(disableResponse(Set(registeredUser)).contains("Failure: Cannot transition"))
           assert(disableResponse(Set(dummy1User))
             .contains("ServerError: ErrorReport(Thurloe,Unable to get user KVPs from profile service,Some(500 Internal Server Error)"))
@@ -340,7 +343,8 @@ final class TrialApiServiceSpec extends BaseServiceSpec with UserApiService with
 
       "Attempting to terminate multiple users in various states should return a map of status lists" in {
         val assortmentOfUserEmails =
-          Seq(disabledUser, enabledUser, enrolledUser, terminatedUser, registeredUser, dummy1User, dummy2User)
+          Seq(disabledUser, enabledUser, enrolledUser, terminatedUser,
+            finalizedUser, registeredUser, dummy1User, dummy2User)
 
         Post(terminatePath, assortmentOfUserEmails) ~> dummyUserIdHeaders(manager) ~> trialApiServiceRoutes ~> check {
           val terminateResponse = responseAs[Map[String, Set[String]]].map(_.swap)
@@ -348,6 +352,7 @@ final class TrialApiServiceSpec extends BaseServiceSpec with UserApiService with
           assert(terminateResponse(Set(enabledUser)).contains("Failure: Cannot transition"))
           assert(terminateResponse(Set(dummy2User)).contains("Failure: Cannot transition"))
           assert(terminateResponse(Set(disabledUser)).contains("Failure: Cannot transition"))
+          assert(terminateResponse(Set(finalizedUser)).contains("Failure: Cannot transition"))
           assert(terminateResponse(Set(enrolledUser)) === StatusUpdate.Success.toString)
           assert(terminateResponse(Set(terminatedUser)) === StatusUpdate.NoChangeRequired.toString)
           assert(terminateResponse(Set(registeredUser)).contains("Failure: Cannot transition"))

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/TrialApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/TrialApiServiceSpec.scala
@@ -216,17 +216,21 @@ final class TrialApiServiceSpec extends BaseServiceSpec with UserApiService with
       }
     }
 
-    s"finalization as a terminated user via $finalizePath" - {
-      "should be NoContent success" in {
-        Post(finalizePath) ~> dummyUserIdHeaders(terminatedUser) ~> userServiceRoutes ~> check {
-          assertResult(NoContent, response.entity.asString) {
-            status
+    // NB: We are being lenient and are considering it a success if users attempt to re-terminate themselves
+    val usersAllowedForFinalization = Seq(terminatedUser, finalizedUser)
+    usersAllowedForFinalization foreach { user =>
+      s"finalization as a $user via $finalizePath" - {
+        "should be NoContent success" in {
+          Post(finalizePath) ~> dummyUserIdHeaders(terminatedUser) ~> userServiceRoutes ~> check {
+            assertResult(NoContent, response.entity.asString) {
+              status
+            }
           }
         }
       }
     }
 
-    val usersDisallowedForFinalization = Seq(enabledUser, disabledUser, enrolledUser, finalizedUser)
+    val usersDisallowedForFinalization = Seq(enabledUser, disabledUser, enrolledUser)
     usersDisallowedForFinalization foreach { disallowedUser =>
       s"finalization as a $disallowedUser via $finalizePath" - {
         "should be a BadRequest" in {

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/TrialApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/TrialApiServiceSpec.scala
@@ -143,55 +143,62 @@ final class TrialApiServiceSpec extends BaseServiceSpec with UserApiService with
   }
 
   "Free Trial Enrollment" - {
-    val enrollPath = "/api/profile/trial"
+    val trialPathBase = "/api/profile/trial"
+    val enrollPaths = Seq(trialPathBase, s"$trialPathBase?operation=enroll")
 
-    "User-initiated enrollment endpoint" - {
-      allHttpMethodsExcept(POST) foreach { method =>
-        s"should reject ${method.toString} method" in {
-          new RequestBuilder(method)(enrollPath) ~> dummyUserIdHeaders(enabledUser) ~> userServiceRoutes ~> check {
-            assert(!handled)
+    enrollPaths foreach { enrollPath =>
+      s"User-initiated enrollment endpoint $enrollPath" - {
+        allHttpMethodsExcept(POST) foreach { method =>
+          s"should reject ${method.toString} method" in {
+            new RequestBuilder(method)(enrollPath) ~> dummyUserIdHeaders(enabledUser) ~> userServiceRoutes ~> check {
+              assert(!handled)
+            }
           }
         }
       }
-    }
 
-    "attempting to enroll as a disabled user" - {
-      "should be a BadRequest" in {
-        Post(enrollPath) ~> dummyUserIdHeaders(disabledUser) ~> userServiceRoutes ~> check {
-          status should equal(BadRequest)
+      s"attempting to enroll as a disabled user via $enrollPath" - {
+        "should be a BadRequest" in {
+          Post(enrollPath) ~> dummyUserIdHeaders(disabledUser) ~> userServiceRoutes ~> check {
+            status should equal(BadRequest)
+          }
         }
       }
-    }
 
-    "attempting to enroll as an enabled user that agreed to terms" - {
-      "should be NoContent success" in {
-        Post(enrollPath) ~> dummyUserIdHeaders(enabledUser) ~> userServiceRoutes ~> check {
-          assertResult(NoContent, response.entity.asString) { status }
-          assert(localRawlsDao.billingProjectAdds == Map("testproject" -> "random@site.com"))
+      s"attempting to enroll as an enabled user that agreed to terms via $enrollPath" - {
+        "should be NoContent success" in {
+          Post(enrollPath) ~> dummyUserIdHeaders(enabledUser) ~> userServiceRoutes ~> check {
+            assertResult(NoContent, response.entity.asString) {
+              status
+            }
+            assert(localRawlsDao.billingProjectAdds == Map("testproject" -> "random@site.com"))
+          }
         }
       }
-    }
 
-    "enrolling as an enabled user that DID NOT agree to terms" - {
-      "should be Forbidden" in {
-        Post(enrollPath) ~> dummyUserIdHeaders(enabledButNotAgreedUser) ~> userServiceRoutes ~> check {
-          assertResult(Forbidden, response.entity.asString) { status }
+      s"enrolling as an enabled user that DID NOT agree to terms via $enrollPath" - {
+        "should be Forbidden" in {
+          Post(enrollPath) ~> dummyUserIdHeaders(enabledButNotAgreedUser) ~> userServiceRoutes ~> check {
+            assertResult(Forbidden, response.entity.asString) {
+              status
+            }
+          }
         }
       }
-    }
 
-    "attempting to enroll as an enrolled user" - {
-      "should be a BadRequest" in {
-        Post(enrollPath) ~> dummyUserIdHeaders(enrolledUser) ~> userServiceRoutes ~> check {
-          status should equal(BadRequest)
+      s"attempting to enroll as an enrolled user via $enrollPath" - {
+        "should be a BadRequest" in {
+          Post(enrollPath) ~> dummyUserIdHeaders(enrolledUser) ~> userServiceRoutes ~> check {
+            status should equal(BadRequest)
+          }
         }
       }
-    }
 
-    "attempting to enroll as a terminated user" - {
-      "should be a BadRequest" in {
-        Post(enrollPath) ~> dummyUserIdHeaders(terminatedUser) ~> userServiceRoutes ~> check {
-          status should equal(BadRequest)
+      s"attempting to enroll as a terminated user via $enrollPath" - {
+        "should be a BadRequest" in {
+          Post(enrollPath) ~> dummyUserIdHeaders(terminatedUser) ~> userServiceRoutes ~> check {
+            status should equal(BadRequest)
+          }
         }
       }
     }


### PR DESCRIPTION
- It enables the UI to hide the free trial banner permanently and addresses [GAWB-3062](https://broadinstitute.atlassian.net/browse/GAWB-3062).

- The user-facing free trial API is enhanced to allow a `Terminated` user's status to be updated as `Finalized`. It's also lenient in that if an already `Finalized` user is attempted to be `Finalized` again, no error is thrown.

- The former URL (`/api/profile/trial`) maps to `enroll` for backwards compatibility and regression concerns. 

- No new timestamp was added to Thurloe KVPs since keeping track of when users are finalized didn't feel useful.

- The tests for user-initiated requests (`/api/profile/trial*`) were grouped together for maintainability.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment