### PR TITLE
GAWB-3556: PerRequestMessage bug for duos/structuredData endpoint

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -4305,7 +4305,7 @@ definitions:
   structuredDataRequest:
     required:
         - generalResearchUse
-        - healthMedicalUseRequired
+        - healthMedicalBiomedicalUseRequired
         - diseaseUseRequired
         - commercialUseProhibited
         - forProfitUseProhibited
@@ -4320,12 +4320,15 @@ definitions:
       generalResearchUse:
         type: boolean
         description: Is the data available for future general research use?
-      healthMedicalUseRequired:
+      healthMedicalBiomedicalUseRequired:
         type: boolean
         description: Is future use limited for health/medical/biomedical research?
       diseaseUseRequired:
+        type: array
+        default: []
         items:
           type: string
+          example: "http://purl.obolibrary.org/obo/DOID_4"
         description: Future use is limited to research involving the following disease area(s). These values must be urls such as "http://purl.obolibrary.org/obo/DOID_12345".
       commercialUseProhibited:
         type: boolean

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/OntologyService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/OntologyService.scala
@@ -39,8 +39,8 @@ class OntologyService(val ontologyDAO: OntologyDAO, val researchPurposeSupport: 
     case DataUseLimitation(dataUseLimitation: StructuredDataRequest) => buildStructuredUseRestrictionAttribute(dataUseLimitation) pipeTo sender
   }
 
-  def buildStructuredUseRestrictionAttribute(request: StructuredDataRequest): Future[Map[String, JsValue]] = {
-    Future(generateStructuredUseRestrictionAttribute(request, ontologyDAO))
+  def buildStructuredUseRestrictionAttribute(request: StructuredDataRequest): Future[PerRequestMessage] = {
+    Future(RequestComplete(generateStructuredUseRestrictionAttribute(request, ontologyDAO)))
   }
 
   def autocompleteOntology(term: String): Future[PerRequestMessage] = {


### PR DESCRIPTION
Fixing a small bug + a correction for the swagger

Built on fiab-ansingh-liked-ewe (104.198.197.63)


Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
