### PR TITLE
GAWB-2937: reduce queries to ontology for parent labels during library reindex

### DIFF
--- a/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/OntologyAutocompleteSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/OntologyAutocompleteSpec.scala
@@ -30,25 +30,14 @@ class OntologyAutocompleteSpec extends FreeSpec {
       val expected = Set(
         // matches in label:
         "acute hemorrhagic leukoencephalitis",
-        "COL4A1-related familial vascular leukoencephalopathy",
         "hypomyelinating leukoencephalopathy",
-        "leukoencephalopathy with vanishing white matter",
         "oral leukoedema",
         "progressive multifocal leukoencephalopathy",
 
         // matches in a synonym:
-        "CADASIL 1",
-        "CADASIL 2",
-        "CADASIL",
-        "hypomyelinating leukodystrophy 7 with or without oligodontia and-or hypogonadotropic hypogonadism", // note label is "leuko" without the "e"
         "Krabbe disease",
         "myelophthisic anemia",
-        "Nasu-Hakola disease",
         "subacute sclerosing panencephalitis"
-
-        // following should not match; consent-ontology service matches in their definitions; orch does not
-        // "hypomyelinating leukodystrophy 4",
-        // "mitochondrial complex I deficiency",
       )
       assertResult(expected) { labels.toSet }
 


### PR DESCRIPTION
As of DataBiosphere/consent#247, merged in Nov 2017, the ontology index contains parent labels. Orchestration was still making additional queries to populate those labels, even though it didn't have to. I've removed those extra queries.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
