### PR TITLE
GAWB-3144: Address sporadic unit test failures

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,3 +6,5 @@ addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.0.0")
 
 // latest coveralls (1.0.0) is *only* compatible with scoverage 1.0.4 or less: https://github.com/scoverage/sbt-coveralls/issues/49
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.0.4")
+
+addSbtPlugin("com.github.tkawachi" % "sbt-repeat" % "0.1.0")


### PR DESCRIPTION
Trying to address GAWB-3144:
https://broadinstitute.atlassian.net/browse/GAWB-3144

## Notes:
Running tests locally in batches of 100 consistently passes for the failing tests in the story.
When run this way, these tests are the only ones that fail:

`NihApiService`
```
[info] NihApiService
[info] - should return NotFound when GET-ting a profile with no NIH username
[info] - should return NotFound when GET-ting a non-existent profile
[info] - should return BadRequest when NIH linking with an invalid JWT
[info] - should link and sync when user is on TCGA whitelist but not TARGET
[info] - should link and sync when user is on TARGET whitelist but not TCGA
[info] - should link and sync when user is on both the TARGET and TCGA whitelists
[info] - should link but not sync when user is on neither the TARGET nor the TCGA whitelist
[info] - should return OK when an expired user re-links. their new link time should be 30 days in the future *** FAILED ***
[info]   1518021624 was not greater than or equal to 1518021625 (NihApiServiceSpec.scala:125)
```
and `ProjectManagerSpec` (see https://broadinstitute.atlassian.net/browse/GAWB-3145)
```
[info] ProjectManagerSpec:
[info] ProjectManager actor, when creating projects
[info] - should insert a record
[info] - should insert multiple records
[info] - multiple inserted records should all be unique
[info] - should impose a delay between multiple project creations
[info] - should trigger project creation in rawls
[info] - should trigger verification of inserted records
[info] - should impose a delay between project creation and verification
[info] - should only verify a project once if it verifies on the first try
[info] - should re-verify a project if it is still creating
[info] - should only retry verification 60 times
[info] - should mark projects as error during verification if they failed to create
[info] - should mark projects as error during verification if they are not returned by Rawls *** FAILED ***
[info]   java.lang.AssertionError: assertion failed: timeout 10 minutes expired:
[info]   at scala.Predef$.assert(Predef.scala:170)
[info]   at akka.testkit.TestKitBase$class.poll$1(TestKit.scala:276)
[info]   at akka.testkit.TestKitBase$class.awaitCond(TestKit.scala:282)
[info]   at akka.testkit.TestKit.awaitCond(TestKit.scala:814)
[info]   at org.broadinstitute.dsde.firecloud.trial.ProjectManagerSpec$$anonfun$1$$anonfun$apply$mcV$sp$20.apply$mcV$sp(ProjectManagerSpec.scala:139)
[info]   at org.broadinstitute.dsde.firecloud.trial.ProjectManagerSpec$$anonfun$1$$anonfun$apply$mcV$sp$20.apply(ProjectManagerSpec.scala:135)
[info]   at org.broadinstitute.dsde.firecloud.trial.ProjectManagerSpec$$anonfun$1$$anonfun$apply$mcV$sp$20.apply(ProjectManagerSpec.scala:135)
[info]   at org.scalatest.Transformer$$anonfun$apply$1.apply$mcV$sp(Transformer.scala:22)
[info]   at org.scalatest.OutcomeOf$class.outcomeOf(OutcomeOf.scala:85)
[info]   at org.scalatest.OutcomeOf$.outcomeOf(OutcomeOf.scala:104)
```

---

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
