### PR TITLE
free trial API support for gpalloc

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -1826,6 +1826,7 @@ paths:
             "Create" will create projects and verify those projects.
             "Verify" will verify all unverified projects in the pool.
             "Count" will return the number of projects in various statuses.
+            "Adopt" will enter a previously-created project into the pool without verifying it.
             "Report" will return a report of all claimed projects.
           required: true
           in: query
@@ -1834,6 +1835,8 @@ paths:
             - create
             - verify
             - count
+            - adopt
+            - scratch
             - report
           default: count
         - name: count
@@ -1841,6 +1844,11 @@ paths:
           required: false
           in: query
           type: number
+        - name: project
+          description: name of project to adopt or scratch; only used for adopt and scratch operations
+          required: false
+          in: query
+          type: string
       responses:
         200:
           description: OK; used for verify operation

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -1827,6 +1827,7 @@ paths:
             "Verify" will verify all unverified projects in the pool.
             "Count" will return the number of projects in various statuses.
             "Adopt" will enter a previously-created project into the pool without verifying it.
+            "Scratch" will mark a pool project as unavailable/errored and disassociate it from any user that claimed it.
             "Report" will return a report of all claimed projects.
           required: true
           in: query

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/TrialApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/TrialApiService.scala
@@ -38,19 +38,24 @@ trait TrialApiService extends HttpService with PerRequestCreator with FireCloudD
         } ~
         path("projects") {
           parameter("count".as[Int] ? 0) { count =>
-            parameter("operation") { op =>
-              requireUserInfo() { userInfo => requestContext =>
-                val message = op.toLowerCase match {
-                  case "create" => Some(TrialService.CreateProjects(userInfo, count))
-                  case "verify" => Some(TrialService.VerifyProjects(userInfo))
-                  case "count" => Some(TrialService.CountProjects(userInfo))
-                  case "report" => Some(TrialService.Report(userInfo))
-                  case _ => None
+            parameter("project".as[String] ? "") { projectName =>
+              parameter("operation") { op =>
+                requireUserInfo() { userInfo =>
+                  requestContext =>
+                    val message = op.toLowerCase match {
+                      case "create" => Some(TrialService.CreateProjects(userInfo, count))
+                      case "verify" => Some(TrialService.VerifyProjects(userInfo))
+                      case "count" => Some(TrialService.CountProjects(userInfo))
+                      case "adopt" => Some(TrialService.AdoptProject(userInfo, projectName))
+                      case "scratch" => Some(TrialService.ScratchProject(userInfo, projectName))
+                      case "report" => Some(TrialService.Report(userInfo))
+                      case _ => None
+                    }
+                    if (message.nonEmpty)
+                      perRequest(requestContext, TrialService.props(trialServiceConstructor), message.get)
+                    else
+                      requestContext.complete(BadRequest, ErrorReport(s"invalid operation '$op'"))
                 }
-                if (message.nonEmpty)
-                  perRequest(requestContext, TrialService.props(trialServiceConstructor), message.get)
-                else
-                  requestContext.complete(BadRequest, ErrorReport(s"invalid operation '$op'"))
               }
             }
           }


### PR DESCRIPTION
This adds the APIs I believe we need in order to use gpalloc for free trial projects within selenium/service tests.

Two new API options "adopt" and "scratch" for POST /api/trial/manager/projects:
* **adopt** takes a pre-existing project (such as provided by gpalloc) and adds it to the free trial pool as ready for immediate use. This operation assumes the project is properly created and ready for use.
* **scratch** marks a project in the pool as unavailable, and disassociates it from any user that previously claimed it.

The assumption is that automated tests would first get a project from gpalloc, then adopt the project into the free trial pool. When cleaning up the test (after success or failure), the test must scratch the project from the pool.

Note this PR is *only* the orch API support for free trial/gpalloc - once this is merged, we need to update the tests themselves to use the new features.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
