### PR TITLE
individual tests should not write to/read from the same files

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/StorageApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/StorageApiSpec.scala
@@ -127,7 +127,7 @@ class StorageApiSpec extends FreeSpec with StorageApiSpecSupport with Matchers w
       }
     }
 
-    "should redirect to a signed url for large (>8MB) files" ignore {
+    "should redirect to a signed url for large (>8MB) files" in {
       implicit val authToken: AuthToken = student.makeAuthToken()
       withLargeFile { largeFile =>
         setStudentAndSA(largeFile, student)
@@ -145,7 +145,7 @@ class StorageApiSpec extends FreeSpec with StorageApiSpecSupport with Matchers w
       }
     }
 
-    "should redirect to a direct-download url when SA doesn't have signing permissions for large (>8MB) files " ignore {
+    "should redirect to a direct-download url when SA doesn't have signing permissions for large (>8MB) files " in {
       implicit val authToken: AuthToken = student.makeAuthToken()
       withLargeFile { largeFile =>
         setStudentOnly(largeFile, student)

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/StorageApiSpecSupport.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/StorageApiSpecSupport.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.dsde.test.api.orch
 
-import java.util.Calendar
+import java.util.{Calendar, UUID}
 
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.workbench.auth.AuthToken
@@ -59,14 +59,16 @@ trait StorageApiSpecSupport extends ScalaFutures with LazyLogging {
   }
 
   def withSmallFile(testCode: GcsPath => Any): Unit = {
+    val uuid = UUID.randomUUID().toString
     val srcPath = smallFileFixture
-    val destPath = GcsPath(fixtureBucket, GcsObjectName(s"$testDir/$smallFileName"))
+    val destPath = GcsPath(fixtureBucket, GcsObjectName(s"$testDir/$uuid/$smallFileName"))
     withFile(srcPath, destPath, testCode)
   }
 
   def withLargeFile(testCode: GcsPath => Any): Unit = {
+    val uuid = UUID.randomUUID().toString
     val srcPath = largeFileFixture
-    val destPath = GcsPath(fixtureBucket, GcsObjectName(s"$testDir/$largeFileName"))
+    val destPath = GcsPath(fixtureBucket, GcsObjectName(s"$testDir/$uuid/$largeFileName"))
     withFile(srcPath, destPath, testCode)
   }
 


### PR DESCRIPTION
Multiple tests in the same spec were using the same file as a fixture - creating it, setting ACLs on it, and deleting it. However, the delete step is a `Future` and we don't wait for deletion to complete before starting the next test. Therefore it's possible for multiple tests to interfere with each other.

We also want the tests to be totally isolated so we could enable parallel tests at some point in the future.

This PR changes the tests so that each test uses an isolated copy of the file.

There were a bunch of test runs before I properly re-enabled tests and those runs should be ignored. Summarizing the test results after re-enabling from the mess of comments below:
* five successful manual runs of swatomation-pipeline (these skipped UI, sam, leo, rawls tests)
* three "successful" runs of swatomation-pipeline via PR trigger:
** all three passed orch integration tests, which is what this PR is about
** one passed 100%
** two failed on unrelated Selenium tests, which I claim are unrelated to this PR

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
