### PR TITLE
Possible fix for WorkspaceApiServiceSpec flakiness [GAWB-3144]

### DIFF
--- a/project/Testing.scala
+++ b/project/Testing.scala
@@ -18,7 +18,7 @@ object Testing {
     javaOptions in Test += "-Des.set.netty.runtime.available.processors=false",
 
     fork in Test := true,
-    parallelExecution in Test := false
+    parallelExecution in Test := true
   )
 
   implicit class ProjectTestSettings(val project: Project) extends AnyVal {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,3 +6,5 @@ addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.0.0")
 
 // latest coveralls (1.0.0) is *only* compatible with scoverage 1.0.4 or less: https://github.com/scoverage/sbt-coveralls/issues/49
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.0.4")
+
+addSbtPlugin("com.github.tkawachi" % "sbt-repeat" % "0.1.0")

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/ExportEntitiesByTypeServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/ExportEntitiesByTypeServiceSpec.scala
@@ -5,12 +5,13 @@ import akka.stream.ActorMaterializer
 import org.broadinstitute.dsde.firecloud.dataaccess.MockRawlsDAO
 import org.broadinstitute.dsde.firecloud.model._
 import org.broadinstitute.dsde.firecloud.webservice.{CookieAuthedApiService, ExportEntitiesApiService}
+import org.scalatest.SequentialNestedSuiteExecution
 import spray.http._
 import spray.http.StatusCodes._
 
 import scala.concurrent.duration._
 
-class ExportEntitiesByTypeServiceSpec extends BaseServiceSpec with ExportEntitiesApiService with CookieAuthedApiService {
+class ExportEntitiesByTypeServiceSpec extends BaseServiceSpec with ExportEntitiesApiService with CookieAuthedApiService with SequentialNestedSuiteExecution {
 
   // On travis, slow processing causes the route to timeout and complete too quickly for the large content checks.
   override implicit val routeTestTimeout = RouteTestTimeout(30.seconds)

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/ExportEntitiesByTypeServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/ExportEntitiesByTypeServiceSpec.scala
@@ -34,6 +34,9 @@ class ExportEntitiesByTypeServiceSpec extends BaseServiceSpec with ExportEntitie
   // Grab the rest so we can double check the returned content to make sure the ignored ones aren't in the response.
   val missingProps: Seq[String] = MockRawlsDAO.largeSampleHeaders.drop(5).map(_.name)
 
+  // We can't use org.scalatest.Sequential to command sibling top-level suits to execute sequentially because Sequential is a class, not a trait.
+  // What we can do is fake our way there by nesting them in a container suite, letting org.scalatest.SequentialNestedSuiteExecution take effect.
+  // Whether this solves the flakiness is a big ???
   "One big suite" - {
 
     "ExportEntitiesApiService-ExportEntitiesByType" - {

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/ExportEntitiesByTypeServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/ExportEntitiesByTypeServiceSpec.scala
@@ -34,239 +34,242 @@ class ExportEntitiesByTypeServiceSpec extends BaseServiceSpec with ExportEntitie
   // Grab the rest so we can double check the returned content to make sure the ignored ones aren't in the response.
   val missingProps: Seq[String] = MockRawlsDAO.largeSampleHeaders.drop(5).map(_.name)
 
-  "ExportEntitiesApiService-ExportEntitiesByType" - {
+  "One big suite" - {
 
-    "when an exception occurs in a paged query response, the response should be handled appropriately" - {
-      "FireCloudException is contained in response chunks" in {
-        // Exception case is generated from the entity query call which is inside of the akka stream code.
-        Get(page3ExceptionFireCloudEntitiesSampleTSVPath) ~> dummyUserIdHeaders("1234") ~> sealRoute(exportEntitiesRoutes) ~> check {
-          handled should be(true)
-          validateErrorInLastChunk(chunks, "FireCloudException")
-        }
-      }
-    }
+    "ExportEntitiesApiService-ExportEntitiesByType" - {
 
-    "when an exception occurs, the response should be handled appropriately" - {
-      "InternalServerError is returned" in {
-        // Exception case is generated from the entity query call which is inside of the akka stream code.
-        Get(exceptionFireCloudEntitiesSampleTSVPath) ~> dummyUserIdHeaders("1234") ~> sealRoute(exportEntitiesRoutes) ~> check {
-          handled should be(true)
-          status should be(InternalServerError)
-          errorReportCheck("Rawls", InternalServerError)
-        }
-      }
-    }
-
-    "when calling GET on exporting a valid entity type with filtered attributes" - {
-      "OK response is returned and attributes are filtered" in {
-        val uri = Uri(largeFireCloudEntitiesSampleTSVPath).withQuery(("attributeNames", filterProps.mkString(",")))
-        Get(uri) ~> dummyUserIdHeaders("1234") ~> sealRoute(exportEntitiesRoutes) ~> check {
-          handled should be(true)
-          status should be(OK)
-          entity shouldNot be(empty) // Entity is the first line of content as output by StreamingActor
-          chunks shouldNot be(empty) // Chunks has all of the rest of the content, as output by StreamingActor
-          headers.contains(HttpHeaders.Connection("Keep-Alive")) should be(true)
-          headers.contains(HttpHeaders.`Content-Disposition`.apply("attachment", Map("filename" -> "sample.txt"))) should be(true)
-          validateLineCount(chunks, MockRawlsDAO.largeSampleSize)
-          validateProps(entity)
-        }
-      }
-    }
-
-    "when calling GET on exporting LARGE (20K) sample TSV" - {
-      "OK response is returned" in {
-        Get(largeFireCloudEntitiesSampleTSVPath) ~> dummyUserIdHeaders("1234") ~> sealRoute(exportEntitiesRoutes) ~> check {
-          handled should be(true)
-          status should be(OK)
-          entity shouldNot be(empty) // Entity is the first line of content as output by StreamingActor
-          chunks shouldNot be(empty) // Chunks has all of the rest of the content, as output by StreamingActor
-          headers.contains(HttpHeaders.Connection("Keep-Alive")) should be(true)
-          headers.contains(HttpHeaders.`Content-Disposition`.apply("attachment", Map("filename" -> "sample.txt"))) should be(true)
-          validateLineCount(chunks, MockRawlsDAO.largeSampleSize)
-        }
-      }
-    }
-
-    "when calling GET on exporting LARGE (5K) sample set file" - {
-      "OK response is returned" in {
-        Get(largeFireCloudEntitiesSampleSetTSVPath) ~> dummyUserIdHeaders("1234") ~> sealRoute(exportEntitiesRoutes) ~> check {
-          handled should be(true)
-          status should be(OK)
-          entity shouldNot be(empty) // Entity is the first line of content as output by StreamingActor
-          headers.contains(HttpHeaders.Connection("Keep-Alive")) should be(true)
-          headers.contains(HttpHeaders.`Content-Disposition`.apply("attachment", Map("filename" -> "sample_set.zip"))) should be(true)
-        }
-      }
-    }
-
-    "when calling GET on exporting a valid collection type" - {
-      "OK response is returned" in {
-        Get(validFireCloudEntitiesSampleSetTSVPath) ~> dummyUserIdHeaders("1234") ~> sealRoute(exportEntitiesRoutes) ~> check {
-          handled should be(true)
-          status should be(OK)
-          entity shouldNot be(empty)
-          headers.contains(HttpHeaders.Connection("Keep-Alive")) should be(true)
-          headers.contains(HttpHeaders.`Content-Disposition`.apply("attachment", Map("filename" -> "sample_set.zip"))) should be(true)
-        }
-      }
-    }
-
-    "when calling GET on exporting a valid entity type" - {
-      "OK response is returned" in {
-        Get(validFireCloudEntitiesSampleTSVPath) ~> dummyUserIdHeaders("1234") ~> sealRoute(exportEntitiesRoutes) ~> check {
-          handled should be(true)
-          status should be(OK)
-          entity shouldNot be(empty)
-          headers.contains(HttpHeaders.Connection("Keep-Alive")) should be(true)
-          headers.contains(HttpHeaders.`Content-Disposition`.apply("attachment", Map("filename" -> "sample.txt"))) should be(true)
-        }
-      }
-    }
-
-    "when calling GET on exporting an invalid collection type" - {
-      "NotFound response is returned" in {
-        Get(invalidFireCloudEntitiesParticipantSetTSVPath) ~> dummyUserIdHeaders("1234") ~> sealRoute(exportEntitiesRoutes) ~> check {
-          handled should be(true)
-          status should be(NotFound)
-        }
-      }
-    }
-
-    "when calling GET on exporting an invalid entity type" - {
-      "NotFound response is returned" in {
-        Get(invalidFireCloudEntitiesSampleTSVPath) ~> dummyUserIdHeaders("1234") ~> sealRoute(exportEntitiesRoutes) ~> check {
-          handled should be(true)
-          status should be(NotFound)
-          errorReportCheck("Rawls", NotFound)
-        }
-      }
-    }
-
-    "when calling POST, PUT, PATCH, DELETE on export path" - {
-      "MethodNotAllowed response is returned" in {
-        List(HttpMethods.POST, HttpMethods.PUT, HttpMethods.DELETE, HttpMethods.PATCH) map { method =>
-          new RequestBuilder(method)(invalidFireCloudEntitiesParticipantSetTSVPath) ~> sealRoute(exportEntitiesRoutes) ~> check {
+      "when an exception occurs in a paged query response, the response should be handled appropriately" - {
+        "FireCloudException is contained in response chunks" in {
+          // Exception case is generated from the entity query call which is inside of the akka stream code.
+          Get(page3ExceptionFireCloudEntitiesSampleTSVPath) ~> dummyUserIdHeaders("1234") ~> sealRoute(exportEntitiesRoutes) ~> check {
             handled should be(true)
-            status shouldNot equal(MethodNotAllowed)
+            validateErrorInLastChunk(chunks, "FireCloudException")
           }
         }
       }
-    }
 
-  }
-
-  val validCookieFireCloudEntitiesLargeSampleTSVPath = "/cookie-authed/workspaces/broad-dsde-dev/large/entities/sample/tsv"
-  val validCookieFireCloudEntitiesSampleSetTSVPath = "/cookie-authed/workspaces/broad-dsde-dev/valid/entities/sample_set/tsv"
-  val validCookieFireCloudEntitiesSampleTSVPath = "/cookie-authed/workspaces/broad-dsde-dev/valid/entities/sample/tsv"
-  val invalidCookieFireCloudEntitiesSampleTSVPath = "/cookie-authed/workspaces/broad-dsde-dev/invalid/entities/sample/tsv"
-  val invalidCookieFireCloudEntitiesParticipantSetTSVPath = "/cookie-authed/workspaces/broad-dsde-dev/invalid/entities/participant_set/tsv"
-  val exceptionCookieFireCloudEntitiesSampleTSVPath = "/cookie-authed/workspaces/broad-dsde-dev/exception/entities/sample/tsv"
-  val page3ExceptionCookieFireCloudEntitiesSampleTSVPath = "/cookie-authed/workspaces/broad-dsde-dev/page3exception/entities/sample/tsv"
-
-  "CookieAuthedApiService-ExportEntitiesByType" - {
-
-    "when an exception occurs in a paged query response, the response should be handled appropriately" - {
-      "FireCloudException is contained in response chunks" in {
-        // Exception case is generated from the entity query call which is inside of the akka stream code.
-        Post(page3ExceptionCookieFireCloudEntitiesSampleTSVPath, FormData(Seq("FCtoken"->"token"))) ~> dummyUserIdHeaders("1234") ~> sealRoute(cookieAuthedRoutes) ~> check {
-          handled should be(true)
-          validateErrorInLastChunk(chunks, "FireCloudException")
-        }
-      }
-    }
-
-    "when an exception occurs, the response should be handled appropriately" - {
-      "InternalServerError is returned" in {
-        // Exception case is generated from the entity query call which is inside of the akka stream code.
-        Post(exceptionCookieFireCloudEntitiesSampleTSVPath, FormData(Seq("FCtoken"->"token"))) ~> dummyUserIdHeaders("1234") ~> sealRoute(cookieAuthedRoutes) ~> check {
-          handled should be(true)
-          status should be(InternalServerError)
-          errorReportCheck("Rawls", InternalServerError)
-        }
-      }
-    }
-
-    "when calling GET on exporting a valid entity type with filtered attributes" - {
-      "OK response is returned and attributes are filtered" in {
-        Post(validCookieFireCloudEntitiesLargeSampleTSVPath, FormData(Seq("FCtoken"->"token", "attributeNames"->filterProps.mkString(",")))) ~> dummyUserIdHeaders("1234") ~> sealRoute(cookieAuthedRoutes) ~> check {
-          handled should be(true)
-          status should be(OK)
-          entity shouldNot be(empty) // Entity is the first line of content as output by StreamingActor
-          chunks shouldNot be(empty) // Chunks has all of the rest of the content, as output by StreamingActor
-          headers.contains(HttpHeaders.Connection("Keep-Alive")) should be(true)
-          headers.contains(HttpHeaders.`Content-Disposition`.apply("attachment", Map("filename" -> "sample.txt"))) should be(true)
-          validateLineCount(chunks, MockRawlsDAO.largeSampleSize)
-          validateProps(entity)
-        }
-      }
-    }
-
-    "when calling POST on exporting LARGE (20K) sample TSV" - {
-      "OK response is returned" in {
-        Post(validCookieFireCloudEntitiesLargeSampleTSVPath, FormData(Seq("FCtoken"->"token"))) ~> sealRoute(cookieAuthedRoutes) ~> check {
-          handled should be(true)
-          status should be(OK)
-          entity shouldNot be(empty)
-          headers.contains(HttpHeaders.Connection("Keep-Alive")) should be(true)
-          headers.contains(HttpHeaders.`Content-Disposition`.apply("attachment", Map("filename" -> "sample.txt"))) should be(true)
-        }
-      }
-    }
-
-    "when calling POST on exporting a valid collection type" - {
-      "OK response is returned" in {
-        Post(validCookieFireCloudEntitiesSampleSetTSVPath, FormData(Seq("FCtoken"->"token"))) ~> sealRoute(cookieAuthedRoutes) ~> check {
-          handled should be(true)
-          status should be(OK)
-          entity shouldNot be(empty)
-          headers.contains(HttpHeaders.Connection("Keep-Alive")) should be(true)
-          headers.contains(HttpHeaders.`Content-Disposition`.apply("attachment", Map("filename" -> "sample_set.zip"))) should be(true)
-        }
-      }
-    }
-
-    "when calling POST on exporting a valid entity type" - {
-      "OK response is returned" in {
-        Post(validCookieFireCloudEntitiesSampleTSVPath, FormData(Seq("FCtoken"->"token"))) ~> sealRoute(cookieAuthedRoutes) ~> check {
-          handled should be(true)
-          status should be(OK)
-          entity shouldNot be(empty)
-          headers.contains(HttpHeaders.Connection("Keep-Alive")) should be(true)
-          headers.contains(HttpHeaders.`Content-Disposition`.apply("attachment", Map("filename" -> "sample.txt"))) should be(true)
-        }
-      }
-    }
-
-    "when calling POST on exporting an invalid collection type" - {
-      "NotFound response is returned" in {
-        Post(invalidCookieFireCloudEntitiesParticipantSetTSVPath, FormData(Seq("FCtoken"->"token"))) ~> sealRoute(cookieAuthedRoutes) ~> check {
-          handled should be(true)
-          status should be(NotFound)
-        }
-      }
-    }
-
-    "when calling POST on exporting an invalid entity type" - {
-      "NotFound response is returned" in {
-        Post(invalidCookieFireCloudEntitiesSampleTSVPath, FormData(Seq("FCtoken"->"token"))) ~> sealRoute(cookieAuthedRoutes) ~> check {
-          handled should be(true)
-          status should be(NotFound)
-          errorReportCheck("Rawls", NotFound)
-        }
-      }
-    }
-
-    "when calling GET, PUT, PATCH, DELETE on export path" - {
-      "MethodNotAllowed response is returned" in {
-        List(HttpMethods.GET, HttpMethods.PUT, HttpMethods.DELETE, HttpMethods.PATCH) map { method =>
-          new RequestBuilder(method)(invalidCookieFireCloudEntitiesParticipantSetTSVPath) ~> sealRoute(cookieAuthedRoutes) ~> check {
+      "when an exception occurs, the response should be handled appropriately" - {
+        "InternalServerError is returned" in {
+          // Exception case is generated from the entity query call which is inside of the akka stream code.
+          Get(exceptionFireCloudEntitiesSampleTSVPath) ~> dummyUserIdHeaders("1234") ~> sealRoute(exportEntitiesRoutes) ~> check {
             handled should be(true)
-            status shouldNot equal(MethodNotAllowed)
+            status should be(InternalServerError)
+            errorReportCheck("Rawls", InternalServerError)
           }
         }
       }
+
+      "when calling GET on exporting a valid entity type with filtered attributes" - {
+        "OK response is returned and attributes are filtered" in {
+          val uri = Uri(largeFireCloudEntitiesSampleTSVPath).withQuery(("attributeNames", filterProps.mkString(",")))
+          Get(uri) ~> dummyUserIdHeaders("1234") ~> sealRoute(exportEntitiesRoutes) ~> check {
+            handled should be(true)
+            status should be(OK)
+            entity shouldNot be(empty) // Entity is the first line of content as output by StreamingActor
+            chunks shouldNot be(empty) // Chunks has all of the rest of the content, as output by StreamingActor
+            headers.contains(HttpHeaders.Connection("Keep-Alive")) should be(true)
+            headers.contains(HttpHeaders.`Content-Disposition`.apply("attachment", Map("filename" -> "sample.txt"))) should be(true)
+            validateLineCount(chunks, MockRawlsDAO.largeSampleSize)
+            validateProps(entity)
+          }
+        }
+      }
+
+      "when calling GET on exporting LARGE (20K) sample TSV" - {
+        "OK response is returned" in {
+          Get(largeFireCloudEntitiesSampleTSVPath) ~> dummyUserIdHeaders("1234") ~> sealRoute(exportEntitiesRoutes) ~> check {
+            handled should be(true)
+            status should be(OK)
+            entity shouldNot be(empty) // Entity is the first line of content as output by StreamingActor
+            chunks shouldNot be(empty) // Chunks has all of the rest of the content, as output by StreamingActor
+            headers.contains(HttpHeaders.Connection("Keep-Alive")) should be(true)
+            headers.contains(HttpHeaders.`Content-Disposition`.apply("attachment", Map("filename" -> "sample.txt"))) should be(true)
+            validateLineCount(chunks, MockRawlsDAO.largeSampleSize)
+          }
+        }
+      }
+
+      "when calling GET on exporting LARGE (5K) sample set file" - {
+        "OK response is returned" in {
+          Get(largeFireCloudEntitiesSampleSetTSVPath) ~> dummyUserIdHeaders("1234") ~> sealRoute(exportEntitiesRoutes) ~> check {
+            handled should be(true)
+            status should be(OK)
+            entity shouldNot be(empty) // Entity is the first line of content as output by StreamingActor
+            headers.contains(HttpHeaders.Connection("Keep-Alive")) should be(true)
+            headers.contains(HttpHeaders.`Content-Disposition`.apply("attachment", Map("filename" -> "sample_set.zip"))) should be(true)
+          }
+        }
+      }
+
+      "when calling GET on exporting a valid collection type" - {
+        "OK response is returned" in {
+          Get(validFireCloudEntitiesSampleSetTSVPath) ~> dummyUserIdHeaders("1234") ~> sealRoute(exportEntitiesRoutes) ~> check {
+            handled should be(true)
+            status should be(OK)
+            entity shouldNot be(empty)
+            headers.contains(HttpHeaders.Connection("Keep-Alive")) should be(true)
+            headers.contains(HttpHeaders.`Content-Disposition`.apply("attachment", Map("filename" -> "sample_set.zip"))) should be(true)
+          }
+        }
+      }
+
+      "when calling GET on exporting a valid entity type" - {
+        "OK response is returned" in {
+          Get(validFireCloudEntitiesSampleTSVPath) ~> dummyUserIdHeaders("1234") ~> sealRoute(exportEntitiesRoutes) ~> check {
+            handled should be(true)
+            status should be(OK)
+            entity shouldNot be(empty)
+            headers.contains(HttpHeaders.Connection("Keep-Alive")) should be(true)
+            headers.contains(HttpHeaders.`Content-Disposition`.apply("attachment", Map("filename" -> "sample.txt"))) should be(true)
+          }
+        }
+      }
+
+      "when calling GET on exporting an invalid collection type" - {
+        "NotFound response is returned" in {
+          Get(invalidFireCloudEntitiesParticipantSetTSVPath) ~> dummyUserIdHeaders("1234") ~> sealRoute(exportEntitiesRoutes) ~> check {
+            handled should be(true)
+            status should be(NotFound)
+          }
+        }
+      }
+
+      "when calling GET on exporting an invalid entity type" - {
+        "NotFound response is returned" in {
+          Get(invalidFireCloudEntitiesSampleTSVPath) ~> dummyUserIdHeaders("1234") ~> sealRoute(exportEntitiesRoutes) ~> check {
+            handled should be(true)
+            status should be(NotFound)
+            errorReportCheck("Rawls", NotFound)
+          }
+        }
+      }
+
+      "when calling POST, PUT, PATCH, DELETE on export path" - {
+        "MethodNotAllowed response is returned" in {
+          List(HttpMethods.POST, HttpMethods.PUT, HttpMethods.DELETE, HttpMethods.PATCH) map { method =>
+            new RequestBuilder(method)(invalidFireCloudEntitiesParticipantSetTSVPath) ~> sealRoute(exportEntitiesRoutes) ~> check {
+              handled should be(true)
+              status shouldNot equal(MethodNotAllowed)
+            }
+          }
+        }
+      }
+
     }
 
+    val validCookieFireCloudEntitiesLargeSampleTSVPath = "/cookie-authed/workspaces/broad-dsde-dev/large/entities/sample/tsv"
+    val validCookieFireCloudEntitiesSampleSetTSVPath = "/cookie-authed/workspaces/broad-dsde-dev/valid/entities/sample_set/tsv"
+    val validCookieFireCloudEntitiesSampleTSVPath = "/cookie-authed/workspaces/broad-dsde-dev/valid/entities/sample/tsv"
+    val invalidCookieFireCloudEntitiesSampleTSVPath = "/cookie-authed/workspaces/broad-dsde-dev/invalid/entities/sample/tsv"
+    val invalidCookieFireCloudEntitiesParticipantSetTSVPath = "/cookie-authed/workspaces/broad-dsde-dev/invalid/entities/participant_set/tsv"
+    val exceptionCookieFireCloudEntitiesSampleTSVPath = "/cookie-authed/workspaces/broad-dsde-dev/exception/entities/sample/tsv"
+    val page3ExceptionCookieFireCloudEntitiesSampleTSVPath = "/cookie-authed/workspaces/broad-dsde-dev/page3exception/entities/sample/tsv"
+
+    "CookieAuthedApiService-ExportEntitiesByType" - {
+
+      "when an exception occurs in a paged query response, the response should be handled appropriately" - {
+        "FireCloudException is contained in response chunks" in {
+          // Exception case is generated from the entity query call which is inside of the akka stream code.
+          Post(page3ExceptionCookieFireCloudEntitiesSampleTSVPath, FormData(Seq("FCtoken" -> "token"))) ~> dummyUserIdHeaders("1234") ~> sealRoute(cookieAuthedRoutes) ~> check {
+            handled should be(true)
+            validateErrorInLastChunk(chunks, "FireCloudException")
+          }
+        }
+      }
+
+      "when an exception occurs, the response should be handled appropriately" - {
+        "InternalServerError is returned" in {
+          // Exception case is generated from the entity query call which is inside of the akka stream code.
+          Post(exceptionCookieFireCloudEntitiesSampleTSVPath, FormData(Seq("FCtoken" -> "token"))) ~> dummyUserIdHeaders("1234") ~> sealRoute(cookieAuthedRoutes) ~> check {
+            handled should be(true)
+            status should be(InternalServerError)
+            errorReportCheck("Rawls", InternalServerError)
+          }
+        }
+      }
+
+      "when calling GET on exporting a valid entity type with filtered attributes" - {
+        "OK response is returned and attributes are filtered" in {
+          Post(validCookieFireCloudEntitiesLargeSampleTSVPath, FormData(Seq("FCtoken" -> "token", "attributeNames" -> filterProps.mkString(",")))) ~> dummyUserIdHeaders("1234") ~> sealRoute(cookieAuthedRoutes) ~> check {
+            handled should be(true)
+            status should be(OK)
+            entity shouldNot be(empty) // Entity is the first line of content as output by StreamingActor
+            chunks shouldNot be(empty) // Chunks has all of the rest of the content, as output by StreamingActor
+            headers.contains(HttpHeaders.Connection("Keep-Alive")) should be(true)
+            headers.contains(HttpHeaders.`Content-Disposition`.apply("attachment", Map("filename" -> "sample.txt"))) should be(true)
+            validateLineCount(chunks, MockRawlsDAO.largeSampleSize)
+            validateProps(entity)
+          }
+        }
+      }
+
+      "when calling POST on exporting LARGE (20K) sample TSV" - {
+        "OK response is returned" in {
+          Post(validCookieFireCloudEntitiesLargeSampleTSVPath, FormData(Seq("FCtoken" -> "token"))) ~> sealRoute(cookieAuthedRoutes) ~> check {
+            handled should be(true)
+            status should be(OK)
+            entity shouldNot be(empty)
+            headers.contains(HttpHeaders.Connection("Keep-Alive")) should be(true)
+            headers.contains(HttpHeaders.`Content-Disposition`.apply("attachment", Map("filename" -> "sample.txt"))) should be(true)
+          }
+        }
+      }
+
+      "when calling POST on exporting a valid collection type" - {
+        "OK response is returned" in {
+          Post(validCookieFireCloudEntitiesSampleSetTSVPath, FormData(Seq("FCtoken" -> "token"))) ~> sealRoute(cookieAuthedRoutes) ~> check {
+            handled should be(true)
+            status should be(OK)
+            entity shouldNot be(empty)
+            headers.contains(HttpHeaders.Connection("Keep-Alive")) should be(true)
+            headers.contains(HttpHeaders.`Content-Disposition`.apply("attachment", Map("filename" -> "sample_set.zip"))) should be(true)
+          }
+        }
+      }
+
+      "when calling POST on exporting a valid entity type" - {
+        "OK response is returned" in {
+          Post(validCookieFireCloudEntitiesSampleTSVPath, FormData(Seq("FCtoken" -> "token"))) ~> sealRoute(cookieAuthedRoutes) ~> check {
+            handled should be(true)
+            status should be(OK)
+            entity shouldNot be(empty)
+            headers.contains(HttpHeaders.Connection("Keep-Alive")) should be(true)
+            headers.contains(HttpHeaders.`Content-Disposition`.apply("attachment", Map("filename" -> "sample.txt"))) should be(true)
+          }
+        }
+      }
+
+      "when calling POST on exporting an invalid collection type" - {
+        "NotFound response is returned" in {
+          Post(invalidCookieFireCloudEntitiesParticipantSetTSVPath, FormData(Seq("FCtoken" -> "token"))) ~> sealRoute(cookieAuthedRoutes) ~> check {
+            handled should be(true)
+            status should be(NotFound)
+          }
+        }
+      }
+
+      "when calling POST on exporting an invalid entity type" - {
+        "NotFound response is returned" in {
+          Post(invalidCookieFireCloudEntitiesSampleTSVPath, FormData(Seq("FCtoken" -> "token"))) ~> sealRoute(cookieAuthedRoutes) ~> check {
+            handled should be(true)
+            status should be(NotFound)
+            errorReportCheck("Rawls", NotFound)
+          }
+        }
+      }
+
+      "when calling GET, PUT, PATCH, DELETE on export path" - {
+        "MethodNotAllowed response is returned" in {
+          List(HttpMethods.GET, HttpMethods.PUT, HttpMethods.DELETE, HttpMethods.PATCH) map { method =>
+            new RequestBuilder(method)(invalidCookieFireCloudEntitiesParticipantSetTSVPath) ~> sealRoute(cookieAuthedRoutes) ~> check {
+              handled should be(true)
+              status shouldNot equal(MethodNotAllowed)
+            }
+          }
+        }
+      }
+
+    }
   }
 
   private def validateLineCount(chunks: List[MessageChunk], count: Int): Unit = {
@@ -279,7 +282,6 @@ class ExportEntitiesByTypeServiceSpec extends BaseServiceSpec with ExportEntitie
     filterProps.map { h => entityHeaderString.contains(h) should be(true) }
     missingProps.map { h => entityHeaderString.contains(h) should be(false) }
   }
-
   private def validateErrorInLastChunk(chunks: List[MessageChunk], message: String): Unit = {
     chunks.reverse.head.data.asString should include (message)
   }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceApiServiceSpec.scala
@@ -13,7 +13,7 @@ import org.joda.time.DateTime
 import org.mockserver.integration.ClientAndServer
 import org.mockserver.integration.ClientAndServer._
 import org.mockserver.model.HttpRequest._
-import org.scalatest.BeforeAndAfterEach
+import org.scalatest.{BeforeAndAfterEach, SequentialNestedSuiteExecution}
 import spray.http._
 import spray.http.StatusCodes._
 import spray.httpx.SprayJsonSupport._
@@ -39,7 +39,7 @@ object WorkspaceApiServiceSpec {
 
 }
 
-class WorkspaceApiServiceSpec extends BaseServiceSpec with WorkspaceApiService with BeforeAndAfterEach {
+class WorkspaceApiServiceSpec extends BaseServiceSpec with WorkspaceApiService with BeforeAndAfterEach with SequentialNestedSuiteExecution {
 
   def actorRefFactory = system
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/trial/ProjectManagerSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/trial/ProjectManagerSpec.scala
@@ -137,7 +137,8 @@ class ProjectManagerSpec extends TestKit(ActorSystem("ProjectManagerSpec")) with
       val (pm, rawlsDAO, trialDAO, googleDAO) = initTestState(mockRawlsDAO = new MissingGetProjectsRawlsDAO)
       pm ! StartCreation(3)
       awaitCond(trialDAO.insertCount == 3, testTimeout, testInterval)
-      awaitCond(trialDAO.verifiedCount == 3 && verifiedProjects.forall(p => p.verified && p.status.contains(CreationStatuses.Error)), testTimeout, testInterval)
+      // Takes longer for unknown reason
+      awaitCond(trialDAO.verifiedCount == 3 && verifiedProjects.forall(p => p.verified && p.status.contains(CreationStatuses.Error)), testTimeout * 2, testInterval)
       system.stop(pm)
     }
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/trial/ProjectManagerSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/trial/ProjectManagerSpec.scala
@@ -129,7 +129,8 @@ class ProjectManagerSpec extends TestKit(ActorSystem("ProjectManagerSpec")) with
       val (pm, rawlsDAO, trialDAO, googleDAO) = initTestState(mockRawlsDAO = new BadGetProjectsRawlsDAO)
       pm ! StartCreation(3)
       awaitCond(trialDAO.insertCount == 3, testTimeout, testInterval)
-      awaitCond(trialDAO.verifiedCount == 3 && verifiedProjects.forall(p => p.verified && p.status.contains(CreationStatuses.Error)), testTimeout, testInterval)
+      // Takes longer for unknown reason
+      awaitCond(trialDAO.verifiedCount == 3 && verifiedProjects.forall(p => p.verified && p.status.contains(CreationStatuses.Error)), testTimeout * 2, testInterval)
       system.stop(pm)
     }
     "should mark projects as error during verification if they are not returned by Rawls" in {


### PR DESCRIPTION
[`ParallelTestExecution`](http://doc.scalatest.org/3.0.1/index.html#org.scalatest.ParallelTestExecution):

> ScalaTest's normal approach for running suites of tests in parallel is to run different suites in parallel, but the tests of any one suite sequentially.

[`SequentialNestedSuiteExecution`](http://doc.scalatest.org/3.0.1/index.html#org.scalatest.SequentialNestedSuiteExecution):

> Mix in this trait into any suite whose nested suites need to be run sequentially even with the rest of the run is being executed concurrently. 

We access `this.searchDao.indexDocumentInvoked` in both `"Workspace updateAttributes tests"` and `"Workspace setAttributes tests"` - these suites are siblings, so maybe they are being run in parallel.

This changeset:
- Disables parallel execution for nested test suites in `WorkspaceApiServiceSpec`
- Attempts to apply the same theory to the flakiness in `ExportEntitiesByTypeServiceSpec`
  - Failure is always in `FireCloudException is contained in response chunks`
  - It looks like that test case may be receiving valid response chunks that belong to another test?
- Selectively bump too-short timeouts in `ProjectManagerSpec`, because that seems like a gimme to improve reliability

Of course, this hinges on exactly what constitues a Suite in FreeSpec - I wasn't able to reason out whether this should actually work.

---

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
