### PR TITLE
GAWB-3133: consume standard HealthMonitor output from Agora in status checks

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
@@ -265,7 +265,6 @@ object ModelJsonProtocol extends WorkspaceJsonSupport {
   implicit val impOntologyTermResource = jsonFormat7(TermResource)
   implicit val impOntologyESTermParent = jsonFormat2(ESTermParent)
 
-  implicit val impAgoraStatus = jsonFormat2(AgoraStatus)
   implicit val impThurloeStatus = jsonFormat2(ThurloeStatus)
   implicit val impDropwizardHealth = jsonFormat2(DropwizardHealth)
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/SystemStatus.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/SystemStatus.scala
@@ -3,6 +3,5 @@ package org.broadinstitute.dsde.firecloud.model
 /**
   * Created by anichols on 4/7/17.
   */
-case class AgoraStatus(status: String, message: List[String])
 case class ThurloeStatus(status: String, error: Option[String])
 case class DropwizardHealth(healthy: Boolean, message: Option[String])


### PR DESCRIPTION
See also:
broadinstitute/agora#237
broadinstitute/rawls#853

Agora will implement the HealthMonitor from workbench-libs. This means that anyone checking its status needs to update what it consumes.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
