### PR TITLE
GAWB-3059: Show Data Use from DUOS

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/DUOS.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/DUOS.scala
@@ -1,8 +1,93 @@
 package org.broadinstitute.dsde.firecloud.model
 
-import spray.json.JsObject
+import spray.json.{JsObject, JsValue, _}
+import DefaultJsonProtocol._
 
 object DUOS {
+
+  case class DuosDataUse(
+    generalUse: Option[Boolean] = None,
+    hmbResearch: Option[Boolean] = None,
+    diseaseRestrictions: Option[Seq[String]] = None,
+    populationOriginsAncestry: Option[Boolean] = None,
+    populationStructure: Option[Boolean] = None,
+    commercialUse: Option[Boolean] = None,
+    methodsResearch: Option[Boolean] = None,
+    aggregateResearch: Option[String] = None,
+    controlSetOption: Option[String] = None,
+    gender: Option[String] = None,
+    pediatric: Option[Boolean] = None,
+    populationRestrictions: Option[Seq[String]] = None,
+    dateRestriction: Option[String] = None,
+    recontactingDataSubjects: Option[Boolean] = None,
+    recontactMay: Option[String] = None,
+    recontactMust: Option[String] = None,
+    genomicPhenotypicData: Option[String] = None,
+    otherRestrictions: Option[Boolean] = None,
+    cloudStorage: Option[String] = None,
+    ethicsApprovalRequired: Option[Boolean] = None,
+    geographicalRestrictions: Option[String] = None,
+    other: Option[String] = None,
+    illegalBehavior: Option[Boolean] = None,
+    addiction: Option[Boolean] = None,
+    sexualDiseases: Option[Boolean] = None,
+    stigmatizeDiseases: Option[Boolean] = None,
+    vulnerablePopulations: Option[Boolean] = None,
+    psychologicalTraits: Option[Boolean] = None,
+    nonBiomedical: Option[Boolean] = None
+  ) {
+    def apply(jsValues: Map[String, JsValue]): DuosDataUse = {
+      def getBoolean(f: String): Option[Boolean] = {
+        jsValues.get(f) match {
+          case x if x.isDefined => Some(jsValues(f).convertTo[Boolean])
+          case _ => None
+        }
+      }
+      def getSeqString(f: String): Option[Seq[String]] = {
+        jsValues.get(f) match {
+          case x if x.isDefined => Some(jsValues(f).convertTo[JsArray].elements.map(_.toString()))
+          case _ => None
+        }
+      }
+      def getString(f: String): Option[String] = {
+        jsValues.get(f) match {
+          case x if x.isDefined => Some(jsValues(f).convertTo[String])
+          case _ => None
+        }
+      }
+      DuosDataUse(
+        generalUse = getBoolean("generalUse"),
+        hmbResearch = getBoolean("hmbResearch"),
+        diseaseRestrictions = getSeqString("diseaseRestrictions"),
+        populationOriginsAncestry = getBoolean("populationOriginsAncestry"),
+        populationStructure = getBoolean("populationStructure"),
+        commercialUse = getBoolean("commercialUse"),
+        methodsResearch = getBoolean("methodsResearch"),
+        aggregateResearch = getString("aggregateResearch"),
+        controlSetOption = getString("controlSetOption"),
+        gender = getString("gender"),
+        pediatric = getBoolean("pediatric"),
+        populationRestrictions = getSeqString("populationRestrictions"),
+        dateRestriction = getString("dateRestriction"),
+        recontactingDataSubjects = getBoolean("recontactingDataSubjects"),
+        recontactMay = getString("recontactMay"),
+        recontactMust = getString("recontactMust"),
+        genomicPhenotypicData = getString("genomicPhenotypicData"),
+        otherRestrictions = getBoolean("otherRestrictions"),
+        cloudStorage = getString("cloudStorage"),
+        ethicsApprovalRequired = getBoolean("ethicsApprovalRequired"),
+        geographicalRestrictions = getString("geographicalRestrictions"),
+        other = getString("other"),
+        illegalBehavior = getBoolean("illegalBehavior"),
+        addiction = getBoolean("addiction"),
+        sexualDiseases = getBoolean("sexualDiseases"),
+        stigmatizeDiseases = getBoolean("stigmatizeDiseases"),
+        vulnerablePopulations = getBoolean("vulnerablePopulations"),
+        psychologicalTraits = getBoolean("psychologicalTraits"),
+        nonBiomedical = getBoolean("nonBiomedical")
+      )
+    }
+  }
 
   case class Consent(
     consentId: String,
@@ -14,7 +99,8 @@ object DUOS {
     dataUseLetter: Option[String] = None,
     useRestriction: Option[JsObject] = None,
     dulName: Option[String] = None,
-    translatedUseRestriction: Option[String] = None
+    translatedUseRestriction: Option[String] = None,
+    dataUse: Option[DuosDataUse] = None
   )
 
   case class ConsentError(

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/DUOS.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/DUOS.scala
@@ -3,6 +3,8 @@ package org.broadinstitute.dsde.firecloud.model
 import spray.json.{JsObject, JsValue, _}
 import DefaultJsonProtocol._
 
+import scala.util.{Success, Try}
+
 object DUOS {
 
   case class DuosDataUse(
@@ -41,20 +43,31 @@ object DUOS {
     def apply(jsValues: Map[String, JsValue]): DuosDataUse = {
       def getBoolean(f: String): Option[Boolean] = {
         jsValues.get(f) match {
-          case x if x.isDefined => Some(jsValues(f).convertTo[Boolean])
+          case x if x.isDefined =>
+            Try(jsValues(f).convertTo[Boolean]) match {
+              case Success(booleanVal) => Some(booleanVal)
+              case _ => None
+            }
           case _ => None
         }
       }
       def getSeqString(f: String): Option[Seq[String]] = {
         jsValues.get(f) match {
           case x if x.isDefined =>
-            Some(jsValues(f).convertTo[JsArray].elements.map(_.convertTo[String]))
+            Try(jsValues(f).convertTo[JsArray].elements.map(_.convertTo[String])) match {
+              case Success(listVal) => Some(listVal)
+              case _ => None
+            }
           case _ => None
         }
       }
       def getString(f: String): Option[String] = {
         jsValues.get(f) match {
-          case x if x.isDefined => Some(jsValues(f).convertTo[String])
+          case x if x.isDefined =>
+            Try(jsValues(f).convertTo[String]) match {
+              case Success(stringVal) => Some(stringVal)
+              case _ => None
+            }
           case _ => None
         }
       }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/DUOS.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/DUOS.scala
@@ -43,31 +43,19 @@ object DUOS {
     def apply(jsValues: Map[String, JsValue]): DuosDataUse = {
       def getBoolean(f: String): Option[Boolean] = {
         jsValues.get(f) match {
-          case x if x.isDefined =>
-            Try(jsValues(f).convertTo[Boolean]) match {
-              case Success(booleanVal) => Some(booleanVal)
-              case _ => None
-            }
+          case Some(b: JsBoolean) => Try(b.convertTo[Boolean]).toOption
           case _ => None
         }
       }
       def getSeqString(f: String): Option[Seq[String]] = {
         jsValues.get(f) match {
-          case x if x.isDefined =>
-            Try(jsValues(f).convertTo[JsArray].elements.map(_.convertTo[String])) match {
-              case Success(listVal) => Some(listVal)
-              case _ => None
-            }
+          case Some(l: JsArray) => Try(l.elements.map(_.convertTo[String])).toOption
           case _ => None
         }
       }
       def getString(f: String): Option[String] = {
         jsValues.get(f) match {
-          case x if x.isDefined =>
-            Try(jsValues(f).convertTo[String]) match {
-              case Success(stringVal) => Some(stringVal)
-              case _ => None
-            }
+          case Some(s: JsString) => Try(s.convertTo[String]).toOption
           case _ => None
         }
       }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/DUOS.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/DUOS.scala
@@ -43,19 +43,19 @@ object DUOS {
     def apply(jsValues: Map[String, JsValue]): DuosDataUse = {
       def getBoolean(f: String): Option[Boolean] = {
         jsValues.get(f) match {
-          case Some(b: JsBoolean) => Try(b.convertTo[Boolean]).toOption
+          case Some(b: JsBoolean) => Some(b.convertTo[Boolean])
           case _ => None
         }
       }
       def getSeqString(f: String): Option[Seq[String]] = {
         jsValues.get(f) match {
-          case Some(l: JsArray) => Try(l.elements.map(_.convertTo[String])).toOption
+          case Some(l: JsArray) => Some(l.elements.collect { case s: JsString => s.value })
           case _ => None
         }
       }
       def getString(f: String): Option[String] = {
         jsValues.get(f) match {
-          case Some(s: JsString) => Try(s.convertTo[String]).toOption
+          case Some(s: JsString) => Some(s.convertTo[String])
           case _ => None
         }
       }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/DUOS.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/DUOS.scala
@@ -43,7 +43,7 @@ object DUOS {
     def apply(jsValues: Map[String, JsValue]): DuosDataUse = {
       def getBoolean(f: String): Option[Boolean] = {
         jsValues.get(f) match {
-          case Some(b: JsBoolean) => Some(b.convertTo[Boolean])
+          case Some(b: JsBoolean) => Some(b.value)
           case _ => None
         }
       }
@@ -55,7 +55,7 @@ object DUOS {
       }
       def getString(f: String): Option[String] = {
         jsValues.get(f) match {
-          case Some(s: JsString) => Some(s.convertTo[String])
+          case Some(s: JsString) => Some(s.value)
           case _ => None
         }
       }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/DUOS.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/DUOS.scala
@@ -35,7 +35,9 @@ object DUOS {
     vulnerablePopulations: Option[Boolean] = None,
     psychologicalTraits: Option[Boolean] = None,
     nonBiomedical: Option[Boolean] = None
-  ) {
+  )
+
+  object DuosDataUse {
     def apply(jsValues: Map[String, JsValue]): DuosDataUse = {
       def getBoolean(f: String): Option[Boolean] = {
         jsValues.get(f) match {
@@ -45,7 +47,8 @@ object DUOS {
       }
       def getSeqString(f: String): Option[Seq[String]] = {
         jsValues.get(f) match {
-          case x if x.isDefined => Some(jsValues(f).convertTo[JsArray].elements.map(_.toString()))
+          case x if x.isDefined =>
+            Some(jsValues(f).convertTo[JsArray].elements.map(_.convertTo[String]))
           case _ => None
         }
       }
@@ -55,7 +58,7 @@ object DUOS {
           case _ => None
         }
       }
-      DuosDataUse(
+      new DuosDataUse(
         generalUse = getBoolean("generalUse"),
         hmbResearch = getBoolean("hmbResearch"),
         diseaseRestrictions = getSeqString("diseaseRestrictions"),

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/DUOS.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/DUOS.scala
@@ -1,9 +1,9 @@
 package org.broadinstitute.dsde.firecloud.model
 
-import spray.json.{JsObject, JsValue, _}
-import DefaultJsonProtocol._
+import spray.json._
+import spray.json.DefaultJsonProtocol._
 
-import scala.util.{Success, Try}
+import scala.util.Try
 
 object DUOS {
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
@@ -15,7 +15,7 @@ import spray.routing.directives.RouteDirectives.complete
 import org.broadinstitute.dsde.rawls.model.UserModelJsonSupport._
 import org.broadinstitute.dsde.rawls.model.WorkspaceACLJsonSupport.WorkspaceAccessLevelFormat
 
-import scala.util.Try
+import scala.util.{Failure, Success, Try}
 
 object ModelJsonProtocol extends WorkspaceJsonSupport {
   import spray.json.DefaultJsonProtocol._
@@ -238,19 +238,25 @@ object ModelJsonProtocol extends WorkspaceJsonSupport {
 
   implicit object impDuosDataUse extends RootJsonFormat[DuosDataUse] {
     override def write(ddu: DuosDataUse): JsValue = {
-      val existingProps: Seq[(String, JsValue)] = ddu.getClass.getDeclaredFields map { f =>
+      val existingProps: Seq[(String, JsValue)] = Try(ddu.getClass.getDeclaredFields.map { f =>
         f.setAccessible(true)
         f.get(ddu) match {
           case Some(x: Boolean) => f.getName -> x.toJson
           case Some(y: String) => f.getName -> y.toJson
-          case Some((h: String) :: tail) => f.getName -> (h +: tail.collect{case z:String => z}).toJson
+          case Some((h: String) :: tail) => f.getName -> (h +: tail.collect { case z: String => z }).toJson
           case _ => f.getName -> JsNull
         }
+      }) match {
+        case Success(props) => props.filterNot(_._2 == JsNull)
+        case Failure(ex) => deserializationError("Error deserializing DuosDataUse object", ex)
       }
-      JsObject(existingProps.filterNot(_._2 == JsNull).toMap)
+      JsObject(existingProps.toMap)
     }
     override def read(json: JsValue): DuosDataUse = {
-      DuosDataUse.apply(json.asJsObject.fields)
+      Try(DuosDataUse.apply(json.asJsObject.fields)) match {
+        case Success(ddu) => ddu
+        case Failure(ex) => serializationError(ex.getMessage)
+      }
     }
   }
   implicit val impDuosConsent = jsonFormat11(Consent)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
@@ -243,14 +243,18 @@ object ModelJsonProtocol extends WorkspaceJsonSupport {
         f.get(ddu) match {
           case Some(x: Boolean) => f.getName -> x.toJson
           case Some(y: String) => f.getName -> y.toJson
-          case Some(head :: tail) => f.getName -> JsArray((head +: tail).map(_.toString.toJson).toVector)
+          case Some(ls: Seq[_]) =>
+            ls.head match {
+              case (a: String) => f.getName -> (a +: ls.tail.map(_.asInstanceOf[String])).toJson
+              case _ => f.getName -> JsNull
+            }
           case _ => f.getName -> JsNull
         }
       }
       JsObject(existingProps.filterNot(_._2 == JsNull).toMap)
     }
     override def read(json: JsValue): DuosDataUse = {
-      DuosDataUse().apply(json.asJsObject.fields)
+      DuosDataUse.apply(json.asJsObject.fields)
     }
   }
   implicit val impDuosConsent = jsonFormat11(Consent)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
@@ -9,7 +9,7 @@ import org.broadinstitute.dsde.firecloud.model.MethodRepository._
 import org.broadinstitute.dsde.firecloud.model.Ontology.{ESTermParent, TermParent, TermResource}
 import org.broadinstitute.dsde.firecloud.model.Trial.ProjectRoles.ProjectRole
 import org.broadinstitute.dsde.firecloud.model.Trial._
-import spray.json.{JsNull, _}
+import spray.json._
 import spray.routing.{MalformedRequestContentRejection, RejectionHandler}
 import spray.routing.directives.RouteDirectives.complete
 import org.broadinstitute.dsde.rawls.model.UserModelJsonSupport._
@@ -243,11 +243,7 @@ object ModelJsonProtocol extends WorkspaceJsonSupport {
         f.get(ddu) match {
           case Some(x: Boolean) => f.getName -> x.toJson
           case Some(y: String) => f.getName -> y.toJson
-          case Some(ls: Seq[_]) =>
-            ls.head match {
-              case (a: String) => f.getName -> (a +: ls.tail.map(_.asInstanceOf[String])).toJson
-              case _ => f.getName -> JsNull
-            }
+          case Some((h: String) :: tail) => f.getName -> (h +: tail.collect{case z:String => z}).toJson
           case _ => f.getName -> JsNull
         }
       }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
@@ -248,14 +248,14 @@ object ModelJsonProtocol extends WorkspaceJsonSupport {
         }
       }) match {
         case Success(props) => props.filterNot(_._2 == JsNull)
-        case Failure(ex) => deserializationError("Error deserializing DuosDataUse object", ex)
+        case Failure(ex) => serializationError(ex.getMessage)
       }
       JsObject(existingProps.toMap)
     }
     override def read(json: JsValue): DuosDataUse = {
       Try(DuosDataUse.apply(json.asJsObject.fields)) match {
         case Success(ddu) => ddu
-        case Failure(ex) => serializationError(ex.getMessage)
+        case Failure(ex) => deserializationError(s"Could not read DuosDataUse value: $json", ex)
       }
     }
   }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/model/DuosModelSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/model/DuosModelSpec.scala
@@ -69,8 +69,7 @@ class DuosModelSpec extends FreeSpec with Matchers {
         val duosDataUse: DuosDataUse = DuosDataUse.apply(jsValues)
         val duosDiseases: Seq[String] = duosDataUse.diseaseRestrictions.getOrElse(Seq.empty[String])
         duosDiseases should not be empty
-        duosDiseases should contain ("DOID_1")
-        duosDiseases.size shouldBe 1
+        duosDiseases should contain theSameElementsInOrderAs Seq("DOID_1")
       }
       "diseaseRestrictions: [DOID_1, DOID_2]" in {
         val diseases = JsArray(JsString("DOID_1"), JsString("DOID_2"))
@@ -78,9 +77,7 @@ class DuosModelSpec extends FreeSpec with Matchers {
         val duosDataUse: DuosDataUse = DuosDataUse.apply(jsValues)
         val duosDiseases: Seq[String] = duosDataUse.diseaseRestrictions.getOrElse(Seq.empty[String])
         duosDiseases should not be empty
-        duosDiseases should contain ("DOID_1")
-        duosDiseases should contain ("DOID_2")
-        duosDiseases.size shouldBe 2
+        duosDiseases should contain theSameElementsInOrderAs Seq("DOID_1", "DOID_2")
       }
       "diseaseRestrictions: [DOID_1, DOID_2, DOID_2]" in {
         val diseases = JsArray(JsString("DOID_1"), JsString("DOID_2"), JsString("DOID_3"))
@@ -88,10 +85,7 @@ class DuosModelSpec extends FreeSpec with Matchers {
         val duosDataUse: DuosDataUse = DuosDataUse.apply(jsValues)
         val duosDiseases: Seq[String] = duosDataUse.diseaseRestrictions.getOrElse(Seq.empty[String])
         duosDiseases should not be empty
-        duosDiseases should contain ("DOID_1")
-        duosDiseases should contain ("DOID_2")
-        duosDiseases should contain ("DOID_3")
-        duosDiseases.size shouldBe 3
+        duosDiseases should contain theSameElementsInOrderAs Seq("DOID_1", "DOID_2", "DOID_3")
       }
       "populationOriginsAncestry: true" in {
         val jsValues: Map[String, JsValue] = Map("populationOriginsAncestry" -> JsBoolean(true))
@@ -139,9 +133,7 @@ class DuosModelSpec extends FreeSpec with Matchers {
         val duosDataUse: DuosDataUse = DuosDataUse.apply(jsValues)
         val duosPops: Seq[String] = duosDataUse.populationRestrictions.getOrElse(Seq.empty[String])
         duosPops should not be empty
-        duosPops should contain ("POP_1")
-        duosPops should contain ("POP_2")
-        duosPops.size shouldBe 2
+        duosPops should contain theSameElementsInOrderAs Seq("POP_1", "POP_2")
       }
       "dateRestriction: 1/1/2018" in {
         val jsValues: Map[String, JsValue] = Map("dateRestriction" -> JsString("1/1/2018"))
@@ -232,35 +224,13 @@ class DuosModelSpec extends FreeSpec with Matchers {
   }
 
   private def assertIsUndefined(duosDataUse: DuosDataUse): Unit = {
-    duosDataUse.generalUse.isDefined shouldBe false
-    duosDataUse.hmbResearch.isDefined shouldBe false
-    duosDataUse.diseaseRestrictions.isDefined shouldBe false
-    duosDataUse.populationOriginsAncestry.isDefined shouldBe false
-    duosDataUse.populationStructure.isDefined shouldBe false
-    duosDataUse.commercialUse.isDefined shouldBe false
-    duosDataUse.methodsResearch.isDefined shouldBe false
-    duosDataUse.aggregateResearch.isDefined shouldBe false
-    duosDataUse.controlSetOption.isDefined shouldBe false
-    duosDataUse.gender.isDefined shouldBe false
-    duosDataUse.pediatric.isDefined shouldBe false
-    duosDataUse.populationRestrictions.isDefined shouldBe false
-    duosDataUse.dateRestriction.isDefined shouldBe false
-    duosDataUse.recontactingDataSubjects.isDefined shouldBe false
-    duosDataUse.recontactMay.isDefined shouldBe false
-    duosDataUse.recontactMust.isDefined shouldBe false
-    duosDataUse.genomicPhenotypicData.isDefined shouldBe false
-    duosDataUse.otherRestrictions.isDefined shouldBe false
-    duosDataUse.cloudStorage.isDefined shouldBe false
-    duosDataUse.ethicsApprovalRequired.isDefined shouldBe false
-    duosDataUse.geographicalRestrictions.isDefined shouldBe false
-    duosDataUse.other.isDefined shouldBe false
-    duosDataUse.illegalBehavior.isDefined shouldBe false
-    duosDataUse.addiction.isDefined shouldBe false
-    duosDataUse.sexualDiseases.isDefined shouldBe false
-    duosDataUse.stigmatizeDiseases.isDefined shouldBe false
-    duosDataUse.vulnerablePopulations.isDefined shouldBe false
-    duosDataUse.psychologicalTraits.isDefined shouldBe false
-    duosDataUse.nonBiomedical.isDefined shouldBe false
+    duosDataUse.getClass.getDeclaredFields map { f =>
+      f.setAccessible(true)
+      f.get(duosDataUse) match {
+        case Some(x) => fail(s"Field ${f.getName} should not be defined")
+        case None => // passing cass
+      }
+    }
   }
 
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/model/DuosModelSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/model/DuosModelSpec.scala
@@ -1,0 +1,219 @@
+package org.broadinstitute.dsde.firecloud.model
+
+import org.broadinstitute.dsde.firecloud.model.DUOS.DuosDataUse
+import org.scalatest.{FreeSpec, Matchers}
+import spray.json._
+
+class DuosModelSpec extends FreeSpec with Matchers {
+
+  private implicit val impDuosDataUse: ModelJsonProtocol.impDuosDataUse.type = ModelJsonProtocol.impDuosDataUse
+
+  "DUOS DuosDataUse" - {
+
+    "Partially formed valid data use json should parse what's valid" - {
+      "generalUse: true, fooBar: 7" in {
+        val jsValues: Map[String, JsValue] = Map(
+          "generalUse" -> JsBoolean(true),
+          "fooBar" -> JsNumber(7)
+        )
+        val duosDataUse: DuosDataUse = DuosDataUse.apply(jsValues)
+        duosDataUse.generalUse.getOrElse(false) shouldBe true
+      }
+    }
+
+    "Incorrectly formed data use json should parse to an empty object" - {
+      "fooBar: 7, barBaz: [FOO, BAR]" in {
+        val vals = JsArray(JsString("FOO"), JsString("BAR"))
+        val jsValues: Map[String, JsValue] = Map(
+          "barBaz" -> JsArray(vals),
+          "fooBar" -> JsNumber(7)
+        )
+        val duosDataUse: DuosDataUse = DuosDataUse.apply(jsValues)
+        duosDataUse.generalUse.isDefined shouldBe false
+        duosDataUse.hmbResearch.isDefined shouldBe false
+        duosDataUse.diseaseRestrictions.isDefined shouldBe false
+        duosDataUse.populationOriginsAncestry.isDefined shouldBe false
+        duosDataUse.populationStructure.isDefined shouldBe false
+        duosDataUse.commercialUse.isDefined shouldBe false
+        duosDataUse.methodsResearch.isDefined shouldBe false
+        duosDataUse.aggregateResearch.isDefined shouldBe false
+        duosDataUse.controlSetOption.isDefined shouldBe false
+        duosDataUse.gender.isDefined shouldBe false
+        duosDataUse.pediatric.isDefined shouldBe false
+        duosDataUse.populationRestrictions.isDefined shouldBe false
+        duosDataUse.dateRestriction.isDefined shouldBe false
+        duosDataUse.recontactingDataSubjects.isDefined shouldBe false
+        duosDataUse.recontactMay.isDefined shouldBe false
+        duosDataUse.recontactMust.isDefined shouldBe false
+        duosDataUse.genomicPhenotypicData.isDefined shouldBe false
+        duosDataUse.otherRestrictions.isDefined shouldBe false
+        duosDataUse.cloudStorage.isDefined shouldBe false
+        duosDataUse.ethicsApprovalRequired.isDefined shouldBe false
+        duosDataUse.geographicalRestrictions.isDefined shouldBe false
+        duosDataUse.other.isDefined shouldBe false
+        duosDataUse.illegalBehavior.isDefined shouldBe false
+        duosDataUse.addiction.isDefined shouldBe false
+        duosDataUse.sexualDiseases.isDefined shouldBe false
+        duosDataUse.stigmatizeDiseases.isDefined shouldBe false
+        duosDataUse.vulnerablePopulations.isDefined shouldBe false
+        duosDataUse.psychologicalTraits.isDefined shouldBe false
+        duosDataUse.nonBiomedical.isDefined shouldBe false
+      }
+    }
+
+    "Correctly formed duos data use json should parse to a DuosDataUse" - {
+      "generalUse: true" in {
+        val jsValues: Map[String, JsValue] = Map("generalUse" -> JsBoolean(true))
+        val duosDataUse: DuosDataUse = DuosDataUse.apply(jsValues)
+        duosDataUse.generalUse.getOrElse(false) shouldBe true
+      }
+      "hmbResearch: true" in {
+        val jsValues: Map[String, JsValue] = Map("hmbResearch" -> JsBoolean(true))
+        val duosDataUse: DuosDataUse = DuosDataUse.apply(jsValues)
+        duosDataUse.hmbResearch.getOrElse(false) shouldBe true
+      }
+      "diseaseRestrictions: [DOID_1, DOID_2]" in {
+        val diseases = JsArray(JsString("DOID_1"), JsString("DOID_2"))
+        val jsValues: Map[String, JsValue] = Map("diseaseRestrictions" -> diseases)
+        val duosDataUse: DuosDataUse = DuosDataUse.apply(jsValues)
+        duosDataUse.diseaseRestrictions.getOrElse(Seq.empty[String]) should not be empty
+        duosDataUse.diseaseRestrictions.getOrElse(Seq.empty[String]) should contain ("DOID_1")
+        duosDataUse.diseaseRestrictions.getOrElse(Seq.empty[String]) should contain ("DOID_2")
+      }
+      "populationOriginsAncestry: true" in {
+        val jsValues: Map[String, JsValue] = Map("populationOriginsAncestry" -> JsBoolean(true))
+        val duosDataUse: DuosDataUse = DuosDataUse.apply(jsValues)
+        duosDataUse.populationOriginsAncestry.getOrElse(false) shouldBe true
+      }
+      "populationStructure: true" in {
+        val jsValues: Map[String, JsValue] = Map("populationStructure" -> JsBoolean(true))
+        val duosDataUse: DuosDataUse = DuosDataUse.apply(jsValues)
+        duosDataUse.populationStructure.getOrElse(false) shouldBe true
+      }
+      "commercialUse: true" in {
+        val jsValues: Map[String, JsValue] = Map("commercialUse" -> JsBoolean(true))
+        val duosDataUse: DuosDataUse = DuosDataUse.apply(jsValues)
+        duosDataUse.commercialUse.getOrElse(false) shouldBe true
+      }
+      "methodsResearch: true" in {
+        val jsValues: Map[String, JsValue] = Map("methodsResearch" -> JsBoolean(true))
+        val duosDataUse: DuosDataUse = DuosDataUse.apply(jsValues)
+        duosDataUse.methodsResearch.getOrElse(false) shouldBe true
+      }
+      "aggregateResearch: Yes" in {
+        val jsValues: Map[String, JsValue] = Map("aggregateResearch" -> JsString("Yes"))
+        val duosDataUse: DuosDataUse = DuosDataUse.apply(jsValues)
+        duosDataUse.aggregateResearch.getOrElse(false) should equal("Yes")
+      }
+      "controlSetOption: No" in {
+        val jsValues: Map[String, JsValue] = Map("controlSetOption" -> JsString("No"))
+        val duosDataUse: DuosDataUse = DuosDataUse.apply(jsValues)
+        duosDataUse.controlSetOption.getOrElse(false) should equal("No")
+      }
+      "gender: F" in {
+        val jsValues: Map[String, JsValue] = Map("gender" -> JsString("F"))
+        val duosDataUse: DuosDataUse = DuosDataUse.apply(jsValues)
+        duosDataUse.gender.getOrElse(false) should equal("F")
+      }
+      "pediatric: true" in {
+        val jsValues: Map[String, JsValue] = Map("pediatric" -> JsBoolean(true))
+        val duosDataUse: DuosDataUse = DuosDataUse.apply(jsValues)
+        duosDataUse.pediatric.getOrElse(false) shouldBe true
+      }
+      "populationRestrictions: [POP_1, POP_2]" in {
+        val pops = JsArray(JsString("POP_1"), JsString("POP_2"))
+        val jsValues: Map[String, JsValue] = Map("populationRestrictions" -> pops)
+        val duosDataUse: DuosDataUse = DuosDataUse.apply(jsValues)
+        duosDataUse.populationRestrictions.getOrElse(Seq.empty[String]) should not be empty
+        duosDataUse.populationRestrictions.getOrElse(Seq.empty[String]) should contain ("POP_1")
+        duosDataUse.populationRestrictions.getOrElse(Seq.empty[String]) should contain ("POP_2")
+      }
+      "dateRestriction: 1/1/2018" in {
+        val jsValues: Map[String, JsValue] = Map("dateRestriction" -> JsString("1/1/2018"))
+        val duosDataUse: DuosDataUse = DuosDataUse.apply(jsValues)
+        duosDataUse.dateRestriction.getOrElse(false) should equal("1/1/2018")
+      }
+      "recontactingDataSubjects: true" in {
+        val jsValues: Map[String, JsValue] = Map("recontactingDataSubjects" -> JsBoolean(true))
+        val duosDataUse: DuosDataUse = DuosDataUse.apply(jsValues)
+        duosDataUse.recontactingDataSubjects.getOrElse(false) shouldBe true
+      }
+      "recontactMay: No" in {
+        val jsValues: Map[String, JsValue] = Map("recontactMay" -> JsString("No"))
+        val duosDataUse: DuosDataUse = DuosDataUse.apply(jsValues)
+        duosDataUse.recontactMay.getOrElse(false) should equal("No")
+      }
+      "recontactMust: Yes" in {
+        val jsValues: Map[String, JsValue] = Map("recontactMust" -> JsString("Yes"))
+        val duosDataUse: DuosDataUse = DuosDataUse.apply(jsValues)
+        duosDataUse.recontactMust.getOrElse(false) should equal("Yes")
+      }
+      "genomicPhenotypicData: Yes" in {
+        val jsValues: Map[String, JsValue] = Map("genomicPhenotypicData" -> JsString("Yes"))
+        val duosDataUse: DuosDataUse = DuosDataUse.apply(jsValues)
+        duosDataUse.genomicPhenotypicData.getOrElse(false) should equal("Yes")
+      }
+      "otherRestrictions: true" in {
+        val jsValues: Map[String, JsValue] = Map("otherRestrictions" -> JsBoolean(true))
+        val duosDataUse: DuosDataUse = DuosDataUse.apply(jsValues)
+        duosDataUse.otherRestrictions.getOrElse(false) shouldBe true
+      }
+      "cloudStorage: No" in {
+        val jsValues: Map[String, JsValue] = Map("cloudStorage" -> JsString("No"))
+        val duosDataUse: DuosDataUse = DuosDataUse.apply(jsValues)
+        duosDataUse.cloudStorage.getOrElse(false) should equal("No")
+      }
+      "ethicsApprovalRequired: true" in {
+        val jsValues: Map[String, JsValue] = Map("ethicsApprovalRequired" -> JsBoolean(true))
+        val duosDataUse: DuosDataUse = DuosDataUse.apply(jsValues)
+        duosDataUse.ethicsApprovalRequired.getOrElse(false) shouldBe true
+      }
+      "geographicalRestrictions: US" in {
+        val jsValues: Map[String, JsValue] = Map("geographicalRestrictions" -> JsString("US"))
+        val duosDataUse: DuosDataUse = DuosDataUse.apply(jsValues)
+        duosDataUse.geographicalRestrictions.getOrElse(false) should equal("US")
+      }
+      "other: Other" in {
+        val jsValues: Map[String, JsValue] = Map("other" -> JsString("Other"))
+        val duosDataUse: DuosDataUse = DuosDataUse.apply(jsValues)
+        duosDataUse.other.getOrElse(false) should equal("Other")
+      }
+      "illegalBehavior: true" in {
+        val jsValues: Map[String, JsValue] = Map("illegalBehavior" -> JsBoolean(true))
+        val duosDataUse: DuosDataUse = DuosDataUse.apply(jsValues)
+        duosDataUse.illegalBehavior.getOrElse(false) shouldBe true
+      }
+      "addiction: true" in {
+        val jsValues: Map[String, JsValue] = Map("addiction" -> JsBoolean(true))
+        val duosDataUse: DuosDataUse = DuosDataUse.apply(jsValues)
+        duosDataUse.addiction.getOrElse(false) shouldBe true
+      }
+      "sexualDiseases: true" in {
+        val jsValues: Map[String, JsValue] = Map("sexualDiseases" -> JsBoolean(true))
+        val duosDataUse: DuosDataUse = DuosDataUse.apply(jsValues)
+        duosDataUse.sexualDiseases.getOrElse(false) shouldBe true
+      }
+      "stigmatizeDiseases: true" in {
+        val jsValues: Map[String, JsValue] = Map("stigmatizeDiseases" -> JsBoolean(true))
+        val duosDataUse: DuosDataUse = DuosDataUse.apply(jsValues)
+        duosDataUse.stigmatizeDiseases.getOrElse(false) shouldBe true
+      }
+      "vulnerablePopulations: true" in {
+        val jsValues: Map[String, JsValue] = Map("vulnerablePopulations" -> JsBoolean(true))
+        val duosDataUse: DuosDataUse = DuosDataUse.apply(jsValues)
+        duosDataUse.vulnerablePopulations.getOrElse(false) shouldBe true
+      }
+      "psychologicalTraits: true" in {
+        val jsValues: Map[String, JsValue] = Map("psychologicalTraits" -> JsBoolean(true))
+        val duosDataUse: DuosDataUse = DuosDataUse.apply(jsValues)
+        duosDataUse.psychologicalTraits.getOrElse(false) shouldBe true
+      }
+      "nonBiomedical: true" in {
+        val jsValues: Map[String, JsValue] = Map("nonBiomedical" -> JsBoolean(true))
+        val duosDataUse: DuosDataUse = DuosDataUse.apply(jsValues)
+        duosDataUse.nonBiomedical.getOrElse(false) shouldBe true
+      }
+    }
+  }
+
+}

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/model/DuosModelSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/model/DuosModelSpec.scala
@@ -72,13 +72,35 @@ class DuosModelSpec extends FreeSpec with Matchers {
         val duosDataUse: DuosDataUse = DuosDataUse.apply(jsValues)
         duosDataUse.hmbResearch.getOrElse(false) shouldBe true
       }
+      "diseaseRestrictions: [DOID_1]" in {
+        val diseases = JsArray(JsString("DOID_1"))
+        val jsValues: Map[String, JsValue] = Map("diseaseRestrictions" -> diseases)
+        val duosDataUse: DuosDataUse = DuosDataUse.apply(jsValues)
+        val duosDiseases: Seq[String] = duosDataUse.diseaseRestrictions.getOrElse(Seq.empty[String])
+        duosDiseases should not be empty
+        duosDiseases should contain ("DOID_1")
+        duosDiseases.size shouldBe 1
+      }
       "diseaseRestrictions: [DOID_1, DOID_2]" in {
         val diseases = JsArray(JsString("DOID_1"), JsString("DOID_2"))
         val jsValues: Map[String, JsValue] = Map("diseaseRestrictions" -> diseases)
         val duosDataUse: DuosDataUse = DuosDataUse.apply(jsValues)
-        duosDataUse.diseaseRestrictions.getOrElse(Seq.empty[String]) should not be empty
-        duosDataUse.diseaseRestrictions.getOrElse(Seq.empty[String]) should contain ("DOID_1")
-        duosDataUse.diseaseRestrictions.getOrElse(Seq.empty[String]) should contain ("DOID_2")
+        val duosDiseases: Seq[String] = duosDataUse.diseaseRestrictions.getOrElse(Seq.empty[String])
+        duosDiseases should not be empty
+        duosDiseases should contain ("DOID_1")
+        duosDiseases should contain ("DOID_2")
+        duosDiseases.size shouldBe 2
+      }
+      "diseaseRestrictions: [DOID_1, DOID_2, DOID_2]" in {
+        val diseases = JsArray(JsString("DOID_1"), JsString("DOID_2"), JsString("DOID_3"))
+        val jsValues: Map[String, JsValue] = Map("diseaseRestrictions" -> diseases)
+        val duosDataUse: DuosDataUse = DuosDataUse.apply(jsValues)
+        val duosDiseases: Seq[String] = duosDataUse.diseaseRestrictions.getOrElse(Seq.empty[String])
+        duosDiseases should not be empty
+        duosDiseases should contain ("DOID_1")
+        duosDiseases should contain ("DOID_2")
+        duosDiseases should contain ("DOID_3")
+        duosDiseases.size shouldBe 3
       }
       "populationOriginsAncestry: true" in {
         val jsValues: Map[String, JsValue] = Map("populationOriginsAncestry" -> JsBoolean(true))
@@ -124,9 +146,11 @@ class DuosModelSpec extends FreeSpec with Matchers {
         val pops = JsArray(JsString("POP_1"), JsString("POP_2"))
         val jsValues: Map[String, JsValue] = Map("populationRestrictions" -> pops)
         val duosDataUse: DuosDataUse = DuosDataUse.apply(jsValues)
-        duosDataUse.populationRestrictions.getOrElse(Seq.empty[String]) should not be empty
-        duosDataUse.populationRestrictions.getOrElse(Seq.empty[String]) should contain ("POP_1")
-        duosDataUse.populationRestrictions.getOrElse(Seq.empty[String]) should contain ("POP_2")
+        val duosPops: Seq[String] = duosDataUse.populationRestrictions.getOrElse(Seq.empty[String])
+        duosPops should not be empty
+        duosPops should contain ("POP_1")
+        duosPops should contain ("POP_2")
+        duosPops.size shouldBe 2
       }
       "dateRestriction: 1/1/2018" in {
         val jsValues: Map[String, JsValue] = Map("dateRestriction" -> JsString("1/1/2018"))

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/model/DuosModelSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/model/DuosModelSpec.scala
@@ -22,6 +22,25 @@ class DuosModelSpec extends FreeSpec with Matchers {
     }
 
     "Incorrectly formed data use json should parse to an empty object" - {
+
+      "generalUse: FOO" in {
+        val jsValues: Map[String, JsValue] = Map("generalUse" -> JsString("FOO"))
+        val duosDataUse: DuosDataUse = DuosDataUse.apply(jsValues)
+        assertIsUndefined(duosDataUse)
+      }
+
+      "diseaseRestrictions: true" in {
+        val jsValues: Map[String, JsValue] = Map("diseaseRestrictions" -> JsBoolean(true))
+        val duosDataUse: DuosDataUse = DuosDataUse.apply(jsValues)
+        assertIsUndefined(duosDataUse)
+      }
+
+      "aggregateResearch: true" in {
+        val jsValues: Map[String, JsValue] = Map("aggregateResearch" -> JsBoolean(true))
+        val duosDataUse: DuosDataUse = DuosDataUse.apply(jsValues)
+        assertIsUndefined(duosDataUse)
+      }
+
       "fooBar: 7, barBaz: [FOO, BAR]" in {
         val vals = JsArray(JsString("FOO"), JsString("BAR"))
         val jsValues: Map[String, JsValue] = Map(
@@ -29,35 +48,7 @@ class DuosModelSpec extends FreeSpec with Matchers {
           "fooBar" -> JsNumber(7)
         )
         val duosDataUse: DuosDataUse = DuosDataUse.apply(jsValues)
-        duosDataUse.generalUse.isDefined shouldBe false
-        duosDataUse.hmbResearch.isDefined shouldBe false
-        duosDataUse.diseaseRestrictions.isDefined shouldBe false
-        duosDataUse.populationOriginsAncestry.isDefined shouldBe false
-        duosDataUse.populationStructure.isDefined shouldBe false
-        duosDataUse.commercialUse.isDefined shouldBe false
-        duosDataUse.methodsResearch.isDefined shouldBe false
-        duosDataUse.aggregateResearch.isDefined shouldBe false
-        duosDataUse.controlSetOption.isDefined shouldBe false
-        duosDataUse.gender.isDefined shouldBe false
-        duosDataUse.pediatric.isDefined shouldBe false
-        duosDataUse.populationRestrictions.isDefined shouldBe false
-        duosDataUse.dateRestriction.isDefined shouldBe false
-        duosDataUse.recontactingDataSubjects.isDefined shouldBe false
-        duosDataUse.recontactMay.isDefined shouldBe false
-        duosDataUse.recontactMust.isDefined shouldBe false
-        duosDataUse.genomicPhenotypicData.isDefined shouldBe false
-        duosDataUse.otherRestrictions.isDefined shouldBe false
-        duosDataUse.cloudStorage.isDefined shouldBe false
-        duosDataUse.ethicsApprovalRequired.isDefined shouldBe false
-        duosDataUse.geographicalRestrictions.isDefined shouldBe false
-        duosDataUse.other.isDefined shouldBe false
-        duosDataUse.illegalBehavior.isDefined shouldBe false
-        duosDataUse.addiction.isDefined shouldBe false
-        duosDataUse.sexualDiseases.isDefined shouldBe false
-        duosDataUse.stigmatizeDiseases.isDefined shouldBe false
-        duosDataUse.vulnerablePopulations.isDefined shouldBe false
-        duosDataUse.psychologicalTraits.isDefined shouldBe false
-        duosDataUse.nonBiomedical.isDefined shouldBe false
+        assertIsUndefined(duosDataUse)
       }
     }
 
@@ -238,6 +229,38 @@ class DuosModelSpec extends FreeSpec with Matchers {
         duosDataUse.nonBiomedical.getOrElse(false) shouldBe true
       }
     }
+  }
+
+  private def assertIsUndefined(duosDataUse: DuosDataUse): Unit = {
+    duosDataUse.generalUse.isDefined shouldBe false
+    duosDataUse.hmbResearch.isDefined shouldBe false
+    duosDataUse.diseaseRestrictions.isDefined shouldBe false
+    duosDataUse.populationOriginsAncestry.isDefined shouldBe false
+    duosDataUse.populationStructure.isDefined shouldBe false
+    duosDataUse.commercialUse.isDefined shouldBe false
+    duosDataUse.methodsResearch.isDefined shouldBe false
+    duosDataUse.aggregateResearch.isDefined shouldBe false
+    duosDataUse.controlSetOption.isDefined shouldBe false
+    duosDataUse.gender.isDefined shouldBe false
+    duosDataUse.pediatric.isDefined shouldBe false
+    duosDataUse.populationRestrictions.isDefined shouldBe false
+    duosDataUse.dateRestriction.isDefined shouldBe false
+    duosDataUse.recontactingDataSubjects.isDefined shouldBe false
+    duosDataUse.recontactMay.isDefined shouldBe false
+    duosDataUse.recontactMust.isDefined shouldBe false
+    duosDataUse.genomicPhenotypicData.isDefined shouldBe false
+    duosDataUse.otherRestrictions.isDefined shouldBe false
+    duosDataUse.cloudStorage.isDefined shouldBe false
+    duosDataUse.ethicsApprovalRequired.isDefined shouldBe false
+    duosDataUse.geographicalRestrictions.isDefined shouldBe false
+    duosDataUse.other.isDefined shouldBe false
+    duosDataUse.illegalBehavior.isDefined shouldBe false
+    duosDataUse.addiction.isDefined shouldBe false
+    duosDataUse.sexualDiseases.isDefined shouldBe false
+    duosDataUse.stigmatizeDiseases.isDefined shouldBe false
+    duosDataUse.vulnerablePopulations.isDefined shouldBe false
+    duosDataUse.psychologicalTraits.isDefined shouldBe false
+    duosDataUse.nonBiomedical.isDefined shouldBe false
   }
 
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/LibraryApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/LibraryApiServiceSpec.scala
@@ -4,7 +4,7 @@ import org.broadinstitute.dsde.firecloud.FireCloudConfig
 import org.broadinstitute.dsde.firecloud.dataaccess.MockRawlsDAO
 import org.broadinstitute.dsde.firecloud.mock.MockUtils
 import org.broadinstitute.dsde.firecloud.mock.MockUtils._
-import org.broadinstitute.dsde.firecloud.model.DUOS.{Consent, ConsentError}
+import org.broadinstitute.dsde.firecloud.model.DUOS.{Consent, ConsentError, DuosDataUse}
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
 import org.broadinstitute.dsde.firecloud.model._
 import org.broadinstitute.dsde.firecloud.webservice.LibraryApiService
@@ -96,7 +96,8 @@ class LibraryApiServiceSpec extends BaseServiceSpec with LibraryApiService with 
     consentServer = startClientAndServer(consentServerPort)
 
     val consentPath = consentUrl.replace(FireCloudConfig.Duos.baseConsentUrl, "")
-    val consent = Consent(consentId = "consent-id-12345", name = "12345", translatedUseRestriction = Some("Translation"))
+    val duosDataUse = DuosDataUse(generalUse = Some(true))
+    val consent = Consent(consentId = "consent-id-12345", name = "12345", translatedUseRestriction = Some("Translation"), dataUse = Some(duosDataUse))
     val consentError = ConsentError(message = "Unapproved", code = BadRequest.intValue)
     val consentNotFound = ConsentError(message = "Not Found", code = NotFound.intValue)
 


### PR DESCRIPTION
## Addresses 
* https://broadinstitute.atlassian.net/browse/GAWB-3059

## Changes
* Added the DUOS data use object to consent. 

## Testing
* I spun this up in a FiaB, added an example consent in the fiab duos ui and voted on it so it would be visible to consent. Orchestration was then able to successfully see the data use object in real time as I made updates to it in the fiab duos. 

![screen shot 2018-01-30 at 6 35 51 pm](https://user-images.githubusercontent.com/116679/35597432-6c62ef56-05ec-11e8-89de-e9e812cf5095.png)


Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
