### PR TITLE
 Restore GET URL for cookie-authed entity TSV download for fc-app-80

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -2408,6 +2408,10 @@ paths:
             type: file
         404:
           description: Workspace or entity type does not exist
+        414:
+          description: |
+           URI length exceeds the configured limit of 2048 characters.
+           Please use the POST endpoint when it's necessary to supply a large number of attribute names.
         500:
           description: Internal Server Error
 
@@ -3561,6 +3565,10 @@ paths:
             type: file
         404:
           description: Workspace or entity type does not exist
+        414:
+          description: |
+           URI length exceeds the configured limit of 2048 characters.
+           Please use the POST endpoint when it's necessary to supply a large number of attribute names.
         500:
           description: Internal Server Error
       security: []

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -3534,6 +3534,36 @@ paths:
         500:
           description: Internal Server Error
       security: []
+    get:
+      tags:
+      - Entities
+      operationId: browserDownloadEntitiesTSVGet
+      summary: |
+        TSV file containing workspace entities of the specified type
+      description: |
+        swagger-ui seems to not handle file downloads, so this endpoint won't function through the ui.
+        It is here for documentation purposes only.
+      produces:
+        - text/plain
+        - application/octet-stream
+      parameters:
+        - $ref: '#/parameters/workspaceNamespaceParam'
+        - $ref: '#/parameters/workspaceNameParam'
+        - $ref: '#/parameters/entityTypeParam'
+        - name: attributeNames
+          description: comma separated list of ordered attribute names to be in downloaded tsv
+          type: string
+          in: query
+      responses:
+        200:
+          description: Workspace entities of specified type in TSV format
+          schema:
+            type: file
+        404:
+          description: Workspace or entity type does not exist
+        500:
+          description: Internal Server Error
+      security: []
 
   /duos/autocomplete/{queryTerm}:
     get:

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/FireCloudRequestBuilding.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/FireCloudRequestBuilding.scala
@@ -3,7 +3,7 @@ package org.broadinstitute.dsde.firecloud.service
 import org.broadinstitute.dsde.firecloud.FireCloudConfig
 import org.broadinstitute.dsde.firecloud.dataaccess.HttpGoogleServicesDAO
 import org.broadinstitute.dsde.firecloud.model.WithAccessToken
-import spray.http.HttpHeaders.{Authorization, RawHeader}
+import spray.http.HttpHeaders.Authorization
 import spray.http._
 import spray.routing.RequestContext
 
@@ -14,7 +14,7 @@ trait FireCloudRequestBuilding extends spray.httpx.RequestBuilding {
 
   // TODO: would be much better to make requestContext implicit, so callers don't have to always pass it in
   // TODO: this could probably be rewritten more tersely in idiomatic scala - for instance, don't create
-    // the OAuth2BearerToken if we're not going to use it. I'm leaving all this longhand for better comprehension.
+  // the OAuth2BearerToken if we're not going to use it. I'm leaving all this longhand for better comprehension.
   def authHeaders(credentials:Option[HttpCredentials]): HttpRequest => HttpRequest = {
     credentials match {
       // if we have authorization credentials, apply them to the outgoing request
@@ -35,18 +35,6 @@ trait FireCloudRequestBuilding extends spray.httpx.RequestBuilding {
 
   def authHeaders(accessToken: WithAccessToken): HttpRequest => HttpRequest = {
     authHeaders(Some(accessToken.accessToken))
-  }
-
-  def dummyAuthHeaders = {
-    addCredentials(OAuth2BearerToken("mF_9.B5f-4.1JqM"))
-  }
-
-  def dummyUserIdHeaders(userId: String, token: String = "access_token", email: String = "random@site.com") = {
-    addCredentials(OAuth2BearerToken("mF_9.B5f-4.1JqM")) ~>
-      addHeader(RawHeader("OIDC_CLAIM_user_id", userId)) ~>
-      addHeader(RawHeader("OIDC_access_token", token)) ~>
-      addHeader(RawHeader("OIDC_CLAIM_email", email)) ~>
-      addHeader(RawHeader("OIDC_CLAIM_expires_in", "100000"))
   }
 
   // with great power comes great responsibility!

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/ApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/ApiServiceSpec.scala
@@ -3,6 +3,7 @@ package org.broadinstitute.dsde.firecloud.service
 import org.broadinstitute.dsde.firecloud.Application
 import org.broadinstitute.dsde.firecloud.dataaccess._
 import org.broadinstitute.dsde.firecloud.mock.MockGoogleServicesDAO
+import org.broadinstitute.dsde.firecloud.utils.TestRequestBuilding
 import org.broadinstitute.dsde.firecloud.webservice.NihApiService
 import org.scalatest.{FlatSpec, Matchers}
 import spray.httpx.SprayJsonSupport
@@ -16,7 +17,7 @@ import scala.concurrent.duration._
   */
 
 // common trait to be inherited by API service tests
-trait ApiServiceSpec extends FlatSpec with Matchers with HttpService with ScalatestRouteTest with SprayJsonSupport with FireCloudRequestBuilding {
+trait ApiServiceSpec extends FlatSpec with Matchers with HttpService with ScalatestRouteTest with SprayJsonSupport with TestRequestBuilding {
   // increase the timeout for ScalatestRouteTest from the default of 1 second, otherwise
   // intermittent failures occur on requests not completing in time
   implicit val routeTestTimeout = RouteTestTimeout(5.seconds)

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/ServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/ServiceSpec.scala
@@ -3,6 +3,7 @@ package org.broadinstitute.dsde.firecloud.service
 import org.broadinstitute.dsde.rawls.model.ErrorReport
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
 import org.broadinstitute.dsde.firecloud.model.spray2akkaStatus
+import org.broadinstitute.dsde.firecloud.utils.TestRequestBuilding
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FreeSpec, Matchers}
 import spray.http.HttpMethods._
@@ -14,7 +15,7 @@ import spray.testkit.ScalatestRouteTest
 import scala.concurrent.duration._
 
 // common Service Spec to be inherited by service tests
-trait ServiceSpec extends FreeSpec with ScalaFutures with ScalatestRouteTest with Matchers with FireCloudRequestBuilding {
+trait ServiceSpec extends FreeSpec with ScalaFutures with ScalatestRouteTest with Matchers with TestRequestBuilding {
 
   implicit val routeTestTimeout = RouteTestTimeout(5.seconds)
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/utils/TestRequestBuilding.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/utils/TestRequestBuilding.scala
@@ -1,0 +1,26 @@
+package org.broadinstitute.dsde.firecloud.utils
+
+import org.broadinstitute.dsde.firecloud.service.FireCloudRequestBuilding
+import spray.http.HttpHeaders.{Cookie, RawHeader}
+import spray.http._
+
+trait TestRequestBuilding extends FireCloudRequestBuilding {
+
+  val dummyToken: String = "mF_9.B5f-4.1JqM"
+
+  def dummyAuthHeaders: RequestTransformer = {
+    addCredentials(OAuth2BearerToken(dummyToken))
+  }
+
+  def dummyUserIdHeaders(userId: String, token: String = "access_token", email: String = "random@site.com"): WithTransformerConcatenation[HttpRequest, HttpRequest] = {
+    addCredentials(OAuth2BearerToken(dummyToken)) ~>
+      addHeader(RawHeader("OIDC_CLAIM_user_id", userId)) ~>
+      addHeader(RawHeader("OIDC_access_token", token)) ~>
+      addHeader(RawHeader("OIDC_CLAIM_email", email)) ~>
+      addHeader(RawHeader("OIDC_CLAIM_expires_in", "100000"))
+  }
+
+  def dummyCookieAuthHeaders: RequestTransformer = {
+    addHeader(Cookie(HttpCookie("FCtoken", dummyToken)))
+  }
+}

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/TrialRegistrationSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/TrialRegistrationSpec.scala
@@ -9,8 +9,7 @@ import org.broadinstitute.dsde.firecloud.model.{BasicProfile, RegistrationInfo, 
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol.{impBasicProfile, impRegistrationInfo}
 import org.broadinstitute.dsde.firecloud.model.Trial.TrialStates._
 import org.broadinstitute.dsde.firecloud.model.Trial.UserTrialStatus
-import org.broadinstitute.dsde.firecloud.service.{BaseServiceSpec, FireCloudRequestBuilding, RegisterService}
-import org.broadinstitute.dsde.rawls.model.RawlsUserEmail
+import org.broadinstitute.dsde.firecloud.service.{BaseServiceSpec, RegisterService}
 import spray.http.HttpResponse
 import spray.http.StatusCodes.{NotFound, OK}
 import spray.httpx.SprayJsonSupport
@@ -19,8 +18,7 @@ import spray.json.DefaultJsonProtocol
 import scala.concurrent.Future
 import scala.util.Try
 
-class TrialRegistrationSpec extends BaseServiceSpec with RegisterApiService with FireCloudRequestBuilding
-  with SprayJsonSupport with DefaultJsonProtocol {
+class TrialRegistrationSpec extends BaseServiceSpec with RegisterApiService with SprayJsonSupport with DefaultJsonProtocol {
 
   def actorRefFactory = system
 


### PR DESCRIPTION
This endpoint was changed from GET to POST in #337.  GET is now restored and comments are added indicating when each is useful.

Also moved some test-only code out of FireCloudRequestBuilding

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [x] Get two thumbsworth of review and PO signoff if necessary
- [x] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
