### PR TITLE
encode workflow cost uri

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/SubmissionService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/SubmissionService.scala
@@ -58,7 +58,7 @@ trait SubmissionService extends HttpService with PerRequestCreator with FireClou
             } ~
             pathPrefix("cost") {
               get {
-                passthrough(s"$workspacesUrl/$namespace/$name/submissions/$submissionId/workflows/$workflowId/cost", GET)
+                passthrough(encodeUri(s"$workspacesUrl/$namespace/$name/submissions/$submissionId/workflows/$workflowId/cost"), GET)
               }
             }
           }


### PR DESCRIPTION
this fixes a bug when viewing workflows for a workspace that has spaces in its name.

it essentially came about as a race condition where this new feature was implemented at the same time as spaces in names were supported, so the new endpoint URI was never wrapped in `encodeUri`

i would like to make it so `encodeUri` cannot be forgotten for any URI that has a workspace name in it, but that would be a larger refactor and i'd like to at least get a fix out in the next release. 

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
