### PR TITLE
add git revision endpoint at /version [risk: medium]

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -1878,6 +1878,19 @@ paths:
         500:
           description: Internal Server Error
 
+  /version:
+    get:
+      tags:
+        - Version
+      operationId: orchestrationVersion
+      summary: Returns the currently deployed version of this service.
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: '#/definitions/OrchestrationVersion'
+      security: []
+
   /version/executionEngine:
     get:
       tags:
@@ -5365,6 +5378,12 @@ definitions:
       notificationKey:
         type: string
       description:
+        type: string
+
+  OrchestrationVersion:
+    type: object
+    properties:
+      version:
         type: string
 
   PermissionReport:

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/StatusApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/StatusApiService.scala
@@ -3,9 +3,18 @@ package org.broadinstitute.dsde.firecloud.webservice
 import java.text.SimpleDateFormat
 
 import org.broadinstitute.dsde.firecloud.service._
+import spray.http.StatusCodes
+import spray.httpx.SprayJsonSupport
+import spray.json.{JsObject, JsString}
 import spray.routing._
+import spray.json.DefaultJsonProtocol._
 
-trait StatusApiService extends HttpService with PerRequestCreator with FireCloudDirectives {
+object BuildTimeVersion {
+  val version = Option(getClass.getPackage.getImplementationVersion)
+  val versionJson = JsObject(Map("version" -> JsString(version.getOrElse("n/a"))))
+}
+
+trait StatusApiService extends HttpService with PerRequestCreator with FireCloudDirectives with SprayJsonSupport {
 
   private final val dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ")
   private implicit val executionContext = actorRefFactory.dispatcher
@@ -16,6 +25,11 @@ trait StatusApiService extends HttpService with PerRequestCreator with FireCloud
     path("status") {
       get { requestContext =>
         perRequest(requestContext, StatusService.props(statusServiceConstructor), StatusService.CollectStatusInfo)
+      }
+    } ~
+    path( "version") {
+      get { requestContext =>
+        requestContext.complete(StatusCodes.OK, BuildTimeVersion.versionJson)
       }
     }
   }


### PR DESCRIPTION
I got frustrated always wondering which version of the app was running in which environment.

This PR adds git revision/hash endpoint at /version. Developers/admins/other interested parties can call this endpoint to see which specific commit is in use. 

The `getOrElse` fallback should should make this code resilient to environments where git information isn't available - notably, when running via ./config/docker-rsync-local-ui.sh. In that local environment, we rsync codebases into a docker volume and don't sync the .git directory. But in Jenkins builds, this information should be available; I verified by starting a custom fiab and saw an API response of:

```
{
  "version": "0.1-ecb1bbc-SNAPSHOT"
}
```

I'm very conservatively labeling this [risk:medium] instead of low. Potentially, an attacker could use the revision information to see which bugs/vulnerabilities have been fixed since the commit in use. However, since our github repo is open-source anyway, this doesn't actually give the attacker any new information - it just makes it slightly easier to know which code is in use when.