### PR TITLE
GAWB-3137: Fix StartupChecksSpec

### DIFF
--- a/src/test/scala/org/broadinstitute/dsde/firecloud/StartupChecksSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/StartupChecksSpec.scala
@@ -85,6 +85,15 @@ class StartupChecksSpec extends BaseServiceSpec {
         val testApp = app.copy(samDAO = mockDAO)
         val check = Await.result(new StartupChecks(testApp, registerSAs = true).check, 3.minutes)
         assert(check)
+
+        // TODO: Failures here:
+        // https://fc-jenkins.dsp-techops.broadinstitute.org/job/firecloud-orchestration-build/482/consoleFull
+        // https://fc-jenkins.dsp-techops.broadinstitute.org/job/firecloud-orchestration-build/478/consoleFull
+        // https://fc-jenkins.dsp-techops.broadinstitute.org/job/firecloud-orchestration-build/476/consoleFull
+        // https://fc-jenkins.dsp-techops.broadinstitute.org/job/firecloud-orchestration-build/472/consoleFull
+        mockDAO.newlyRegisteredUsers.map { v => println(s"[StartupChecksSpec]: mockDAO.newlyRegisteredUsers value: $v") }
+        tokens.values.map { v => println(s"[StartupChecksSpec]: tokens.values value: $v") }
+
         assertResult(tokens.values.toSet) {mockDAO.newlyRegisteredUsers.toSet}
       }
       "should pass when only one SA needs to be registered, and succeeds" - {

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/StartupChecksSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/StartupChecksSpec.scala
@@ -78,37 +78,13 @@ class StartupChecksSpec extends BaseServiceSpec {
     }
 
     "When automatic registration of SAs is enabled" - {
-      "should pass when all SAs need to be registered, and succeed" - {
+      "should pass when all SAs need to be registered, and succeed" in {
         val mockDAO = new StartupChecksMockSamDAO(
           notFounds = Seq(tokens.head._2),
           unregisteredTokens = tokens.tail.values.toSeq)
         val testApp = app.copy(samDAO = mockDAO)
         val check = Await.result(new StartupChecks(testApp, registerSAs = true).check, 3.minutes)
         assert(check)
-
-        // TODO: Failures here:
-        // https://fc-jenkins.dsp-techops.broadinstitute.org/job/firecloud-orchestration-build/472/consoleFull
-        // https://fc-jenkins.dsp-techops.broadinstitute.org/job/firecloud-orchestration-build/476/consoleFull
-        // https://fc-jenkins.dsp-techops.broadinstitute.org/job/firecloud-orchestration-build/478/consoleFull
-        // https://fc-jenkins.dsp-techops.broadinstitute.org/job/firecloud-orchestration-build/482/consoleFull
-        // https://fc-jenkins.dsp-techops.broadinstitute.org/job/firecloud-orchestration-build/497/consoleFull
-        // https://fc-jenkins.dsp-techops.broadinstitute.org/job/firecloud-orchestration-build/498/consoleFull
-        // Success:
-        // https://fc-jenkins.dsp-techops.broadinstitute.org/job/firecloud-orchestration-build/499/consoleFull
-
-        /*
-         *
-         * [StartupChecksSpec]: mockDAO.newlyRegisteredUsers value: billingManagerAccessToken
-           [StartupChecksSpec]: tokens.values value: adminUserAccessToken
-           [StartupChecksSpec]: tokens.values value: billingManagerAccessToken
-           [info] DeferredAbortedSuite:
-           [info] Exception encountered when attempting to run a suite with class name: org.scalatest.DeferredAbortedSuite *** ABORTED ***
-           [info]   Exception encountered when attempting to run a suite with class name: org.scalatest.DeferredAbortedSuite (StartupChecksSpec.scala:97)
-         */
-
-        mockDAO.newlyRegisteredUsers.map { v => println(s"[StartupChecksSpec]: mockDAO.newlyRegisteredUsers value: $v") }
-        tokens.values.map { v => println(s"[StartupChecksSpec]: tokens.values value: $v") }
-
         assertResult(tokens.values.toSet) {mockDAO.newlyRegisteredUsers.toSet}
       }
       "should pass when only one SA needs to be registered, and succeeds" in {

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/StartupChecksSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/StartupChecksSpec.scala
@@ -87,16 +87,31 @@ class StartupChecksSpec extends BaseServiceSpec {
         assert(check)
 
         // TODO: Failures here:
-        // https://fc-jenkins.dsp-techops.broadinstitute.org/job/firecloud-orchestration-build/482/consoleFull
-        // https://fc-jenkins.dsp-techops.broadinstitute.org/job/firecloud-orchestration-build/478/consoleFull
-        // https://fc-jenkins.dsp-techops.broadinstitute.org/job/firecloud-orchestration-build/476/consoleFull
         // https://fc-jenkins.dsp-techops.broadinstitute.org/job/firecloud-orchestration-build/472/consoleFull
+        // https://fc-jenkins.dsp-techops.broadinstitute.org/job/firecloud-orchestration-build/476/consoleFull
+        // https://fc-jenkins.dsp-techops.broadinstitute.org/job/firecloud-orchestration-build/478/consoleFull
+        // https://fc-jenkins.dsp-techops.broadinstitute.org/job/firecloud-orchestration-build/482/consoleFull
+        // https://fc-jenkins.dsp-techops.broadinstitute.org/job/firecloud-orchestration-build/497/consoleFull
+        // https://fc-jenkins.dsp-techops.broadinstitute.org/job/firecloud-orchestration-build/498/consoleFull
+        // Success:
+        // https://fc-jenkins.dsp-techops.broadinstitute.org/job/firecloud-orchestration-build/499/consoleFull
+
+        /*
+         *
+         * [StartupChecksSpec]: mockDAO.newlyRegisteredUsers value: billingManagerAccessToken
+           [StartupChecksSpec]: tokens.values value: adminUserAccessToken
+           [StartupChecksSpec]: tokens.values value: billingManagerAccessToken
+           [info] DeferredAbortedSuite:
+           [info] Exception encountered when attempting to run a suite with class name: org.scalatest.DeferredAbortedSuite *** ABORTED ***
+           [info]   Exception encountered when attempting to run a suite with class name: org.scalatest.DeferredAbortedSuite (StartupChecksSpec.scala:97)
+         */
+
         mockDAO.newlyRegisteredUsers.map { v => println(s"[StartupChecksSpec]: mockDAO.newlyRegisteredUsers value: $v") }
         tokens.values.map { v => println(s"[StartupChecksSpec]: tokens.values value: $v") }
 
         assertResult(tokens.values.toSet) {mockDAO.newlyRegisteredUsers.toSet}
       }
-      "should pass when only one SA needs to be registered, and succeeds" - {
+      "should pass when only one SA needs to be registered, and succeeds" in {
         val mockDAO = new StartupChecksMockSamDAO(
           notFounds = Seq(tokens.head._2))
         val testApp = app.copy(samDAO = mockDAO)
@@ -104,7 +119,7 @@ class StartupChecksSpec extends BaseServiceSpec {
         assert(check)
         assertResult(Set(tokens.head._2)) {mockDAO.newlyRegisteredUsers.toSet}
       }
-      "should fail if automatic registration fails for the single unregistered SA" - {
+      "should fail if automatic registration fails for the single unregistered SA" in {
         val mockDAO = new StartupChecksMockSamDAO(
           notFounds = Seq(tokens.head._2),
           cantRegister = Seq(tokens.head._2))
@@ -113,7 +128,7 @@ class StartupChecksSpec extends BaseServiceSpec {
         assert(!check)
         assert(mockDAO.newlyRegisteredUsers.isEmpty)
       }
-      "should fail if automatic registration fails for any of the unregistered SAs" - {
+      "should fail if automatic registration fails for any of the unregistered SAs" in {
         val mockDAO = new StartupChecksMockSamDAO(
           notFounds = tokens.values.toSeq,
           cantRegister = Seq(tokens.head._2))


### PR DESCRIPTION
## Addresses:
* https://broadinstitute.atlassian.net/browse/GAWB-3137

## Changes:
* Moved internal state of the mock dao to an actor. When inside the class, it did not return consistent results. Inside of an actor, the results are consistent.
* Updated logic for the test that threw an error.
* Updated `-` -> `in` so the tests would be run more consistently.

---

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
