### PR TITLE
api tests for storage endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,4 @@ crashlytics-build.properties
 *.pid
 .DS_Store
 
+automation/src/test/resources

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -13,7 +13,7 @@ object Dependencies {
   val workbenchGoogle: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-google" % workbenchGoogleV excludeAll excludeWorkbenchModel
   val excludeWorkbenchGoogle = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-google_2.11")
 
-  val workbenchServiceTestV = "0.9-fc954ca"
+  val workbenchServiceTestV = "0.9-f2db01b"
   val workbenchServiceTest: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-service-test" % workbenchServiceTestV % "test" classifier "tests" excludeAll (excludeWorkbenchGoogle, excludeWorkbenchModel)
 
   val rootDependencies = Seq(

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
   val jacksonV = "2.8.4"
   val akkaV = "2.5.7"
-  val akkaHttpV = "10.0.10"
+  val akkaHttpV = "10.1.0"
 
   val workbenchModelV  = "0.10-6800f3a"
   val workbenchModel: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-model" % workbenchModelV
@@ -25,7 +25,7 @@ object Dependencies {
     "com.fasterxml.jackson.module" % "jackson-module-scala_2.11" % jacksonV,
     "net.virtual-void" %% "json-lenses" % "0.6.2" % "test",
     "ch.qos.logback" % "logback-classic" % "1.2.3",
-    "com.google.apis" % "google-api-services-oauth2" % "v1-rev112-1.20.0" excludeAll (
+    "com.google.apis" % "google-api-services-oauth2" % "v1-rev127-1.22.0" excludeAll (
       ExclusionRule("com.google.guava", "guava-jdk5"),
       ExclusionRule("org.apache.httpcomponents", "httpclient")
     ),

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/StorageApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/StorageApiSpec.scala
@@ -32,7 +32,7 @@ class StorageApiSpec extends FreeSpec with Matchers {
   case class StorageObject(bucketName: String, objectKey: String)
 
   val publicUrl = StorageObject("fixtures-for-tests", "public/small-text-file.txt")
-  val largeFile = StorageObject("fixtures-for-tests", "public/ninemegabytes.file")
+  val largeFile = StorageObject("fixtures-for-tests", "student-and-SA/ninemegabytes.file")
   val pngFile   = StorageObject("fixtures-for-tests", "public/broad_logo.png")
   val overriddenContentType = StorageObject("fixtures-for-tests", "public/content-type-override.txt")
   val nonExistent = StorageObject("fixtures-for-tests", "thisdoesntexist/now/or/inthefuture.nope")

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/StorageApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/StorageApiSpec.scala
@@ -1,0 +1,182 @@
+package org.broadinstitute.dsde.test.api.orch
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.model.{HttpResponse, StatusCodes}
+import akka.http.scaladsl.model.headers._
+import akka.stream.ActorMaterializer
+import org.broadinstitute.dsde.workbench.auth.AuthToken
+import org.broadinstitute.dsde.workbench.config.UserPool
+import org.broadinstitute.dsde.workbench.service.{Orchestration, RestException}
+import org.broadinstitute.dsde.workbench.service.Orchestration.storage.ObjectMetadata
+import org.scalatest.{FreeSpec, Matchers}
+
+import scala.concurrent.{Await, ExecutionContextExecutor}
+import scala.concurrent.duration._
+
+/*
+  This test suite relies on a set of static, preconfigured fixtures that exist in the gs://fixtures-for-tests
+  bucket (in the broad-dsde-qa project). Those fixtures have permissions set on them that mirror how FireCloud
+  applies permissions to workspace buckets - i.e. their permissions use proxy groups.
+
+  If the static fixtures change, these tests are likely to fail.
+
+  If the set of test-suite users - specifically the potter-family students - change and the permissions on the
+  fixtures are not updated, these tests are likely to fail. Failures may be intermittent.
+ */
+
+class StorageApiSpec extends FreeSpec with Matchers {
+  implicit val system: ActorSystem = ActorSystem()
+  implicit val materializer: ActorMaterializer = ActorMaterializer()
+  implicit val ec: ExecutionContextExecutor = system.dispatcher
+
+  case class StorageObject(bucketName: String, objectKey: String)
+
+  val publicUrl = StorageObject("fixtures-for-tests", "public/small-text-file.txt")
+  val largeFile = StorageObject("fixtures-for-tests", "public/ninemegabytes.file")
+  val pngFile   = StorageObject("fixtures-for-tests", "public/broad_logo.png")
+  val overriddenContentType = StorageObject("fixtures-for-tests", "public/content-type-override.txt")
+  val nonExistent = StorageObject("fixtures-for-tests", "thisdoesntexist/now/or/inthefuture.nope")
+  val noAccess = StorageObject("fixtures-for-tests", "no-access/noaccess-text-file.txt")
+  val smallText = StorageObject("fixtures-for-tests", "student-and-SA/small-text-file.txt")
+  val noSAPermissions = StorageObject("fixtures-for-tests", "student-only/ninemegabytes.file")
+
+  // NB: for requests to nonexistent objects, Google returns a 403 unless the user ALSO has permission to
+  // list the contents of the associated bucket, in which case Google returns a 404. In this suite, we do not
+  // attempt to test the various error codes that Google is responsible for; we simply want to test that when
+  // we get an error code back from Google, we propagate it to the user. Therefore, we have tests here that
+  // check for a 403 when requesting non-existent objects, which may seem wrong at first glance to anyone
+  // reading this code.
+
+  "metadata endpoint" - {
+
+    "should return metadata response for a public object" in {
+      implicit val authToken: AuthToken = UserPool.chooseStudent.makeAuthToken()
+      val result:ObjectMetadata = Orchestration.storage.getObjectMetadata(publicUrl.bucketName, publicUrl.objectKey)
+      assertResult(publicUrl.bucketName) { result.bucket }
+      assertResult(publicUrl.objectKey) { result.name }
+    }
+
+    "should return metadata response for an object I have permissions to" in {
+      implicit val authToken: AuthToken = UserPool.chooseStudent.makeAuthToken()
+      val result:ObjectMetadata = Orchestration.storage.getObjectMetadata(smallText.bucketName, smallText.objectKey)
+      assertResult(smallText.bucketName) { result.bucket }
+      assertResult(smallText.objectKey) { result.name }
+    }
+
+    "should return 403 for a non-existent object" in {
+      implicit val authToken: AuthToken = UserPool.chooseStudent.makeAuthToken()
+      val requestEx = intercept[RestException] {
+        Orchestration.storage.getObjectMetadata(nonExistent.bucketName, nonExistent.objectKey)
+      }
+      assert(requestEx.getMessage.toLowerCase.contains("forbidden"))
+    }
+
+    "should return 403 for a file I don't have permissions to" in {
+      implicit val authToken: AuthToken = UserPool.chooseStudent.makeAuthToken()
+      val requestEx = intercept[RestException] {
+        Orchestration.storage.getObjectMetadata(noAccess.bucketName, noAccess.objectKey)
+      }
+      assert(requestEx.getMessage.toLowerCase.contains("forbidden"))
+    }
+
+  }
+
+  "cookie-authed download endpoint" - {
+
+    "should return 403 for a non-existent object" in {
+      implicit val authToken: AuthToken = UserPool.chooseStudent.makeAuthToken()
+      val response = Orchestration.storage.getObjectDownload(nonExistent.bucketName, nonExistent.objectKey)
+      assertResult(StatusCodes.Forbidden) { response.status }
+    }
+
+    "should return 403 for a file I don't have permissions to" in {
+      implicit val authToken: AuthToken = UserPool.chooseStudent.makeAuthToken()
+      val response = Orchestration.storage.getObjectDownload(noAccess.bucketName, noAccess.objectKey)
+      assertResult(StatusCodes.Forbidden) { response.status }
+    }
+
+    "should return OK for small (<8MB) public files" in {
+      implicit val authToken: AuthToken = UserPool.chooseStudent.makeAuthToken()
+      val response:HttpResponse = Orchestration.storage.getObjectDownload(publicUrl.bucketName, publicUrl.objectKey)
+
+      assertResult(StatusCodes.OK) { response.status }
+
+      val contentLength:Long = response.header[`Content-Length`].map(_.length).getOrElse(-1)
+      assert(contentLength < 8 * 1024 * 1024, s"content-length should be under 8MB; was $contentLength" )
+    }
+
+    "should return content directly for small (<8MB) files" in {
+      implicit val authToken: AuthToken = UserPool.chooseStudent.makeAuthToken()
+      val response:HttpResponse = Orchestration.storage.getObjectDownload(smallText.bucketName, smallText.objectKey)
+
+      assertResult(StatusCodes.OK) { response.status }
+
+      val contentLength:Long = response.header[`Content-Length`].map(_.length).getOrElse(-1)
+      assert(contentLength < 8 * 1024 * 1024, s"content-length should be under 8MB; was $contentLength" )
+
+      val responseString: String = Await.result(response.entity.toStrict(2.minutes).map(_.data.utf8String), 2.minutes)
+      assertResult("this is a small text file.") { responseString }
+    }
+
+    "should redirect to a signed url for large (>8MB) files" in {
+      implicit val authToken: AuthToken = UserPool.chooseStudent.makeAuthToken()
+      val response:HttpResponse = Orchestration.storage.getObjectDownload(largeFile.bucketName, largeFile.objectKey)
+
+      assertResult(StatusCodes.TemporaryRedirect) { response.status }
+
+      val redirectUriOption = response.header[Location].map(_.getUri())
+      assert(redirectUriOption.isDefined, "redirect should have a Location header")
+      redirectUriOption.map { redirectUri =>
+        assert(redirectUri.query().toMultiMap.containsKey("GoogleAccessId"), "signed url should have GoogleAccessId query param")
+        assert(redirectUri.query().toMultiMap.containsKey("Expires"), "signed url should have Expires query param")
+        assert(redirectUri.query().toMultiMap.containsKey("Signature"), "signed url should have Signature query param")
+
+        assert(redirectUri.path().contains(largeFile.bucketName), "signed url should contain bucket")
+        assert(redirectUri.path().contains(largeFile.objectKey), "signed url should contain object key")
+      }
+    }
+
+    "should redirect to a direct-download url when SA doesn't have signing permissions for large (>8MB) files " in {
+      implicit val authToken: AuthToken = UserPool.chooseStudent.makeAuthToken()
+      val response:HttpResponse = Orchestration.storage.getObjectDownload(noSAPermissions.bucketName, noSAPermissions.objectKey)
+
+      assertResult(StatusCodes.TemporaryRedirect) { response.status }
+
+      val redirectUriOption = response.header[Location].map(_.getUri())
+      assert(redirectUriOption.isDefined, "redirect should have a Location header")
+      redirectUriOption.map { redirectUri =>
+        val expected = s"https://storage.cloud.google.com/${noSAPermissions.bucketName}/${noSAPermissions.objectKey}"
+        assertResult(expected) { redirectUri.toString }
+      }
+    }
+
+    "should propagate inferred content-type" in {
+      implicit val authToken: AuthToken = UserPool.chooseStudent.makeAuthToken()
+      val response:HttpResponse = Orchestration.storage.getObjectDownload(pngFile.bucketName, pngFile.objectKey)
+
+      assertResult(StatusCodes.OK) { response.status }
+
+      val contentType = response.header[`Content-Type`].map(_.contentType.toString())
+
+      assertResult(Some("image/png"),
+        "content type for png should be inferred and returned") {
+        contentType
+      }
+    }
+
+    "should propagate overriden content-type" in {
+      implicit val authToken: AuthToken = UserPool.chooseStudent.makeAuthToken()
+      val response:HttpResponse = Orchestration.storage.getObjectDownload(overriddenContentType.bucketName, overriddenContentType.objectKey)
+
+      assertResult(StatusCodes.OK) { response.status }
+
+      val contentType = response.header[`Content-Type`].map(_.contentType.toString())
+
+      assertResult(Some("application/json"),
+        "content type for png should be inferred and returned") {
+        contentType
+      }
+    }
+
+  }
+}

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/StorageApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/StorageApiSpec.scala
@@ -4,41 +4,49 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.model.{HttpResponse, StatusCodes}
 import akka.http.scaladsl.model.headers._
 import akka.stream.ActorMaterializer
+import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.workbench.auth.AuthToken
-import org.broadinstitute.dsde.workbench.config.UserPool
+import org.broadinstitute.dsde.workbench.config.{Credentials, UserPool}
+import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GcsObjectName, GcsPath}
 import org.broadinstitute.dsde.workbench.service.{Orchestration, RestException}
 import org.broadinstitute.dsde.workbench.service.Orchestration.storage.ObjectMetadata
 import org.scalatest.{FreeSpec, Matchers}
 
 import scala.concurrent.{Await, ExecutionContextExecutor}
 import scala.concurrent.duration._
+import scala.language.implicitConversions
 
 /*
-  This test suite relies on a set of static, preconfigured fixtures that exist in the gs://fixtures-for-tests
-  bucket (in the broad-dsde-qa project). Those fixtures have permissions set on them that mirror how FireCloud
-  applies permissions to workspace buckets - i.e. their permissions use proxy groups.
+  This test suite relies on a set of static fixtures that exist in the gs://fixtures-for-tests
+  bucket (in the broad-dsde-qa project). Some of these fixtures have permissions preconfigured - for the public-file
+  and no-access tests. If the permissions on these fixtures change, these tests will fail.
 
-  If the static fixtures change, these tests are likely to fail.
-
-  If the set of test-suite users - specifically the potter-family students - change and the permissions on the
-  fixtures are not updated, these tests are likely to fail. Failures may be intermittent.
+  The default object ACL for new files in the gs://fixtures-for-tests is set very narrowly, with three individual
+  Workbench developers as owners and no other access. This allows tests to ensure they are setting ACLs appropriate
+  to the test; no chance of unexpected read access due to default ACLs. If the default ACL for this bucket changes,
+  these tests are likely to fail.
  */
 
-class StorageApiSpec extends FreeSpec with Matchers {
+class StorageApiSpec extends FreeSpec with StorageApiSpecSupport with Matchers with LazyLogging {
   implicit val system: ActorSystem = ActorSystem()
   implicit val materializer: ActorMaterializer = ActorMaterializer()
   implicit val ec: ExecutionContextExecutor = system.dispatcher
 
-  case class StorageObject(bucketName: String, objectKey: String)
+  val student: Credentials = UserPool.chooseStudent
+  logger.info(s"StorageApiSpec running as student <${student.email}>")
 
-  val publicUrl = StorageObject("fixtures-for-tests", "public/small-text-file.txt")
-  val largeFile = StorageObject("fixtures-for-tests", "student-and-SA/ninemegabytes.file")
-  val pngFile   = StorageObject("fixtures-for-tests", "public/broad_logo.png")
-  val overriddenContentType = StorageObject("fixtures-for-tests", "public/content-type-override.txt")
-  val nonExistent = StorageObject("fixtures-for-tests", "thisdoesntexist/now/or/inthefuture.nope")
-  val noAccess = StorageObject("fixtures-for-tests", "no-access/noaccess-text-file.txt")
-  val smallText = StorageObject("fixtures-for-tests", "student-and-SA/small-text-file.txt")
-  val noSAPermissions = StorageObject("fixtures-for-tests", "student-only/ninemegabytes.file")
+  // implicit conversions to allow shorthand for working with GcsPath/GcsBucketName/GcsObjectName
+  implicit def stringToBucketName(s: String): GcsBucketName = GcsBucketName(s)
+  implicit def stringToObjectName(s: String): GcsObjectName = GcsObjectName(s)
+  implicit def bucketNameToString(b: GcsBucketName): String = b.value
+  implicit def objectNameToString(o: GcsObjectName): String = o.value
+
+  val publicUrl = GcsPath("fixtures-for-tests", "fixtures/public/small-text-file.txt")
+  val pngFile   = GcsPath("fixtures-for-tests", "fixtures/public/broad_logo.png")
+  val overriddenContentType = GcsPath("fixtures-for-tests", "fixtures/public/content-type-override.txt")
+
+  val noAccess = GcsPath("fixtures-for-tests", "fixtures/noaccess/noaccess.txt")
+  val nonExistent = GcsPath("fixtures-for-tests", "thisdoesntexist/now/or/inthefuture.nope")
 
   // NB: for requests to nonexistent objects, Google returns a 403 unless the user ALSO has permission to
   // list the contents of the associated bucket, in which case Google returns a 404. In this suite, we do not
@@ -50,23 +58,26 @@ class StorageApiSpec extends FreeSpec with Matchers {
   "metadata endpoint" - {
 
     "should return metadata response for a public object" in {
-      implicit val authToken: AuthToken = UserPool.chooseStudent.makeAuthToken()
-      val result:ObjectMetadata = Orchestration.storage.getObjectMetadata(publicUrl.bucketName, publicUrl.objectKey)
-      assertResult(publicUrl.bucketName) { result.bucket }
-      assertResult(publicUrl.objectKey) { result.name }
+      implicit val authToken: AuthToken = student.makeAuthToken()
+      val result:ObjectMetadata = Orchestration.storage.getObjectMetadata(publicUrl.bucketName, publicUrl.objectName)
+      assertResult(publicUrl.bucketName.value) { result.bucket }
+      assertResult(publicUrl.objectName.value) { result.name }
     }
 
     "should return metadata response for an object I have permissions to" in {
-      implicit val authToken: AuthToken = UserPool.chooseStudent.makeAuthToken()
-      val result:ObjectMetadata = Orchestration.storage.getObjectMetadata(smallText.bucketName, smallText.objectKey)
-      assertResult(smallText.bucketName) { result.bucket }
-      assertResult(smallText.objectKey) { result.name }
+      implicit val token = student.makeAuthToken()
+      withSmallFile { smallFile =>
+        setStudentAndSA(smallFile, student)
+        val result:ObjectMetadata = Orchestration.storage.getObjectMetadata(smallFile.bucketName, smallFile.objectName)
+        assertResult(smallFile.bucketName.value) { result.bucket }
+        assertResult(smallFile.objectName.value) { result.name }
+      }
     }
 
     "should return 403 for a non-existent object" in {
-      implicit val authToken: AuthToken = UserPool.chooseStudent.makeAuthToken()
+      implicit val authToken: AuthToken = student.makeAuthToken()
       val requestEx = intercept[RestException] {
-        Orchestration.storage.getObjectMetadata(nonExistent.bucketName, nonExistent.objectKey)
+        Orchestration.storage.getObjectMetadata(nonExistent.bucketName, nonExistent.objectName)
       }
       assert(requestEx.getMessage.toLowerCase.contains("forbidden"))
     }
@@ -74,7 +85,7 @@ class StorageApiSpec extends FreeSpec with Matchers {
     "should return 403 for a file I don't have permissions to" in {
       implicit val authToken: AuthToken = UserPool.chooseStudent.makeAuthToken()
       val requestEx = intercept[RestException] {
-        Orchestration.storage.getObjectMetadata(noAccess.bucketName, noAccess.objectKey)
+        Orchestration.storage.getObjectMetadata(noAccess.bucketName, noAccess.objectName)
       }
       assert(requestEx.getMessage.toLowerCase.contains("forbidden"))
     }
@@ -84,80 +95,76 @@ class StorageApiSpec extends FreeSpec with Matchers {
   "cookie-authed download endpoint" - {
 
     "should return 403 for a non-existent object" in {
-      implicit val authToken: AuthToken = UserPool.chooseStudent.makeAuthToken()
-      val response = Orchestration.storage.getObjectDownload(nonExistent.bucketName, nonExistent.objectKey)
+      implicit val authToken: AuthToken = student.makeAuthToken()
+      val response = Orchestration.storage.getObjectDownload(nonExistent.bucketName, nonExistent.objectName)
       assertResult(StatusCodes.Forbidden) { response.status }
     }
 
     "should return 403 for a file I don't have permissions to" in {
-      implicit val authToken: AuthToken = UserPool.chooseStudent.makeAuthToken()
-      val response = Orchestration.storage.getObjectDownload(noAccess.bucketName, noAccess.objectKey)
+      implicit val authToken: AuthToken = student.makeAuthToken()
+      val response = Orchestration.storage.getObjectDownload(noAccess.bucketName, noAccess.objectName)
       assertResult(StatusCodes.Forbidden) { response.status }
     }
 
     "should return OK for small (<8MB) public files" in {
-      implicit val authToken: AuthToken = UserPool.chooseStudent.makeAuthToken()
-      val response:HttpResponse = Orchestration.storage.getObjectDownload(publicUrl.bucketName, publicUrl.objectKey)
-
+      implicit val authToken: AuthToken = student.makeAuthToken()
+      val response:HttpResponse = Orchestration.storage.getObjectDownload(publicUrl.bucketName, publicUrl.objectName)
       assertResult(StatusCodes.OK) { response.status }
-
       val contentLength:Long = response.header[`Content-Length`].map(_.length).getOrElse(-1)
       assert(contentLength < 8 * 1024 * 1024, s"content-length should be under 8MB; was $contentLength" )
     }
 
     "should return content directly for small (<8MB) files" in {
-      implicit val authToken: AuthToken = UserPool.chooseStudent.makeAuthToken()
-      val response:HttpResponse = Orchestration.storage.getObjectDownload(smallText.bucketName, smallText.objectKey)
-
-      assertResult(StatusCodes.OK) { response.status }
-
-      val contentLength:Long = response.header[`Content-Length`].map(_.length).getOrElse(-1)
-      assert(contentLength < 8 * 1024 * 1024, s"content-length should be under 8MB; was $contentLength" )
-
-      val responseString: String = Await.result(response.entity.toStrict(2.minutes).map(_.data.utf8String), 2.minutes)
-      assertResult("this is a small text file.") { responseString }
+      implicit val authToken: AuthToken = student.makeAuthToken()
+      withSmallFile { smallFile =>
+        setStudentOnly(smallFile, student)
+        val response:HttpResponse = Orchestration.storage.getObjectDownload(smallFile.bucketName, smallFile.objectName)
+        assertResult(StatusCodes.OK) { response.status }
+        val contentLength:Long = response.header[`Content-Length`].map(_.length).getOrElse(-1)
+        assert(contentLength < 8 * 1024 * 1024, s"content-length should be under 8MB; was $contentLength" )
+        val responseString: String = Await.result(response.entity.toStrict(2.minutes).map(_.data.utf8String), 2.minutes)
+        assertResult("this is a small text file.") { responseString }
+      }
     }
 
     "should redirect to a signed url for large (>8MB) files" in {
-      implicit val authToken: AuthToken = UserPool.chooseStudent.makeAuthToken()
-      val response:HttpResponse = Orchestration.storage.getObjectDownload(largeFile.bucketName, largeFile.objectKey)
-
-      assertResult(StatusCodes.TemporaryRedirect) { response.status }
-
-      val redirectUriOption = response.header[Location].map(_.getUri())
-      assert(redirectUriOption.isDefined, "redirect should have a Location header")
-      redirectUriOption.map { redirectUri =>
-        assert(redirectUri.query().toMultiMap.containsKey("GoogleAccessId"), "signed url should have GoogleAccessId query param")
-        assert(redirectUri.query().toMultiMap.containsKey("Expires"), "signed url should have Expires query param")
-        assert(redirectUri.query().toMultiMap.containsKey("Signature"), "signed url should have Signature query param")
-
-        assert(redirectUri.path().contains(largeFile.bucketName), "signed url should contain bucket")
-        assert(redirectUri.path().contains(largeFile.objectKey), "signed url should contain object key")
+      implicit val authToken: AuthToken = student.makeAuthToken()
+      withLargeFile { largeFile =>
+        setStudentAndSA(largeFile, student)
+        val response:HttpResponse = Orchestration.storage.getObjectDownload(largeFile.bucketName, largeFile.objectName)
+        assertResult(StatusCodes.TemporaryRedirect) { response.status }
+        val redirectUriOption = response.header[Location].map(_.getUri())
+        assert(redirectUriOption.isDefined, "redirect should have a Location header")
+        redirectUriOption.map { redirectUri =>
+          assert(redirectUri.query().toMultiMap.containsKey("GoogleAccessId"), "signed url should have GoogleAccessId query param")
+          assert(redirectUri.query().toMultiMap.containsKey("Expires"), "signed url should have Expires query param")
+          assert(redirectUri.query().toMultiMap.containsKey("Signature"), "signed url should have Signature query param")
+          assert(redirectUri.path().contains(largeFile.bucketName), "signed url should contain bucket")
+          assert(redirectUri.path().contains(largeFile.objectName), "signed url should contain object key")
+        }
       }
     }
 
     "should redirect to a direct-download url when SA doesn't have signing permissions for large (>8MB) files " in {
-      implicit val authToken: AuthToken = UserPool.chooseStudent.makeAuthToken()
-      val response:HttpResponse = Orchestration.storage.getObjectDownload(noSAPermissions.bucketName, noSAPermissions.objectKey)
-
-      assertResult(StatusCodes.TemporaryRedirect) { response.status }
-
-      val redirectUriOption = response.header[Location].map(_.getUri())
-      assert(redirectUriOption.isDefined, "redirect should have a Location header")
-      redirectUriOption.map { redirectUri =>
-        val expected = s"https://storage.cloud.google.com/${noSAPermissions.bucketName}/${noSAPermissions.objectKey}"
-        assertResult(expected) { redirectUri.toString }
+      implicit val authToken: AuthToken = student.makeAuthToken()
+      withLargeFile { largeFile =>
+        setStudentOnly(largeFile, student)
+        val response:HttpResponse = Orchestration.storage.getObjectDownload(largeFile.bucketName, largeFile.objectName)
+        assertResult(StatusCodes.TemporaryRedirect) { response.status }
+        val redirectUriOption = response.header[Location].map(_.getUri())
+        assert(redirectUriOption.isDefined, "redirect should have a Location header")
+        redirectUriOption.map { redirectUri =>
+          val expected = s"https://storage.cloud.google.com/${largeFile.bucketName.value}/${largeFile.objectName.value}"
+          assertResult(expected) { redirectUri.toString }
+        }
       }
     }
 
     "should propagate inferred content-type" in {
-      implicit val authToken: AuthToken = UserPool.chooseStudent.makeAuthToken()
-      val response:HttpResponse = Orchestration.storage.getObjectDownload(pngFile.bucketName, pngFile.objectKey)
-
+      implicit val authToken: AuthToken = student.makeAuthToken()
+      val response:HttpResponse = Orchestration.storage.getObjectDownload(pngFile.bucketName, pngFile.objectName)
       assertResult(StatusCodes.OK) { response.status }
-
       val contentType = response.header[`Content-Type`].map(_.contentType.toString())
-
       assertResult(Some("image/png"),
         "content type for png should be inferred and returned") {
         contentType
@@ -165,13 +172,10 @@ class StorageApiSpec extends FreeSpec with Matchers {
     }
 
     "should propagate overriden content-type" in {
-      implicit val authToken: AuthToken = UserPool.chooseStudent.makeAuthToken()
-      val response:HttpResponse = Orchestration.storage.getObjectDownload(overriddenContentType.bucketName, overriddenContentType.objectKey)
-
+      implicit val authToken: AuthToken = student.makeAuthToken()
+      val response:HttpResponse = Orchestration.storage.getObjectDownload(overriddenContentType.bucketName, overriddenContentType.objectName)
       assertResult(StatusCodes.OK) { response.status }
-
       val contentType = response.header[`Content-Type`].map(_.contentType.toString())
-
       assertResult(Some("application/json"),
         "content type for png should be inferred and returned") {
         contentType
@@ -179,4 +183,5 @@ class StorageApiSpec extends FreeSpec with Matchers {
     }
 
   }
+
 }

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/StorageApiSpecSupport.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/StorageApiSpecSupport.scala
@@ -54,7 +54,7 @@ trait StorageApiSpecSupport extends ScalaFutures with LazyLogging {
       testCode(destPath)
     } finally {
       logger.debug(s"cleaning up $destPath ...")
-      // googleStorageDAO.removeObject(destPath.bucketName, destPath.objectName)
+       googleStorageDAO.removeObject(destPath.bucketName, destPath.objectName)
     }
   }
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/StorageApiSpecSupport.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/StorageApiSpecSupport.scala
@@ -1,0 +1,88 @@
+package org.broadinstitute.dsde.test.api.orch
+
+import java.util.Calendar
+
+import com.typesafe.scalalogging.LazyLogging
+import org.broadinstitute.dsde.workbench.auth.AuthToken
+import org.broadinstitute.dsde.workbench.config.{Config, Credentials}
+import org.broadinstitute.dsde.workbench.dao.Google.googleStorageDAO
+import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
+import org.broadinstitute.dsde.workbench.model.google.GcsEntityTypes.{Group, User}
+import org.broadinstitute.dsde.workbench.model.google.GcsRoles.Reader
+import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GcsEntity, GcsObjectName, GcsPath}
+import org.broadinstitute.dsde.workbench.service.Sam
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.time.{Minutes, Seconds, Span}
+
+import scala.util.{Failure, Success, Try}
+
+trait StorageApiSpecSupport extends ScalaFutures with LazyLogging {
+
+  implicit val storagePatience: PatienceConfig = PatienceConfig(timeout = scaled(Span(1, Minutes)), interval = scaled(Span(1, Seconds)))
+
+  // these are hardcoded and should never change. They refer to a static pre-created bucket in broad-dsde-qa.
+  final val fixtureBucket: GcsBucketName = GcsBucketName("fixtures-for-tests")
+  final val fixtureDir: String = "fixtures"
+
+  final val smallFileName: String = "small-text-file.txt"
+  final val largeFileName: String = "ninemegabytes.file"
+  final val imageFileName: String = "broad_logo.png"
+
+  final val smallFileFixture: GcsPath = GcsPath(fixtureBucket, GcsObjectName(s"$fixtureDir/$smallFileName"))
+  final val largeFileFixture: GcsPath = GcsPath(fixtureBucket, GcsObjectName(s"$fixtureDir/$largeFileName"))
+  final val imageFileFixture: GcsPath = GcsPath(fixtureBucket, GcsObjectName(s"$fixtureDir/$imageFileName"))
+
+  // temporary subdirectory to hold files for a single run of tests.
+  lazy val testDir: String = {
+    val tag = "apitest"
+    val time = Calendar.getInstance.getTime.toInstant.getEpochSecond
+    val username = Try(System.getProperty("user.name")) match {
+      case Success(str) => str.toLowerCase
+      case Failure(_) => "unknownuser"
+    }
+    val hostname = Try(java.net.InetAddress.getLocalHost.getHostName) match {
+      case Success(str) => str.toLowerCase
+      case Failure(_) => "unknownhostname"
+    }
+    Seq(tag, username, hostname, time).mkString("_")
+  }
+
+  private def withFile(srcPath: GcsPath, destPath: GcsPath, testCode: GcsPath => Any): Unit = {
+    logger.debug(s"copying $srcPath to $destPath ...")
+    googleStorageDAO.copyObject(srcPath.bucketName, srcPath.objectName, destPath.bucketName, destPath.objectName).futureValue
+    try {
+      testCode(destPath)
+    } finally {
+      logger.debug(s"cleaning up $destPath ...")
+      // googleStorageDAO.removeObject(destPath.bucketName, destPath.objectName)
+    }
+  }
+
+  def withSmallFile(testCode: GcsPath => Any): Unit = {
+    val srcPath = smallFileFixture
+    val destPath = GcsPath(fixtureBucket, GcsObjectName(s"$testDir/$smallFileName"))
+    withFile(srcPath, destPath, testCode)
+  }
+
+  def withLargeFile(testCode: GcsPath => Any): Unit = {
+    val srcPath = largeFileFixture
+    val destPath = GcsPath(fixtureBucket, GcsObjectName(s"$testDir/$largeFileName"))
+    withFile(srcPath, destPath, testCode)
+  }
+
+  def setStudentOnly(path: GcsPath, student: Credentials)(implicit token: AuthToken): Unit = {
+    // give student's proxy group access to this file
+    val proxyGroup = Sam.user.proxyGroup(student.email)
+    val proxyGroupEntity = GcsEntity(proxyGroup, Group)
+    googleStorageDAO.setObjectAccessControl(path.bucketName, path.objectName, proxyGroupEntity, Reader).futureValue
+  }
+
+  def setStudentAndSA(path: GcsPath, student: Credentials)(implicit token: AuthToken): Unit = {
+    // give student's proxy group access to this file
+    setStudentOnly(path, student)
+    // give signing SA access to this file
+    val signingSAEntity = GcsEntity(WorkbenchEmail(Config.GCS.orchStorageSigningSA), User)
+    googleStorageDAO.setObjectAccessControl(path.bucketName, path.objectName, signingSAEntity, Reader).futureValue
+  }
+
+}


### PR DESCRIPTION
in support of DataBiosphere/firecloud-app#33. This PR adds api service tests for the storage endpoints; a future PR will be making changes to those endpoints to remove the need for end-user oauth storage scopes.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
