### PR TITLE
escape spaces in bagit urls

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/EntityClient.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/EntityClient.scala
@@ -285,7 +285,7 @@ class EntityClient (requestContext: RequestContext)(implicit protected val execu
 
       //Java URL handles http, https, ftp, file, and jar protocols.
       //We're only OK with https to avoid MITM attacks.
-      val bagitURL = new URL(bagitRq.bagitURL)
+      val bagitURL = new URL(bagitRq.bagitURL.replace(" ", "%20"))
       val acceptableProtocols = Seq("https") //for when we inevitably change our mind and need to support others
       if (!acceptableProtocols.contains(bagitURL.getProtocol)) {
         Future.successful(RequestCompleteWithErrorReport(StatusCodes.BadRequest, "Invalid bagitURL protocol: must be https only"))


### PR DESCRIPTION
Java URLs really don't like spaces, and users sometimes give them to us.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
