### PR TITLE
Refactor storage codepath

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -20,7 +20,6 @@ security:
     - openid
     - email
     - profile
-    - https://www.googleapis.com/auth/devstorage.full_control
 
 securityDefinitions:
   googleoauth:
@@ -31,7 +30,6 @@ securityDefinitions:
       openid: open id authorization
       email: email authorization
       profile: profile authorization
-      https://www.googleapis.com/auth/devstorage.full_control: GCS storage
       https://www.googleapis.com/auth/cloud-billing: GCS billing
 
 ##########################################################################################
@@ -1588,7 +1586,6 @@ paths:
           - openid
           - email
           - profile
-          - https://www.googleapis.com/auth/devstorage.full_control
           - https://www.googleapis.com/auth/cloud-billing
 
   /api/profile/importstatus:

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -20,6 +20,7 @@ security:
     - openid
     - email
     - profile
+    - https://www.googleapis.com/auth/devstorage.full_control
 
 securityDefinitions:
   googleoauth:
@@ -30,6 +31,7 @@ securityDefinitions:
       openid: open id authorization
       email: email authorization
       profile: profile authorization
+      https://www.googleapis.com/auth/devstorage.full_control: GCS storage
       https://www.googleapis.com/auth/cloud-billing: GCS billing
 
 ##########################################################################################
@@ -1586,6 +1588,7 @@ paths:
           - openid
           - email
           - profile
+          - https://www.googleapis.com/auth/devstorage.full_control
           - https://www.googleapis.com/auth/cloud-billing
 
   /api/profile/importstatus:

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/GoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/GoogleServicesDAO.scala
@@ -5,6 +5,7 @@ import java.io.InputStream
 import akka.actor.ActorRefFactory
 import com.google.api.services.sheets.v4.model.{SpreadsheetProperties, ValueRange}
 import org.broadinstitute.dsde.firecloud.model.{ObjectMetadata, WithAccessToken}
+import org.broadinstitute.dsde.firecloud.service.PerRequest.PerRequestMessage
 import org.broadinstitute.dsde.rawls.model.ErrorReportSource
 import org.broadinstitute.dsde.workbench.util.health.SubsystemStatus
 import spray.http.HttpResponse
@@ -27,10 +28,10 @@ trait GoogleServicesDAO extends ReportsSubsystemStatus {
   def getTrialSpreadsheetAccessToken: String
   def getBucketObjectAsInputStream(bucketName: String, objectKey: String): InputStream
   def getObjectResourceUrl(bucketName: String, objectKey: String): String
-  def getUserProfile(requestContext: RequestContext)
+  def getUserProfile(accessToken: WithAccessToken)
                     (implicit actorRefFactory: ActorRefFactory, executionContext: ExecutionContext): Future[HttpResponse]
-  def getDownload(requestContext: RequestContext, bucketName: String, objectKey: String, userAuthToken: String)
-                 (implicit actorRefFactory: ActorRefFactory, executionContext: ExecutionContext): Unit
+  def getDownload(bucketName: String, objectKey: String, userAuthToken: WithAccessToken)
+                 (implicit actorRefFactory: ActorRefFactory, executionContext: ExecutionContext): Future[PerRequestMessage]
   def getObjectMetadata(bucketName: String, objectKey: String, userAuthToken: String)
                     (implicit actorRefFactory: ActorRefFactory, executionContext: ExecutionContext): Future[ObjectMetadata]
   def fetchPriceList(implicit actorRefFactory: ActorRefFactory, executionContext: ExecutionContext): Future[GooglePriceList]

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/FireCloudRequestBuilding.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/FireCloudRequestBuilding.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.dsde.firecloud.service
 
 import org.broadinstitute.dsde.firecloud.FireCloudConfig
 import org.broadinstitute.dsde.firecloud.dataaccess.HttpGoogleServicesDAO
+import org.broadinstitute.dsde.firecloud.model.WithAccessToken
 import spray.http.HttpHeaders.{Authorization, RawHeader}
 import spray.http._
 import spray.routing.RequestContext
@@ -14,21 +15,26 @@ trait FireCloudRequestBuilding extends spray.httpx.RequestBuilding {
   // TODO: would be much better to make requestContext implicit, so callers don't have to always pass it in
   // TODO: this could probably be rewritten more tersely in idiomatic scala - for instance, don't create
     // the OAuth2BearerToken if we're not going to use it. I'm leaving all this longhand for better comprehension.
-  def authHeaders(requestContext: RequestContext) = {
-
-    // inspect headers for a pre-existing Authorization: header
-    val authorizationHeader: Option[HttpCredentials] = (requestContext.request.headers collect {
-        case Authorization(h) => h
-    }).headOption
-
-    authorizationHeader match {
+  def authHeaders(credentials:Option[HttpCredentials]): HttpRequest => HttpRequest = {
+    credentials match {
       // if we have authorization credentials, apply them to the outgoing request
       case Some(c) => addCredentials(c) ~> addFireCloudCredentials
       // else, noop. But the noop needs to return an identity function in order to compile.
       // alternately, we could throw an error here, since we assume some authorization should exist.
       case None => (r: HttpRequest) => r ~> addFireCloudCredentials
     }
+  }
 
+  def authHeaders(requestContext: RequestContext): HttpRequest => HttpRequest = {
+    // inspect headers for a pre-existing Authorization: header
+    val authorizationHeader: Option[HttpCredentials] = requestContext.request.headers collectFirst {
+      case Authorization(h) => h
+    }
+    authHeaders(authorizationHeader)
+  }
+
+  def authHeaders(accessToken: WithAccessToken): HttpRequest => HttpRequest = {
+    authHeaders(Some(accessToken.accessToken))
   }
 
   def dummyAuthHeaders = {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/CookieAuthedApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/CookieAuthedApiService.scala
@@ -44,7 +44,7 @@ trait CookieAuthedApiService extends HttpService with PerRequestCreator with Fir
 
         perRequest(requestContext,
           StorageService.props(storageServiceConstructor, userInfoFromCookie),
-          StorageService.GetObjectStats(bucket, obj.toString))
+          StorageService.GetDownload(bucket, obj.toString))
       }
     }
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/UserApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/UserApiService.scala
@@ -218,8 +218,10 @@ trait UserApiService extends HttpService with PerRequestCreator with FireCloudRe
           passthrough(UserApiService.samRegisterUserURL, HttpMethods.GET)
         }
       } ~
-      path("userinfo") { requestContext =>
-        requestContext.complete(HttpGoogleServicesDAO.getUserProfile(requestContext))
+      path("userinfo") {
+        requireUserInfo() { userInfo => requestContext =>
+          requestContext.complete(HttpGoogleServicesDAO.getUserProfile(userInfo))
+        }
       } ~
       pathPrefix("profile") {
         // GET /profile - get all keys for current user

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockGoogleServicesDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockGoogleServicesDAO.scala
@@ -7,8 +7,9 @@ import com.google.api.services.sheets.v4.model.{SpreadsheetProperties, ValueRang
 import org.broadinstitute.dsde.firecloud.FireCloudException
 import org.broadinstitute.dsde.firecloud.dataaccess._
 import org.broadinstitute.dsde.firecloud.model.{ObjectMetadata, WithAccessToken}
+import org.broadinstitute.dsde.firecloud.service.PerRequest.{PerRequestMessage, RequestComplete}
 import org.broadinstitute.dsde.workbench.util.health.SubsystemStatus
-import spray.http.HttpResponse
+import spray.http.{HttpResponse, StatusCodes}
 import spray.json.JsObject
 import spray.json._
 import spray.routing.RequestContext
@@ -85,10 +86,10 @@ class MockGoogleServicesDAO extends GoogleServicesDAO {
                                 (implicit actorRefFactory: ActorRefFactory, executionContext: ExecutionContext): Future[ObjectMetadata] = {
     Future.successful(ObjectMetadata("foo", "bar", "baz", "bla", "blah", None, "blahh", "blahh", "blahh", "blahh", "blahh", "blahh", Option("blahh"), Option("blahh"), Option("blahh"), None))
   }
-  override def getUserProfile(requestContext: RequestContext)
+  override def getUserProfile(accessToken: WithAccessToken)
                              (implicit actorRefFactory: ActorRefFactory, executionContext: ExecutionContext): Future[HttpResponse] = Future.failed(new UnsupportedOperationException)
-  override def getDownload(requestContext: RequestContext, bucketName: String, objectKey: String, userAuthToken: String)
-                          (implicit actorRefFactory: ActorRefFactory, executionContext: ExecutionContext): Unit = {}
+  override def getDownload(bucketName: String, objectKey: String, userAuthToken: WithAccessToken)
+                          (implicit actorRefFactory: ActorRefFactory, executionContext: ExecutionContext): Future[PerRequestMessage] = {Future.successful(RequestComplete(StatusCodes.NotImplemented))}
   override def fetchPriceList(implicit actorRefFactory: ActorRefFactory, executionContext: ExecutionContext): Future[GooglePriceList] = {
     Future.successful(GooglePriceList(GooglePrices(UsPriceItem(BigDecimal(0.01)), UsTieredPriceItem(Map(1024L -> BigDecimal(0.12)))), "v0", "18-November-2016"))
   }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/ExportEntitiesByTypeServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/ExportEntitiesByTypeServiceSpec.scala
@@ -12,6 +12,8 @@ import scala.concurrent.duration._
 
 class ExportEntitiesByTypeServiceSpec extends BaseServiceSpec with ExportEntitiesApiService with CookieAuthedApiService {
 
+  override val storageServiceConstructor: UserInfo => StorageService = StorageService.constructor(app)
+
   // On travis, slow processing causes the route to timeout and complete too quickly for the large content checks.
   override implicit val routeTestTimeout = RouteTestTimeout(30.seconds)
 


### PR DESCRIPTION
This is a refactor in prep for DataBiosphere/firecloud-app#33. This PR should have zero end-user functional changes. It re-routes the cookie-authed storage endpoint to use PerRequest via StorageService - this will make it easier to adopt pets and remove OAuth storage scope once the Sam dependencies are met.

There's a bunch more I thought about refactoring - such as using Google client libraries instead of making REST calls to known Google URLs - but I wanted to keep this PR manageable.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
