### PR TITLE
always return 200 from /status

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -3507,14 +3507,14 @@ paths:
       tags:
         - Status
       summary: |
-        An orchestrated status check for underlying systems: Agora, Thurloe, Elasticsearch, Rawls
+        An orchestrated status check that includes a health report of underlying systems
       responses:
         200:
-          description: All systems OK.
+          description: This service is healthy; check payload for subsystem health.
           schema:
             $ref: '#/definitions/SystemStatus'
         500:
-          description: Problem with one or more systems. See response for details.
+          description: This service is not healthy; therefore, payload may be missing or incomplete.
           schema:
             $ref: '#/definitions/SystemStatus'
       security: []

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/StatusService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/StatusService.scala
@@ -37,8 +37,10 @@ class StatusService (val healthMonitor: ActorRef)
 
   def collectStatusInfo(): Future[PerRequestMessage] = {
     (healthMonitor ? GetCurrentStatus).mapTo[StatusCheckResponse].map { statusCheckResponse =>
-      val httpStatus = if (statusCheckResponse.ok) StatusCodes.OK else StatusCodes.InternalServerError
-      RequestComplete(httpStatus, statusCheckResponse)
+      // if we've successfully reached this point, always return a 200, so the load balancers
+      // don't think orchestration is down. the statusCheckResponse will still contain ok: true|false
+      // in its payload, depending on the status of subsystems.
+      RequestComplete(StatusCodes.OK, statusCheckResponse)
     }
   }
 }


### PR DESCRIPTION
no jira, but this is bubbling up (has bubbled up) as a priority issue.

/status endpoint, which the load balancers read, now always returns a 200 as long as orchestration is able to serve a response. The payload of the response still contains details on all of the subsystems' health.

We must make the same/similar change in all the various subsystems - rawls, etc. etc.

Requirements are that /status endpoints should return 200 when up or degraded, and 500 when down. "Degraded" is up to each service to define, but follows the general guideline that when independent subsystems (e.g. orch:agora) are down, the parent service should return 200; when critical subsystems (e.g. agora:mongo) are down, the parent service should return 500. I am declaring that orchestration has no critical subsystems - if any of the subsystems are down, orch can still serve responses to at least some portions of its API.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
