### PR TITLE
GAWB-3144: Update test

### DIFF
--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/MutableDAOWorkspaceApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/MutableDAOWorkspaceApiServiceSpec.scala
@@ -1,20 +1,21 @@
 package org.broadinstitute.dsde.firecloud.service
 
+import akka.actor.ActorSystem
 import org.broadinstitute.dsde.firecloud.FireCloudConfig
 import org.broadinstitute.dsde.firecloud.model.{UserInfo, WithAccessToken}
 import org.broadinstitute.dsde.firecloud.webservice.WorkspaceApiService
 import org.broadinstitute.dsde.rawls.model.Workspace
 import org.joda.time.DateTime
-import org.scalatest.{BeforeAndAfterEach, FreeSpec, Matchers}
 import org.scalatest.concurrent.ScalaFutures
-import spray.http.StatusCodes.{BadRequest, MethodNotAllowed, OK}
+import org.scalatest.{BeforeAndAfterEach, FreeSpec, Matchers}
+import spray.http.StatusCodes.OK
 import spray.http._
 import spray.testkit.ScalatestRouteTest
 
 
 class MockApplication(request: HttpRequest) extends BaseServiceSpec with WorkspaceApiService {
 
-  def actorRefFactory = system
+  def actorRefFactory: ActorSystem = system
   val workspaceServiceConstructor: (WithAccessToken) => WorkspaceService = WorkspaceService.constructor(app)
   val permissionReportServiceConstructor: (UserInfo) => PermissionReportService = PermissionReportService.constructor(app)
 
@@ -43,7 +44,7 @@ class MutableDAOWorkspaceApiServiceSpec extends FreeSpec with ScalaFutures with 
     Map(), //attributes
     Map(), //acls
     Map(), //authdomain acls
-    false //locked
+    isLocked = false //locked
   )
   private final val workspacesRoot = FireCloudConfig.Rawls.authPrefix + FireCloudConfig.Rawls.workspacesPath
   private final val updateAttributesPath = workspacesRoot + "/%s/%s/updateAttributes".format(workspace.namespace, workspace.name)

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/MutableDAOWorkspaceApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/MutableDAOWorkspaceApiServiceSpec.scala
@@ -1,0 +1,120 @@
+package org.broadinstitute.dsde.firecloud.service
+
+import org.broadinstitute.dsde.firecloud.FireCloudConfig
+import org.broadinstitute.dsde.firecloud.model.{UserInfo, WithAccessToken}
+import org.broadinstitute.dsde.firecloud.webservice.WorkspaceApiService
+import org.broadinstitute.dsde.rawls.model.Workspace
+import org.joda.time.DateTime
+import org.scalatest.{BeforeAndAfterEach, FreeSpec, Matchers}
+import org.scalatest.concurrent.ScalaFutures
+import spray.http.StatusCodes.{BadRequest, MethodNotAllowed, OK}
+import spray.http._
+import spray.testkit.ScalatestRouteTest
+
+
+class MockApplication(request: HttpRequest) extends BaseServiceSpec with WorkspaceApiService {
+
+  def actorRefFactory = system
+  val workspaceServiceConstructor: (WithAccessToken) => WorkspaceService = WorkspaceService.constructor(app)
+  val permissionReportServiceConstructor: (UserInfo) => PermissionReportService = PermissionReportService.constructor(app)
+
+  lazy val checkRequest: (HttpResponse, StatusCode) = {
+    request ~> dummyUserIdHeaders("1234") ~> sealRoute(workspaceRoutes) ~> check {(response, status)}
+  }
+
+  lazy val isIndexDocumentInvoked: Boolean = {
+    this.searchDao.indexDocumentInvoked
+  }
+
+}
+
+
+class MutableDAOWorkspaceApiServiceSpec extends FreeSpec with ScalaFutures with ScalatestRouteTest with Matchers with BeforeAndAfterEach {
+
+  val workspace = Workspace(
+    "namespace",
+    "name",
+    Set.empty,
+    "workspace_id",
+    "buckety_bucket",
+    DateTime.now(),
+    DateTime.now(),
+    "my_workspace_creator",
+    Map(), //attributes
+    Map(), //acls
+    Map(), //authdomain acls
+    false //locked
+  )
+  private final val workspacesRoot = FireCloudConfig.Rawls.authPrefix + FireCloudConfig.Rawls.workspacesPath
+  private final val updateAttributesPath = workspacesRoot + "/%s/%s/updateAttributes".format(workspace.namespace, workspace.name)
+  private final val setAttributesPath = workspacesRoot + "/%s/%s/setAttributes".format(workspace.namespace, workspace.name)
+
+  "Workspace updateAttributes tests" - {
+
+    "when calling PATCH on workspaces/*/*/updateAttributes path" - {
+
+      "should 200 OK if the payload is ok" in {
+        val request = Patch(updateAttributesPath,
+          HttpEntity(MediaTypes.`application/json`, """[
+                                                      |  {
+                                                      |    "op": "AddUpdateAttribute",
+                                                      |    "attributeName": "library:dataCategory",
+                                                      |    "addUpdateAttribute": "test-attribute-value"
+                                                      |  }
+                                                      |]""".stripMargin))
+        val app = new MockApplication(request)
+        val (response, status) = app.checkRequest
+        status should equal(OK)
+        assert(!app.isIndexDocumentInvoked, "Should not be indexing an unpublished WS")
+      }
+
+      "should republish if the document is already published" in {
+
+        val request = Patch(workspacesRoot + "/%s/%s/updateAttributes".format(WorkspaceApiServiceSpec.publishedWorkspace.namespace, WorkspaceApiServiceSpec.publishedWorkspace.name),
+          HttpEntity(MediaTypes.`application/json`, """[
+                                                      |  {
+                                                      |    "op": "AddUpdateAttribute",
+                                                      |    "attributeName": "library:dataCategory",
+                                                      |    "addUpdateAttribute": "test-attribute-value"
+                                                      |  }
+                                                      |]""".stripMargin))
+        val app = new MockApplication(request)
+        val (response, status) = app.checkRequest
+        status should equal(OK)
+        assert(app.isIndexDocumentInvoked, "Should have republished this published WS when changing attributes")
+      }
+
+    }
+  }
+
+  "Workspace setAttributes tests" - {
+
+    "when calling PATCH on workspaces/*/*/setAttributes path" - {
+
+      "should 200 OK if the payload is ok" in {
+        val request = Patch(setAttributesPath,
+          HttpEntity(MediaTypes.`application/json`, """{"description": "something",
+                                                      | "array": [1, 2, 3]
+                                                      | }""".stripMargin))
+        val app = new MockApplication(request)
+        val (response, status) = app.checkRequest
+        status should equal(OK)
+        assert(!app.isIndexDocumentInvoked, "Should not be indexing an unpublished WS")
+      }
+
+      "should republish if the document is already published" in {
+        val request = Patch(workspacesRoot + "/%s/%s/setAttributes".format(WorkspaceApiServiceSpec.publishedWorkspace.namespace, WorkspaceApiServiceSpec.publishedWorkspace.name),
+          HttpEntity(MediaTypes.`application/json`, """{"description": "something",
+                                                      | "array": [1, 2, 3]
+                                                      | }""".stripMargin))
+        val app = new MockApplication(request)
+        val (response, status) = app.checkRequest
+        status should equal(OK)
+        assert(app.isIndexDocumentInvoked, "Should have republished this published WS when changing attributes")
+      }
+
+    }
+
+  }
+
+}

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceApiServiceSpec.scala
@@ -223,14 +223,6 @@ class WorkspaceApiServiceSpec extends BaseServiceSpec with WorkspaceApiService w
     rawlsServer.stop
   }
 
-  override def beforeEach(): Unit = {
-    this.searchDao.reset
-  }
-
-  override def afterEach(): Unit = {
-    this.searchDao.reset
-  }
-
   "WorkspaceService Passthrough Negative Tests" - {
 
     "Passthrough tests on the /workspaces path" - {
@@ -871,40 +863,6 @@ class WorkspaceApiServiceSpec extends BaseServiceSpec with WorkspaceApiService w
             status should equal(BadRequest)
           }
         }
-
-        "should 200 OK if the payload is ok" in {
-          (Patch(updateAttributesPath,
-            HttpEntity(MediaTypes.`application/json`, """[
-                                                        |  {
-                                                        |    "op": "AddUpdateAttribute",
-                                                        |    "attributeName": "library:dataCategory",
-                                                        |    "addUpdateAttribute": "test-attribute-value"
-                                                        |  }
-                                                        |]""".stripMargin))
-            ~> dummyUserIdHeaders("1234")
-            ~> sealRoute(workspaceRoutes)) ~> check {
-            status should equal(OK)
-            assert(!this.searchDao.indexDocumentInvoked, "Should not be indexing an unpublished WS")
-          }
-        }
-
-        "should republish if the document is already published" in {
-
-          (Patch(workspacesRoot + "/%s/%s/updateAttributes".format(WorkspaceApiServiceSpec.publishedWorkspace.namespace, WorkspaceApiServiceSpec.publishedWorkspace.name),
-            HttpEntity(MediaTypes.`application/json`, """[
-                                                        |  {
-                                                        |    "op": "AddUpdateAttribute",
-                                                        |    "attributeName": "library:dataCategory",
-                                                        |    "addUpdateAttribute": "test-attribute-value"
-                                                        |  }
-                                                        |]""".stripMargin))
-            ~> dummyUserIdHeaders("1234")
-            ~> sealRoute(workspaceRoutes)) ~> check {
-            status should equal(OK)
-            assert(this.searchDao.indexDocumentInvoked, "Should have republished this published WS when changing attributes")
-          }
-        }
-
       }
     }
 
@@ -926,31 +884,6 @@ class WorkspaceApiServiceSpec extends BaseServiceSpec with WorkspaceApiService w
             ~> dummyUserIdHeaders("1234")
             ~> sealRoute(workspaceRoutes)) ~> check {
             status should equal(BadRequest)
-          }
-        }
-
-        "should 200 OK if the payload is ok" in {
-          (Patch(setAttributesPath,
-            HttpEntity(MediaTypes.`application/json`, """{"description": "something",
-                                                        | "array": [1, 2, 3]
-                                                        | }""".stripMargin))
-            ~> dummyUserIdHeaders("1234")
-            ~> sealRoute(workspaceRoutes)) ~> check {
-            status should equal(OK)
-            assert(!this.searchDao.indexDocumentInvoked, "Should not be indexing an unpublished WS")
-          }
-        }
-
-        "should republish if the document is already published" in {
-
-          (Patch(workspacesRoot + "/%s/%s/setAttributes".format(WorkspaceApiServiceSpec.publishedWorkspace.namespace, WorkspaceApiServiceSpec.publishedWorkspace.name),
-            HttpEntity(MediaTypes.`application/json`, """{"description": "something",
-                                                        | "array": [1, 2, 3]
-                                                        | }""".stripMargin))
-            ~> dummyUserIdHeaders("1234")
-            ~> sealRoute(workspaceRoutes)) ~> check {
-            status should equal(OK)
-            assert(this.searchDao.indexDocumentInvoked, "Should have republished this published WS when changing attributes")
           }
         }
 


### PR DESCRIPTION
## Addresses
https://broadinstitute.atlassian.net/browse/GAWB-3144

## Notes
Certain unit tests depended upon changing internal state of application DAOs. Due to tests being running in parallel, this introduces concurrency problems. This PR moves those dependent tests to a different structure where a new app is spun up for each test instead of spinning up the app once and running all tests inside of the single instance. 

This PR makes the most minimal set of changes to avoid the pattern of relying on internal mutable DAO state. I am open to the idea of expanding this to a larger suite of tests.

---

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
