### PR TITLE
GAWB-3060: index data use restriction pulled from Consent (from ORSP)

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ConsentDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ConsentDAO.scala
@@ -12,4 +12,6 @@ trait ConsentDAO extends ReportsSubsystemStatus {
 
   override def serviceName:String = ConsentDAO.serviceName
 
+  def getRestriction(orspId: String): Unit
+
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ConsentDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ConsentDAO.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.firecloud.dataaccess
 
+import org.broadinstitute.dsde.firecloud.model.DUOS.DuosDataUse
 import org.broadinstitute.dsde.firecloud.model.WithAccessToken
 import org.broadinstitute.dsde.rawls.model.ErrorReportSource
 
@@ -15,6 +16,6 @@ trait ConsentDAO extends ReportsSubsystemStatus {
 
   override def serviceName:String = ConsentDAO.serviceName
 
-  def getRestriction(orspId: String)(implicit userInfo: WithAccessToken): Future[Option[String]] // TODO: will be DuosDataUse
+  def getRestriction(orspId: String)(implicit userInfo: WithAccessToken): Future[Option[DuosDataUse]]
 
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ConsentDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ConsentDAO.scala
@@ -2,6 +2,8 @@ package org.broadinstitute.dsde.firecloud.dataaccess
 
 import org.broadinstitute.dsde.rawls.model.ErrorReportSource
 
+import scala.concurrent.Future
+
 object ConsentDAO {
   lazy val serviceName = "Consent"
 }
@@ -12,6 +14,6 @@ trait ConsentDAO extends ReportsSubsystemStatus {
 
   override def serviceName:String = ConsentDAO.serviceName
 
-  def getRestriction(orspId: String): Unit
+  def getRestriction(orspId: String): Future[Option[String]] // TODO: will be DuosDataUse
 
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ConsentDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ConsentDAO.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.firecloud.dataaccess
 
+import org.broadinstitute.dsde.firecloud.model.WithAccessToken
 import org.broadinstitute.dsde.rawls.model.ErrorReportSource
 
 import scala.concurrent.Future
@@ -14,6 +15,6 @@ trait ConsentDAO extends ReportsSubsystemStatus {
 
   override def serviceName:String = ConsentDAO.serviceName
 
-  def getRestriction(orspId: String): Future[Option[String]] // TODO: will be DuosDataUse
+  def getRestriction(orspId: String)(implicit userInfo: WithAccessToken): Future[Option[String]] // TODO: will be DuosDataUse
 
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpConsentDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpConsentDAO.scala
@@ -2,9 +2,11 @@ package org.broadinstitute.dsde.firecloud.dataaccess
 
 import akka.actor.ActorSystem
 import org.broadinstitute.dsde.firecloud.FireCloudConfig
+import org.broadinstitute.dsde.firecloud.model.DUOS.Consent
 import org.broadinstitute.dsde.firecloud.utils.RestJsonClient
 import org.broadinstitute.dsde.workbench.util.health.SubsystemStatus
-import spray.http.{HttpResponse, Uri}
+import spray.http.Uri
+import spray.httpx.unmarshalling._
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -13,12 +15,11 @@ class HttpConsentDAO(implicit val system: ActorSystem, implicit val executionCon
   private val consentUri = Uri(FireCloudConfig.Duos.baseConsentUrl)
 
 
-  override def getRestriction(orspId: String): Unit = {
+  override def getRestriction(orspId: String): Future[Option[String]] = {
     val consentUrl = FireCloudConfig.Duos.baseConsentUrl + "/api/consent"
     val req = Get(Uri(consentUrl).withQuery(("name", orspId)))
-    // authedRequestToObject[DataUseRestriction](req) // 404 or 200, primitive lives in object.dataUse
-    None
-
+    // TODO: will be in dataUse
+    authedRequestToObject[Consent](req) map (_.dataUseLetter)
   }
 
   override def status: Future[SubsystemStatus] = {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpConsentDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpConsentDAO.scala
@@ -2,14 +2,13 @@ package org.broadinstitute.dsde.firecloud.dataaccess
 
 import akka.actor.ActorSystem
 import org.broadinstitute.dsde.firecloud.FireCloudConfig
-import org.broadinstitute.dsde.firecloud.model.DUOS.Consent
+import org.broadinstitute.dsde.firecloud.model.DUOS.{Consent, DuosDataUse}
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol.impDuosConsent
 import org.broadinstitute.dsde.firecloud.model.WithAccessToken
 import org.broadinstitute.dsde.firecloud.utils.RestJsonClient
 import org.broadinstitute.dsde.workbench.util.health.SubsystemStatus
 import spray.http.Uri
 import spray.httpx.SprayJsonSupport._
-
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -18,11 +17,10 @@ class HttpConsentDAO(implicit val system: ActorSystem, implicit val executionCon
 
   private val consentUri = Uri(FireCloudConfig.Duos.baseConsentUrl)
 
-  override def getRestriction(orspId: String)(implicit userInfo: WithAccessToken): Future[Option[String]] = {
+  override def getRestriction(orspId: String)(implicit userInfo: WithAccessToken): Future[Option[DuosDataUse]] = {
     val consentUrl = FireCloudConfig.Duos.baseConsentUrl + "/api/consent"
     val req = Get(Uri(consentUrl).withQuery(("name", orspId)))
-    // TODO: will be in dataUse
-    authedRequestToObject[Consent](req) map (_.dataUseLetter)
+    authedRequestToObject[Consent](req) map (_.dataUse)
   }
 
   override def status: Future[SubsystemStatus] = {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpConsentDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpConsentDAO.scala
@@ -3,19 +3,22 @@ package org.broadinstitute.dsde.firecloud.dataaccess
 import akka.actor.ActorSystem
 import org.broadinstitute.dsde.firecloud.FireCloudConfig
 import org.broadinstitute.dsde.firecloud.model.DUOS.Consent
+import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol.impDuosConsent
+import org.broadinstitute.dsde.firecloud.model.WithAccessToken
 import org.broadinstitute.dsde.firecloud.utils.RestJsonClient
 import org.broadinstitute.dsde.workbench.util.health.SubsystemStatus
 import spray.http.Uri
-import spray.httpx.unmarshalling._
+import spray.httpx.SprayJsonSupport._
+
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class HttpConsentDAO(implicit val system: ActorSystem, implicit val executionContext: ExecutionContext) extends ConsentDAO with RestJsonClient {
+class HttpConsentDAO(implicit val system: ActorSystem, implicit val executionContext: ExecutionContext)
+  extends ConsentDAO with RestJsonClient {
 
   private val consentUri = Uri(FireCloudConfig.Duos.baseConsentUrl)
 
-
-  override def getRestriction(orspId: String): Future[Option[String]] = {
+  override def getRestriction(orspId: String)(implicit userInfo: WithAccessToken): Future[Option[String]] = {
     val consentUrl = FireCloudConfig.Duos.baseConsentUrl + "/api/consent"
     val req = Get(Uri(consentUrl).withQuery(("name", orspId)))
     // TODO: will be in dataUse

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpConsentDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpConsentDAO.scala
@@ -12,6 +12,15 @@ class HttpConsentDAO(implicit val system: ActorSystem, implicit val executionCon
 
   private val consentUri = Uri(FireCloudConfig.Duos.baseConsentUrl)
 
+
+  override def getRestriction(orspId: String): Unit = {
+    val consentUrl = FireCloudConfig.Duos.baseConsentUrl + "/api/consent"
+    val req = Get(Uri(consentUrl).withQuery(("name", orspId)))
+    // authedRequestToObject[DataUseRestriction](req) // 404 or 200, primitive lives in object.dataUse
+    None
+
+  }
+
   override def status: Future[SubsystemStatus] = {
     getStatusFromDropwizardChecks(unAuthedRequest(Get(consentUri.withPath(Uri.Path("/status")))))
   }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupport.scala
@@ -119,7 +119,21 @@ trait DataUseRestrictionSupport extends LazyLogging {
       case _ => Map.empty[AttributeName,Attribute]
     }
 
-    val result = Map.empty[AttributeName, Attribute] ++ gru ++ hmb ++ ncu ++ nmds ++ rspd ++ nagr ++ nctrl ++ ds ++ rspop // ++ npu ++ irb
+    // gender restrictions: RS-G, RS-FM, RS-M
+    val rsg = duosDataUse.gender match {
+      case Some(f:String) if "female".equals(f.toLowerCase) => Map(
+        AttributeName.withLibraryNS("RS-G") -> AttributeBoolean(true),
+        AttributeName.withLibraryNS("RS-FM") -> AttributeBoolean(true)
+      )
+      case Some(m:String) if "male".equals(m.toLowerCase) => Map(
+        AttributeName.withLibraryNS("RS-G") -> AttributeBoolean(true),
+        AttributeName.withLibraryNS("RS-M") -> AttributeBoolean(true)
+      )
+      case _ => Map.empty[AttributeName,Attribute]
+    }
+
+    val result = Map.empty[AttributeName, Attribute] ++ gru ++ hmb ++ ncu ++ nmds ++
+      rspd ++ nagr ++ nctrl ++ ds ++ rspop ++ rsg // ++ npu ++ irb
 
     logger.debug("inbound DuosDataUse: " + duosDataUse)
     logger.debug("outbound attrs: " + result)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupport.scala
@@ -94,6 +94,7 @@ trait DataUseRestrictionSupport extends LazyLogging {
     // DUOS has no concept of "IRB review required"
     // val irb = None
 
+    // disease restrictions: DS, DS_URL
     val ds = duosDataUse.diseaseRestrictions match {
       case Some(Seq()) => Map.empty[AttributeName,Attribute]
       case Some(nodeList) =>
@@ -108,7 +109,17 @@ trait DataUseRestrictionSupport extends LazyLogging {
       case _ => Map.empty[AttributeName,Attribute]
     }
 
-    val result = Map.empty[AttributeName, Attribute] ++ gru ++ hmb ++ ncu ++ nmds ++ rspd ++ nagr ++ nctrl ++ ds // ++ npu ++ irb
+    // population restrictions: RS-POP
+    val rspop = duosDataUse.populationRestrictions match {
+      case Some(Seq()) => Map.empty[AttributeName,Attribute]
+      case Some(populations) =>
+        Map(
+          AttributeName.withLibraryNS("RS-PD") -> AttributeValueList(populations.map(AttributeString))
+        )
+      case _ => Map.empty[AttributeName,Attribute]
+    }
+
+    val result = Map.empty[AttributeName, Attribute] ++ gru ++ hmb ++ ncu ++ nmds ++ rspd ++ nagr ++ nctrl ++ ds ++ rspop // ++ npu ++ irb
 
     logger.debug("inbound DuosDataUse: " + duosDataUse)
     logger.debug("outbound attrs: " + result)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupport.scala
@@ -148,10 +148,10 @@ trait DataUseRestrictionSupport extends LazyLogging {
     (existing -
       structuredUseRestrictionAttributeName -
       consentCodesAttributeName --
-      allDurFieldNames.map(x => AttributeName.withLibraryNS(x))) ++ preferred
+      allDurFieldNames.map(AttributeName.withLibraryNS)) ++ preferred
   }
 
-  // TODO: namespaces on allDurFieldNames??!?!?
+  // TODO: this method needs to respect attribute namespaces: see GAWB-3173
   private def getDataUseAttributes(workspace: Workspace): Map[AttributeName, Attribute] = {
 
     // Find all library attributes that contribute to data use restrictions

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupport.scala
@@ -72,7 +72,7 @@ trait DataUseRestrictionSupport extends LazyLogging {
     // these are straightforward mappings
     val gru = duosDataUse.generalUse.map ( AttributeName.withLibraryNS("GRU") -> AttributeBoolean(_) )
     val hmb = duosDataUse.hmbResearch.map ( AttributeName.withLibraryNS("HMB") -> AttributeBoolean(_) )
-    val rspd = duosDataUse.vulnerablePopulations.map ( AttributeName.withLibraryNS("RS-PD") -> AttributeBoolean(_) )
+    val rspd = duosDataUse.pediatric.map ( AttributeName.withLibraryNS("RS-PD") -> AttributeBoolean(_) )
     val ncu = duosDataUse.commercialUse.map ( AttributeName.withLibraryNS("NCU") -> AttributeBoolean(_) )
     val nmds = duosDataUse.methodsResearch.map ( AttributeName.withLibraryNS("NMDS") -> AttributeBoolean(_) )
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/LibraryService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/LibraryService.scala
@@ -61,7 +61,8 @@ class LibraryService (protected val argUserInfo: UserInfo,
 
   lazy val log = LoggerFactory.getLogger(getClass)
 
-  implicit val userInfo = argUserInfo
+  implicit val userToken = argUserInfo
+
   // attributes come in as standard json so we can use json schema for validation. Thus,
   // we need to use the plain-array deserialization.
   implicit val impAttributeFormat: AttributeFormat = new AttributeFormat with PlainArrayAttributeListSerializer
@@ -165,7 +166,7 @@ class LibraryService (protected val argUserInfo: UserInfo,
    */
   private def internalPatchWorkspaceAndRepublish(ns: String, name: String, allOperations: Seq[AttributeUpdateOperation], isPublished: Boolean): Future[Workspace] = {
       rawlsDAO.updateLibraryAttributes(ns, name, allOperations) map { newws =>
-      republishDocument(newws, ontologyDAO, searchDAO)
+      republishDocument(newws, ontologyDAO, searchDAO, consentDAO)
       newws
     }
   }
@@ -188,7 +189,7 @@ class LibraryService (protected val argUserInfo: UserInfo,
         Future(RequestCompleteWithErrorReport(BadRequest, errorMessage.getOrElse(BadRequest.defaultMessage)))
       else {
         // user requested a change in published flag, and metadata is valid; make the change.
-        setWorkspacePublishedStatus(workspaceResponse.workspace, publishArg, rawlsDAO, ontologyDAO, searchDAO) map { ws =>
+        setWorkspacePublishedStatus(workspaceResponse.workspace, publishArg, rawlsDAO, ontologyDAO, searchDAO, consentDAO) map { ws =>
           RequestComplete(ws)
         }
       }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/LibraryService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/LibraryService.scala
@@ -26,8 +26,9 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
 
 object LibraryService {
-  final val publishedFlag = AttributeName("library","published")
-  final val discoverableWSAttribute = AttributeName("library","discoverableByGroups")
+  final val publishedFlag = AttributeName.withLibraryNS("published")
+  final val discoverableWSAttribute = AttributeName.withLibraryNS("discoverableByGroups")
+  final val orspIdAttribute = AttributeName.withLibraryNS("orsp")
   final val schemaLocation = "library/attribute-definitions.json"
 
   sealed trait LibraryServiceMessage
@@ -201,7 +202,7 @@ class LibraryService (protected val argUserInfo: UserInfo,
         Future(RequestComplete(NoContent))
       else {
         logger.info("reindex: requesting ontology parents for workspaces ...")
-        val toIndex: Future[Seq[Document]] = indexableDocuments(workspaces, ontologyDAO)
+        val toIndex: Future[Seq[Document]] = indexableDocuments(workspaces, ontologyDAO, consentDAO)
         toIndex map { documents =>
           logger.info("reindex: resetting index ...")
           searchDAO.recreateIndex()

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/LibraryService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/LibraryService.scala
@@ -4,7 +4,7 @@ import akka.actor.{Actor, Props}
 import akka.pattern._
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.{Application, FireCloudConfig, FireCloudException, FireCloudExceptionWithErrorReport}
-import org.broadinstitute.dsde.firecloud.dataaccess.{OntologyDAO, RawlsDAO, SearchDAO}
+import org.broadinstitute.dsde.firecloud.dataaccess.{ConsentDAO, OntologyDAO, RawlsDAO, SearchDAO}
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.firecloud.model._
 import org.broadinstitute.dsde.firecloud.service.LibraryService._
@@ -46,14 +46,15 @@ object LibraryService {
   }
 
   def constructor(app: Application)(userInfo: UserInfo)(implicit executionContext: ExecutionContext) =
-    new LibraryService(userInfo, app.rawlsDAO, app.searchDAO, app.ontologyDAO)
+    new LibraryService(userInfo, app.rawlsDAO, app.searchDAO, app.ontologyDAO, app.consentDAO)
 }
 
 
 class LibraryService (protected val argUserInfo: UserInfo,
                       val rawlsDAO: RawlsDAO,
                       val searchDAO: SearchDAO,
-                      val ontologyDAO: OntologyDAO)
+                      val ontologyDAO: OntologyDAO,
+                      val consentDAO: ConsentDAO)
                      (implicit protected val executionContext: ExecutionContext) extends Actor
   with LibraryServiceSupport with AttributeSupport with PermissionsSupport with SprayJsonSupport with LazyLogging with WorkspacePublishingSupport {
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/LibraryServiceSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/LibraryServiceSupport.scala
@@ -61,7 +61,7 @@ trait LibraryServiceSupport extends DataUseRestrictionSupport with LazyLogging {
     futureRestrictions.map { restrictions =>
       val restrictionMap:Map[String,AttributeMap] = restrictions.map {
         case (orspId, None) => orspId -> Map.empty[AttributeName, Attribute]
-        case (orspId, Some(dataUseOption)) => orspId -> generateStructuredUseRestrictionAttribute(dataUseOption, ontologyDAO)
+        case (orspId, Some(dataUse)) => orspId -> generateStructuredUseRestrictionAttribute(dataUse, ontologyDAO)
       }.toMap
 
       val annotatedWorkspaces = workspaces map { ws =>

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/LibraryServiceSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/LibraryServiceSupport.scala
@@ -37,7 +37,7 @@ trait LibraryServiceSupport extends DataUseRestrictionSupport with LazyLogging {
 
   def indexableDocuments(workspaces: Seq[Workspace], ontologyDAO: OntologyDAO, consentDAO: ConsentDAO)(implicit userToken: WithAccessToken, ec: ExecutionContext): Future[Seq[Document]] = {
     // find all the ontology nodes in this list of workspaces
-    val nodes = uniqueStrings(workspaces, AttributeName.withLibraryNS("diseaseOntologyID"))
+    val nodes = uniqueWorkspaceStringAttributes(workspaces, AttributeName.withLibraryNS("diseaseOntologyID"))
 
     // query ontology for this set of nodes, save in a map
     val parentCache = nodes map {id => (id, lookupParentNodes(id, ontologyDAO))}
@@ -45,7 +45,7 @@ trait LibraryServiceSupport extends DataUseRestrictionSupport with LazyLogging {
     logger.debug(s"have parent results for ${parentMap.size} ontology nodes")
 
     // identify the unique ORSP codes in this list of workspaces
-    val orspIds = uniqueStrings(workspaces, orspIdAttribute)
+    val orspIds = uniqueWorkspaceStringAttributes(workspaces, orspIdAttribute)
 
     // set up an exception-resilient Future to get the ORSP restrictions for those codes
     val futureRestrictions:Future[Set[(String, Option[DuosDataUse])]] = Future.sequence(orspIds map {orspId =>
@@ -119,7 +119,7 @@ trait LibraryServiceSupport extends DataUseRestrictionSupport with LazyLogging {
     }
   }
 
-  def uniqueStrings(workspaces: Seq[Workspace], attributeName: AttributeName): Set[String] = {
+  def uniqueWorkspaceStringAttributes(workspaces: Seq[Workspace], attributeName: AttributeName): Set[String] = {
     val valueSeq:Seq[String] = workspaces.collect {
       case w if w.attributes.contains(attributeName) =>
         w.attributes(attributeName)

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockConsentDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockConsentDAO.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.firecloud.dataaccess
 
+import org.broadinstitute.dsde.firecloud.model.WithAccessToken
 import org.broadinstitute.dsde.workbench.util.health.SubsystemStatus
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -8,7 +9,7 @@ import scala.concurrent.Future
 class MockConsentDAO extends ConsentDAO {
 
 
-  override def getRestriction(orspId: String): Future[Option[String]] = Future.successful(None)
+  override def getRestriction(orspId: String)(implicit userInfo: WithAccessToken): Future[Option[String]] = Future.successful(None)
 
   def status: Future[SubsystemStatus] = Future(SubsystemStatus(ok = true, None))
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockConsentDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockConsentDAO.scala
@@ -7,6 +7,9 @@ import scala.concurrent.Future
 
 class MockConsentDAO extends ConsentDAO {
 
+
+  override def getRestriction(orspId: String): Unit = None
+
   def status: Future[SubsystemStatus] = Future(SubsystemStatus(ok = true, None))
 
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockConsentDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockConsentDAO.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.firecloud.dataaccess
 
+import org.broadinstitute.dsde.firecloud.model.DUOS.DuosDataUse
 import org.broadinstitute.dsde.firecloud.model.WithAccessToken
 import org.broadinstitute.dsde.workbench.util.health.SubsystemStatus
 
@@ -9,7 +10,7 @@ import scala.concurrent.Future
 class MockConsentDAO extends ConsentDAO {
 
 
-  override def getRestriction(orspId: String)(implicit userInfo: WithAccessToken): Future[Option[String]] = Future.successful(None)
+  override def getRestriction(orspId: String)(implicit userInfo: WithAccessToken): Future[Option[DuosDataUse]] = Future.successful(None)
 
   def status: Future[SubsystemStatus] = Future(SubsystemStatus(ok = true, None))
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockConsentDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockConsentDAO.scala
@@ -8,7 +8,7 @@ import scala.concurrent.Future
 class MockConsentDAO extends ConsentDAO {
 
 
-  override def getRestriction(orspId: String): Unit = None
+  override def getRestriction(orspId: String): Future[Option[String]] = Future.successful(None)
 
   def status: Future[SubsystemStatus] = Future(SubsystemStatus(ok = true, None))
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockConsentDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockConsentDAO.scala
@@ -1,8 +1,11 @@
 package org.broadinstitute.dsde.firecloud.dataaccess
 
+import org.broadinstitute.dsde.firecloud.FireCloudExceptionWithErrorReport
 import org.broadinstitute.dsde.firecloud.model.DUOS.DuosDataUse
+import org.broadinstitute.dsde.firecloud.model.ErrorReportExtensions.FCErrorReport
 import org.broadinstitute.dsde.firecloud.model.WithAccessToken
 import org.broadinstitute.dsde.workbench.util.health.SubsystemStatus
+import spray.http.{HttpResponse, StatusCodes}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -10,7 +13,21 @@ import scala.concurrent.Future
 class MockConsentDAO extends ConsentDAO {
 
 
-  override def getRestriction(orspId: String)(implicit userInfo: WithAccessToken): Future[Option[DuosDataUse]] = Future.successful(None)
+  override def getRestriction(orspId: String)(implicit userInfo: WithAccessToken): Future[Option[DuosDataUse]] = {
+    orspId match {
+      case "MOCK-111" =>
+        val ddu = new DuosDataUse(
+          commercialUse = Some(true),
+          controlSetOption = Some("Yes")
+        )
+        Future.successful(Some(ddu))
+      case "MOCK-NOTFOUND" => Future.failed(new FireCloudExceptionWithErrorReport(FCErrorReport(HttpResponse(StatusCodes.NotFound))))
+      case "MOCK-EXCEPTION" => Future.failed(new FireCloudExceptionWithErrorReport(FCErrorReport(HttpResponse(StatusCodes.InternalServerError))))
+      case _ => Future.successful(None)
+    }
+
+
+  }
 
   def status: Future[SubsystemStatus] = Future(SubsystemStatus(ok = true, None))
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/DataUseRestrictionSearchSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/DataUseRestrictionSearchSpec.scala
@@ -1,8 +1,8 @@
 package org.broadinstitute.dsde.firecloud.integrationtest
 
-import org.broadinstitute.dsde.firecloud.dataaccess.MockOntologyDAO
+import org.broadinstitute.dsde.firecloud.dataaccess.{MockConsentDAO, MockOntologyDAO}
 import org.broadinstitute.dsde.firecloud.integrationtest.ESIntegrationSupport._
-import org.broadinstitute.dsde.firecloud.model.LibrarySearchResponse
+import org.broadinstitute.dsde.firecloud.model.{AccessToken, LibrarySearchResponse, WithAccessToken}
 import org.broadinstitute.dsde.firecloud.service.DataUseRestrictionTestFixtures.DataUseRestriction
 import org.broadinstitute.dsde.firecloud.service.{DataUseRestrictionTestFixtures, LibraryServiceSupport}
 import org.broadinstitute.dsde.rawls.model.{AttributeName, Workspace}
@@ -17,13 +17,15 @@ class DataUseRestrictionSearchSpec extends FreeSpec with SearchResultValidation 
 
   val datasets: Seq[Workspace] = DataUseRestrictionTestFixtures.allDatasets
 
+  implicit val userToken: WithAccessToken = AccessToken("DataUseRestrictionSearchSpec")
+
   override def beforeAll: Unit = {
     // use re-create here, since instantiating the DAO will create it in the first place
     searchDAO.recreateIndex()
     // make sure we specify refresh=true here; otherwise, the documents may not be available in the index by the
     // time the tests start, leading to test failures.
     logger.info("indexing fixtures ...")
-    val docs = Await.result(indexableDocuments(datasets, new MockOntologyDAO), dur)
+    val docs = Await.result(indexableDocuments(datasets, new MockOntologyDAO, new MockConsentDAO), dur)
     searchDAO.bulkIndex(docs, refresh = true)
     logger.info("... fixtures indexed.")
   }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupportSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupportSpec.scala
@@ -345,6 +345,33 @@ class DataUseRestrictionSupportSpec extends FreeSpec with Matchers with DataUseR
 
           assert(attrs.isEmpty)
         }
+        "should handle gender = Male" in {
+          val attrs = generateStructuredUseRestrictionAttribute(new DuosDataUse(
+            gender = Some("Male")
+          ), ontologyDAO)
+          val expected = Map(
+            AttributeName.withLibraryNS("RS-G") -> AttributeBoolean(true),
+            AttributeName.withLibraryNS("RS-M") -> AttributeBoolean(true)
+          )
+          assertResult(expected) {attrs}
+        }
+        "should handle gender = Female" in {
+          val attrs = generateStructuredUseRestrictionAttribute(new DuosDataUse(
+            gender = Some("Female")
+          ), ontologyDAO)
+          val expected = Map(
+            AttributeName.withLibraryNS("RS-G") -> AttributeBoolean(true),
+            AttributeName.withLibraryNS("RS-FM") -> AttributeBoolean(true)
+          )
+          assertResult(expected) {attrs}
+        }
+        "should ignore invalid gender values" in {
+          val attrs = generateStructuredUseRestrictionAttribute(new DuosDataUse(
+            gender = Some("invalid")
+          ), ontologyDAO)
+
+          assert(attrs.isEmpty)
+        }
         "should ignore the DUOS keys that FireCloud doesn't implement" in {
 
           // The properties that are commented out are the ones that FireCloud implements.
@@ -358,9 +385,9 @@ class DataUseRestrictionSupportSpec extends FreeSpec with Matchers with DataUseR
 //            controlSetOption = None,
 //            pediatric = None,
 //            populationRestrictions = None,
+//            gender = None,
             populationOriginsAncestry = Some(true),
             populationStructure = Some(true),
-            gender = Some("Female"),
             vulnerablePopulations = Some(true),
             dateRestriction = Some("today"),
             recontactingDataSubjects = Some(true),

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupportSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupportSpec.scala
@@ -198,7 +198,7 @@ class DataUseRestrictionSupportSpec extends FreeSpec with Matchers with DataUseR
             generalUse = Some(true),
             hmbResearch = Some(true),
             commercialUse = Some(true),
-            vulnerablePopulations = Some(true),
+            pediatric = Some(true),
             methodsResearch = Some(true)
           ), ontologyDAO)
           val expected = Map(
@@ -215,7 +215,7 @@ class DataUseRestrictionSupportSpec extends FreeSpec with Matchers with DataUseR
             generalUse = Some(false),
             hmbResearch = Some(false),
             commercialUse = Some(false),
-            vulnerablePopulations = Some(false),
+            pediatric = Some(false),
             methodsResearch = Some(false)
           ), ontologyDAO)
           val expected = Map(
@@ -232,7 +232,7 @@ class DataUseRestrictionSupportSpec extends FreeSpec with Matchers with DataUseR
             generalUse = Some(true),
             hmbResearch = Some(false),
             commercialUse = Some(true),
-            vulnerablePopulations = Some(false),
+            pediatric = Some(false),
             methodsResearch = Some(true)
           ), ontologyDAO)
           val expected = Map(
@@ -334,11 +334,11 @@ class DataUseRestrictionSupportSpec extends FreeSpec with Matchers with DataUseR
 //            methodsResearch = None,
 //            aggregateResearch = None,
 //            controlSetOption = None,
-//            vulnerablePopulations = None,
+//            pediatric = None,
             populationOriginsAncestry = Some(true),
             populationStructure = Some(true),
             gender = Some("Female"),
-            pediatric = Some(true),
+            vulnerablePopulations = Some(true),
             populationRestrictions = Some(Seq("one","two")),
             dateRestriction = Some("today"),
             recontactingDataSubjects = Some(true),

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupportSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupportSpec.scala
@@ -324,16 +324,19 @@ class DataUseRestrictionSupportSpec extends FreeSpec with Matchers with DataUseR
           assert(attrs.isEmpty)
         }
         "should ignore the DUOS keys that FireCloud doesn't implement" in {
+
+          // The properties that are commented out are the ones that FireCloud implements.
           val attrs = generateStructuredUseRestrictionAttribute(new DuosDataUse(
-//            generalUse: Option[Boolean] = None,
-//            hmbResearch: Option[Boolean] = None,
-//            diseaseRestrictions: Option[Seq[String]] = None,
+//            generalUse = None,
+//            hmbResearch = None,
+//            diseaseRestrictions = None,
+//            commercialUse = None,
+//            methodsResearch = None,
+//            aggregateResearch = None,
+//            controlSetOption = None,
+//            vulnerablePopulations = None,
             populationOriginsAncestry = Some(true),
             populationStructure = Some(true),
-//            commercialUse: Option[Boolean] = None,
-//            methodsResearch: Option[Boolean] = None,
-//            aggregateResearch: Option[String] = None,
-//            controlSetOption: Option[String] = None,
             gender = Some("Female"),
             pediatric = Some(true),
             populationRestrictions = Some(Seq("one","two")),
@@ -351,7 +354,6 @@ class DataUseRestrictionSupportSpec extends FreeSpec with Matchers with DataUseR
             addiction = Some(true),
             sexualDiseases = Some(true),
             stigmatizeDiseases = Some(true),
-//            vulnerablePopulations: Option[Boolean] = None,
             psychologicalTraits = Some(true),
             nonBiomedical = Some(true)
           ), ontologyDAO)
@@ -449,20 +451,7 @@ class DataUseRestrictionSupportSpec extends FreeSpec with Matchers with DataUseR
         val expected = Map.empty[AttributeName,Attribute]
         assertResult(expected) {actual}
       }
-      /*
-        private val booleanCodes: Seq[String] = Seq("GRU", "HMB", "NCU", "NPU", "NMDS", "NAGR", "NCTRL", "RS-PD", "IRB")
-  private val genderCodes: Seq[String] = Seq("RS-G", "RS-FM", "RS-M")
-  private val duRestrictionFieldNames: Seq[String] = booleanCodes ++ genderCodes ++ Seq("DS_URL", "RS-POP")
-  val allDurFieldNames: Seq[String] = duRestrictionFieldNames ++ Seq("DS")
-
-  private val diseaseLabelsAttributeName: AttributeName = AttributeName.withLibraryNS("DS")
-  val structuredUseRestrictionAttributeName: AttributeName = AttributeName.withLibraryNS("structuredUseRestriction")
-  val consentCodesAttributeName: AttributeName = AttributeName.withLibraryNS("consentCodes")
-
-       */
-
     }
-
 
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupportSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupportSpec.scala
@@ -323,6 +323,28 @@ class DataUseRestrictionSupportSpec extends FreeSpec with Matchers with DataUseR
           ), ontologyDAO)
           assert(attrs.isEmpty)
         }
+        "should handle populationRestrictions string lists" in {
+          val attrs = generateStructuredUseRestrictionAttribute(new DuosDataUse(
+            populationRestrictions = Some(Seq(
+              "population 1",
+              "population 2"
+            ))
+          ), ontologyDAO)
+          val expected = Map(
+            AttributeName.withLibraryNS("RS-PD") -> AttributeValueList(Seq(
+              AttributeString("population 1"),
+              AttributeString("population 2")
+            ))
+          )
+          assertResult(expected) {attrs}
+        }
+        "should handle empty populationRestrictions" in {
+          val attrs = generateStructuredUseRestrictionAttribute(new DuosDataUse(
+            populationRestrictions = Some(Seq.empty[String])
+          ), ontologyDAO)
+
+          assert(attrs.isEmpty)
+        }
         "should ignore the DUOS keys that FireCloud doesn't implement" in {
 
           // The properties that are commented out are the ones that FireCloud implements.
@@ -335,11 +357,11 @@ class DataUseRestrictionSupportSpec extends FreeSpec with Matchers with DataUseR
 //            aggregateResearch = None,
 //            controlSetOption = None,
 //            pediatric = None,
+//            populationRestrictions = None,
             populationOriginsAncestry = Some(true),
             populationStructure = Some(true),
             gender = Some("Female"),
             vulnerablePopulations = Some(true),
-            populationRestrictions = Some(Seq("one","two")),
             dateRestriction = Some("today"),
             recontactingDataSubjects = Some(true),
             recontactMay = Some("sure"),

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/LibraryServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/LibraryServiceSpec.scala
@@ -850,13 +850,13 @@ class LibraryServiceSpec extends BaseServiceSpec with FreeSpecLike with LibraryS
       "should return an empty list when no workspaces" in {
         val workspaces = Seq.empty[Workspace]
         assertResult(Set.empty[String]) {
-          uniqueStrings(workspaces, AttributeName.withDefaultNS("description"))
+          uniqueWorkspaceStringAttributes(workspaces, AttributeName.withDefaultNS("description"))
         }
       }
       "should return an empty list when no attributes" in {
         val workspaces = makeWorkspacesWithAttributes(Seq(Map(), Map(), Map()))
         assertResult(Set.empty[String]) {
-          uniqueStrings(workspaces, AttributeName.withDefaultNS("description"))
+          uniqueWorkspaceStringAttributes(workspaces, AttributeName.withDefaultNS("description"))
         }
       }
       "should return a list when some attributes" in {
@@ -866,7 +866,7 @@ class LibraryServiceSpec extends BaseServiceSpec with FreeSpecLike with LibraryS
           Map(AttributeName.withLibraryNS("something") -> AttributeString("three"))
         ))
         assertResult(Set("one","two","three")) {
-          uniqueStrings(workspaces, AttributeName.withLibraryNS("something"))
+          uniqueWorkspaceStringAttributes(workspaces, AttributeName.withLibraryNS("something"))
         }
       }
       "should not return duplicate attributes" in {
@@ -876,7 +876,7 @@ class LibraryServiceSpec extends BaseServiceSpec with FreeSpecLike with LibraryS
           Map(AttributeName.withDefaultNS("something") -> AttributeString("two"))
         ))
         assertResult(Set("one","two")) {
-          uniqueStrings(workspaces, AttributeName.withDefaultNS("something"))
+          uniqueWorkspaceStringAttributes(workspaces, AttributeName.withDefaultNS("something"))
         }
       }
       "should ignore non-string attributes" in {
@@ -886,7 +886,7 @@ class LibraryServiceSpec extends BaseServiceSpec with FreeSpecLike with LibraryS
           Map(AttributeName.withDefaultNS("something") -> AttributeValueList(Seq(AttributeString("two"))))
         ))
         assertResult(Set("one")) {
-          uniqueStrings(workspaces, AttributeName.withDefaultNS("something"))
+          uniqueWorkspaceStringAttributes(workspaces, AttributeName.withDefaultNS("something"))
         }
       }
       "should ignore attributes beyond our target name" in {
@@ -901,7 +901,7 @@ class LibraryServiceSpec extends BaseServiceSpec with FreeSpecLike with LibraryS
           )
         ))
         assertResult(Set("one","two")) {
-          uniqueStrings(workspaces, AttributeName.withDefaultNS("something"))
+          uniqueWorkspaceStringAttributes(workspaces, AttributeName.withDefaultNS("something"))
         }
       }
       "should ignore workspaces that don't have our target name" in {
@@ -912,7 +912,7 @@ class LibraryServiceSpec extends BaseServiceSpec with FreeSpecLike with LibraryS
           Map(AttributeName.withDefaultNS("something") -> AttributeString("four"))
         ))
         assertResult(Set("one","four")) {
-          uniqueStrings(workspaces, AttributeName.withDefaultNS("something"))
+          uniqueWorkspaceStringAttributes(workspaces, AttributeName.withDefaultNS("something"))
         }
       }
     }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/LibraryServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/LibraryServiceSpec.scala
@@ -794,30 +794,5 @@ class LibraryServiceSpec extends BaseServiceSpec with FreeSpecLike with LibraryS
         }
       }
     }
-    "when translating DUOS restrictions to FireCloud restrictions" - {
-      "should default if DUOS is empty" in {
-        fail("not implemented")
-      }
-      "should translate booleans" in {
-        fail("not implemented")
-      }
-      "should translate disease ontology nodes" in {
-        fail("not implemented")
-      }
-      "should ignore the DUOS keys that FireCloud doesn't implement" in {
-        fail("not implemented")
-      }
-    }
-    "when annotating a workspace with ORSP-based data use" - {
-      "should add attributes when none exist" in {
-        fail("not implemented")
-      }
-      "should overwrite pre-existing attributes" in {
-        fail("not implemented")
-      }
-      "should remove pre-existing attributes" in {
-        fail("not implemented")
-      }
-    }
   }
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/LibraryServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/LibraryServiceSpec.scala
@@ -26,6 +26,8 @@ import scala.util.Try
 class LibraryServiceSpec extends BaseServiceSpec with FreeSpecLike with LibraryServiceSupport with AttributeSupport with ElasticSearchDAOSupport {
   def toName(s:String) = AttributeName.fromDelimitedName(s)
 
+  implicit val userToken: WithAccessToken = AccessToken("LibraryServiceSpec")
+
   val libraryAttributePredicate = (k: AttributeName) => k.namespace == AttributeName.libraryNamespace && k.name != LibraryService.publishedFlag.name
 
   val existingLibraryAttrs = Map("library:keyone"->"valone", "library:keytwo"->"valtwo", "library:keythree"->"valthree", "library:keyfour"->"valfour").toJson.convertTo[AttributeMap]
@@ -237,7 +239,7 @@ class LibraryServiceSpec extends BaseServiceSpec with FreeSpecLike with LibraryS
           AttributeName.withDefaultNS("authorizationDomain") -> AttributeValueList(Seq(AttributeString(testGroup1Ref.membersGroupName.value), AttributeString(testGroup2Ref.membersGroupName.value)))
         ))
         assertResult(expected) {
-          Await.result(indexableDocuments(Seq(w), ontologyDao), dur).head
+          Await.result(indexableDocuments(Seq(w), ontologyDao, consentDao), dur).head
         }
       }
     }
@@ -258,7 +260,7 @@ class LibraryServiceSpec extends BaseServiceSpec with FreeSpecLike with LibraryS
           AttributeName.withDefaultNS("authorizationDomain") -> AttributeValueList(Seq(AttributeString(testGroup1Ref.membersGroupName.value), AttributeString(testGroup2Ref.membersGroupName.value)))
         ))
         assertResult(expected) {
-          Await.result(indexableDocuments(Seq(w), ontologyDao), dur).head
+          Await.result(indexableDocuments(Seq(w), ontologyDao, consentDao), dur).head
         }
       }
     }
@@ -275,7 +277,7 @@ class LibraryServiceSpec extends BaseServiceSpec with FreeSpecLike with LibraryS
           AttributeName.withDefaultNS("authorizationDomain") -> AttributeValueList(Seq(AttributeString(testGroup1Ref.membersGroupName.value), AttributeString(testGroup2Ref.membersGroupName.value)))
         ))
         assertResult(expected) {
-          Await.result(indexableDocuments(Seq(w), ontologyDao), dur).head
+          Await.result(indexableDocuments(Seq(w), ontologyDao, consentDao), dur).head
         }
       }
       "should be the different for attribute operations" in {
@@ -301,7 +303,7 @@ class LibraryServiceSpec extends BaseServiceSpec with FreeSpecLike with LibraryS
           AttributeName.withDefaultNS("authorizationDomain") -> AttributeValueList(Seq(AttributeString(testGroup1Ref.membersGroupName.value), AttributeString(testGroup2Ref.membersGroupName.value)))
         ))
         assertResult(expected) {
-          Await.result(indexableDocuments(Seq(w), ontologyDao), dur).head
+          Await.result(indexableDocuments(Seq(w), ontologyDao, consentDao), dur).head
         }
       }
     }
@@ -323,7 +325,7 @@ class LibraryServiceSpec extends BaseServiceSpec with FreeSpecLike with LibraryS
           AttributeName.withDefaultNS("authorizationDomain") -> AttributeValueList(Seq(AttributeString(testGroup1Ref.membersGroupName.value), AttributeString(testGroup2Ref.membersGroupName.value)))
         ))
         assertResult(expected) {
-          Await.result(indexableDocuments(Seq(w), ontologyDao), dur).head
+          Await.result(indexableDocuments(Seq(w), ontologyDao, consentDao), dur).head
         }
       }
     }
@@ -344,7 +346,7 @@ class LibraryServiceSpec extends BaseServiceSpec with FreeSpecLike with LibraryS
           AttributeName.withDefaultNS("authorizationDomain") -> AttributeValueList(Seq(AttributeString(testGroup1Ref.membersGroupName.value), AttributeString(testGroup2Ref.membersGroupName.value)))
         ))
         assertResult(expected) {
-          Await.result(indexableDocuments(Seq(w), ontologyDao), dur).head
+          Await.result(indexableDocuments(Seq(w), ontologyDao, consentDao), dur).head
         }
       }
     }
@@ -367,7 +369,7 @@ class LibraryServiceSpec extends BaseServiceSpec with FreeSpecLike with LibraryS
           AttributeName.withDefaultNS("authorizationDomain") -> AttributeValueList(Seq(AttributeString(testGroup1Ref.membersGroupName.value), AttributeString(testGroup2Ref.membersGroupName.value)))
         ))
         assertResult(expected) {
-          Await.result(indexableDocuments(Seq(w), ontologyDao), dur).head
+          Await.result(indexableDocuments(Seq(w), ontologyDao, consentDao), dur).head
         }
       }
     }
@@ -386,7 +388,7 @@ class LibraryServiceSpec extends BaseServiceSpec with FreeSpecLike with LibraryS
           AttributeName.withDefaultNS("authorizationDomain") -> AttributeValueList(Seq(AttributeString(testGroup1Ref.membersGroupName.value), AttributeString(testGroup2Ref.membersGroupName.value)))
         ))
         assertResult(expected) {
-          Await.result(indexableDocuments(Seq(w), ontologyDao), dur).head
+          Await.result(indexableDocuments(Seq(w), ontologyDao, consentDao), dur).head
         }
       }
       "should generate indexable document with no parent info when DOID has no parents" in {
@@ -401,7 +403,7 @@ class LibraryServiceSpec extends BaseServiceSpec with FreeSpecLike with LibraryS
           AttributeName.withDefaultNS("authorizationDomain") -> AttributeValueList(Seq(AttributeString(testGroup1Ref.membersGroupName.value), AttributeString(testGroup2Ref.membersGroupName.value)))
         ))
         assertResult(expected) {
-          Await.result(indexableDocuments(Seq(w), ontologyDao), dur).head
+          Await.result(indexableDocuments(Seq(w), ontologyDao, consentDao), dur).head
         }
       }
       "should generate indexable document with no parent info when DOID not valid" in {
@@ -416,7 +418,7 @@ class LibraryServiceSpec extends BaseServiceSpec with FreeSpecLike with LibraryS
           AttributeName.withDefaultNS("authorizationDomain") -> AttributeValueList(Seq(AttributeString(testGroup1Ref.membersGroupName.value), AttributeString(testGroup2Ref.membersGroupName.value)))
         ))
         assertResult(expected) {
-          Await.result(indexableDocuments(Seq(w), ontologyDao), dur).head
+          Await.result(indexableDocuments(Seq(w), ontologyDao, consentDao), dur).head
         }
       }
     }
@@ -790,6 +792,31 @@ class LibraryServiceSpec extends BaseServiceSpec with FreeSpecLike with LibraryS
         assertResult(Set("one","four")) {
           uniqueStrings(workspaces, AttributeName.withDefaultNS("something"))
         }
+      }
+    }
+    "when translating DUOS restrictions to FireCloud restrictions" - {
+      "should default if DUOS is empty" in {
+        fail("not implemented")
+      }
+      "should translate booleans" in {
+        fail("not implemented")
+      }
+      "should translate disease ontology nodes" in {
+        fail("not implemented")
+      }
+      "should ignore the DUOS keys that FireCloud doesn't implement" in {
+        fail("not implemented")
+      }
+    }
+    "when annotating a workspace with ORSP-based data use" - {
+      "should add attributes when none exist" in {
+        fail("not implemented")
+      }
+      "should overwrite pre-existing attributes" in {
+        fail("not implemented")
+      }
+      "should remove pre-existing attributes" in {
+        fail("not implemented")
       }
     }
   }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/LibraryServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/LibraryServiceSpec.scala
@@ -422,6 +422,128 @@ class LibraryServiceSpec extends BaseServiceSpec with FreeSpecLike with LibraryS
         }
       }
     }
+    "with an ORSP id in attributes" - {
+      // most of this is unit-tested in DataUseRestrictionSupportSpec; tests here are intentionally high level
+
+      // default json object fields to represent the indexed data use restriction
+      val defaultDataUseFields = Map(
+        "NPU" -> JsBoolean(false),
+        "RS-PD" -> JsBoolean(false),
+        "NCU" -> JsBoolean(false),
+        "RS-G" -> JsBoolean(false),
+        "IRB" -> JsBoolean(false),
+        "NAGR" -> JsBoolean(false),
+        "RS-FM" -> JsBoolean(false),
+        "RS-M" -> JsBoolean(false),
+        "NMDS" -> JsBoolean(false),
+        "NCTRL" -> JsBoolean(false),
+        "GRU" -> JsBoolean(false),
+        "HMB" -> JsBoolean(false),
+        "RS-POP" -> JsArray(),
+        "DS" -> JsArray()
+      )
+
+      "should populate data use restrictions from Consent" in {
+        val w = testWorkspace.copy(attributes = Map(
+          orspIdAttribute -> AttributeString("MOCK-111")
+        ))
+        val expected = Document(testUUID.toString, Map(
+          orspIdAttribute -> AttributeString("MOCK-111"),
+          consentCodesAttributeName -> AttributeValueList(Seq(AttributeString("NCU"), AttributeString("NCTRL"))),
+          structuredUseRestrictionAttributeName -> AttributeValueRawJson(JsObject(
+            defaultDataUseFields ++ Map(
+              "NCU" -> JsBoolean(true),
+              "NCTRL" -> JsBoolean(true)
+            )).prettyPrint),
+          AttributeName.withDefaultNS("name") -> AttributeString(testWorkspace.name),
+          AttributeName.withDefaultNS("namespace") -> AttributeString(testWorkspace.namespace),
+          AttributeName.withDefaultNS("workspaceId") -> AttributeString(testWorkspace.workspaceId),
+          AttributeName.withDefaultNS("authorizationDomain") -> AttributeValueList(Seq(AttributeString(testGroup1Ref.membersGroupName.value), AttributeString(testGroup2Ref.membersGroupName.value)))
+        ))
+        assertResult(expected) {
+          Await.result(indexableDocuments(Seq(w), ontologyDao, consentDao), dur).head
+        }
+      }
+      "should clear and overwrite pre-existing data use attributes" in {
+        val w = testWorkspace.copy(attributes = Map(
+          orspIdAttribute -> AttributeString("MOCK-111"),
+          AttributeName.withLibraryNS("NCU") -> AttributeBoolean(false), // should be overwritten by orsp DU
+          AttributeName.withLibraryNS("GRU") -> AttributeBoolean(true) // overrides the default, should be erased by orsp DU
+        ))
+        val expected = Document(testUUID.toString, Map(
+          orspIdAttribute -> AttributeString("MOCK-111"),
+          consentCodesAttributeName -> AttributeValueList(Seq(AttributeString("NCU"), AttributeString("NCTRL"))),
+          structuredUseRestrictionAttributeName -> AttributeValueRawJson(JsObject(
+            defaultDataUseFields ++ Map(
+              "NCU" -> JsBoolean(true),
+              "NCTRL" -> JsBoolean(true)
+            )).prettyPrint),
+          AttributeName.withDefaultNS("name") -> AttributeString(testWorkspace.name),
+          AttributeName.withDefaultNS("namespace") -> AttributeString(testWorkspace.namespace),
+          AttributeName.withDefaultNS("workspaceId") -> AttributeString(testWorkspace.workspaceId),
+          AttributeName.withDefaultNS("authorizationDomain") -> AttributeValueList(Seq(AttributeString(testGroup1Ref.membersGroupName.value), AttributeString(testGroup2Ref.membersGroupName.value)))
+        ))
+        assertResult(expected) {
+          Await.result(indexableDocuments(Seq(w), ontologyDao, consentDao), dur).head
+        }
+      }
+      "should preserve pre-existing non-data use attributes" in {
+        val w = testWorkspace.copy(attributes = Map(
+          orspIdAttribute -> AttributeString("MOCK-111"),
+          AttributeName.withLibraryNS("datasetName") -> AttributeString("my cohort"),
+          AttributeName.withLibraryNS("projectName") -> AttributeString("my project")
+
+        ))
+        val expected = Document(testUUID.toString, Map(
+          orspIdAttribute -> AttributeString("MOCK-111"),
+          consentCodesAttributeName -> AttributeValueList(Seq(AttributeString("NCU"), AttributeString("NCTRL"))),
+          structuredUseRestrictionAttributeName -> AttributeValueRawJson(JsObject(
+            defaultDataUseFields ++ Map(
+              "NCU" -> JsBoolean(true),
+              "NCTRL" -> JsBoolean(true)
+            )).prettyPrint),
+          AttributeName.withLibraryNS("datasetName") -> AttributeString("my cohort"),
+          AttributeName.withLibraryNS("projectName") -> AttributeString("my project"),
+          AttributeName.withDefaultNS("name") -> AttributeString(testWorkspace.name),
+          AttributeName.withDefaultNS("namespace") -> AttributeString(testWorkspace.namespace),
+          AttributeName.withDefaultNS("workspaceId") -> AttributeString(testWorkspace.workspaceId),
+          AttributeName.withDefaultNS("authorizationDomain") -> AttributeValueList(Seq(AttributeString(testGroup1Ref.membersGroupName.value), AttributeString(testGroup2Ref.membersGroupName.value)))
+        ))
+        assertResult(expected) {
+          Await.result(indexableDocuments(Seq(w), ontologyDao, consentDao), dur).head
+        }
+      }
+      "should generate indexable document without any data use restrictions if ORSP id not found" in {
+        val w = testWorkspace.copy(attributes = Map(
+          orspIdAttribute -> AttributeString("MOCK-NOTFOUND")
+        ))
+        val expected = Document(testUUID.toString, Map(
+          orspIdAttribute -> AttributeString("MOCK-NOTFOUND"),
+          AttributeName.withDefaultNS("name") -> AttributeString(testWorkspace.name),
+          AttributeName.withDefaultNS("namespace") -> AttributeString(testWorkspace.namespace),
+          AttributeName.withDefaultNS("workspaceId") -> AttributeString(testWorkspace.workspaceId),
+          AttributeName.withDefaultNS("authorizationDomain") -> AttributeValueList(Seq(AttributeString(testGroup1Ref.membersGroupName.value), AttributeString(testGroup2Ref.membersGroupName.value)))
+        ))
+        assertResult(expected) {
+          Await.result(indexableDocuments(Seq(w), ontologyDao, consentDao), dur).head
+        }
+      }
+      "should generate indexable document without any data use restrictions if ORSP request throws exception" in {
+        val w = testWorkspace.copy(attributes = Map(
+          orspIdAttribute -> AttributeString("MOCK-EXCEPTION")
+        ))
+        val expected = Document(testUUID.toString, Map(
+          orspIdAttribute -> AttributeString("MOCK-EXCEPTION"),
+          AttributeName.withDefaultNS("name") -> AttributeString(testWorkspace.name),
+          AttributeName.withDefaultNS("namespace") -> AttributeString(testWorkspace.namespace),
+          AttributeName.withDefaultNS("workspaceId") -> AttributeString(testWorkspace.workspaceId),
+          AttributeName.withDefaultNS("authorizationDomain") -> AttributeValueList(Seq(AttributeString(testGroup1Ref.membersGroupName.value), AttributeString(testGroup2Ref.membersGroupName.value)))
+        ))
+        assertResult(expected) {
+          Await.result(indexableDocuments(Seq(w), ontologyDao, consentDao), dur).head
+        }
+      }
+    }
     "in its runtime schema definition" - {
       "has valid JSON" in {
         val fileContents = FileUtils.readAllTextFromResource("library/attribute-definitions.json")


### PR DESCRIPTION
I still need to discuss testing strategy with QA (Andrew), but possibly this coverage is enough.

A bunch of lines of code changed in minimal ways, because I needed to pass the consent DAO around.

To test in the dev env, you can use ORSP-590 or ORSP-640.

You probably don't want to review commit-by-commit because the first 1 or 2 commits were heavily refactored.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
