### PR TITLE
mtalbott add me param

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -3767,12 +3767,6 @@ paths:
         - Profile
       operationId: me
       summary: Returns registration and activation status for the current user
-      parameters:
-        - in: query
-          description: when set to true only returns user details and ldap status
-          name: userDetailsOnly
-          required: false
-          type: string
       responses:
         200:
           description: OK

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -3767,6 +3767,12 @@ paths:
         - Profile
       operationId: me
       summary: Returns registration and activation status for the current user
+      parameters:
+        - in: query
+          description: when set to true only returns user details and ldap status
+          name: userDetailsOnly
+          required: false
+          type: string
       responses:
         200:
           description: OK

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
@@ -218,6 +218,7 @@ object ModelJsonProtocol extends WorkspaceJsonSupport {
 
   implicit val impWorkbenchUserInfo = jsonFormat2(WorkbenchUserInfo)
   implicit val impWorkbenchEnabled = jsonFormat3(WorkbenchEnabled)
+  implicit val impWorkbenchEnabledV2 = jsonFormat3(WorkbenchEnabledV2)
   implicit val impRegistrationInfo = jsonFormat3(RegistrationInfo)
   implicit val impRegistrationInfoV2 = jsonFormat3(RegistrationInfoV2)
   implicit val impCurator = jsonFormat1(Curator)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
@@ -219,6 +219,7 @@ object ModelJsonProtocol extends WorkspaceJsonSupport {
   implicit val impWorkbenchUserInfo = jsonFormat2(WorkbenchUserInfo)
   implicit val impWorkbenchEnabled = jsonFormat3(WorkbenchEnabled)
   implicit val impRegistrationInfo = jsonFormat3(RegistrationInfo)
+  implicit val impRegistrationInfoV2 = jsonFormat3(RegistrationInfoV2)
   implicit val impCurator = jsonFormat1(Curator)
   implicit val impUserImportPermission = jsonFormat2(UserImportPermission)
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/UserInfo.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/UserInfo.scala
@@ -37,6 +37,7 @@ object AccessToken{
 case class OAuthUser(sub: String, email: String)
 
 case class RegistrationInfo(userInfo: WorkbenchUserInfo, enabled: WorkbenchEnabled, messages:Option[List[String]] = None)
+case class RegistrationInfoV2(userSubjectId: String, userEmail: String, enabled: Boolean)
 
 case class WorkbenchUserInfo(userSubjectId: String, userEmail: String)
 case class WorkbenchEnabled(google: Boolean, ldap: Boolean, allUsersGroup: Boolean)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/UserInfo.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/UserInfo.scala
@@ -41,6 +41,7 @@ case class RegistrationInfoV2(userSubjectId: String, userEmail: String, enabled:
 
 case class WorkbenchUserInfo(userSubjectId: String, userEmail: String)
 case class WorkbenchEnabled(google: Boolean, ldap: Boolean, allUsersGroup: Boolean)
+case class WorkbenchEnabledV2(enabled: Boolean, inAllUsersGroup: Boolean, inGoogleProxyGroup: Boolean)
 
 // TODO: roll into RawlsEnabled? combine with an isAdmin role?
 case class Curator(curator: Boolean)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/UserApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/UserApiService.scala
@@ -77,7 +77,7 @@ trait UserApiService extends HttpService with PerRequestCreator with FireCloudRe
 
   val userServiceRoutes =
     path("me") {
-      parameter("V2".?) { V2 =>
+      parameter("userDetailsOnly".?) { userDetailsOnly =>
         get { requestContext =>
 
           // inspect headers for a pre-existing Authorization: header
@@ -92,7 +92,7 @@ trait UserApiService extends HttpService with PerRequestCreator with FireCloudRe
             // browser sent Authorization header; try to query Sam for user status
             case Some(_) =>
               val pipeline = authHeaders(requestContext) ~> sendReceive
-              val version2 = V2.exists(_.equalsIgnoreCase("true"))
+              val version2 = userDetailsOnly.exists(_.equalsIgnoreCase("true"))
               val samRequest = if (version2) Get(UserApiService.samRegisterUserV2URL) else Get(UserApiService.samRegisterUserURL)
               pipeline(samRequest) onComplete {
                 case Success(response: HttpResponse) =>

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/UserApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/UserApiService.scala
@@ -279,10 +279,10 @@ trait UserApiService extends HttpService with PerRequestCreator with FireCloudRe
           case InternalServerError =>
             respondWithErrorReport(InternalServerError, "Identity service encountered an unknown error, please try again.", requestContext)
           case OK =>
-            response.entity.as[WorkbenchEnabled] match {
+            response.entity.as[WorkbenchEnabledV2] match {
               case Right(diagnostics) =>
-                if (diagnostics.allUsersGroup && diagnostics.google) {
-                  val v1RegInfo = RegistrationInfo(WorkbenchUserInfo(regInfo.userSubjectId, regInfo.userEmail), diagnostics)
+                if (diagnostics.inAllUsersGroup && diagnostics.inGoogleProxyGroup) {
+                  val v1RegInfo = RegistrationInfo(WorkbenchUserInfo(regInfo.userSubjectId, regInfo.userEmail), WorkbenchEnabled(diagnostics.inGoogleProxyGroup, diagnostics.enabled, diagnostics.inAllUsersGroup))
                   requestContext.complete(OK, v1RegInfo)
                 } else {
                   respondWithErrorReport(Forbidden, "FireCloud user not activated.", requestContext)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/UserApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/UserApiService.scala
@@ -77,8 +77,9 @@ trait UserApiService extends HttpService with PerRequestCreator with FireCloudRe
 
   val userServiceRoutes =
     path("me") {
-      get { requestContext =>
-        parameter("V2".?) { V2 =>
+      parameter("V2".?) { V2 =>
+        get { requestContext =>
+
           // inspect headers for a pre-existing Authorization: header
           val authorizationHeader: Option[HttpCredentials] = (requestContext.request.headers collect {
             case Authorization(h) => h

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/UserApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/UserApiService.scala
@@ -45,6 +45,9 @@ object UserApiService {
   val samRegisterUserPath = "/register/user"
   val samRegisterUserURL = FireCloudConfig.Sam.baseUrl + samRegisterUserPath
 
+  val samRegisterUserV2Path = "/register/user/v2/self/info"
+  val samRegisterUserV2URL = FireCloudConfig.Sam.baseUrl + samRegisterUserV2Path
+
   val rawlsGroupBasePath = FireCloudConfig.Rawls.authPrefix + "/groups"
   val rawlsGroupBaseUrl = FireCloudConfig.Rawls.baseUrl + rawlsGroupBasePath
 
@@ -75,57 +78,73 @@ trait UserApiService extends HttpService with PerRequestCreator with FireCloudRe
   val userServiceRoutes =
     path("me") {
       get { requestContext =>
+        parameter("V2".?) { V2 =>
+          // inspect headers for a pre-existing Authorization: header
+          val authorizationHeader: Option[HttpCredentials] = (requestContext.request.headers collect {
+            case Authorization(h) => h
+          }).headOption
 
-        // inspect headers for a pre-existing Authorization: header
-        val authorizationHeader: Option[HttpCredentials] = (requestContext.request.headers collect {
-          case Authorization(h) => h
-        }).headOption
-
-        authorizationHeader match {
-          // no Authorization header; the user must be unauthorized
-          case None =>
-            respondWithErrorReport(Unauthorized, "No authorization header in request.", requestContext)
-          // browser sent Authorization header; try to query Sam for user status
-          case Some(_) =>
-            val pipeline = authHeaders(requestContext) ~> sendReceive
-            val samRequest = Get(UserApiService.samRegisterUserURL)
-            pipeline(samRequest) onComplete {
-              case Success(response: HttpResponse) =>
-                response.status match {
-                  // Sam rejected our request. User is either invalid or their token timed out; this is truly unauthorized
-                  case Unauthorized =>
-                    respondWithErrorReport(Unauthorized, "Request rejected by identity service - invalid user or expired token.", requestContext)
-                  // Sam 404 means the user is not registered with FireCloud
-                  case NotFound =>
-                    respondWithErrorReport(NotFound, "FireCloud user registration not found.", requestContext)
-                  // Sam error? boo. All we can do is respond with an error.
-                  case InternalServerError =>
-                    respondWithErrorReport(InternalServerError, "Identity service encountered an unknown error, please try again.", requestContext)
-                  // Sam found the user; we'll try to parse the response and inspect it
-                  case OK =>
-                    val respJson = response.entity.as[RegistrationInfo]
-                    respJson match {
-                      case Right(regInfo) =>
-                        if (regInfo.enabled.google && regInfo.enabled.ldap && regInfo.enabled.allUsersGroup) {
-                          // Sam says the user is fully registered and activated!
-                          requestContext.complete(OK, regInfo)
-                        } else {
-                          // Sam knows about the user, but the user isn't activated
-                          respondWithErrorReport(Forbidden, "FireCloud user not activated.", requestContext)
+          authorizationHeader match {
+            // no Authorization header; the user must be unauthorized
+            case None =>
+              respondWithErrorReport(Unauthorized, "No authorization header in request.", requestContext)
+            // browser sent Authorization header; try to query Sam for user status
+            case Some(_) =>
+              val pipeline = authHeaders(requestContext) ~> sendReceive
+              val version2 = V2.exists(_.equalsIgnoreCase("true"))
+              val samRequest = if (version2) Get(UserApiService.samRegisterUserV2URL) else Get(UserApiService.samRegisterUserURL)
+              pipeline(samRequest) onComplete {
+                case Success(response: HttpResponse) =>
+                  response.status match {
+                    // Sam rejected our request. User is either invalid or their token timed out; this is truly unauthorized
+                    case Unauthorized =>
+                      respondWithErrorReport(Unauthorized, "Request rejected by identity service - invalid user or expired token.", requestContext)
+                    // Sam 404 means the user is not registered with FireCloud
+                    case NotFound =>
+                      respondWithErrorReport(NotFound, "FireCloud user registration not found.", requestContext)
+                    // Sam error? boo. All we can do is respond with an error.
+                    case InternalServerError =>
+                      respondWithErrorReport(InternalServerError, "Identity service encountered an unknown error, please try again.", requestContext)
+                    // Sam found the user; we'll try to parse the response and inspect it
+                    case OK =>
+                      if (version2) {
+                        val respJson = response.entity.as[RegistrationInfoV2]
+                        respJson match {
+                          case Right(regInfo) =>
+                            if (regInfo.enabled) {
+                              requestContext.complete(OK,regInfo)
+                            } else {
+                              respondWithErrorReport(Forbidden, "FireCloud user not activated.", requestContext)
+                            }
+                          case Left(_) =>
+                            respondWithErrorReport(InternalServerError, "Received unparseable response from identity service.", requestContext)
                         }
-                      // we couldn't parse the Sam response. Respond with an error.
-                      case Left(_) =>
-                        // TODO: no obvious way to include the JSON parsing error in the ErrorReport. We define `message` below and it does not belong there.
-                        respondWithErrorReport(InternalServerError, "Received unparseable response from identity service.", requestContext)
-                    }
-                  case x =>
-                    // if we get any other error from Sam, pass that error on
-                    respondWithErrorReport(x.intValue, "Unexpected response validating registration: " + x.toString, requestContext)
-                }
-              // we couldn't reach Sam (within timeout period). Respond with a Service Unavailable error.
-              case Failure(error) =>
-                respondWithErrorReport(ServiceUnavailable, "Identity service did not produce a timely response, please try again later.", error, requestContext)
-            }
+                      } else {
+                        val respJson = response.entity.as[RegistrationInfo]
+                        respJson match {
+                          case Right(regInfo) =>
+                            if (regInfo.enabled.google && regInfo.enabled.ldap && regInfo.enabled.allUsersGroup) {
+                              // Sam says the user is fully registered and activated!
+                              requestContext.complete(OK, regInfo)
+                            } else {
+                              // Sam knows about the user, but the user isn't activated
+                              respondWithErrorReport(Forbidden, "FireCloud user not activated.", requestContext)
+                            }
+                          // we couldn't parse the Sam response. Respond with an error.
+                          case Left(_) =>
+                            // TODO: no obvious way to include the JSON parsing error in the ErrorReport. We define `message` below and it does not belong there.
+                            respondWithErrorReport(InternalServerError, "Received unparseable response from identity service.", requestContext)
+                        }
+                      }
+                    case x =>
+                      // if we get any other error from Sam, pass that error on
+                      respondWithErrorReport(x.intValue, "Unexpected response validating registration: " + x.toString, requestContext)
+                  }
+                // we couldn't reach Sam (within timeout period). Respond with a Service Unavailable error.
+                case Failure(error) =>
+                  respondWithErrorReport(ServiceUnavailable, "Identity service did not produce a timely response, please try again later.", error, requestContext)
+              }
+          }
         }
       }
     } ~

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/UserApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/UserApiService.scala
@@ -77,58 +77,31 @@ trait UserApiService extends HttpService with PerRequestCreator with FireCloudRe
 
   val userServiceRoutes =
     path("me") {
-      get { requestContext =>
+      parameter("userDetailsOnly".?) { userDetailsOnly =>
+        get { requestContext =>
 
-        // inspect headers for a pre-existing Authorization: header
-        val authorizationHeader: Option[HttpCredentials] = (requestContext.request.headers collect {
-          case Authorization(h) => h
-        }).headOption
+          // inspect headers for a pre-existing Authorization: header
+          val authorizationHeader: Option[HttpCredentials] = (requestContext.request.headers collect {
+            case Authorization(h) => h
+          }).headOption
 
-        authorizationHeader match {
-          // no Authorization header; the user must be unauthorized
-          case None =>
-            respondWithErrorReport(Unauthorized, "No authorization header in request.", requestContext)
-          // browser sent Authorization header; try to query Sam for user status
-          case Some(_) =>
-            val pipeline = authHeaders(requestContext) ~> sendReceive
-            val samRequest = Get(UserApiService.samRegisterUserURL)
-            pipeline(samRequest) onComplete {
-              case Success(response: HttpResponse) =>
-                response.status match {
-                  // Sam rejected our request. User is either invalid or their token timed out; this is truly unauthorized
-                  case Unauthorized =>
-                    respondWithErrorReport(Unauthorized, "Request rejected by identity service - invalid user or expired token.", requestContext)
-                  // Sam 404 means the user is not registered with FireCloud
-                  case NotFound =>
-                    respondWithErrorReport(NotFound, "FireCloud user registration not found.", requestContext)
-                  // Sam error? boo. All we can do is respond with an error.
-                  case InternalServerError =>
-                    respondWithErrorReport(InternalServerError, "Identity service encountered an unknown error, please try again.", requestContext)
-                  // Sam found the user; we'll try to parse the response and inspect it
-                  case OK =>
-                    val respJson = response.entity.as[RegistrationInfo]
-                    respJson match {
-                      case Right(regInfo) =>
-                        if (regInfo.enabled.google && regInfo.enabled.ldap && regInfo.enabled.allUsersGroup) {
-                          // Sam says the user is fully registered and activated!
-                          requestContext.complete(OK, regInfo)
-                        } else {
-                          // Sam knows about the user, but the user isn't activated
-                          respondWithErrorReport(Forbidden, "FireCloud user not activated.", requestContext)
-                        }
-                      // we couldn't parse the Sam response. Respond with an error.
-                      case Left(_) =>
-                        // TODO: no obvious way to include the JSON parsing error in the ErrorReport. We define `message` below and it does not belong there.
-                        respondWithErrorReport(InternalServerError, "Received unparseable response from identity service.", requestContext)
-                    }
-                  case x =>
-                    // if we get any other error from Sam, pass that error on
-                    respondWithErrorReport(x.intValue, "Unexpected response validating registration: " + x.toString, requestContext)
-                }
-              // we couldn't reach Sam (within timeout period). Respond with a Service Unavailable error.
-              case Failure(error) =>
-                respondWithErrorReport(ServiceUnavailable, "Identity service did not produce a timely response, please try again later.", error, requestContext)
-            }
+          authorizationHeader match {
+            // no Authorization header; the user must be unauthorized
+            case None =>
+              respondWithErrorReport(Unauthorized, "No authorization header in request.", requestContext)
+            // browser sent Authorization header; try to query Sam for user status
+            case Some(_) =>
+              val pipeline = authHeaders(requestContext) ~> sendReceive
+              val version2 = userDetailsOnly.exists(_.equalsIgnoreCase("true"))
+              val samRequest = if (version2) Get(UserApiService.samRegisterUserV2URL) else Get(UserApiService.samRegisterUserURL)
+              pipeline(samRequest) onComplete {
+                case Success(response: HttpResponse) =>
+                  handleSamResponse(response, requestContext, version2)
+                // we couldn't reach Sam (within timeout period). Respond with a Service Unavailable error.
+                case Failure(error) =>
+                  respondWithErrorReport(ServiceUnavailable, "Identity service did not produce a timely response, please try again later.", error, requestContext)
+              }
+          }
         }
       }
     } ~

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/UserApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/UserApiServiceSpec.scala
@@ -503,7 +503,7 @@ class UserApiServiceSpec extends BaseServiceSpec with RegisterApiService with Us
       "OK response is returned" in {
         mockServerGetResponse(UserApiService.samRegisterUserV2Path, enabledV2UserBody, OK.intValue)
 
-        Get(s"/me?userDetailsOnly=true") ~> dummyAuthHeaders ~> sealRoute(userServiceRoutes) ~> check {
+        Get(s"/me/v2") ~> dummyAuthHeaders ~> sealRoute(userServiceRoutes) ~> check {
           status should equal(OK)
         }
       }
@@ -513,7 +513,7 @@ class UserApiServiceSpec extends BaseServiceSpec with RegisterApiService with Us
       "Forbidden response is returned" in {
         mockServerGetResponse(UserApiService.samRegisterUserV2Path, noLdapV2UserBody, OK.intValue)
 
-        Get(s"/me?userDetailsOnly=true") ~> dummyAuthHeaders ~> sealRoute(userServiceRoutes) ~> check {
+        Get(s"/me/v2") ~> dummyAuthHeaders ~> sealRoute(userServiceRoutes) ~> check {
           assert(response.entity.asString.contains("FireCloud user not activated"))
           status should equal(Forbidden)
         }
@@ -524,55 +524,55 @@ class UserApiServiceSpec extends BaseServiceSpec with RegisterApiService with Us
       "InternalServerError response is returned" in {
         mockServerGetResponse(UserApiService.samRegisterUserV2Path, uglyJsonBody, OK.intValue)
 
-        Get(s"/me?userDetailsOnly=true") ~> dummyAuthHeaders ~> sealRoute(userServiceRoutes) ~> check {
+        Get(s"/me/v2") ~> dummyAuthHeaders ~> sealRoute(userServiceRoutes) ~> check {
           assert(response.entity.asString.contains("Received unparseable response from identity service"))
           status should equal(InternalServerError)
         }
       }
     }
-
-    "when calling /me?userDetailsOnly=false and sam says not-google-enabled" - {
-      "Forbidden response is returned" in {
-        mockServerGetResponse(UserApiService.samRegisterUserPath, noGoogleV1UserBody, OK.intValue)
-
-        Get(s"/me?userDetailsOnly=false") ~> dummyAuthHeaders ~> sealRoute(userServiceRoutes) ~> check {
-          assert(response.entity.asString.contains("FireCloud user not activated"))
-          status should equal(Forbidden)
-        }
-      }
-    }
-
-    "when calling /me?userDetailsOnly=false and sam says not-ldap-enabled" - {
-      "Forbidden response is returned" in {
-        mockServerGetResponse(UserApiService.samRegisterUserPath, noLdapV1UserBody, OK.intValue)
-
-        Get(s"/me?userDetailsOnly=false") ~> dummyAuthHeaders ~> sealRoute(userServiceRoutes) ~> check {
-          assert(response.entity.asString.contains("FireCloud user not activated"))
-          status should equal(Forbidden)
-        }
-      }
-    }
-
-    "when calling /me?userDetailsOnly=false and sam says fully enabled" - {
-      "OK response is returned" in {
-        mockServerGetResponse(UserApiService.samRegisterUserPath, enabledV1UserBody, OK.intValue)
-
-        Get(s"/me?userDetailsOnly=false") ~> dummyAuthHeaders ~> sealRoute(userServiceRoutes) ~> check {
-          status should equal(OK)
-        }
-      }
-    }
-
-    "when calling /me?userDetailsOnly=false and sam returns ugly json" - {
-      "InternalServerError response is returned" in {
-        mockServerGetResponse(UserApiService.samRegisterUserPath, uglyJsonBody, OK.intValue)
-
-        Get(s"/me?userDetailsOnly=false") ~> dummyAuthHeaders ~> sealRoute(userServiceRoutes) ~> check {
-          assert(response.entity.asString.contains("Received unparseable response from identity service"))
-          status should equal(InternalServerError)
-        }
-      }
-    }
+//
+//    "when calling /me?userDetailsOnly=false and sam says not-google-enabled" - {
+//      "Forbidden response is returned" in {
+//        mockServerGetResponse(UserApiService.samRegisterUserPath, noGoogleV1UserBody, OK.intValue)
+//
+//        Get(s"/me?userDetailsOnly=false") ~> dummyAuthHeaders ~> sealRoute(userServiceRoutes) ~> check {
+//          assert(response.entity.asString.contains("FireCloud user not activated"))
+//          status should equal(Forbidden)
+//        }
+//      }
+//    }
+//
+//    "when calling /me?userDetailsOnly=false and sam says not-ldap-enabled" - {
+//      "Forbidden response is returned" in {
+//        mockServerGetResponse(UserApiService.samRegisterUserPath, noLdapV1UserBody, OK.intValue)
+//
+//        Get(s"/me?userDetailsOnly=false") ~> dummyAuthHeaders ~> sealRoute(userServiceRoutes) ~> check {
+//          assert(response.entity.asString.contains("FireCloud user not activated"))
+//          status should equal(Forbidden)
+//        }
+//      }
+//    }
+//
+//    "when calling /me?userDetailsOnly=false and sam says fully enabled" - {
+//      "OK response is returned" in {
+//        mockServerGetResponse(UserApiService.samRegisterUserPath, enabledV1UserBody, OK.intValue)
+//
+//        Get(s"/me?userDetailsOnly=false") ~> dummyAuthHeaders ~> sealRoute(userServiceRoutes) ~> check {
+//          status should equal(OK)
+//        }
+//      }
+//    }
+//
+//    "when calling /me?userDetailsOnly=false and sam returns ugly json" - {
+//      "InternalServerError response is returned" in {
+//        mockServerGetResponse(UserApiService.samRegisterUserPath, uglyJsonBody, OK.intValue)
+//
+//        Get(s"/me?userDetailsOnly=false") ~> dummyAuthHeaders ~> sealRoute(userServiceRoutes) ~> check {
+//          assert(response.entity.asString.contains("Received unparseable response from identity service"))
+//          status should equal(InternalServerError)
+//        }
+//      }
+//    }
 
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/UserApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/UserApiServiceSpec.scala
@@ -67,9 +67,9 @@ class UserApiServiceSpec extends BaseServiceSpec with RegisterApiService with Us
   val enabledV2UserBody = """{"userSubjectId": "1111111111", "userEmail": "no@nope.org", "enabled": true}"""
   val noLdapV2UserBody = """{"userSubjectId": "1111111111", "userEmail": "no@nope.org", "enabled": false}"""
 
-  val enabledV2DiagnosticsBody = """{"google": true, "ldap": true, "allUsersGroup": true}"""
-  val noLdapV2DiagnosticsBody = """{"google": true, "ldap": false, "allUsersGroup": true}"""
-  val noGoogleV2DiagnosticsBody = """{"google": false, "ldap": true, "allUsersGroup": true}"""
+  val enabledV2DiagnosticsBody = """{"enabled": true, "inAllUsersGroup": true, "inGoogleProxyGroup": true}"""
+  val noLdapV2DiagnosticsBody = """{"enabled": false, "inAllUsersGroup": true, "inGoogleProxyGroup": true}"""
+  val noGoogleV2DiagnosticsBody = """{"enabled": true, "inAllUsersGroup": true, "inGoogleProxyGroup": false}"""
 
   val uglyJsonBody = """{"userInfo": "whaaaaaaat??"}"""
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/UserApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/UserApiServiceSpec.scala
@@ -1,6 +1,5 @@
 package org.broadinstitute.dsde.firecloud.service
 
-import akka.http.javadsl.model.StatusCodes
 import org.broadinstitute.dsde.firecloud.dataaccess.RawlsDAO
 import org.broadinstitute.dsde.firecloud.mock.MockUtils
 import org.broadinstitute.dsde.firecloud.mock.MockUtils._

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/UserApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/UserApiServiceSpec.scala
@@ -503,7 +503,7 @@ class UserApiServiceSpec extends BaseServiceSpec with RegisterApiService with Us
       "OK response is returned" in {
         mockServerGetResponse(UserApiService.samRegisterUserV2Path, enabledV2UserBody, OK.intValue)
 
-        Get(s"/me/v2") ~> dummyAuthHeaders ~> sealRoute(userServiceRoutes) ~> check {
+        Get(s"/me?userDetailsOnly=true") ~> dummyAuthHeaders ~> sealRoute(userServiceRoutes) ~> check {
           status should equal(OK)
         }
       }
@@ -513,7 +513,7 @@ class UserApiServiceSpec extends BaseServiceSpec with RegisterApiService with Us
       "Forbidden response is returned" in {
         mockServerGetResponse(UserApiService.samRegisterUserV2Path, noLdapV2UserBody, OK.intValue)
 
-        Get(s"/me/v2") ~> dummyAuthHeaders ~> sealRoute(userServiceRoutes) ~> check {
+        Get(s"/me?userDetailsOnly=true") ~> dummyAuthHeaders ~> sealRoute(userServiceRoutes) ~> check {
           assert(response.entity.asString.contains("FireCloud user not activated"))
           status should equal(Forbidden)
         }
@@ -524,55 +524,55 @@ class UserApiServiceSpec extends BaseServiceSpec with RegisterApiService with Us
       "InternalServerError response is returned" in {
         mockServerGetResponse(UserApiService.samRegisterUserV2Path, uglyJsonBody, OK.intValue)
 
-        Get(s"/me/v2") ~> dummyAuthHeaders ~> sealRoute(userServiceRoutes) ~> check {
+        Get(s"/me?userDetailsOnly=true") ~> dummyAuthHeaders ~> sealRoute(userServiceRoutes) ~> check {
           assert(response.entity.asString.contains("Received unparseable response from identity service"))
           status should equal(InternalServerError)
         }
       }
     }
-//
-//    "when calling /me?userDetailsOnly=false and sam says not-google-enabled" - {
-//      "Forbidden response is returned" in {
-//        mockServerGetResponse(UserApiService.samRegisterUserPath, noGoogleV1UserBody, OK.intValue)
-//
-//        Get(s"/me?userDetailsOnly=false") ~> dummyAuthHeaders ~> sealRoute(userServiceRoutes) ~> check {
-//          assert(response.entity.asString.contains("FireCloud user not activated"))
-//          status should equal(Forbidden)
-//        }
-//      }
-//    }
-//
-//    "when calling /me?userDetailsOnly=false and sam says not-ldap-enabled" - {
-//      "Forbidden response is returned" in {
-//        mockServerGetResponse(UserApiService.samRegisterUserPath, noLdapV1UserBody, OK.intValue)
-//
-//        Get(s"/me?userDetailsOnly=false") ~> dummyAuthHeaders ~> sealRoute(userServiceRoutes) ~> check {
-//          assert(response.entity.asString.contains("FireCloud user not activated"))
-//          status should equal(Forbidden)
-//        }
-//      }
-//    }
-//
-//    "when calling /me?userDetailsOnly=false and sam says fully enabled" - {
-//      "OK response is returned" in {
-//        mockServerGetResponse(UserApiService.samRegisterUserPath, enabledV1UserBody, OK.intValue)
-//
-//        Get(s"/me?userDetailsOnly=false") ~> dummyAuthHeaders ~> sealRoute(userServiceRoutes) ~> check {
-//          status should equal(OK)
-//        }
-//      }
-//    }
-//
-//    "when calling /me?userDetailsOnly=false and sam returns ugly json" - {
-//      "InternalServerError response is returned" in {
-//        mockServerGetResponse(UserApiService.samRegisterUserPath, uglyJsonBody, OK.intValue)
-//
-//        Get(s"/me?userDetailsOnly=false") ~> dummyAuthHeaders ~> sealRoute(userServiceRoutes) ~> check {
-//          assert(response.entity.asString.contains("Received unparseable response from identity service"))
-//          status should equal(InternalServerError)
-//        }
-//      }
-//    }
+
+    "when calling /me?userDetailsOnly=false and sam says not-google-enabled" - {
+      "Forbidden response is returned" in {
+        mockServerGetResponse(UserApiService.samRegisterUserPath, noGoogleV1UserBody, OK.intValue)
+
+        Get(s"/me?userDetailsOnly=false") ~> dummyAuthHeaders ~> sealRoute(userServiceRoutes) ~> check {
+          assert(response.entity.asString.contains("FireCloud user not activated"))
+          status should equal(Forbidden)
+        }
+      }
+    }
+
+    "when calling /me?userDetailsOnly=false and sam says not-ldap-enabled" - {
+      "Forbidden response is returned" in {
+        mockServerGetResponse(UserApiService.samRegisterUserPath, noLdapV1UserBody, OK.intValue)
+
+        Get(s"/me?userDetailsOnly=false") ~> dummyAuthHeaders ~> sealRoute(userServiceRoutes) ~> check {
+          assert(response.entity.asString.contains("FireCloud user not activated"))
+          status should equal(Forbidden)
+        }
+      }
+    }
+
+    "when calling /me?userDetailsOnly=false and sam says fully enabled" - {
+      "OK response is returned" in {
+        mockServerGetResponse(UserApiService.samRegisterUserPath, enabledV1UserBody, OK.intValue)
+
+        Get(s"/me?userDetailsOnly=false") ~> dummyAuthHeaders ~> sealRoute(userServiceRoutes) ~> check {
+          status should equal(OK)
+        }
+      }
+    }
+
+    "when calling /me?userDetailsOnly=false and sam returns ugly json" - {
+      "InternalServerError response is returned" in {
+        mockServerGetResponse(UserApiService.samRegisterUserPath, uglyJsonBody, OK.intValue)
+
+        Get(s"/me?userDetailsOnly=false") ~> dummyAuthHeaders ~> sealRoute(userServiceRoutes) ~> check {
+          assert(response.entity.asString.contains("Received unparseable response from identity service"))
+          status should equal(InternalServerError)
+        }
+      }
+    }
 
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/UserApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/UserApiServiceSpec.scala
@@ -668,5 +668,4 @@ class UserApiServiceSpec extends BaseServiceSpec with RegisterApiService with Us
     }
 
   }
-
 }


### PR DESCRIPTION
Change /me endpoint to accept a parameter which utilizes the register/user/v2/self/info endpoint instead of the register/user/v1 endpoint to cutdown on expensive calls to populate the google field

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
