### PR TITLE
GAWB-3272: logit metrics

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/Application.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/Application.scala
@@ -18,4 +18,5 @@ case class Application(agoraDAO: AgoraDAO,
                        samDAO: SamDAO,
                        searchDAO: SearchDAO,
                        thurloeDAO: ThurloeDAO,
-                       trialDAO: TrialDAO)
+                       trialDAO: TrialDAO,
+                       logitDAO: LogitDAO)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
@@ -174,9 +174,9 @@ object FireCloudConfig {
 
   object Metrics {
     private val metrics = config.getConfig("metrics")
-    val logitUrl: Option[String] = if (metrics.hasPath("logitUrl")) Some(metrics.getString("logitUrl")) else None
-    val logitApiKey: Option[String] = if (metrics.hasPath("logitApiKey")) Some(metrics.getString("logitApiKey")) else None
     val logitFrequencyMinutes = metrics.getInt("logitFrequencyMinutes")
+    val logitUrl: String = metrics.getString("logitUrl")
+    val logitApiKey: Option[String] = if (metrics.hasPath("logitApiKey")) Some(metrics.getString("logitApiKey")) else None
     val entityWorkspaceNamespace: Option[String] = if (metrics.hasPath("entityWorkspaceNamespace")) Some(metrics.getString("entityWorkspaceNamespace")) else None
     val entityWorkspaceName: Option[String] = if (metrics.hasPath("entityWorkspaceName")) Some(metrics.getString("entityWorkspaceName")) else None
   }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
@@ -171,4 +171,13 @@ object FireCloudConfig {
     val managerGroup = trial.getString("managerGroup")
     val billingAccount = trial.getString("billingAccount")
   }
+
+  object Metrics {
+    private val metrics = config.getConfig("metrics")
+    val logitUrl: Option[String] = if (metrics.hasPath("logitUrl")) Some(metrics.getString("logitUrl")) else None
+    val logitApiKey: Option[String] = if (metrics.hasPath("logitApiKey")) Some(metrics.getString("logitApiKey")) else None
+    val logitFrequencyMinutes = metrics.getInt("logitFrequencyMinutes")
+    val entityWorkspaceNamespace: Option[String] = if (metrics.hasPath("entityWorkspaceNamespace")) Some(metrics.getString("entityWorkspaceNamespace")) else None
+    val entityWorkspaceName: Option[String] = if (metrics.hasPath("entityWorkspaceName")) Some(metrics.getString("entityWorkspaceName")) else None
+  }
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudServiceActor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudServiceActor.scala
@@ -49,7 +49,7 @@ class FireCloudServiceActor extends HttpServiceActor with FireCloudDirectives
 
   val elasticSearchClient: TransportClient = ElasticUtils.buildClient(FireCloudConfig.ElasticSearch.servers, FireCloudConfig.ElasticSearch.clusterName)
 
-  val logitMetricsEnabled = FireCloudConfig.Metrics.logitUrl.isDefined && FireCloudConfig.Metrics.logitApiKey.isDefined
+  val logitMetricsEnabled = FireCloudConfig.Metrics.logitApiKey.isDefined
 
   val agoraDAO:AgoraDAO = new HttpAgoraDAO(FireCloudConfig.Agora)
   val rawlsDAO:RawlsDAO = new HttpRawlsDAO
@@ -61,7 +61,7 @@ class FireCloudServiceActor extends HttpServiceActor with FireCloudDirectives
   val searchDAO:SearchDAO = new ElasticSearchDAO(elasticSearchClient, FireCloudConfig.ElasticSearch.indexName, ontologyDAO)
   val trialDAO:TrialDAO = new ElasticSearchTrialDAO(elasticSearchClient, FireCloudConfig.ElasticSearch.trialIndexName)
   val logitDAO:LogitDAO = if (logitMetricsEnabled)
-      new HttpLogitDAO(FireCloudConfig.Metrics.logitUrl.get, FireCloudConfig.Metrics.logitApiKey.get)
+      new HttpLogitDAO(FireCloudConfig.Metrics.logitUrl, FireCloudConfig.Metrics.logitApiKey.get)
     else
       new NoopLogitDAO
 
@@ -82,7 +82,7 @@ class FireCloudServiceActor extends HttpServiceActor with FireCloudDirectives
     val initialDelay = 1 + scala.util.Random.nextInt(10)
     system.scheduler.schedule(initialDelay.minutes, FireCloudConfig.Metrics.logitFrequencyMinutes.minutes, metricsActor, MetricsActor.RecordMetrics)
   } else {
-    logger.info("Logit url or apikey not found in configuration. Logit metrics are disabled for this instance.")
+    logger.info("Logit apikey not found in configuration. Logit metrics are disabled for this instance.")
   }
 
   val exportEntitiesByTypeConstructor: (ExportEntitiesByTypeArguments) => ExportEntitiesByTypeActor = ExportEntitiesByTypeActor.constructor(app, materializer)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpLogitDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpLogitDAO.scala
@@ -1,0 +1,49 @@
+package org.broadinstitute.dsde.firecloud.dataaccess
+import com.typesafe.scalalogging.LazyLogging
+import org.broadinstitute.dsde.firecloud.model.Metrics.LogitMetric
+import org.broadinstitute.dsde.firecloud.model.MetricsFormat.LogitMetricFormat
+import spray.client.pipelining._
+import spray.http.{HttpHeader, HttpHeaders}
+import spray.http.HttpHeaders.RawHeader
+import spray.http.MediaTypes.`application/json`
+import spray.http.StatusCodes.Accepted
+
+class HttpLogitDAO(logitUrlOption: Option[String], logitApiKeyOption: Option[String]) extends LogitDAO with LazyLogging {
+
+  private val enabled = logitUrlOption.isDefined && logitApiKeyOption.isDefined
+  private val logitUrl = logitUrlOption.getOrElse("")
+  private val logitApiKey = logitApiKeyOption.getOrElse("")
+
+  // TODO: accept url and apiKey
+  // TODO: disable everything if no apiKey
+
+
+
+  /*
+Requirements
+Valid JSON content
+API key (find this on your dashboard) sent in the headers
+Content-Type header set as application/json
+Either POST or PUT to https://api.logit.io/v2
+
+curl -i -H "ApiKey: your-api-key" -i -H "Content-Type: application/json" -H "LogType: SampleHttpLog" https://api.logit.io/v2 -d '{"test":"test","example": { "a": 1, "b": 2 } }'
+
+Response
+You should expect to receive a 202 Accepted response code for a successful message
+ */
+
+  override def recordMetric(logtype: String, metric: LogitMetric): Unit = {
+    if (enabled) {
+      val pipeline = Put(logitUrl, metric) ~> addHeader(RawHeader("ApiKey", logitApiKey)) ~> addHeader(HttpHeaders.`Content-Type`(`application/json`)) ~> sendReceive
+      pipeline map { logitResponse =>
+        logitResponse.status match {
+          case Accepted => logger.info("Logit request succeeded!")
+          case _ => logger.error(s"Logit request returned: $logitResponse")
+        }
+      } recover {
+        case e:Exception => logger.error(s"Exception calling logit: ${e.getMessage}")
+      }
+
+    }
+  }
+}

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpLogitDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpLogitDAO.scala
@@ -1,49 +1,53 @@
 package org.broadinstitute.dsde.firecloud.dataaccess
+
+import akka.actor.ActorRefFactory
 import com.typesafe.scalalogging.LazyLogging
+import org.broadinstitute.dsde.firecloud.metrics.MetricsException
+import org.broadinstitute.dsde.firecloud.model.Metrics
 import org.broadinstitute.dsde.firecloud.model.Metrics.LogitMetric
 import org.broadinstitute.dsde.firecloud.model.MetricsFormat.LogitMetricFormat
 import spray.client.pipelining._
-import spray.http.{HttpHeader, HttpHeaders}
 import spray.http.HttpHeaders.RawHeader
-import spray.http.MediaTypes.`application/json`
 import spray.http.StatusCodes.Accepted
+import spray.httpx.SprayJsonSupport
 
-class HttpLogitDAO(logitUrlOption: Option[String], logitApiKeyOption: Option[String]) extends LogitDAO with LazyLogging {
+import scala.concurrent.{ExecutionContext, Future}
 
-  private val enabled = logitUrlOption.isDefined && logitApiKeyOption.isDefined
-  private val logitUrl = logitUrlOption.getOrElse("")
-  private val logitApiKey = logitApiKeyOption.getOrElse("")
-
-  // TODO: accept url and apiKey
-  // TODO: disable everything if no apiKey
-
-
+class HttpLogitDAO(logitUrl: String, logitApiKey: String)
+                  (implicit actorRefFactory: ActorRefFactory, executionContext: ExecutionContext) extends LogitDAO with SprayJsonSupport with LazyLogging {
 
   /*
-Requirements
-Valid JSON content
-API key (find this on your dashboard) sent in the headers
-Content-Type header set as application/json
-Either POST or PUT to https://api.logit.io/v2
+    Requirements to send to Logit:
+      - Valid JSON content
+      - API key (find this on your dashboard) sent in the headers
+      - Content-Type header set as application/json
+      - Either POST or PUT to https://api.logit.io/v2
 
-curl -i -H "ApiKey: your-api-key" -i -H "Content-Type: application/json" -H "LogType: SampleHttpLog" https://api.logit.io/v2 -d '{"test":"test","example": { "a": 1, "b": 2 } }'
 
-Response
-You should expect to receive a 202 Accepted response code for a successful message
- */
+    curl -i -H "ApiKey: your-api-key" -i -H "Content-Type: application/json" -H "LogType: SampleHttpLog" https://api.logit.io/v2 -d '{"test":"test","example": { "a": 1, "b": 2 } }'
 
-  override def recordMetric(logtype: String, metric: LogitMetric): Unit = {
-    if (enabled) {
-      val pipeline = Put(logitUrl, metric) ~> addHeader(RawHeader("ApiKey", logitApiKey)) ~> addHeader(HttpHeaders.`Content-Type`(`application/json`)) ~> sendReceive
-      pipeline map { logitResponse =>
-        logitResponse.status match {
-          case Accepted => logger.info("Logit request succeeded!")
-          case _ => logger.error(s"Logit request returned: $logitResponse")
-        }
-      } recover {
-        case e:Exception => logger.error(s"Exception calling logit: ${e.getMessage}")
+    Response
+      - You should expect to receive a 202 Accepted response code for a successful message
+  */
+
+  override def recordMetric(metric: LogitMetric): Future[LogitMetric] = {
+    val pipeline = Put(logitUrl, metric) ~>
+      addHeader(RawHeader("LogType", Metrics.LOG_TYPE)) ~>
+      addHeader(RawHeader("ApiKey", logitApiKey)) ~>
+      sendReceive
+
+    pipeline map { logitResponse =>
+      logitResponse.status match {
+        case Accepted =>
+          logger.debug(s"Logit request succeeded: ${LogitMetricFormat.write(metric).compactPrint}")
+          metric
+        case _ =>
+          throw new MetricsException(s"Logit returned ${logitResponse.status} on metrics request: $logitResponse")
       }
-
+    } recover {
+      case e:Exception =>
+        throw new MetricsException(s"Exception calling logit: ${e.getMessage}", e)
     }
   }
+
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpLogitDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpLogitDAO.scala
@@ -23,7 +23,6 @@ class HttpLogitDAO(logitUrl: String, logitApiKey: String)
       - Content-Type header set as application/json
       - Either POST or PUT to https://api.logit.io/v2
 
-
     curl -i -H "ApiKey: your-api-key" -i -H "Content-Type: application/json" -H "LogType: SampleHttpLog" https://api.logit.io/v2 -d '{"test":"test","example": { "a": 1, "b": 2 } }'
 
     Response

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/LogitDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/LogitDAO.scala
@@ -8,5 +8,4 @@ trait LogitDAO {
 
   def recordMetric(metric: LogitMetric): Future[LogitMetric]
 
-
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/LogitDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/LogitDAO.scala
@@ -1,11 +1,12 @@
 package org.broadinstitute.dsde.firecloud.dataaccess
 
 import org.broadinstitute.dsde.firecloud.model.Metrics.LogitMetric
-import spray.json.JsObject
+
+import scala.concurrent.Future
 
 trait LogitDAO {
 
-  def recordMetric(logtype: String, metric: LogitMetric)
+  def recordMetric(metric: LogitMetric): Future[LogitMetric]
 
 
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/LogitDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/LogitDAO.scala
@@ -1,0 +1,11 @@
+package org.broadinstitute.dsde.firecloud.dataaccess
+
+import org.broadinstitute.dsde.firecloud.model.Metrics.LogitMetric
+import spray.json.JsObject
+
+trait LogitDAO {
+
+  def recordMetric(logtype: String, metric: LogitMetric)
+
+
+}

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/NoopLogitDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/NoopLogitDAO.scala
@@ -1,0 +1,10 @@
+package org.broadinstitute.dsde.firecloud.dataaccess
+import org.broadinstitute.dsde.firecloud.model.Metrics
+import org.broadinstitute.dsde.firecloud.model.Metrics.NoopMetric
+
+import scala.concurrent.Future
+
+class NoopLogitDAO extends LogitDAO {
+  override def recordMetric(metric: Metrics.LogitMetric): Future[Metrics.LogitMetric] =
+    Future.successful(NoopMetric)
+}

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/NoopLogitDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/NoopLogitDAO.scala
@@ -1,10 +1,9 @@
 package org.broadinstitute.dsde.firecloud.dataaccess
-import org.broadinstitute.dsde.firecloud.model.Metrics
-import org.broadinstitute.dsde.firecloud.model.Metrics.NoopMetric
+import org.broadinstitute.dsde.firecloud.model.Metrics.{LogitMetric, NoopMetric}
 
 import scala.concurrent.Future
 
 class NoopLogitDAO extends LogitDAO {
-  override def recordMetric(metric: Metrics.LogitMetric): Future[Metrics.LogitMetric] =
+  override def recordMetric(metric: LogitMetric): Future[LogitMetric] =
     Future.successful(NoopMetric)
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/RawlsDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/RawlsDAO.scala
@@ -3,6 +3,7 @@ package org.broadinstitute.dsde.firecloud.dataaccess
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.FireCloudConfig
 import org.broadinstitute.dsde.firecloud.model.MethodRepository.AgoraConfigurationShort
+import org.broadinstitute.dsde.firecloud.model.Metrics.AdminStats
 import org.broadinstitute.dsde.firecloud.model.Trial.ProjectRoles.ProjectRole
 import org.broadinstitute.dsde.firecloud.model.Trial.{RawlsBillingProjectMember, RawlsBillingProjectMembership}
 import org.broadinstitute.dsde.firecloud.model._
@@ -75,6 +76,8 @@ trait RawlsDAO extends LazyLogging with ReportsSubsystemStatus {
   def adminAddMemberToGroup(groupName: String, memberList: RawlsGroupMemberList): Future[Boolean]
 
   def adminOverwriteGroupMembership(groupName: String, memberList: RawlsGroupMemberList): Future[Boolean]
+
+  def adminStats(startDate: DateTime, endDate: DateTime, workspaceNamespace: Option[String], workspaceName: Option[String]): Future[AdminStats]
 
   def fetchAllEntitiesOfType(workspaceNamespace: String, workspaceName: String, entityType: String)(implicit userToken: UserInfo): Future[Seq[Entity]]
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/metrics/MetricsActor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/metrics/MetricsActor.scala
@@ -1,0 +1,53 @@
+package org.broadinstitute.dsde.firecloud.metrics
+
+import akka.actor.{Actor, Props}
+import com.typesafe.scalalogging.LazyLogging
+import org.broadinstitute.dsde.firecloud.{Application, FireCloudConfig}
+import org.broadinstitute.dsde.firecloud.FireCloudConfig.FireCloud
+import org.broadinstitute.dsde.firecloud.dataaccess.{HttpLogitDAO, LogitDAO, RawlsDAO}
+import org.broadinstitute.dsde.firecloud.metrics.MetricsActor.RecordMetrics
+import org.broadinstitute.dsde.firecloud.model.Metrics.LogitMetric
+import org.joda.time.DateTime
+import spray.json.JsObject
+
+object MetricsActor {
+  sealed trait MetricsActorMessage
+  case object RecordMetrics extends MetricsActorMessage
+
+  def props(app: Application) = Props(new MetricsActor(app.logitDAO, app.rawlsDAO))
+
+}
+
+class MetricsActor(logitDAO: LogitDAO, rawlsDAO: RawlsDAO) extends Actor with LazyLogging {
+  // TODO: run in an independent context?
+  import context.dispatcher
+
+  override def receive: Receive = {
+    case RecordMetrics => recordMetrics
+  }
+
+  private def recordMetrics = {
+    /*  calculate the start/end date to use when querying rawls for stats.
+        because the entity counts are not time-bound, we don't care what we send for start/end date, as long as
+        we send legal values. So, send a 1-second span to make Rawls' SQL queries
+        as light as possible.
+     */
+    val endDate = new DateTime()
+    val startDate = endDate.minusSeconds(1)
+    val workspaceNamespace = FireCloudConfig.Metrics.entityWorkspaceNamespace
+    val workspaceName = FireCloudConfig.Metrics.entityWorkspaceName
+
+    // get admin-stats from rawls
+    rawlsDAO.adminStats(startDate, endDate, workspaceNamespace, workspaceName) map { stats =>
+      // we only care to log samples right now
+      val numSamples = stats.statistics.currentEntityStatistics.entityStats.getOrElse("sample", 0)
+
+      val metric = LogitMetric(numSamples)
+
+      logitDAO.recordMetric(numSamples.toString, metric)
+    } recover {
+      case e:Exception => logger.error("MetricsActor.recordMetrics failure: " + e.getMessage)
+    }
+  }
+
+}

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/metrics/MetricsActor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/metrics/MetricsActor.scala
@@ -1,14 +1,15 @@
 package org.broadinstitute.dsde.firecloud.metrics
 
 import akka.actor.{Actor, Props}
+import akka.pattern.pipe
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.{Application, FireCloudConfig}
-import org.broadinstitute.dsde.firecloud.FireCloudConfig.FireCloud
-import org.broadinstitute.dsde.firecloud.dataaccess.{HttpLogitDAO, LogitDAO, RawlsDAO}
+import org.broadinstitute.dsde.firecloud.dataaccess.{LogitDAO, RawlsDAO}
 import org.broadinstitute.dsde.firecloud.metrics.MetricsActor.RecordMetrics
-import org.broadinstitute.dsde.firecloud.model.Metrics.LogitMetric
+import org.broadinstitute.dsde.firecloud.model.Metrics.{LogitMetric, NoopMetric, NumObjects}
 import org.joda.time.DateTime
-import spray.json.JsObject
+
+import scala.concurrent.Future
 
 object MetricsActor {
   sealed trait MetricsActorMessage
@@ -19,14 +20,13 @@ object MetricsActor {
 }
 
 class MetricsActor(logitDAO: LogitDAO, rawlsDAO: RawlsDAO) extends Actor with LazyLogging {
-  // TODO: run in an independent context?
   import context.dispatcher
 
   override def receive: Receive = {
-    case RecordMetrics => recordMetrics
+    case RecordMetrics => recordMetrics pipeTo sender
   }
 
-  private def recordMetrics = {
+  private def recordMetrics: Future[LogitMetric] = {
     /*  calculate the start/end date to use when querying rawls for stats.
         because the entity counts are not time-bound, we don't care what we send for start/end date, as long as
         we send legal values. So, send a 1-second span to make Rawls' SQL queries
@@ -38,15 +38,20 @@ class MetricsActor(logitDAO: LogitDAO, rawlsDAO: RawlsDAO) extends Actor with La
     val workspaceName = FireCloudConfig.Metrics.entityWorkspaceName
 
     // get admin-stats from rawls
-    rawlsDAO.adminStats(startDate, endDate, workspaceNamespace, workspaceName) map { stats =>
+    rawlsDAO.adminStats(startDate, endDate, workspaceNamespace, workspaceName) flatMap { stats =>
       // we only care to log samples right now
       val numSamples = stats.statistics.currentEntityStatistics.entityStats.getOrElse("sample", 0)
+      val metric = NumObjects(numSamples)
 
-      val metric = LogitMetric(numSamples)
-
-      logitDAO.recordMetric(numSamples.toString, metric)
+      logitDAO.recordMetric(metric) recover {
+        case t:Throwable =>
+          logger.warn(s"LogitDAO.recordMetric failure: ${t.getMessage}", t)
+          NoopMetric
+      }
     } recover {
-      case e:Exception => logger.error("MetricsActor.recordMetrics failure: " + e.getMessage)
+      case t:Throwable =>
+        logger.warn(s"MetricsActor.recordMetrics failure: ${t.getMessage}", t)
+        NoopMetric
     }
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/metrics/MetricsException.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/metrics/MetricsException.scala
@@ -1,0 +1,5 @@
+package org.broadinstitute.dsde.firecloud.metrics
+
+import org.broadinstitute.dsde.firecloud.FireCloudException
+
+class MetricsException(message:String, cause:Throwable = null) extends FireCloudException(message, cause)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/Metrics.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/Metrics.scala
@@ -1,0 +1,49 @@
+package org.broadinstitute.dsde.firecloud.model
+
+import org.broadinstitute.dsde.firecloud.model.Metrics.{AdminStats, CurrentEntityStatistics, LogitMetric, Statistics}
+import spray.json.DefaultJsonProtocol._
+import spray.json.JsObject
+
+object Metrics {
+
+  /*
+
+
+    "currentEntityStatistics": {
+      "entityStats": {
+        "pair_set": 32,
+        "participant": 1361235,
+        "sample_set": 370,
+        "participant_set": 5018,
+        "sample": 1620664,
+        "pair": 14151
+      },
+      "workspaceNamespace": "broad-dsde-dev"
+    },
+
+   */
+
+  // we could/should represent EntityStats as a Map[String, Int]
+  // case class EntityStats(sample: Option[Int], pair: Option[Int], participant: Option[Int], sample_set: Option[Int], pair_set: Option[Int], participant_set: Option[Int])
+  case class CurrentEntityStatistics(workspaceNamespace: Option[String], workspaceName: Option[String], entityStats: Map[String, Int])
+  case class Statistics(currentEntityStatistics: CurrentEntityStatistics)
+  case class AdminStats(startDate: String, endDate: String, statistics: Statistics)
+
+
+  // TODO: build out
+  case class LogitMetric(numSamples: Int)
+
+}
+
+// ModelJsonProtocol is getting big and unwieldy, keeping the json formats local to the model as a new paradigm
+trait MetricsFormat {
+  // implicit val EntityStatsFormat = jsonFormat6(EntityStats)
+  implicit val CurrentEntityStatisticsFormat = jsonFormat3(CurrentEntityStatistics)
+  implicit val StatisticsFormat = jsonFormat1(Statistics)
+  implicit val AdminStatsFormat = jsonFormat3(AdminStats)
+
+  implicit val LogitMetricFormat = jsonFormat1(LogitMetric)
+
+}
+
+object MetricsFormat extends MetricsFormat

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/Metrics.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/Metrics.scala
@@ -9,19 +9,20 @@ object Metrics {
   final val LOG_TYPE = "FCMetric"
   final val METRICTYPE_KEY = "metricType"
 
+  // structures returned by Rawls
   case class CurrentEntityStatistics(workspaceNamespace: Option[String], workspaceName: Option[String], entityStats: Map[String, Int])
   case class Statistics(currentEntityStatistics: CurrentEntityStatistics)
   case class AdminStats(startDate: String, endDate: String, statistics: Statistics)
 
+  // structures sent to Logit and otherwise used in *LogitDAO
   abstract class LogitMetric
   case object NoopMetric extends LogitMetric
   case class NumObjects(numSamples: Int) extends LogitMetric
 
 }
 
-// ModelJsonProtocol is getting big and unwieldy, keeping the json formats local to the model as a new paradigm
+// ModelJsonProtocol is getting big and unwieldy, keeping the json formats local to the model
 trait MetricsFormat {
-  // implicit val EntityStatsFormat = jsonFormat6(EntityStats)
   implicit val CurrentEntityStatisticsFormat = jsonFormat3(CurrentEntityStatistics)
   implicit val StatisticsFormat = jsonFormat1(Statistics)
   implicit val AdminStatsFormat = jsonFormat3(AdminStats)

--- a/src/test/resources/reference.conf
+++ b/src/test/resources/reference.conf
@@ -82,6 +82,13 @@ trial {
   billingAccount = "billingAccounts/dummy"
 }
 
+metrics {
+  logitUrl = "fake-url"
+  logitApiKey = "fake-api-key"
+  logitFrequencyMinutes = 2
+  entityWorkspaceNamespace = "some-namespace"
+}
+
 # these are the settings currently used at runtime; copy them here
 # so we're testing under similar conditions.
 spray.can.host-connector {

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockLogitDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockLogitDAO.scala
@@ -1,6 +1,9 @@
 package org.broadinstitute.dsde.firecloud.dataaccess
+import org.broadinstitute.dsde.firecloud.model.Metrics
 import spray.json.JsObject
 
+import scala.concurrent.Future
+
 class MockLogitDAO extends LogitDAO {
-  override def recordMetric(logtype: String, metric: JsObject): Unit = ???
+  override def recordMetric(metric: Metrics.LogitMetric): Future[Metrics.LogitMetric] = ???
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockLogitDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockLogitDAO.scala
@@ -1,0 +1,6 @@
+package org.broadinstitute.dsde.firecloud.dataaccess
+import spray.json.JsObject
+
+class MockLogitDAO extends LogitDAO {
+  override def recordMetric(logtype: String, metric: JsObject): Unit = ???
+}

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockRawlsDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockRawlsDAO.scala
@@ -232,6 +232,9 @@ class MockRawlsDAO  extends RawlsDAO {
     Future.successful(true)
   }
 
+
+  override def adminStats(startDate: DateTime, endDate: DateTime, workspaceNamespace: Option[String], workspaceName: Option[String]): Future[Metrics.AdminStats] = ???
+
   override def getGroupsForUser(implicit userToken: WithAccessToken): Future[Seq[String]] = {
     Future.successful(Seq("TestUserGroup"))
   }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/metrics/MetricsSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/metrics/MetricsSpec.scala
@@ -61,7 +61,7 @@ class MetricsSpec extends BaseServiceSpec {
 
 }
 
-class MetricsSpecMockLogitDAO(numFailures: Int, numSamples: Int) extends MockLogitDAO with Assertions {
+class MetricsSpecMockLogitDAO(numFailures: Int, numSamples: Int) extends MockLogitDAO {
   val q = new java.util.concurrent.ConcurrentLinkedQueue[Int]
 
   override def recordMetric(metric: LogitMetric): Future[LogitMetric] = {

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/metrics/MetricsSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/metrics/MetricsSpec.scala
@@ -1,0 +1,89 @@
+package org.broadinstitute.dsde.firecloud.metrics
+
+import org.broadinstitute.dsde.firecloud.dataaccess.{MockLogitDAO, MockRawlsDAO}
+import org.broadinstitute.dsde.firecloud.model.Metrics
+import org.broadinstitute.dsde.firecloud.model.Metrics._
+import org.broadinstitute.dsde.firecloud.model.MetricsFormat.LogitMetricFormat
+import org.broadinstitute.dsde.firecloud.service.BaseServiceSpec
+import org.joda.time.DateTime
+import org.scalatest.Assertions
+import spray.json.{JsNumber, JsObject, JsString}
+import akka.pattern._
+import org.broadinstitute.dsde.firecloud.FireCloudException
+
+import scala.concurrent.{Await, Future}
+import scala.concurrent.duration._
+
+class MetricsSpec extends BaseServiceSpec {
+
+  implicit val duration: Duration = 2.minutes
+  implicit val askTimeout: akka.util.Timeout = 2.minutes
+
+  "JSON serialization for metrics models" - {
+    "should serialize noop metric to empty object" in {
+      assertResult(JsObject()) {LogitMetricFormat.write(NoopMetric)}
+    }
+    "should serialize numobjects metric correctly" in {
+      List(Integer.MIN_VALUE, -1, 0, 1, 42, 123456789, Integer.MAX_VALUE) foreach { num =>
+        val numObjects = NumObjects(num)
+        val expected = JsObject(Map("metricType" -> JsString("NumObjects"), "numSamples" -> JsNumber(num)))
+        assertResult(expected) {LogitMetricFormat.write(numObjects)}
+      }
+    }
+  }
+
+  "MetricsActor" - {
+    "should be resilient to failures retrieving stats from rawls" in {
+      val seed = 123+scala.util.Random.nextInt(1000)
+      val testApp = app.copy(rawlsDAO = new MetricsSpecMockRawlsDAO(numFailures=2, numSamples=seed), logitDAO = new MetricsSpecMockLogitDAO(numFailures=0, numSamples=seed))
+      val metricsActor = system.actorOf(MetricsActor.props(testApp), "metrics-spec-failing-rawls-actor")
+      assertResult(NoopMetric) { Await.result(metricsActor ? MetricsActor.RecordMetrics, duration) } // expect failure
+      assertResult(NoopMetric) { Await.result(metricsActor ? MetricsActor.RecordMetrics, duration) } // expect failure
+      assertResult(NumObjects(seed)) { Await.result(metricsActor ? MetricsActor.RecordMetrics, duration) } // expect success
+    }
+    "should be resilient to failures sending data to logit" in {
+      val seed = 123+scala.util.Random.nextInt(1000)
+      val testApp = app.copy(rawlsDAO = new MetricsSpecMockRawlsDAO(numFailures=0, numSamples=seed), logitDAO = new MetricsSpecMockLogitDAO(numFailures=2, numSamples=seed))
+      val metricsActor = system.actorOf(MetricsActor.props(testApp), "metrics-spec-failing-logit-actor")
+      assertResult(NoopMetric) { Await.result(metricsActor ? MetricsActor.RecordMetrics, duration) } // expect failure
+      assertResult(NoopMetric) { Await.result(metricsActor ? MetricsActor.RecordMetrics, duration) } // expect failure
+      assertResult(NumObjects(seed)) { Await.result(metricsActor ? MetricsActor.RecordMetrics, duration) } // expect success
+    }
+    "should extract number of samples from rawls and send to logit" in {
+      val seed = 123+scala.util.Random.nextInt(1000)
+      val testApp = app.copy(rawlsDAO = new MetricsSpecMockRawlsDAO(numFailures=0, numSamples=seed), logitDAO = new MetricsSpecMockLogitDAO(numFailures=0, numSamples=seed))
+      val metricsActor = system.actorOf(MetricsActor.props(testApp), "metrics-spec-actor")
+      assertResult(NumObjects(seed)) { Await.result(metricsActor ? MetricsActor.RecordMetrics, duration) }
+      assertResult(NumObjects(seed)) { Await.result(metricsActor ? MetricsActor.RecordMetrics, duration) }
+    }
+  }
+
+
+}
+
+class MetricsSpecMockLogitDAO(numFailures: Int, numSamples: Int) extends MockLogitDAO with Assertions {
+  val q = new java.util.concurrent.ConcurrentLinkedQueue[Int]
+
+  override def recordMetric(metric: LogitMetric): Future[LogitMetric] = {
+    if (q.size() >= numFailures) {
+      Future.successful(metric)
+    } else {
+      q.add(q.size())
+      Future.failed(new MetricsException("intentional LogitDAO exception for MetricsSpec"))
+    }
+  }
+}
+
+
+class MetricsSpecMockRawlsDAO(numFailures: Int, numSamples: Int) extends MockRawlsDAO {
+  val q = new java.util.concurrent.ConcurrentLinkedQueue[Int]
+
+  override def adminStats(startDate: DateTime, endDate: DateTime, workspaceNamespace: Option[String], workspaceName: Option[String]): Future[Metrics.AdminStats] = {
+    if (q.size() >= numFailures) {
+      Future.successful(AdminStats("2001-01-01", "2002-02-02", Statistics(CurrentEntityStatistics(None, None, Map("sample"->numSamples, "participant"->numSamples*2)))))
+    } else {
+      q.add(q.size())
+      Future.failed(new FireCloudException("intentional RawlsDAO exception for MetricsSpec"))
+    }
+  }
+}

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/ApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/ApiServiceSpec.scala
@@ -33,11 +33,12 @@ trait ApiServiceSpec extends FlatSpec with Matchers with HttpService with Scalat
     val searchDao: MockSearchDAO
     val thurloeDao: MockThurloeDAO
     val trialDao: MockTrialDAO
+    val logitDao: LogitDAO
 
     def actorRefFactory = system
 
     val nihServiceConstructor = NihService.constructor(
-      new Application(agoraDao, googleDao, ontologyDao, consentDao, rawlsDao, samDao, searchDao, thurloeDao, trialDao)
+      new Application(agoraDao, googleDao, ontologyDao, consentDao, rawlsDao, samDao, searchDao, thurloeDao, trialDao, logitDao)
     )_
 
   }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/BaseServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/BaseServiceSpec.scala
@@ -16,8 +16,9 @@ class BaseServiceSpec extends ServiceSpec with BeforeAndAfter {
   val searchDao:MockSearchDAO = new MockSearchDAO
   val thurloeDao:MockThurloeDAO = new MockThurloeDAO
   val trialDao:MockTrialDAO = new MockTrialDAO
+  val logitDao:MockLogitDAO = new MockLogitDAO
 
   val app:Application =
-    new Application(agoraDao, googleServicesDao, ontologyDao, consentDao, rawlsDao, samDao, searchDao, thurloeDao, trialDao)
+    new Application(agoraDao, googleServicesDao, ontologyDao, consentDao, rawlsDao, samDao, searchDao, thurloeDao, trialDao, logitDao)
 
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/NihApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/NihApiServiceSpec.scala
@@ -26,10 +26,10 @@ class NihApiServiceSpec extends ApiServiceSpec {
   //JWT for NIH username "not-on-whitelist" (don't ever add this to the mock whitelists in MockGoogleServicesDAO.scala)
   val validJwtNotOnWhitelist = JWTWrapper("eyJhbGciOiJIUzI1NiJ9.bm90LW9uLXdoaXRlbGlzdA.DayvfECuGAQsXx-MEwXiuQyq86Eqc3Lmn46_9BGs6t0")
 
-  case class TestApiService(agoraDao: MockAgoraDAO, googleDao: MockGoogleServicesDAO, ontologyDao: MockOntologyDAO, consentDao: MockConsentDAO, rawlsDao: MockRawlsDAO, samDao: MockSamDAO, searchDao: MockSearchDAO, thurloeDao: MockThurloeDAO, trialDao: MockTrialDAO)(implicit val executionContext: ExecutionContext) extends ApiServices
+  case class TestApiService(agoraDao: MockAgoraDAO, googleDao: MockGoogleServicesDAO, ontologyDao: MockOntologyDAO, consentDao: MockConsentDAO, rawlsDao: MockRawlsDAO, samDao: MockSamDAO, searchDao: MockSearchDAO, thurloeDao: MockThurloeDAO, trialDao: MockTrialDAO, logitDao: MockLogitDAO)(implicit val executionContext: ExecutionContext) extends ApiServices
 
   def withDefaultApiServices[T](testCode: TestApiService => T): T = {
-    val apiService = new TestApiService(new MockAgoraDAO, new MockGoogleServicesDAO, new MockOntologyDAO, new MockConsentDAO, new MockRawlsDAO, new MockSamDAO, new MockSearchDAO, new MockThurloeDAO, new MockTrialDAO)
+    val apiService = new TestApiService(new MockAgoraDAO, new MockGoogleServicesDAO, new MockOntologyDAO, new MockConsentDAO, new MockRawlsDAO, new MockSamDAO, new MockSearchDAO, new MockThurloeDAO, new MockTrialDAO, new MockLogitDAO)
     testCode(apiService)
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceServiceSpec.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.dsde.firecloud.service
 import akka.testkit.TestActorRef
-import org.broadinstitute.dsde.firecloud.dataaccess.{MockRawlsDAO, MockSearchDAO}
+import org.broadinstitute.dsde.firecloud.dataaccess.{MockLogitDAO, MockRawlsDAO, MockSearchDAO}
 import org.broadinstitute.dsde.firecloud.{Application, FireCloudException}
 import org.broadinstitute.dsde.firecloud.model.{AccessToken, WithAccessToken, WorkspaceDeleteResponse}
 import org.broadinstitute.dsde.firecloud.service.PerRequest.{RequestComplete, RequestCompleteWithHeaders}
@@ -15,7 +15,7 @@ import scala.concurrent.duration._
 
 class WorkspaceServiceSpec extends BaseServiceSpec with BeforeAndAfterEach {
 
-  val customApp = Application(agoraDao, googleServicesDao, ontologyDao, consentDao, new MockRawlsDeleteWSDAO(), samDao, new MockSearchDeleteWSDAO(), thurloeDao, trialDao)
+  val customApp = Application(agoraDao, googleServicesDao, ontologyDao, consentDao, new MockRawlsDeleteWSDAO(), samDao, new MockSearchDeleteWSDAO(), thurloeDao, trialDao, new MockLogitDAO)
 
   val workspaceServiceConstructor: (WithAccessToken) => WorkspaceService = WorkspaceService.constructor(customApp)
 


### PR DESCRIPTION
requires broadinstitute/firecloud-develop#1056
requires broadinstitute/rawls#883

This PR adds a new actor and a new DAO to communicate with Logit. Every 6 hours (configurable), orch queries Rawls to count the number of samples in a given set of workspaces, then sends that metric to Logit.

I'm building this in orch specifically, because in a future story (GAWB-3265) we'll also query Library for stats, and send those stats to Logit as well.

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
