### PR TITLE
[GAWB-3600]: Adding test coverage for user profile billing projects

### DIFF
--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -13,7 +13,7 @@ object Dependencies {
   val workbenchGoogle: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-google" % workbenchGoogleV excludeAll excludeWorkbenchModel
   val excludeWorkbenchGoogle = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-google_2.11")
 
-  val workbenchServiceTestV = "0.9-cbc35de"
+  val workbenchServiceTestV = "0.9-fc954ca"
   val workbenchServiceTest: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-service-test" % workbenchServiceTestV % "test" classifier "tests" excludeAll (excludeWorkbenchGoogle, excludeWorkbenchModel)
 
   val rootDependencies = Seq(

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/OrchestrationApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/OrchestrationApiSpec.scala
@@ -228,6 +228,7 @@ class OrchestrationApiSpec extends FreeSpec with Matchers with ScalaFutures with
     }
 
     "querying for an individual billing project status" - {
+
       "should get the user's billing project" in {
         val ownerUser: Credentials = UserPool.chooseProjectOwner
         val ownerToken: AuthToken = ownerUser.makeAuthToken()
@@ -257,7 +258,6 @@ class OrchestrationApiSpec extends FreeSpec with Matchers with ScalaFutures with
         val ownerUser: Credentials = UserPool.chooseProjectOwner
         val user: Credentials = UserPool.chooseStudent
         val userToken: AuthToken = user.makeAuthToken()
-
         withCleanBillingProject(ownerUser) { projectName =>
           nowPrint(s"Querying for (student) user profile billing project status: $projectName")
           val getException = intercept[RestException] {


### PR DESCRIPTION
See https://broadinstitute.atlassian.net/browse/GAWB-3600

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
