### PR TITLE
Perf logging for selected calls to external services [risk: low]

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -15,7 +15,7 @@
         </filter>
     </appender>
 
-    <logger name="PerformanceLogging" level="warn" additivity="false">
+    <logger name="PerformanceLogging" level="info" additivity="false">
         <appender-ref ref="console"/>
     </logger>
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchDAOSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchDAOSupport.scala
@@ -1,6 +1,7 @@
 package org.broadinstitute.dsde.firecloud.dataaccess
 
 import java.net.InetAddress
+import java.time.Instant
 
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.FireCloudException
@@ -18,16 +19,16 @@ trait ElasticSearchDAOSupport extends LazyLogging with PerformanceLogging {
 
 
   def executeESRequest[T <: ActionRequest, U <: ActionResponse, V <: ActionRequestBuilder[T, U, V]](req: V): U = {
-    val tick = System.currentTimeMillis
+    val tick = Instant.now()
     val responseTry = Try(req.get())
-    val tock = System.currentTimeMillis
+    val tock = Instant.now()
     responseTry match {
       case Success(s) =>
         perfLogger.info(perfmsg(req.getClass.getSimpleName, "success", tick, tock))
         s
       case Failure(f) =>
         perfLogger.info(perfmsg(req.getClass.getSimpleName, "failure", tick, tock))
-        logger.warn(s"ElasticSearch %s request failed in %s ms: %s".format(req.getClass.getName, tock-tick, f.getMessage))
+        logger.warn(s"ElasticSearch %s request failed in %s ms: %s".format(req.getClass.getName, tock.toEpochMilli-tick.toEpochMilli, f.getMessage))
         throw new FireCloudException("ElasticSearch request failed", f)
     }
   }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchDAOSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchDAOSupport.scala
@@ -20,14 +20,14 @@ trait ElasticSearchDAOSupport extends LazyLogging with PerformanceLogging {
   def executeESRequest[T <: ActionRequest, U <: ActionResponse, V <: ActionRequestBuilder[T, U, V]](req: V): U = {
     val tick = System.currentTimeMillis
     val responseTry = Try(req.get())
-    val elapsed = System.currentTimeMillis - tick
+    val tock = System.currentTimeMillis
     responseTry match {
       case Success(s) =>
-        perfLogger.info(perfmsg(req.getClass.getSimpleName, elapsed, "success"))
+        perfLogger.info(perfmsg(req.getClass.getSimpleName, "success", tick, tock))
         s
       case Failure(f) =>
-        perfLogger.info(perfmsg(req.getClass.getSimpleName, elapsed, "failure"))
-        logger.warn(s"ElasticSearch %s request failed in %s ms: %s".format(req.getClass.getName, elapsed, f.getMessage))
+        perfLogger.info(perfmsg(req.getClass.getSimpleName, "failure", tick, tock))
+        logger.warn(s"ElasticSearch %s request failed in %s ms: %s".format(req.getClass.getName, tock-tick, f.getMessage))
         throw new FireCloudException("ElasticSearch request failed", f)
     }
   }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpSamDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpSamDAO.scala
@@ -20,11 +20,11 @@ class HttpSamDAO( implicit val system: ActorSystem, implicit val executionContex
   extends SamDAO with RestJsonClient {
 
   override def registerUser(implicit userInfo: WithAccessToken): Future[RegistrationInfo] = {
-    authedRequestToObject[RegistrationInfo](Post(samUserRegistrationUrl))
+    authedRequestToObject[RegistrationInfo](Post(samUserRegistrationUrl), label=Some("HttpSamDAO.registerUser"))
   }
 
   override def getRegistrationStatus(implicit userInfo: WithAccessToken): Future[RegistrationInfo] = {
-    authedRequestToObject[RegistrationInfo](Get(samUserRegistrationUrl))
+    authedRequestToObject[RegistrationInfo](Get(samUserRegistrationUrl), label=Some("HttpSamDAO.getRegistrationStatus"))
   }
 
   override def adminGetUserByEmail(email: RawlsUserEmail): Future[RegistrationInfo] = {
@@ -33,14 +33,14 @@ class HttpSamDAO( implicit val system: ActorSystem, implicit val executionContex
 
   override def isGroupMember(groupName: WorkbenchGroupName, userInfo: UserInfo): Future[Boolean] = {
     implicit val accessToken = userInfo
-    authedRequestToObject[List[String]](Get(samResourceRoles(managedGroupResourceTypeName, groupName.value))).map { allRoles =>
+    authedRequestToObject[List[String]](Get(samResourceRoles(managedGroupResourceTypeName, groupName.value)), label=Some("HttpSamDAO.isGroupMember")).map { allRoles =>
       allRoles.map(ManagedGroupRoles.withName).toSet.intersect(ManagedGroupRoles.membershipRoles).nonEmpty
     }
   }
 
   override def getPetServiceAccountTokenForUser(user: WithAccessToken, scopes: Seq[String]): Future[AccessToken] = {
     implicit val accessToken = user
-    authedRequestToObject[String](Post(samArbitraryPetTokenUrl, scopes)).map { quotedToken =>
+    authedRequestToObject[String](Post(samArbitraryPetTokenUrl, scopes), label=Some("HttpSamDAO.getPetServiceAccountTokenForUser")).map { quotedToken =>
       // Sam returns a quoted string. We need the token without the quotes.
       val token = if (quotedToken.startsWith("\"") && quotedToken.endsWith("\"") )
         quotedToken.substring(1,quotedToken.length-1)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/utils/PerformanceLogging.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/utils/PerformanceLogging.scala
@@ -1,15 +1,24 @@
 package org.broadinstitute.dsde.firecloud.utils
 
+import java.time.{Instant, LocalDateTime, ZoneId}
+import java.time.format.DateTimeFormatter
+
 import com.typesafe.scalalogging.Logger
 import org.slf4j.LoggerFactory
 
 trait PerformanceLogging {
 
   val perfLogger: Logger = Logger(LoggerFactory.getLogger("PerformanceLogging"))
+  val systemTimeZone = ZoneId.systemDefault()
+  val dateFormatter = DateTimeFormatter.ISO_LOCAL_TIME
 
-  def perfmsg(caller: String, msg: String, start: Long, finish: Long): String = {
-    val elapsed = finish - start
-    s"[$caller] took [$elapsed] ms, start [$start], finish [$finish]: $msg"
+  def perfmsg(caller: String, msg: String, start: Instant, finish: Instant): String = {
+    lazy val elapsed = finish.toEpochMilli - start.toEpochMilli
+
+    lazy val startStr = LocalDateTime.ofInstant(start, systemTimeZone).format(dateFormatter)
+    lazy val finishStr = LocalDateTime.ofInstant(finish, systemTimeZone).format(dateFormatter)
+
+    s"[$caller] took [$elapsed] ms, start [$startStr], finish [$finishStr]: $msg"
   }
 
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/utils/PerformanceLogging.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/utils/PerformanceLogging.scala
@@ -7,7 +7,9 @@ trait PerformanceLogging {
 
   val perfLogger: Logger = Logger(LoggerFactory.getLogger("PerformanceLogging"))
 
-  def perfmsg(caller: String, time: Long) =              s"[$caller] took [$time] ms"
-  def perfmsg(caller: String, time: Long, msg: String) = s"[$caller] took [$time] ms: $msg"
+  def perfmsg(caller: String, msg: String, start: Long, finish: Long): String = {
+    val elapsed = finish - start
+    s"[$caller] took [$elapsed] ms, start [$start], finish [$finish]: $msg"
+  }
 
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/utils/RestJsonClient.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/utils/RestJsonClient.scala
@@ -61,8 +61,8 @@ trait RestJsonClient extends FireCloudRequestBuilding with PerformanceLogging {
 
     finalPipeline(req) map { res =>
       if (tick != NoPerfLabel) {
-        val elapsed = System.currentTimeMillis() - tick
-        perfLogger.info(perfmsg(label.get, elapsed))
+        val tock = System.currentTimeMillis()
+        perfLogger.info(perfmsg(label.get, res.status.value, tick, tock))
       }
 
       res
@@ -105,8 +105,8 @@ trait RestJsonClient extends FireCloudRequestBuilding with PerformanceLogging {
     resp map { response =>
 
       if (label.nonEmpty && tick != NoPerfLabel) {
-        val elapsed = System.currentTimeMillis() - tick
-        perfLogger.info(perfmsg(label.get, elapsed))
+        val tock = System.currentTimeMillis()
+        perfLogger.info(perfmsg(label.get, response.status.value, tick, tock))
       }
 
       response.status match {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/utils/RestJsonClient.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/utils/RestJsonClient.scala
@@ -1,5 +1,7 @@
 package org.broadinstitute.dsde.firecloud.utils
 
+import java.time.Instant
+
 import akka.actor.{ActorRef, ActorSystem}
 import org.broadinstitute.dsde.firecloud.FireCloudExceptionWithErrorReport
 import org.broadinstitute.dsde.firecloud.model.ErrorReportExtensions.FCErrorReport
@@ -23,7 +25,7 @@ trait RestJsonClient extends FireCloudRequestBuilding with PerformanceLogging {
   implicit val system: ActorSystem
   implicit val executionContext: ExecutionContext
 
-  private final val NoPerfLabel: Long = -1
+  private final val NoPerfLabel: Instant = Instant.MIN
 
   def unAuthedRequest(req: HttpRequest, compressed: Boolean = false, useFireCloudHeader: Boolean = false,
                       connector: Option[ActorRef] = None, label: Option[String] = None): Future[HttpResponse] = {
@@ -57,11 +59,11 @@ trait RestJsonClient extends FireCloudRequestBuilding with PerformanceLogging {
 
     val finalPipeline = addCreds.map(creds => creds ~> pipeline).getOrElse(pipeline)
 
-    val tick = if (label.nonEmpty) System.currentTimeMillis() else NoPerfLabel
+    val tick = if (label.nonEmpty) Instant.now() else NoPerfLabel
 
     finalPipeline(req) map { res =>
       if (tick != NoPerfLabel) {
-        val tock = System.currentTimeMillis()
+        val tock = Instant.now()
         perfLogger.info(perfmsg(label.get, res.status.value, tick, tock))
       }
 
@@ -90,7 +92,7 @@ trait RestJsonClient extends FireCloudRequestBuilding with PerformanceLogging {
   private def requestToObject[T](auth: Boolean, req: HttpRequest, compressed: Boolean = false, useFireCloudHeader: Boolean = false,
                                  connector: Option[ActorRef] = None, label: Option[String] = None)
                                 (implicit userInfo: WithAccessToken, unmarshaller: Unmarshaller[T], ers: ErrorReportSource): Future[T] = {
-    val tick = if (label.nonEmpty) System.currentTimeMillis() else NoPerfLabel
+    val tick = if (label.nonEmpty) Instant.now() else NoPerfLabel
 
     val resp = if(auth) {
       userAuthedRequest(req, compressed, useFireCloudHeader, connector)
@@ -100,12 +102,12 @@ trait RestJsonClient extends FireCloudRequestBuilding with PerformanceLogging {
     resultsToObject(resp, label, tick)
   }
 
-  private def resultsToObject[T](resp: Future[HttpResponse], label: Option[String] = None, tick: Long = NoPerfLabel)
+  private def resultsToObject[T](resp: Future[HttpResponse], label: Option[String] = None, tick: Instant = NoPerfLabel)
                                 (implicit unmarshaller: Unmarshaller[T], ers: ErrorReportSource): Future[T] = {
     resp map { response =>
 
       if (label.nonEmpty && tick != NoPerfLabel) {
-        val tock = System.currentTimeMillis()
+        val tock = Instant.now()
         perfLogger.info(perfmsg(label.get, response.status.value, tick, tock))
       }
 


### PR DESCRIPTION
This adds some performance logging for calls from orch to Sam and Thurloe.

logs look like this:
```
root [INFO] [20:39:35.938] [ForkJoinPool-2-worker-1] PerformanceLogging - [HttpSamDAO.getRegistrationStatus] took [377] ms, start [20:39:35.561], finish [20:39:35.938]: 200 OK
root [INFO] [20:39:36.056] [ForkJoinPool-2-worker-5] PerformanceLogging - [HttpSamDAO.getRegistrationStatus] took [393] ms, start [20:39:35.662], finish [20:39:36.055]: 200 OK
root [INFO] [20:40:35.307] [ForkJoinPool-2-worker-5] PerformanceLogging - [IndicesExistsRequestBuilder] took [39] ms, start [20:40:35.268], finish [20:40:35.307]: success
root [INFO] [20:40:35.308] [ForkJoinPool-2-worker-1] PerformanceLogging - [IndicesExistsRequestBuilder] took [40] ms, start [20:40:35.268], finish [20:40:35.308]: success
root [INFO] [20:40:35.674] [ForkJoinPool-2-worker-5] PerformanceLogging - [HttpSamDAO.getRegistrationStatus] took [314] ms, start [20:40:35.36], finish [20:40:35.674]: 200 OK
root [INFO] [20:40:35.851] [ForkJoinPool-2-worker-3] PerformanceLogging - [HttpSamDAO.getRegistrationStatus] took [392] ms, start [20:40:35.459], finish [20:40:35.851]: 200 OK
```

This is an incremental step towards better perf analysis. I'd like to follow this up with the ability to perform request tracing - i.e. label each request to Sam/Thurloe/Rawls/whatever with the parent end-user request that generated it. I'd also like to follow up with more PRs to add logging for other DAOs - right now it's just Sam and Thurloe, since those are the two services involved in some bottlenecks we've identified. Reviewer, please consider this an incremental PR - does it offer enough benefit to merge as-is, even though there's additional work we'd like to see?



-----

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
