### PR TITLE
send sum of Library numSubjects to logit

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
@@ -183,5 +183,6 @@ object FireCloudConfig {
     val logitApiKey: Option[String] = if (metrics.hasPath("logitApiKey")) Some(metrics.getString("logitApiKey")) else None
     val entityWorkspaceNamespace: Option[String] = if (metrics.hasPath("entityWorkspaceNamespace")) Some(metrics.getString("entityWorkspaceNamespace")) else None
     val entityWorkspaceName: Option[String] = if (metrics.hasPath("entityWorkspaceName")) Some(metrics.getString("entityWorkspaceName")) else None
+    val libraryNamespaces: List[String] = metrics.getStringList("libraryWorkspaceNamespace").asScala.toList
   }
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/SearchDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/SearchDAO.scala
@@ -1,6 +1,7 @@
 package org.broadinstitute.dsde.firecloud.dataaccess
 
 import com.typesafe.scalalogging.LazyLogging
+import org.broadinstitute.dsde.firecloud.model.Metrics.LogitMetric
 import org.broadinstitute.dsde.firecloud.model._
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
 import org.broadinstitute.dsde.rawls.model.ErrorReportSource
@@ -27,5 +28,8 @@ trait SearchDAO extends LazyLogging with ReportsSubsystemStatus {
   def findDocuments(criteria: LibrarySearchParams, groups: Seq[String]): Future[LibrarySearchResponse]
   def suggestionsFromAll(criteria: LibrarySearchParams, groups: Seq[String]): Future[LibrarySearchResponse]
   def suggestionsForFieldPopulate(field: String, text: String): Future[Seq[String]]
+
+  def statistics: LogitMetric
+
   override def serviceName:String = SearchDAO.serviceName
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/metrics/MetricsActor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/metrics/MetricsActor.scala
@@ -39,7 +39,7 @@ class MetricsActor(logitDAO: LogitDAO, rawlsDAO: RawlsDAO, searchDAO: SearchDAO)
 
     // get admin-stats from rawls
     rawlsDAO.adminStats(startDate, endDate, workspaceNamespace, workspaceName) flatMap { stats =>
-      // we only care to log samples right now
+      // out of all the metrics Rawls returns, we only care to extract the number of samples right now
       val numSamples = stats.statistics.currentEntityStatistics.entityStats.getOrElse("sample", 0)
 
       // get sum of samples from Library

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/Metrics.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/Metrics.scala
@@ -17,7 +17,7 @@ object Metrics {
   // structures sent to Logit and otherwise used in *LogitDAO
   abstract class LogitMetric
   case object NoopMetric extends LogitMetric
-  case class NumObjects(numSamples: Int) extends LogitMetric
+  case class NumSamples(numSamples: Int) extends LogitMetric
   case class NumSubjects(numSubjects: Int) extends LogitMetric
   case class SamplesAndSubjects(numSamples: Int, numSubjects: Int) extends LogitMetric
 
@@ -32,7 +32,7 @@ trait MetricsFormat {
   implicit object LogitMetricFormat extends RootJsonFormat[LogitMetric] {
     override def write(obj: LogitMetric): JsValue = obj match {
       case NoopMetric => JsObject()
-      case ns:NumObjects => JsObject(Map(METRICTYPE_KEY -> JsString("NumObjects"), "numSamples" -> JsNumber(ns.numSamples)))
+      case ns:NumSamples => JsObject(Map(METRICTYPE_KEY -> JsString("NumSamples"), "numSamples" -> JsNumber(ns.numSamples)))
       case ns:NumSubjects => JsObject(Map(METRICTYPE_KEY -> JsString("NumSubjects"), "numSubjects" -> JsNumber(ns.numSubjects)))
       case ss:SamplesAndSubjects => JsObject(Map(
         METRICTYPE_KEY -> JsString("SamplesAndSubjects"),

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/Metrics.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/Metrics.scala
@@ -18,6 +18,8 @@ object Metrics {
   abstract class LogitMetric
   case object NoopMetric extends LogitMetric
   case class NumObjects(numSamples: Int) extends LogitMetric
+  case class NumSubjects(numSubjects: Int) extends LogitMetric
+  case class SamplesAndSubjects(numSamples: Int, numSubjects: Int) extends LogitMetric
 
 }
 
@@ -31,6 +33,12 @@ trait MetricsFormat {
     override def write(obj: LogitMetric): JsValue = obj match {
       case NoopMetric => JsObject()
       case ns:NumObjects => JsObject(Map(METRICTYPE_KEY -> JsString("NumObjects"), "numSamples" -> JsNumber(ns.numSamples)))
+      case ns:NumSubjects => JsObject(Map(METRICTYPE_KEY -> JsString("NumSubjects"), "numSubjects" -> JsNumber(ns.numSubjects)))
+      case ss:SamplesAndSubjects => JsObject(Map(
+        METRICTYPE_KEY -> JsString("SamplesAndSubjects"),
+        "numSamples" -> JsNumber(ss.numSamples),
+        "numSubjects" -> JsNumber(ss.numSubjects)
+      ))
     }
 
     override def read(json: JsValue): LogitMetric = ??? // no need for reads

--- a/src/test/resources/reference.conf
+++ b/src/test/resources/reference.conf
@@ -88,6 +88,7 @@ metrics {
   logitApiKey = "fake-api-key"
   logitFrequencyMinutes = 2
   entityWorkspaceNamespace = "some-namespace"
+  libraryWorkspaceNamespace = ["library-ns-1", "library-ns-2"]
 }
 
 # these are the settings currently used at runtime; copy them here

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockSearchDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockSearchDAO.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.firecloud.dataaccess
 
+import org.broadinstitute.dsde.firecloud.model.Metrics.{LogitMetric, NumSubjects}
 import org.broadinstitute.dsde.firecloud.model._
 import org.broadinstitute.dsde.workbench.util.health.SubsystemStatus
 import spray.json.JsValue
@@ -48,6 +49,9 @@ class MockSearchDAO extends SearchDAO {
     populateSuggestInvoked = true
     Future(Seq(field, text))
   }
+
+
+  override def statistics: LogitMetric = NumSubjects(-1)
 
   def reset = {
     indexDocumentInvoked = false

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/StatisticsSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/StatisticsSpec.scala
@@ -1,0 +1,110 @@
+package org.broadinstitute.dsde.firecloud.integrationtest
+
+import com.typesafe.scalalogging.LazyLogging
+import org.broadinstitute.dsde.firecloud.integrationtest.ESIntegrationSupport._
+import org.broadinstitute.dsde.firecloud.model.Document
+import org.broadinstitute.dsde.firecloud.model.Metrics.NumSubjects
+import org.broadinstitute.dsde.rawls.model.{AttributeName, AttributeNumber, AttributeString}
+import org.scalatest.{BeforeAndAfterEach, FreeSpec, Matchers}
+
+class StatisticsSpec extends FreeSpec with Matchers with BeforeAndAfterEach with LazyLogging {
+
+  // "library-ns-1" and "library-ns-2" are codified in reference.conf
+  private val ignoredTuples:Seq[(String,Int)] = Seq(
+    ("should-be-ignored", 944),
+    ("some-other-namespace", 777),
+    ("library-ns-1-2", 888888) // namespace value is really close but not exact!
+  )
+
+  private val ns1Tuples:Seq[(String,Int)] = Seq(
+    ("library-ns-1", 101),
+    ("library-ns-1", 102)
+  )
+
+  private val ns2Tuples:Seq[(String,Int)] = Seq(
+    ("library-ns-2", 220),
+    ("library-ns-2", 225)
+  )
+
+  private def documentsFrom(tuples: Seq[(String,Int)]): Seq[Document] = {
+    tuples map {
+      case (namespace, numSubjects) =>
+        Document(s"$namespace::$numSubjects", Map(
+          AttributeName.withDefaultNS("namespace") -> AttributeString(namespace),
+          AttributeName.withLibraryNS("numSubjects") -> AttributeNumber(numSubjects),
+          // just to see if we can confuse the query
+          AttributeName.withLibraryNS("dulvn") -> AttributeNumber(-9999999),
+          AttributeName.withDefaultNS("name") -> AttributeString("library-ns-1"),
+          AttributeName.withLibraryNS("useLimitationOption") -> AttributeString("library-ns-2")
+        )
+      )
+    }
+  }
+
+  override def beforeEach = {
+    // use re-create here, since instantiating the DAO will create it in the first place
+    searchDAO.recreateIndex()
+  }
+
+  override def afterEach = {
+    searchDAO.deleteIndex()
+  }
+
+  "SearchDAO.statistics" - {
+
+    "should return 0 when no documents in the index" in {
+      assertResult(NumSubjects(0)) {
+        searchDAO.statistics
+      }
+    }
+
+    "should return 0 when only non-target namespaces exist" in {
+      searchDAO.bulkIndex(documentsFrom(ignoredTuples), refresh = true)
+      assertResult(NumSubjects(0)) {
+        searchDAO.statistics
+      }
+    }
+
+    "should sum across the first target namespace" in {
+      searchDAO.bulkIndex(documentsFrom(ns1Tuples), refresh = true)
+      assertResult(NumSubjects(203)) {
+        searchDAO.statistics
+      }
+    }
+
+    "should sum across the first target namespace, while ignoring non-targets" in {
+      searchDAO.bulkIndex(documentsFrom(ns1Tuples ++ ignoredTuples), refresh = true)
+      assertResult(NumSubjects(203)) {
+        searchDAO.statistics
+      }
+    }
+
+    "should sum across a second target namespace" in {
+      searchDAO.bulkIndex(documentsFrom(ns2Tuples), refresh = true)
+      assertResult(NumSubjects(445)) {
+        searchDAO.statistics
+      }
+    }
+
+    "should sum across a second target namespace, while ignoring non-targets" in {
+      searchDAO.bulkIndex(documentsFrom(ns2Tuples ++ ignoredTuples), refresh = true)
+      assertResult(NumSubjects(445)) {
+        searchDAO.statistics
+      }
+    }
+
+    "should sum across multiple target namespaces" in {
+      searchDAO.bulkIndex(documentsFrom(ns1Tuples ++ ns2Tuples), refresh = true)
+      assertResult(NumSubjects(648)) {
+        searchDAO.statistics
+      }
+    }
+
+    "should sum across multiple target namespaces, while ignoring non-targets" in {
+      searchDAO.bulkIndex(documentsFrom(ns1Tuples ++ ns2Tuples ++ ignoredTuples), refresh = true)
+      assertResult(NumSubjects(648)) {
+        searchDAO.statistics
+      }
+    }
+  }
+}

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/metrics/MetricsSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/metrics/MetricsSpec.scala
@@ -25,8 +25,8 @@ class MetricsSpec extends BaseServiceSpec {
     }
     "should serialize NumObjects metric correctly" in {
       List(Integer.MIN_VALUE, -1, 0, 1, 42, 123456789, Integer.MAX_VALUE) foreach { num =>
-        val numObjects = NumObjects(num)
-        val expected = JsObject(Map("metricType" -> JsString("NumObjects"), "numSamples" -> JsNumber(num)))
+        val numObjects = NumSamples(num)
+        val expected = JsObject(Map("metricType" -> JsString("NumSamples"), "numSamples" -> JsNumber(num)))
         assertResult(expected) {LogitMetricFormat.write(numObjects)}
       }
     }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/metrics/MetricsSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/metrics/MetricsSpec.scala
@@ -23,11 +23,11 @@ class MetricsSpec extends BaseServiceSpec {
     "should serialize noop metric to empty object" in {
       assertResult(JsObject()) {LogitMetricFormat.write(NoopMetric)}
     }
-    "should serialize NumObjects metric correctly" in {
+    "should serialize NumSamples metric correctly" in {
       List(Integer.MIN_VALUE, -1, 0, 1, 42, 123456789, Integer.MAX_VALUE) foreach { num =>
-        val numObjects = NumSamples(num)
+        val numSamples = NumSamples(num)
         val expected = JsObject(Map("metricType" -> JsString("NumSamples"), "numSamples" -> JsNumber(num)))
-        assertResult(expected) {LogitMetricFormat.write(numObjects)}
+        assertResult(expected) {LogitMetricFormat.write(numSamples)}
       }
     }
     "should serialize NumSubjects metric correctly" in {

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/metrics/MetricsSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/metrics/MetricsSpec.scala
@@ -32,9 +32,9 @@ class MetricsSpec extends BaseServiceSpec {
     }
     "should serialize NumSubjects metric correctly" in {
       List(Integer.MIN_VALUE, -1, 0, 1, 42, 123456789, Integer.MAX_VALUE) foreach { num =>
-        val numObjects = NumSubjects(num)
+        val numSubjects = NumSubjects(num)
         val expected = JsObject(Map("metricType" -> JsString("NumSubjects"), "numSubjects" -> JsNumber(num)))
-        assertResult(expected) {LogitMetricFormat.write(numObjects)}
+        assertResult(expected) {LogitMetricFormat.write(numSubjects)}
       }
     }
     "should serialize SamplesAndSubjects metric correctly" in {
@@ -93,13 +93,22 @@ class MetricsSpec extends BaseServiceSpec {
         searchDAO = new MetricsSpecMockSearchDAO(numFailures=0, numSubjects=seed-2),
         logitDAO = new MetricsSpecMockLogitDAO(numFailures=0))
       val metricsActor = system.actorOf(MetricsActor.props(testApp), "metrics-spec-actor")
+      // MetricsActor operates on a repeating schedule (e.g. every 6 hours). Mimic that here
+      // by asking it for metrics twice in a row to make sure it operates correctly on the second try.
       assertResult(SamplesAndSubjects(seed, seed-2)) { Await.result(metricsActor ? MetricsActor.RecordMetrics, duration) }
       assertResult(SamplesAndSubjects(seed, seed-2)) { Await.result(metricsActor ? MetricsActor.RecordMetrics, duration) }
     }
   }
 
-
 }
+
+/* =======================================================================================
+      Mock DAOs to support these tests. Each of these DAOs accepts a "numFailures" argument.
+      When numFailures is non-zero, each DAO will throw an Exception/Future.failed
+      the first $numFailures times it is called. This allows calling code to test resilience
+      to errors.
+   ======================================================================================= */
+
 
 class MetricsSpecMockLogitDAO(numFailures: Int) extends MockLogitDAO {
   val q = new java.util.concurrent.ConcurrentLinkedQueue[Int]


### PR DESCRIPTION
this is databiosphere/firecloud-app#35.

We calculate the sum of the "number of subjects" field in Library - for datasets in specified namespaces - and send them to Logit for visualization in Kibana.

The issue specifies a requirement that this has an API endpoint but I don't believe that requirement to be true. I'll talk to PO to ensure this, but for now I'm submitting this PR without that feature (and will clarify once I have clarity).

Unit + it:tests only, but I think they're decent coverage.

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
