### PR TITLE
firecloud-app#10: orch automation tests

### DIFF
--- a/automation/Dockerfile-tests
+++ b/automation/Dockerfile-tests
@@ -1,0 +1,10 @@
+FROM iflavoursbv/sbt-openjdk-8-alpine
+
+COPY src /app/src
+COPY test.sh /app
+COPY project /app/project
+COPY build.sbt /app
+
+WORKDIR /app
+
+ENTRYPOINT ["bash", "test.sh"]

--- a/automation/README.md
+++ b/automation/README.md
@@ -1,0 +1,78 @@
+Quickstart: running integration tests locally on Mac/Docker 
+
+## Running in docker
+
+See [firecloud-automated-testing](https://github.com/broadinstitute/firecloud-automated-testing).
+
+
+## Running directly (with real chrome)
+
+### Set Up
+
+```
+brew install chromedriver
+```
+
+Note: Orchestration integration tests are not currently web-based but may fail due to dependencies without chromedriver
+
+Render configs:
+```bash
+./render-local-env.sh [branch of firecloud-automated-testing] [vault token] [env] [service root]
+```
+
+**Arguments:** (arguments are positional)
+
+* branch of firecloud-automated-testing
+    * Configs branch; defaults to `master`
+* Vault auth token
+	* Defaults to reading it from the .vault-token via `$(cat ~/.vault-token)`.
+* env
+	* Environment of your FiaB; defaults to `dev`
+* service root
+    * the name of your local clone of firecloud-orchestration if not `firecloud-orchestration`
+	
+##### Using a local UI
+
+Set `LOCAL_UI=true` before calling `render-local-env.sh`.   When starting your UI, run:
+
+```bash
+FIAB=true ./config/docker-rsync-local-ui.sh
+```
+	
+### Run tests
+
+#### From IntelliJ
+
+First, you need to set some default VM parameters for ScalaTest run configurations. In IntelliJ, go to `Run` > `Edit Configurations...`, select `ScalaTest` under `Defaults`, and add these VM parameters:
+
+```
+-Djsse.enableSNIExtension=false -Dheadless=false
+```
+
+Also make sure that there is a `Build` task configured to run before launch.
+
+Now, simply open the test spec, right-click on the class name or a specific test string, and select `Run` or `Debug` as needed. A good one to start with is `GoogleSpec` to make sure your base configuration is correct. All test code lives in `automation/src/test/scala`. FireCloud test suites can be found in `automation/src/test/scala/org/broadinstitute/dsde/firecloud/test`.
+
+#### From the command line
+
+To run all tests:
+
+```bash
+sbt test -Djsse.enableSNIExtension=false -Dheadless=false
+```
+
+To run a single suite:
+
+```bash
+sbt -Djsse.enableSNIExtension=false -Dheadless=false "testOnly *GoogleSpec"
+```
+
+To run a single test within a suite:
+
+```bash
+# matches test via substring
+sbt -Djsse.enableSNIExtension=false -Dheadless=false "testOnly *GoogleSpec -- -z \"have a search field\""
+```
+
+For more information see [SBT's documentation](http://www.scala-sbt.org/0.13/docs/Testing.html#Test+Framework+Arguments).
+

--- a/automation/build.sbt
+++ b/automation/build.sbt
@@ -1,0 +1,6 @@
+import Settings._
+
+lazy val orchIntegration = project.in(file("."))
+  .settings(rootSettings:_*)
+
+version := "1.0"

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -1,0 +1,53 @@
+import sbt._
+
+object Dependencies {
+  val jacksonV = "2.8.4"
+  val akkaV = "2.5.7"
+  val akkaHttpV = "10.0.10"
+
+  val workbenchModelV  = "0.10-6800f3a"
+  val workbenchModel: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-model" % workbenchModelV
+  val excludeWorkbenchModel = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-model_2.11")
+
+  val workbenchGoogleV = "0.16-847c3ff"
+  val workbenchGoogle: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-google" % workbenchGoogleV excludeAll excludeWorkbenchModel
+  val excludeWorkbenchGoogle = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-google_2.11")
+
+  val workbenchServiceTestV = "0.7-847c3ff"
+  val workbenchServiceTest: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-service-test" % workbenchServiceTestV % "test" classifier "tests" excludeAll (excludeWorkbenchGoogle, excludeWorkbenchModel)
+
+  val rootDependencies = Seq(
+    // proactively pull in latest versions of Jackson libs, instead of relying on the versions
+    // specified as transitive dependencies, due to OWASP DependencyCheck warnings for earlier versions.
+    "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonV,
+    "com.fasterxml.jackson.core" % "jackson-databind" % jacksonV,
+    "com.fasterxml.jackson.core" % "jackson-core" % jacksonV,
+    "com.fasterxml.jackson.module" % "jackson-module-scala_2.11" % jacksonV,
+    "ch.qos.logback" % "logback-classic" % "1.2.3",
+    "com.google.apis" % "google-api-services-oauth2" % "v1-rev112-1.20.0" excludeAll (
+      ExclusionRule("com.google.guava", "guava-jdk5"),
+      ExclusionRule("org.apache.httpcomponents", "httpclient")
+    ),
+    "com.google.api-client" % "google-api-client" % "1.22.0" excludeAll (
+      ExclusionRule("com.google.guava", "guava-jdk5"),
+      ExclusionRule("org.apache.httpcomponents", "httpclient")),
+    "org.webjars"           %  "swagger-ui"    % "2.2.5",
+    "com.typesafe.akka"   %%  "akka-http-core"     % akkaHttpV,
+    "com.typesafe.akka"   %%  "akka-stream-testkit" % akkaV,
+    "com.typesafe.akka"   %%  "akka-http"           % akkaHttpV,
+    "com.typesafe.akka"   %%  "akka-testkit"        % akkaV     % "test",
+    "com.typesafe.akka"   %%  "akka-slf4j"          % akkaV,
+    "org.specs2"          %%  "specs2-core"   % "3.7"  % "test",
+    "org.scalatest"       %%  "scalatest"     % "3.0.1"   % "test",
+    "org.seleniumhq.selenium" % "selenium-java" % "3.8.1" % "test",
+    "com.typesafe.scala-logging" %% "scala-logging" % "3.1.0",
+
+    workbenchServiceTest,
+    workbenchModel,
+    workbenchGoogle,
+
+
+    // required by workbenchGoogle
+    "com.typesafe.akka" %% "akka-http-spray-json" % "10.0.6" % "provided"
+  )
+}

--- a/automation/project/Settings.scala
+++ b/automation/project/Settings.scala
@@ -1,0 +1,49 @@
+import Dependencies._
+import sbt.Keys._
+import sbt._
+
+object Settings {
+
+  // for org.broadinstitute.dsde.workbench modules
+  val artifactory = "https://broadinstitute.jfrog.io/broadinstitute/"
+  val commonResolvers = List(
+    "artifactory-releases" at artifactory + "libs-release",
+    "artifactory-snapshots" at artifactory + "libs-snapshot"
+  )
+
+  //coreDefaultSettings + defaultConfigs = the now deprecated defaultSettings
+  val commonBuildSettings = Defaults.coreDefaultSettings ++ Defaults.defaultConfigs ++ Seq(
+    javaOptions += "-Xmx2G",
+    javacOptions ++= Seq("-source", "1.8", "-target", "1.8")
+  )
+
+  val commonCompilerSettings = Seq(
+    "-unchecked",
+    "-deprecation",
+    "-feature",
+    "-encoding", "utf8",
+    "-target:jvm-1.8",
+    "-Xmax-classfile-name", "100"
+  )
+
+  val testSettings = List(
+    testOptions in Test += Tests.Argument("-oF")
+  )
+
+  //common settings for all sbt subprojects
+  val commonSettings =
+    commonBuildSettings ++ testSettings ++ List(
+    organization  := "org.broadinstitute.dsde.firecloud",
+    scalaVersion  := "2.11.12",
+    resolvers ++= commonResolvers,
+    scalacOptions ++= commonCompilerSettings
+  )
+
+  //the full list of settings for the root project that's ultimately the one we build into a fat JAR and run
+  //coreDefaultSettings (inside commonSettings) sets the project name, which we want to override, so ordering is important.
+  //thus commonSettings needs to be added first.
+  val rootSettings = commonSettings ++ List(
+    name := "orchIntegration",
+    libraryDependencies ++= rootDependencies
+  )
+}

--- a/automation/project/build.properties
+++ b/automation/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version = 0.13.17

--- a/automation/project/plugins.sbt
+++ b/automation/project/plugins.sbt
@@ -1,0 +1,1 @@
+logLevel := Level.Warn

--- a/automation/render-local-env.sh
+++ b/automation/render-local-env.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -e
+
+## Run from automation/
+## Clones the firecloud-automated-testing repo, pulls templatized configs, and renders them to src/test/resources
+
+# Defaults
+WORKING_DIR=$PWD
+VAULT_TOKEN=$(cat ~/.vault-token)
+FIRECLOUD_AUTOMATED_TESTING_BRANCH=master
+ENV=dev
+SERVICE=firecloud-orchestration
+LOCAL_UI=${LOCAL_UI:-false}  # local ui defaults to false unless set in the env
+
+# Parameters
+FIRECLOUD_AUTOMATED_TESTING_BRANCH=${1:-$FIRECLOUD_AUTOMATED_TESTING_BRANCH}
+VAULT_TOKEN=${2:-$VAULT_TOKEN}
+ENV=${3:-$ENV}
+SERVICE_ROOT=${4:-$SERVICE}
+
+SCRIPT_ROOT=${SERVICE_ROOT}/automation
+
+confirm () {
+    # call with a prompt string or use a default
+    read -r -p "${1:-Are you sure?} [y/N] " response
+    case $response in
+        [yY])
+            shift
+            $@
+            ;;
+        *)
+            ;;
+    esac
+}
+
+# clone the firecloud-automated-testing repo
+clone_repo() {
+    original_dir=$PWD
+    cd ../..
+    echo "Currently in ${PWD}"
+    confirm "OK to clone here?" git clone git@github.com:broadinstitute/firecloud-automated-testing.git
+    cd $original_dir
+}
+
+pull_configs() {
+    original_dir=$WORKING_DIR
+    cd ../..
+    cd firecloud-automated-testing
+    echo "Currently in ${PWD}"
+    git stash
+    git checkout ${FIRECLOUD_AUTOMATED_TESTING_BRANCH}
+    git pull
+    cd $original_dir
+}
+
+render_configs() {
+    original_dir=$WORKING_DIR
+    cd ../..
+    docker pull broadinstitute/dsde-toolbox:dev
+    docker run -it --rm -e VAULT_TOKEN=${VAULT_TOKEN} \
+        -e ENVIRONMENT=${ENV} -e ROOT_DIR=${WORKING_DIR} -v $PWD/firecloud-automated-testing/configs:/input -v $PWD/$SCRIPT_ROOT:/output \
+        -e OUT_PATH=/output/src/test/resources -e INPUT_PATH=/input -e LOCAL_UI=$LOCAL_UI \
+        broadinstitute/dsde-toolbox:dev render-templates.sh
+
+    # pull service-specific application.conf
+    docker run -it --rm -e VAULT_TOKEN=${VAULT_TOKEN} \
+        -e ENVIRONMENT=${ENV} -e ROOT_DIR=${WORKING_DIR} -v $PWD/firecloud-automated-testing/configs/$SERVICE:/input -v $PWD/$SCRIPT_ROOT:/output \
+        -e OUT_PATH=/output/src/test/resources -e INPUT_PATH=/input -e LOCAL_UI=$LOCAL_UI \
+        broadinstitute/dsde-toolbox:dev render-templates.sh
+    cd $original_dir
+}
+
+if [[ $PWD != *"${SCRIPT_ROOT}" ]]; then
+    echo "Error: this script needs to be running from the ${SCRIPT_ROOT} directory!"
+    exit 1
+fi
+confirm "Clone firecloud-automated-testing repo?  Skip if you have already run this step before." clone_repo
+confirm "Checkout ${FIRECLOUD_AUTOMATED_TESTING_BRANCH}? This will stash local changes.  If N, configs will be built from local changes." pull_configs
+render_configs

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/OrchestrationApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/OrchestrationApiSpec.scala
@@ -1,0 +1,155 @@
+package org.broadinstitute.dsde.firecloud.test.api.orch
+
+import java.time.Instant
+
+import akka.http.scaladsl.model.StatusCodes
+import com.google.api.client.googleapis.json.GoogleJsonResponseException
+import com.google.api.services.bigquery.model.{GetQueryResultsResponse, JobReference}
+import org.broadinstitute.dsde.workbench.auth.AuthToken
+import org.broadinstitute.dsde.workbench.config.{Credentials, UserPool}
+import org.broadinstitute.dsde.workbench.dao.Google.googleBigQueryDAO
+import org.broadinstitute.dsde.workbench.fixture.BillingFixtures
+import org.broadinstitute.dsde.workbench.service.{Orchestration, RestException}
+import org.scalatest.concurrent.{Eventually, ScalaFutures}
+import org.scalatest.time.{Minutes, Seconds, Span}
+import org.scalatest.{FreeSpec, Matchers}
+import org.broadinstitute.dsde.workbench.model.google.GoogleProject
+
+class OrchestrationApiSpec extends FreeSpec with Matchers with ScalaFutures with Eventually
+  with BillingFixtures {
+  implicit override val patienceConfig: PatienceConfig = PatienceConfig(timeout = scaled(Span(5, Seconds)))
+
+  def nowPrint(text: String): Unit = {
+    println(s"${Instant.now} : $text")
+  }
+
+  "Orchestration" - {
+    "should grant and remove google role access" in {
+      // google roles can take a while to take effect
+      implicit val patienceConfig: PatienceConfig = PatienceConfig(timeout = scaled(Span(1, Minutes)), interval = scaled(Span(10, Seconds)))
+
+      val ownerUser: Credentials = UserPool.chooseProjectOwner
+      val ownerToken: AuthToken = ownerUser.makeAuthToken()
+      val role = "bigquery.jobUser"
+
+      val user: Credentials = UserPool.chooseStudent
+      val userToken: AuthToken = user.makeAuthToken()
+      val bigQuery = googleBigQueryDAO(userToken)
+
+      // Willy Shakes uses this insult twice
+
+      val shakespeareQuery = "SELECT COUNT(*) AS scullion_count FROM publicdata.samples.shakespeare WHERE word='scullion'"
+
+      def assertExpectedShakespeareResult(response: GetQueryResultsResponse): Unit = {
+        val resultRows = response.getRows
+        resultRows.size shouldBe 1
+        val resultFields = resultRows.get(0).getF
+        resultFields.size shouldBe 1
+        resultFields.get(0).getV.toString shouldBe "2"
+      }
+
+      nowPrint("Begin Test")
+
+      withCleanBillingProject(ownerUser) { projectName =>
+
+        nowPrint("Project created")
+
+        val preRoleFailure = bigQuery.startQuery(GoogleProject(projectName), "meh").failed.futureValue
+
+        preRoleFailure shouldBe a[GoogleJsonResponseException]
+        preRoleFailure.getMessage should include(user.email)
+        preRoleFailure.getMessage should include(projectName)
+        preRoleFailure.getMessage should include("bigquery.jobs.create")
+
+        nowPrint("Passed - user can't query in new project")
+
+        Orchestration.billing.addGoogleRoleToBillingProjectUser(projectName, user.email, role)(ownerToken)
+
+        nowPrint("Role granted")
+
+        // The google role might not have been applied the first time we call startQuery() - poll until it has
+        val queryReference = eventually {
+          val start = bigQuery.startQuery(GoogleProject(projectName), shakespeareQuery).futureValue
+          start shouldBe a[JobReference]
+          start
+        }
+
+        nowPrint("Passed - user can start query after role granted")
+
+        // poll for query status until it completes
+        val queryJob = eventually {
+          val job = bigQuery.getQueryStatus(queryReference).futureValue
+          job.getStatus.getState shouldBe "DONE"
+          job
+        }
+
+        val queryResult = bigQuery.getQueryResult(queryJob).futureValue
+        assertExpectedShakespeareResult(queryResult)
+
+        nowPrint("Passed - query completed")
+
+        Orchestration.billing.removeGoogleRoleFromBillingProjectUser(projectName, user.email, role)(ownerToken)
+
+        nowPrint("Role denied")
+
+        // The google role might not have been removed the first time we call startQuery() - poll until it has
+        val postRoleFailure = eventually {
+          val failure = bigQuery.startQuery(GoogleProject(projectName), shakespeareQuery).failed.futureValue
+          failure shouldBe a[GoogleJsonResponseException]
+          failure
+        }
+
+        postRoleFailure.getMessage should include(user.email)
+        postRoleFailure.getMessage should include(projectName)
+        postRoleFailure.getMessage should include("bigquery.jobs.create")
+
+        nowPrint("Passed - user can't query after role denied")
+      }
+
+      nowPrint("End Test")
+    }
+
+    "should not allow access alteration for arbitrary google roles" in {
+      val ownerUser: Credentials = UserPool.chooseProjectOwner
+      val ownerToken: AuthToken = ownerUser.makeAuthToken()
+      val roles = Seq("bigquery.admin", "bigquery.dataEditor", "bigquery.user")
+
+      val user: Credentials = UserPool.chooseStudent
+
+      withCleanBillingProject(ownerUser) { projectName =>
+        roles foreach { role =>
+          val addEx = intercept[RestException] {
+            Orchestration.billing.addGoogleRoleToBillingProjectUser(projectName, user.email, role)(ownerToken)
+          }
+          addEx.getMessage should include(role)
+
+          val removeEx = intercept[RestException] {
+            Orchestration.billing.removeGoogleRoleFromBillingProjectUser(projectName, user.email, role)(ownerToken)
+          }
+          removeEx.getMessage should include(role)
+        }
+      }
+    }
+
+    "should not allow access alteration by non-owners" in {
+      val Seq(userA: Credentials, userB: Credentials) = UserPool.chooseStudents(2)
+      val userAToken: AuthToken = userA.makeAuthToken()
+
+      val role = "bigquery.jobUser"
+      val errorMsg = "You must be a project owner"
+      val unownedProject = "broad-dsde-dev"
+
+      val addEx = intercept[RestException] {
+        Orchestration.billing.addGoogleRoleToBillingProjectUser(unownedProject, userB.email, role)(userAToken)
+      }
+      addEx.getMessage should include(errorMsg)
+      addEx.getMessage should include(StatusCodes.Forbidden.intValue.toString)
+
+      val removeEx = intercept[RestException] {
+        Orchestration.billing.removeGoogleRoleFromBillingProjectUser(unownedProject, userB.email, role)(userAToken)
+      }
+      removeEx.getMessage should include(errorMsg)
+      removeEx.getMessage should include(StatusCodes.Forbidden.intValue.toString)
+    }
+  }
+}

--- a/automation/test.sh
+++ b/automation/test.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+SBT_CMD=${1-"testOnly -- -l ProdTest"}
+echo $SBT_CMD
+
+set -o pipefail
+
+sbt -Djsse.enableSNIExtension=false -Dheadless=true "${SBT_CMD}"
+TEST_EXIT_CODE=$?
+sbt clean
+
+if [[ $TEST_EXIT_CODE != 0 ]]; then exit $TEST_EXIT_CODE; fi

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
 # build was failing on sbt 1.0.2, so pin to sbt 0.13.
-sbt.version=0.13.16
+sbt.version=0.13.17


### PR DESCRIPTION
this is issue databiosphere/firecloud-app#10

requires broadinstitute/firecloud-automated-testing#24

This adds service-layer automation test scaffolding for orchestration. If we have this, we can effectively write autotests at the orch layer instead of at the UI layer (assuming the test isn't inspecting visual elements).

Goal of this PR is to get the scaffolding working; later PRs and epics will add/migrate tests. The only test inside the scaffolding is the `OrchestrationApiSpec`, which currently lives in firecloud-ui.

After this PR (and the prerequisite in firecloud-automated-testing), developers can stand up their own fiab and run tests manually.

Still remaining to do after this PR merges:
* configure Jenkins to run these tests automatically
* remove `OrchestrationApiSpec` from firecloud-ui

Reviewer: this is almost completely a cut-and-paste of the scaffolding found in Sam (which is almost the same as that found in Rawls and Leo). You might want to do a diff to see which lines of code you actually care to review.

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
