### PR TITLE
GAWB-3145: move mutable data to internal actor

### DIFF
--- a/src/test/scala/org/broadinstitute/dsde/firecloud/trial/ProjectManagerSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/trial/ProjectManagerSpec.scala
@@ -333,10 +333,10 @@ object MockDAOData {
         verifiedProjects = Seq.empty[TrialProject]
         rawlsProjectsCallCount = 0
         rawlsCreatedProjects = Seq.empty[String]
-      case InsertProject(project: TrialProject) => insertedProjects = insertedProjects ++ Seq(project)
-      case VerifiedProject(project: TrialProject) => verifiedProjects = verifiedProjects ++ Seq(project)
+      case InsertProject(project: TrialProject) => insertedProjects = insertedProjects :+ project
+      case VerifiedProject(project: TrialProject) => verifiedProjects = verifiedProjects :+ project
       case BumpRawlsProjectCallsCount => rawlsProjectsCallCount += 1
-      case RawlsCreatedProjects(project: String) => rawlsCreatedProjects = rawlsCreatedProjects ++ Seq(project)
+      case RawlsCreatedProjects(project: String) => rawlsCreatedProjects = rawlsCreatedProjects :+ project
       case GetInsertedProjects => sender ! insertedProjects
       case GetVerifiedProjects => sender ! verifiedProjects
       case GetProjectCallsCount => sender ! rawlsProjectsCallCount
@@ -346,5 +346,3 @@ object MockDAOData {
   }
 
 }
-
-

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/trial/ProjectManagerSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/trial/ProjectManagerSpec.scala
@@ -190,7 +190,7 @@ object ProjectManagerSpec {
   }
 
   def increaseRawlsProjectsCallCount(): Unit = {
-    projectStateActor ! IncreaseRawlsProjectCallsCount
+    projectStateActor ! BumpRawlsProjectCallsCount
   }
 
   def rawlsGetProjectsCallCount: Int = {
@@ -206,7 +206,7 @@ object ProjectManagerSpec {
     def createCount: Int = rawlsCreatedProjects.size
 
     override def createProject(projectName: String, billingAccount: String)(implicit userToken: WithAccessToken): Future[Boolean] = {
-      projectStateActor ! AddCreatedProject(projectName)
+      projectStateActor ! RawlsCreatedProjects(projectName)
       Future.successful(true)
     }
 
@@ -308,8 +308,8 @@ object MockDAOData {
   case object Init
   case class InsertProject(p: TrialProject)
   case class VerifiedProject(p: TrialProject)
-  case object IncreaseRawlsProjectCallsCount
-  case class AddCreatedProject(p: String)
+  case object BumpRawlsProjectCallsCount
+  case class RawlsCreatedProjects(p: String)
   case object GetInsertedProjects
   case object GetVerifiedProjects
   case object GetProjectCallsCount
@@ -330,8 +330,8 @@ object MockDAOData {
         rawlsCreatedProjects = Seq.empty[String]
       case InsertProject(project: TrialProject) => insertedProjects = insertedProjects ++ Seq(project)
       case VerifiedProject(project: TrialProject) => verifiedProjects = verifiedProjects ++ Seq(project)
-      case IncreaseRawlsProjectCallsCount => rawlsProjectsCallCount += 1
-      case AddCreatedProject(project: String) => rawlsCreatedProjects = rawlsCreatedProjects ++ Seq(project)
+      case BumpRawlsProjectCallsCount => rawlsProjectsCallCount += 1
+      case RawlsCreatedProjects(project: String) => rawlsCreatedProjects = rawlsCreatedProjects ++ Seq(project)
       case GetInsertedProjects => sender ! insertedProjects
       case GetVerifiedProjects => sender ! verifiedProjects
       case GetProjectCallsCount => sender ! rawlsProjectsCallCount

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/trial/ProjectManagerSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/trial/ProjectManagerSpec.scala
@@ -306,14 +306,19 @@ object MockDAOData {
   implicit val timeout: Timeout = Timeout(3.seconds)
 
   case object Init
+
+  // Setters
   case class InsertProject(p: TrialProject)
   case class VerifiedProject(p: TrialProject)
   case object BumpRawlsProjectCallsCount
   case class RawlsCreatedProjects(p: String)
+
+  // Getters
   case object GetInsertedProjects
   case object GetVerifiedProjects
   case object GetProjectCallsCount
   case object GetCreatedProjects
+
   //noinspection ActorMutableStateInspection
   class RegisterTrialProjectActor extends Actor {
 


### PR DESCRIPTION
## Addresses 
https://broadinstitute.atlassian.net/browse/GAWB-3145

## Notes:
I tried to minimize the changes to this class as much as possible. I left all tests exactly as is and isolated the refactoring to how internal DAO state is updated and retrieved. I tried different ways of using concurrency-safe data structures (i.e., `AtomicReference`, `.synchronized`, `ConcurrentHashMap`, etc.) but still found errors when running many test runs. So, I resorted to the sledgehammer approach of putting everything into an actor and restricting updates/access to actor messages. 

## Testing:
From the command line:
```
sbt "repeat 100 test-only *ProjectManagerSpec"
```
Run as many times as you feel necessary.

## Automated Testing:
There are 10 successful build jobs in a row. I have seen `NihApiServiceSpec` fail much less frequently than `ProjectManagerSpec`. That problem is documented here: https://broadinstitute.atlassian.net/browse/GAWB-3183 and this PR does not try to address `NihApiServiceSpec`

```
Run 1: 
Feb 8, 2018 10:07:29 PM
https://fc-jenkins.dsp-techops.broadinstitute.org/job/firecloud-orchestration-build/549/

Run 2:
Feb 8, 2018 10:25:14 PM
https://fc-jenkins.dsp-techops.broadinstitute.org/job/firecloud-orchestration-build/550/

Run 3:
Feb 8, 2018 10:29:35 PM
https://fc-jenkins.dsp-techops.broadinstitute.org/job/firecloud-orchestration-build/551/

Run 4:
Feb 9, 2018 6:34:17 AM
https://fc-jenkins.dsp-techops.broadinstitute.org/job/firecloud-orchestration-build/552/

Run 5:
Feb 9, 2018 6:38:32 AM
https://fc-jenkins.dsp-techops.broadinstitute.org/job/firecloud-orchestration-build/553/

Run 6:
Feb 9, 2018 6:48:41 AM
https://fc-jenkins.dsp-techops.broadinstitute.org/job/firecloud-orchestration-build/554/

Run 7:
Feb 9, 2018 6:53:05 AM
https://fc-jenkins.dsp-techops.broadinstitute.org/job/firecloud-orchestration-build/555/

Run 8:
Feb 9, 2018 6:57:35 AM
https://fc-jenkins.dsp-techops.broadinstitute.org/job/firecloud-orchestration-build/556/

Run 9: 
Feb 9, 2018 7:01:53 AM
https://fc-jenkins.dsp-techops.broadinstitute.org/job/firecloud-orchestration-build/557/

Run 10: 
Feb 9, 2018 7:07:41 AM
https://fc-jenkins.dsp-techops.broadinstitute.org/job/firecloud-orchestration-build/558/
```


---

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
