### PR TITLE
23: automate free-credits spreadsheet updates

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -44,3 +44,10 @@ userprofile {
 googlecloud {
   priceListUrl: "https://cloudpricingcalculator.appspot.com/static/data/pricelist.json"
 }
+
+trial {
+  spreadsheet {
+    id = ""
+    updateFrequencyMinutes = 0
+  }
+}

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -31,9 +31,6 @@ securityDefinitions:
       openid: open id authorization
       email: email authorization
       profile: profile authorization
-      https://www.googleapis.com/auth/drive: Google Drive Access
-      https://www.googleapis.com/auth/drive.file: Google Drive Files
-      https://www.googleapis.com/auth/spreadsheets: Google Spreadsheets Access
       https://www.googleapis.com/auth/devstorage.full_control: GCS storage
       https://www.googleapis.com/auth/cloud-billing: GCS billing
 
@@ -1832,67 +1829,6 @@ paths:
           description: You must be a campaign manager to call this endpoint.
         500:
           description: Internal Server Error
-
-  /api/trial/manager/report:
-    post:
-      tags:
-        - Trial (FireCloud Credits)
-      operationId: createReportTrialProjects
-      summary: Create a Spreadsheet Report of projects in the FireCloud Free Credits Program; for managers of the Program only.
-      responses:
-        200:
-          description: OK; report data spreadsheet is created
-          schema:
-            $ref: '#/definitions/SpreadsheetResponse'
-        403:
-          description: You must be a campaign manager to call this endpoint.
-        500:
-          description: Internal Server Error
-      security:
-        - googleoauth:
-          - openid
-          - email
-          - profile
-          - https://www.googleapis.com/auth/drive
-          - https://www.googleapis.com/auth/drive.file
-          - https://www.googleapis.com/auth/spreadsheets
-          - https://www.googleapis.com/auth/devstorage.full_control
-
-  /api/trial/manager/report/{spreadsheetId}:
-    put:
-      tags:
-        - Trial (FireCloud Credits)
-      operationId: updateReportTrialProjects
-      summary: Update a Spreadsheet Report of projects in the FireCloud Free Credits Program; for managers of the Program only.
-      parameters:
-        - name: spreadsheetId
-          description: |
-            The spreadsheet id to update. The spreadsheet id can be found in the url of the link.
-            For example, in the link "https://docs.google.com/spreadsheets/d/long-random-string/edit",
-            the string "long-random-string" is the "spreadsheetId" value.
-          required: true
-          in: path
-          type: string
-      responses:
-        200:
-          description: OK; report data spreadsheet is updated
-          schema:
-            $ref: '#/definitions/SpreadsheetResponse'
-        403:
-          description: You must be a campaign manager to call this endpoint.
-        404:
-          description: The spreadsheet id provided was not found.
-        500:
-          description: Internal Server Error
-      security:
-        - googleoauth:
-          - openid
-          - email
-          - profile
-          - https://www.googleapis.com/auth/drive
-          - https://www.googleapis.com/auth/drive.file
-          - https://www.googleapis.com/auth/spreadsheets
-          - https://www.googleapis.com/auth/devstorage.full_control
 
   /version/executionEngine:
     get:
@@ -5360,14 +5296,6 @@ definitions:
       sortDirection:
         type: string
         description: asc or desc; defaults to asc if not specified
-
-  SpreadsheetResponse:
-    description: ''
-    type: object
-    properties:
-      spreadsheetUrl:
-        type: string
-        description: The url of the created/updated spreadsheet
 
   StackTraceElement:
     description: ''

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
@@ -171,6 +171,9 @@ object FireCloudConfig {
     val managerGroup = trial.getString("managerGroup")
     val billingAccount = trial.getString("billingAccount")
     val projectBufferSize = trial.getInt("projectBufferSize")
+    val spreadsheet = trial.getConfig("spreadsheet")
+    val spreadsheetId = spreadsheet.getString("id")
+    val spreadsheetUpdateFrequencyMinutes = spreadsheet.getInt("updateFrequencyMinutes")
   }
 
   object Metrics {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/GoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/GoogleServicesDAO.scala
@@ -34,7 +34,7 @@ trait GoogleServicesDAO extends ReportsSubsystemStatus {
   def getObjectMetadata(bucketName: String, objectKey: String, userAuthToken: String)
                     (implicit actorRefFactory: ActorRefFactory, executionContext: ExecutionContext): Future[ObjectMetadata]
   def fetchPriceList(implicit actorRefFactory: ActorRefFactory, executionContext: ExecutionContext): Future[GooglePriceList]
-  def updateSpreadsheet(userInfo: WithAccessToken, spreadsheetId: String, content: ValueRange): JsObject
+  def updateSpreadsheet(withAccessToken: WithAccessToken, spreadsheetId: String, content: ValueRange): JsObject
 
   def trialBillingManagerRemoveBillingAccount(projectName: String, targetUserEmail: String): Boolean
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/GoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/GoogleServicesDAO.scala
@@ -4,7 +4,7 @@ import java.io.InputStream
 
 import akka.actor.ActorRefFactory
 import com.google.api.services.sheets.v4.model.{SpreadsheetProperties, ValueRange}
-import org.broadinstitute.dsde.firecloud.model.{ObjectMetadata, UserInfo}
+import org.broadinstitute.dsde.firecloud.model.{ObjectMetadata, WithAccessToken}
 import org.broadinstitute.dsde.rawls.model.ErrorReportSource
 import org.broadinstitute.dsde.workbench.util.health.SubsystemStatus
 import spray.http.HttpResponse
@@ -24,6 +24,7 @@ trait GoogleServicesDAO extends ReportsSubsystemStatus {
   def getAdminUserAccessToken: String
   def getTrialBillingManagerAccessToken: String
   def getTrialBillingManagerEmail: String
+  def getTrialSpreadsheetAccessToken: String
   def getBucketObjectAsInputStream(bucketName: String, objectKey: String): InputStream
   def getObjectResourceUrl(bucketName: String, objectKey: String): String
   def getUserProfile(requestContext: RequestContext)
@@ -33,8 +34,7 @@ trait GoogleServicesDAO extends ReportsSubsystemStatus {
   def getObjectMetadata(bucketName: String, objectKey: String, userAuthToken: String)
                     (implicit actorRefFactory: ActorRefFactory, executionContext: ExecutionContext): Future[ObjectMetadata]
   def fetchPriceList(implicit actorRefFactory: ActorRefFactory, executionContext: ExecutionContext): Future[GooglePriceList]
-  def createSpreadsheet(requestContext: RequestContext, userInfo: UserInfo, props: SpreadsheetProperties): JsObject
-  def updateSpreadsheet(requestContext: RequestContext, userInfo: UserInfo, spreadsheetId: String, content: ValueRange): JsObject
+  def updateSpreadsheet(userInfo: WithAccessToken, spreadsheetId: String, content: ValueRange): JsObject
 
   def trialBillingManagerRemoveBillingAccount(projectName: String, targetUserEmail: String): Boolean
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
@@ -9,18 +9,17 @@ import com.google.api.client.http.HttpResponseException
 import com.google.api.client.json.jackson2.JacksonFactory
 import com.google.api.services.cloudbilling.Cloudbilling
 import com.google.api.services.cloudbilling.model.ProjectBillingInfo
-import com.google.api.services.compute.ComputeScopes
+import com.google.api.services.sheets.v4.SheetsScopes
 import com.google.api.services.sheets.v4.Sheets
-import com.google.api.services.sheets.v4.model.{Spreadsheet, SpreadsheetProperties, ValueRange}
+import com.google.api.services.sheets.v4.model.ValueRange
 import com.google.api.services.storage.{Storage, StorageScopes}
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.model.ErrorReportExtensions.FCErrorReport
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol.impGoogleObjectMetadata
-import org.broadinstitute.dsde.firecloud.model.{OAuthUser, ObjectMetadata, UserInfo}
+import org.broadinstitute.dsde.firecloud.model.{OAuthUser, ObjectMetadata, WithAccessToken}
 import org.broadinstitute.dsde.firecloud.service.FireCloudRequestBuilding
 import org.broadinstitute.dsde.firecloud.{FireCloudConfig, FireCloudExceptionWithErrorReport}
 import org.broadinstitute.dsde.workbench.util.health.SubsystemStatus
-import org.slf4j.LoggerFactory
 import spray.client.pipelining._
 import spray.http.StatusCodes._
 import spray.http._
@@ -80,6 +79,7 @@ object HttpGoogleServicesDAO extends GoogleServicesDAO with FireCloudRequestBuil
   val storageReadOnly = Seq(StorageScopes.DEVSTORAGE_READ_ONLY)
   // the scope we want is not defined in CloudbillingScopes, so we hardcode it here
   val billingScope = Seq("https://www.googleapis.com/auth/cloud-billing")
+  val spreadsheetScopes = Seq(SheetsScopes.SPREADSHEETS)
 
   val httpTransport = GoogleNetHttpTransport.newTrustedTransport
   val jsonFactory = JacksonFactory.getDefaultInstance
@@ -106,19 +106,25 @@ object HttpGoogleServicesDAO extends GoogleServicesDAO with FireCloudRequestBuil
     googleCredential.getAccessToken
   }
 
-  def getTrialBillingManagerCredential: Credential = {
+  def getTrialBillingManagerCredential(addlScopes: Seq[String] = billingScope): Credential = {
     val builder = new GoogleCredential.Builder()
       .setTransport(httpTransport)
       .setJsonFactory(jsonFactory)
       .setServiceAccountId(trialBillingPemFileClientId)
-      .setServiceAccountScopes(authScopes ++ billingScope)
+      .setServiceAccountScopes(authScopes ++ addlScopes)
       .setServiceAccountPrivateKeyFromPemFile(new java.io.File(trialBillingPemFile))
 
     builder.build()
   }
 
   def getTrialBillingManagerAccessToken = {
-    val googleCredential = getTrialBillingManagerCredential
+    val googleCredential = getTrialBillingManagerCredential(billingScope)
+    googleCredential.refreshToken()
+    googleCredential.getAccessToken
+  }
+
+  def getTrialSpreadsheetAccessToken = {
+    val googleCredential = getTrialBillingManagerCredential(spreadsheetScopes)
     googleCredential.refreshToken()
     googleCredential.getAccessToken
   }
@@ -311,33 +317,14 @@ object HttpGoogleServicesDAO extends GoogleServicesDAO with FireCloudRequestBuil
   }
 
   /**
-    * Saves a google drive spreadsheet with the provided SpreadsheetProperties object.
-    * Note that this does not *populate* the spreadsheet, just creates it with the provided properties
-    * Call GoogleServicesDAO#updateSpreadsheet to add data once a spreadsheet is created.
-    *
-    * @param requestContext RequestContext
-    * @param userInfo       UserInfo
-    * @param props          SpreadsheetProperties
-    * @return               JsObject representing the Google Create response
-    */
-  def createSpreadsheet(requestContext: RequestContext, userInfo: UserInfo, props: SpreadsheetProperties): JsObject = {
-    val credential = new GoogleCredential().setAccessToken(userInfo.accessToken.token)
-    val service = new Sheets.Builder(httpTransport, jsonFactory, credential).setApplicationName("FireCloud").build()
-    val spreadsheet = new Spreadsheet().setProperties(props)
-    val response = service.spreadsheets().create(spreadsheet).execute()
-    response.toString.parseJson.asJsObject
-  }
-
-  /**
     * Updates an existing google drive spreadsheet with the provided data.
     *
-    * @param requestContext RequestContext
-    * @param userInfo       UserInfo
+    * @param userInfo       WithAccessToken
     * @param spreadsheetId  Spreadsheet ID
     * @param newContent     ValueRange
     * @return               JsObject representing the Google Update response
     */
-  def updateSpreadsheet(requestContext: RequestContext, userInfo: UserInfo, spreadsheetId: String, newContent: ValueRange): JsObject = {
+  def updateSpreadsheet(userInfo: WithAccessToken, spreadsheetId: String, newContent: ValueRange): JsObject = {
     val credential = new GoogleCredential().setAccessToken(userInfo.accessToken.token)
     val service = new Sheets.Builder(httpTransport, jsonFactory, credential).setApplicationName("FireCloud").build()
 
@@ -391,7 +378,7 @@ object HttpGoogleServicesDAO extends GoogleServicesDAO with FireCloudRequestBuil
 
     // as the service account, get the current billing info to make sure we are removing the right thing.
     // this call will fail if the free-tier billing account has already been removed from the project.
-    val billingService = getCloudBillingManager(getTrialBillingManagerCredential)
+    val billingService = getCloudBillingManager(getTrialBillingManagerCredential())
 
     val readRequest = billingService.projects().getBillingInfo(projectName)
     Try(executeGoogleRequest[ProjectBillingInfo](readRequest)) match {
@@ -412,7 +399,7 @@ object HttpGoogleServicesDAO extends GoogleServicesDAO with FireCloudRequestBuil
           // indicates we want to remove the billing account association.
           val noBillingInfo = new ProjectBillingInfo().setBillingAccountName("")
           // generate the request to send to Google
-          val noBillingRequest = getCloudBillingManager(getTrialBillingManagerCredential)
+          val noBillingRequest = getCloudBillingManager(getTrialBillingManagerCredential())
             .projects().updateBillingInfo(projectName, noBillingInfo)
           // send the request
           val updatedProject = executeGoogleRequest[ProjectBillingInfo](noBillingRequest)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
@@ -118,7 +118,7 @@ object HttpGoogleServicesDAO extends GoogleServicesDAO with FireCloudRequestBuil
   }
 
   def getTrialBillingManagerAccessToken = {
-    val googleCredential = getTrialBillingManagerCredential(billingScope)
+    val googleCredential = getTrialBillingManagerCredential()
     googleCredential.refreshToken()
     googleCredential.getAccessToken
   }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
@@ -319,13 +319,13 @@ object HttpGoogleServicesDAO extends GoogleServicesDAO with FireCloudRequestBuil
   /**
     * Updates an existing google drive spreadsheet with the provided data.
     *
-    * @param userInfo       WithAccessToken
+    * @param withAccessToken       WithAccessToken
     * @param spreadsheetId  Spreadsheet ID
     * @param newContent     ValueRange
     * @return               JsObject representing the Google Update response
     */
-  def updateSpreadsheet(userInfo: WithAccessToken, spreadsheetId: String, newContent: ValueRange): JsObject = {
-    val credential = new GoogleCredential().setAccessToken(userInfo.accessToken.token)
+  def updateSpreadsheet(withAccessToken: WithAccessToken, spreadsheetId: String, newContent: ValueRange): JsObject = {
+    val credential = new GoogleCredential().setAccessToken(withAccessToken.accessToken.token)
     val service = new Sheets.Builder(httpTransport, jsonFactory, credential).setApplicationName("FireCloud").build()
 
     // Retrieve existing records

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/TrialService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/TrialService.scala
@@ -442,7 +442,7 @@ final class TrialService
         case Failure(e) =>
           e match {
             case g: GoogleJsonResponseException =>
-              logger.warn(s"Unable to update spreadsheet [$spreadsheetId]: ${g.getDetails.getMessage}")
+              logger.error(s"Unable to update spreadsheet [$spreadsheetId]: ${g.getDetails.getMessage}")
               val code = StatusCodes.getForKey(g.getDetails.getCode).getOrElse(StatusCodes.InternalServerError)
               throw new FireCloudExceptionWithErrorReport(ErrorReport(code, e.getMessage))
             case _ => throw e

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/TrialService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/TrialService.scala
@@ -47,8 +47,7 @@ object TrialService {
   case class CountProjects(userInfo:UserInfo) extends TrialServiceMessage
   case class Report(userInfo:UserInfo) extends TrialServiceMessage
   case class RecordUserAgreement(userInfo: UserInfo) extends TrialServiceMessage
-  case class CreateBillingReport(requestContext: RequestContext, userInfo: UserInfo) extends TrialServiceMessage
-  case class UpdateBillingReport(requestContext: RequestContext, userInfo: UserInfo, spreadsheetId: String) extends TrialServiceMessage
+  case class UpdateBillingReport(spreadsheetId: String) extends TrialServiceMessage
 
   def props(service: () => TrialService): Props = {
     Props(service())
@@ -80,10 +79,7 @@ final class TrialService
     case CountProjects(userInfo) => asTrialCampaignManager {countProjects}(userInfo) pipeTo sender
     case Report(userInfo) => asTrialCampaignManager {projectReport}(userInfo) pipeTo sender
     case RecordUserAgreement(userInfo) => recordUserAgreement(userInfo) pipeTo sender
-    case CreateBillingReport(requestContext, userInfo) =>
-      asTrialCampaignManager { createBillingReport(requestContext, userInfo) }(userInfo) pipeTo sender
-    case UpdateBillingReport(requestContext, userInfo, spreadsheetId) =>
-      asTrialCampaignManager { updateBillingReport(requestContext, userInfo, spreadsheetId) }(userInfo) pipeTo sender
+    case UpdateBillingReport(spreadsheetId) => updateBillingReport(spreadsheetId) pipeTo sender
     case x => throw new FireCloudException("unrecognized message: " + x.toString)
   }
 
@@ -429,36 +425,32 @@ final class TrialService
     }
   }
 
-  private def createBillingReport(requestContext: RequestContext, userInfo: UserInfo): Future[PerRequestMessage] = {
-    val properties: SpreadsheetProperties = makeSpreadsheetProperties("Trial Billing Project Report")
-    val sheet: JsObject = googleDAO.createSpreadsheet(requestContext, userInfo, properties)
-    Try(sheet.fields.getOrElse("spreadsheetId", JsString("")).asInstanceOf[JsString].value) match {
-      case Success(spreadsheetId) if spreadsheetId.nonEmpty =>
-        updateBillingReport(requestContext, userInfo, spreadsheetId)
-      case Failure(e) =>
-        logger.error(s"Unable to create new google spreadsheet for user context [${userInfo.userEmail}]: ${e.getMessage}")
-        throw new FireCloudExceptionWithErrorReport(ErrorReport(StatusCodes.InternalServerError, e.getMessage))
-    }
-  }
+  /** This method operates with service account credentials and can thus be invoked by anyone.
+    * As the developer, be careful about when you call this.
+    */
+  private def updateBillingReport(spreadsheetId: String): Future[SpreadsheetResponse] = {
+    // get SA credential
+    val saToken = AccessToken(googleDAO.getTrialSpreadsheetAccessToken)
 
-  private def updateBillingReport(requestContext: RequestContext, userInfo: UserInfo, spreadsheetId: String): Future[PerRequestMessage] = {
     val majorDimension: String = "ROWS"
     val range: String = "Sheet1!A1"
-    makeSpreadsheetValues(userInfo, trialDao, thurloeDao, majorDimension, range).map { content =>
-      Try (googleDAO.updateSpreadsheet(requestContext, userInfo, spreadsheetId, content)) match {
+    makeSpreadsheetValues(saToken, trialDao, thurloeDao, majorDimension, range).map { content =>
+      Try (googleDAO.updateSpreadsheet(saToken, spreadsheetId, content)) match {
         case Success(updatedSheet) =>
-          RequestComplete(OK, makeSpreadsheetResponse(spreadsheetId))
+          logger.info(s"Successfully updated spreadsheet [$spreadsheetId].")
+          makeSpreadsheetResponse(spreadsheetId)
         case Failure(e) =>
           e match {
             case g: GoogleJsonResponseException =>
-              logger.warn(s"Unable to update spreadsheet for user context [${userInfo.userEmail}]: ${g.getDetails.getMessage}")
-              RequestCompleteWithErrorReport(g.getDetails.getCode, g.getDetails.getMessage)
+              logger.warn(s"Unable to update spreadsheet [$spreadsheetId]: ${g.getDetails.getMessage}")
+              val code = StatusCodes.getForKey(g.getDetails.getCode).getOrElse(StatusCodes.InternalServerError)
+              throw new FireCloudExceptionWithErrorReport(ErrorReport(code, e.getMessage))
             case _ => throw e
           }
       }
     }.recoverWith {
       case e: Throwable =>
-        logger.error(s"Unable to update google spreadsheet for user context [${userInfo.userEmail}]: ${e.getMessage}")
+        logger.error(s"Unable to update google spreadsheet [$spreadsheetId]: ${e.getMessage}")
         throw new FireCloudExceptionWithErrorReport(ErrorReport(StatusCodes.InternalServerError, e.getMessage))
     }
   }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/TrialServiceSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/TrialServiceSupport.scala
@@ -11,7 +11,7 @@ import org.broadinstitute.dsde.firecloud.{FireCloudConfig, FireCloudException}
 import org.broadinstitute.dsde.firecloud.dataaccess.{SamDAO, ThurloeDAO, TrialDAO}
 import org.broadinstitute.dsde.firecloud.model.Trial.TrialStates.{Disabled, Enabled, TrialState}
 import org.broadinstitute.dsde.firecloud.model.Trial.{SpreadsheetResponse, TrialProject, UserTrialStatus}
-import org.broadinstitute.dsde.firecloud.model.{FireCloudKeyValue, Profile, ProfileWrapper, UserInfo, WorkbenchUserInfo}
+import org.broadinstitute.dsde.firecloud.model.{FireCloudKeyValue, Profile, ProfileWrapper, UserInfo, WithAccessToken, WorkbenchUserInfo}
 
 import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future}
@@ -45,7 +45,7 @@ trait TrialServiceSupport extends LazyLogging {
     new SpreadsheetProperties().setTitle(s"$title: $dateString")
   }
 
-  def makeSpreadsheetValues(managerInfo: UserInfo, trialDAO: TrialDAO, thurloeDAO: ThurloeDAO, majorDimension: String, range: String)
+  def makeSpreadsheetValues(managerInfo: WithAccessToken, trialDAO: TrialDAO, thurloeDAO: ThurloeDAO, majorDimension: String, range: String)
     (implicit executionContext: ExecutionContext): Future[ValueRange] = {
 
     // get the list of projects from ES

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/TrialApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/TrialApiService.scala
@@ -55,24 +55,6 @@ trait TrialApiService extends HttpService with PerRequestCreator with FireCloudD
             }
           }
         }
-      } ~
-      path("report") {
-        post {
-          requireUserInfo() { userInfo => requestContext =>
-            perRequest(requestContext, TrialService.props(trialServiceConstructor),
-              TrialService.CreateBillingReport(requestContext, userInfo)
-            )
-          }
-        }
-      } ~
-      path("report" / Segment) { (spreadsheetId) =>
-        put {
-          requireUserInfo() { userInfo => requestContext =>
-            perRequest(requestContext, TrialService.props(trialServiceConstructor),
-              TrialService.UpdateBillingReport(requestContext, userInfo, spreadsheetId)
-            )
-          }
-        }
       }
     }
   }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAOSpec.scala
@@ -91,7 +91,7 @@ class HttpGoogleServicesDAOSpec extends FlatSpec with Matchers with PrivateMetho
       )
     }
 
-    // This happens when calling updateBillingReport the first time from within createBillingReport
+    // This happens when calling updateBillingReport on an empty/new spreadsheet
     it should "not explode if existing content is empty (no headers)" in {
       check(
         newContent = List(headers, row1, row2, row3),

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockGoogleServicesDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockGoogleServicesDAO.scala
@@ -92,7 +92,7 @@ class MockGoogleServicesDAO extends GoogleServicesDAO {
   override def fetchPriceList(implicit actorRefFactory: ActorRefFactory, executionContext: ExecutionContext): Future[GooglePriceList] = {
     Future.successful(GooglePriceList(GooglePrices(UsPriceItem(BigDecimal(0.01)), UsTieredPriceItem(Map(1024L -> BigDecimal(0.12)))), "v0", "18-November-2016"))
   }
-  override def updateSpreadsheet(userInfo: WithAccessToken, spreadsheetId: String, content: ValueRange): JsObject = spreadsheetUpdateJson
+  override def updateSpreadsheet(withAccessToken: WithAccessToken, spreadsheetId: String, content: ValueRange): JsObject = spreadsheetUpdateJson
 
 
   override def trialBillingManagerRemoveBillingAccount(projectName: String, targetUserEmail: String): Boolean = false

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockGoogleServicesDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockGoogleServicesDAO.scala
@@ -6,7 +6,7 @@ import akka.actor.ActorRefFactory
 import com.google.api.services.sheets.v4.model.{SpreadsheetProperties, ValueRange}
 import org.broadinstitute.dsde.firecloud.FireCloudException
 import org.broadinstitute.dsde.firecloud.dataaccess._
-import org.broadinstitute.dsde.firecloud.model.{ObjectMetadata, UserInfo}
+import org.broadinstitute.dsde.firecloud.model.{ObjectMetadata, WithAccessToken}
 import org.broadinstitute.dsde.workbench.util.health.SubsystemStatus
 import spray.http.HttpResponse
 import spray.json.JsObject
@@ -72,6 +72,7 @@ class MockGoogleServicesDAO extends GoogleServicesDAO {
   override def getAdminUserAccessToken: String = "adminUserAccessToken"
   override def getTrialBillingManagerAccessToken: String = "billingManagerAccessToken"
   override def getTrialBillingManagerEmail: String = "mock-trial-billing-mgr-email"
+  override def getTrialSpreadsheetAccessToken: String = "trialSpreadsheetAccessToken"
   override def getBucketObjectAsInputStream(bucketName: String, objectKey: String): InputStream = {
     objectKey match {
       case "target-whitelist.txt" => new ByteArrayInputStream("firecloud-dev\ntarget-user".getBytes("UTF-8"))
@@ -91,8 +92,7 @@ class MockGoogleServicesDAO extends GoogleServicesDAO {
   override def fetchPriceList(implicit actorRefFactory: ActorRefFactory, executionContext: ExecutionContext): Future[GooglePriceList] = {
     Future.successful(GooglePriceList(GooglePrices(UsPriceItem(BigDecimal(0.01)), UsTieredPriceItem(Map(1024L -> BigDecimal(0.12)))), "v0", "18-November-2016"))
   }
-  override def createSpreadsheet(requestContext: RequestContext, userInfo: UserInfo, props: SpreadsheetProperties): JsObject = spreadsheetJson
-  override def updateSpreadsheet(requestContext: RequestContext, userInfo: UserInfo, spreadsheetId: String, content: ValueRange): JsObject = spreadsheetUpdateJson
+  override def updateSpreadsheet(userInfo: WithAccessToken, spreadsheetId: String, content: ValueRange): JsObject = spreadsheetUpdateJson
 
 
   override def trialBillingManagerRemoveBillingAccount(projectName: String, targetUserEmail: String): Boolean = false

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/TrialApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/TrialApiServiceSpec.scala
@@ -612,7 +612,7 @@ final class TrialApiServiceSpec extends BaseServiceSpec with UserApiService with
 
   final class TrialApiServiceSpecGoogleDAO extends MockGoogleServicesDAO {
 
-    override def updateSpreadsheet(userInfo: WithAccessToken, spreadsheetId: String, content: ValueRange): JsObject = {
+    override def updateSpreadsheet(withAccessToken: WithAccessToken, spreadsheetId: String, content: ValueRange): JsObject = {
       spreadsheetId match {
         case "invalid" =>
           // A lot of java overhead to generate the right exception...

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/TrialApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/TrialApiServiceSpec.scala
@@ -492,70 +492,6 @@ final class TrialApiServiceSpec extends BaseServiceSpec with UserApiService with
     }
   }
 
-  "Campaign manager report endpoints" - {
-
-    "Create Report endpoint" - {
-
-      allHttpMethodsExcept(POST) foreach { method =>
-        s"should reject ${method.toString} method" in {
-          new RequestBuilder(method)("/trial/manager/report") ~> dummyUserIdHeaders(manager) ~> trialApiServiceRoutes ~> check {
-            assert(!handled)
-          }
-        }
-      }
-
-      "should succeed with a create request" in {
-        Post("/trial/manager/report") ~> dummyUserIdHeaders(manager) ~> trialApiServiceRoutes ~> check {
-          assert(status.isSuccess)
-          assertResult(OK) {status}
-        }
-      }
-
-      "non-campaign manager should fail creating request" in {
-        Post("/trial/manager/report") ~> dummyUserIdHeaders(unauthorizedUser) ~> trialApiServiceRoutes ~> check {
-          assert(status.isFailure)
-          assertResult(Forbidden) {status}
-        }
-      }
-
-    }
-
-    "Update Report endpoint" - {
-
-      allHttpMethodsExcept(PUT) foreach { method =>
-        s"should reject ${method.toString} method" in {
-          new RequestBuilder(method)("/trial/manager/report/valid") ~> dummyUserIdHeaders(manager) ~> trialApiServiceRoutes ~> check {
-            assert(!handled)
-          }
-        }
-      }
-
-      "should succeed with an update request" in {
-        Put("/trial/manager/report/valid") ~> dummyUserIdHeaders(manager) ~> trialApiServiceRoutes ~> check {
-          assert(status.isSuccess)
-          assertResult(OK) {status}
-        }
-      }
-
-      "invalid spreadsheet id should fail an update request" in {
-        Put("/trial/manager/report/invalid") ~> dummyUserIdHeaders(manager) ~> trialApiServiceRoutes ~> check {
-          println(response)
-          assert(status.isFailure)
-          assertResult(NotFound) {status}
-        }
-      }
-
-      "non-campaign manager should fail an update request" in {
-        Put("/trial/manager/report/valid") ~> dummyUserIdHeaders(unauthorizedUser) ~> trialApiServiceRoutes ~> check {
-          assert(status.isFailure)
-          assertResult(Forbidden) {status}
-        }
-      }
-
-    }
-
-  }
-
   class TrialApiServiceSpecTrialDAO extends ProjectManagerSpecTrialDAO {
     override def claimProjectRecord(userInfo: WorkbenchUserInfo, randomizationFactor: Int = 20): TrialProject = {
       TrialProject(RawlsBillingProjectName("projectfor-" + userInfo.userEmail), true, Some(userInfo), Some(CreationStatuses.Ready))
@@ -676,7 +612,7 @@ final class TrialApiServiceSpec extends BaseServiceSpec with UserApiService with
 
   final class TrialApiServiceSpecGoogleDAO extends MockGoogleServicesDAO {
 
-    override def updateSpreadsheet(requestContext: RequestContext, userInfo: UserInfo, spreadsheetId: String, content: ValueRange): JsObject = {
+    override def updateSpreadsheet(userInfo: WithAccessToken, spreadsheetId: String, content: ValueRange): JsObject = {
       spreadsheetId match {
         case "invalid" =>
           // A lot of java overhead to generate the right exception...


### PR DESCRIPTION
This is for databiosphere/firecloud-app#23. It requires broadinstitute/firecloud-develop#1103.

Note that the conf file (from firecloud-develop) disables updates in the local and fiab envs. If you want to test it out in fiab or local, you'll need to manually update your conf.

* Removes the user-accessible endpoints for creating and updating spreadsheets, including removing swagger's request for those scopes
* Adds a scheduled execution of the update-spreadsheet method
* Method signature tweaks to support the previous

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
