### PR TITLE
get rid of mutable state in actor

### DIFF
--- a/src/test/scala/org/broadinstitute/dsde/firecloud/StartupChecksSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/StartupChecksSpec.scala
@@ -9,7 +9,6 @@ import org.broadinstitute.dsde.firecloud.service.BaseServiceSpec
 import org.broadinstitute.dsde.rawls.model.ErrorReport
 import spray.http.StatusCodes.{InternalServerError, NotFound}
 
-import scala.collection.mutable
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 import scala.language.postfixOps
@@ -165,11 +164,10 @@ case class RegisterUserToken(entity: String)
 case object ListUserTokens
 class RegisterTokenActor extends Actor {
 
-  private var entitySet = mutable.Set.empty[String]
-
-  override def receive: Receive = {
-    case RegisterUserToken(entity) => entitySet += entity
-    case ListUserTokens => sender ! entitySet.toSeq
+  def receive: Receive = register(Set.empty[String])
+  def register(entities: Set[String]): Receive = {
+    case RegisterUserToken(entity) => context become register(entities + entity)
+    case ListUserTokens => sender ! entities.toSeq
   }
 
 }


### PR DESCRIPTION
## Addresses
One part of https://broadinstitute.atlassian.net/browse/GAWB-2949

## Testing
Tests for this specific code have not failed since moving state to an actor. To be re-assured that no concurrency problems still exist, run sbt "repeat 100 test-only *StartupChecksSpec"

--

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
