### PR TITLE
increase timeout for storage api tests for slow Jenkins

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/StorageApiSpecSupport.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/StorageApiSpecSupport.scala
@@ -18,7 +18,7 @@ import scala.util.{Failure, Success, Try}
 
 trait StorageApiSpecSupport extends ScalaFutures with LazyLogging {
 
-  implicit val storagePatience: PatienceConfig = PatienceConfig(timeout = scaled(Span(1, Minutes)), interval = scaled(Span(1, Seconds)))
+  implicit val storagePatience: PatienceConfig = PatienceConfig(timeout = scaled(Span(4, Minutes)), interval = scaled(Span(2, Seconds)))
 
   // these are hardcoded and should never change. They refer to a static pre-created bucket in broad-dsde-qa.
   final val fixtureBucket: GcsBucketName = GcsBucketName("fixtures-for-tests")


### PR DESCRIPTION
I saw a timeout on one test. Making this PR ready in case we need to increase timeouts.



Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
