### PR TITLE
Corrected test and endpoint behavior

### DIFF
--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/ExportEntitiesByTypeServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/ExportEntitiesByTypeServiceSpec.scala
@@ -143,17 +143,6 @@ class ExportEntitiesByTypeServiceSpec extends BaseServiceSpec with ExportEntitie
       }
     }
 
-    "when calling POST, PUT, PATCH, DELETE on export path" - {
-      "MethodNotAllowed response is returned" in {
-        List(HttpMethods.POST, HttpMethods.PUT, HttpMethods.DELETE, HttpMethods.PATCH) map { method =>
-          new RequestBuilder(method)(invalidFireCloudEntitiesParticipantSetTSVPath) ~> sealRoute(exportEntitiesRoutes) ~> check {
-            handled should be(true)
-            status shouldNot equal(MethodNotAllowed)
-          }
-        }
-      }
-    }
-
   }
 
   val validCookieFireCloudEntitiesLargeSampleTSVPath = "/cookie-authed/workspaces/broad-dsde-dev/large/entities/sample/tsv"
@@ -187,7 +176,7 @@ class ExportEntitiesByTypeServiceSpec extends BaseServiceSpec with ExportEntitie
       }
     }
 
-    "when calling GET on exporting a valid entity type with filtered attributes" - {
+    "when calling POST on exporting a valid entity type with filtered attributes" - {
       "OK response is returned and attributes are filtered" in {
         Post(validCookieFireCloudEntitiesLargeSampleTSVPath, FormData(Seq("FCtoken"->"token", "attributeNames"->filterProps.mkString(",")))) ~> dummyUserIdHeaders("1234") ~> sealRoute(cookieAuthedRoutes) ~> check {
           handled should be(true)
@@ -262,7 +251,9 @@ class ExportEntitiesByTypeServiceSpec extends BaseServiceSpec with ExportEntitie
         List(HttpMethods.GET, HttpMethods.PUT, HttpMethods.DELETE, HttpMethods.PATCH) map { method =>
           new RequestBuilder(method)(invalidCookieFireCloudEntitiesParticipantSetTSVPath) ~> sealRoute(cookieAuthedRoutes) ~> check {
             handled should be(true)
-            status shouldNot equal(MethodNotAllowed)
+            withClue(s"Method $method:") {
+              status should equal(MethodNotAllowed)
+            }
           }
         }
       }


### PR DESCRIPTION
I saw something odd in the area I was working on for fc-app 80 so I wanted to fix it before making further changes.

Tests now check for the behavior Swagger describes correctly.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
