### PR TITLE
GAWB-3947: update serviceTest version to get bugfixes [risk: low]

### DIFF
--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -15,7 +15,7 @@ object Dependencies {
   val workbenchGoogle: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-google" % workbenchGoogleV excludeAll excludeWorkbenchModel
   val excludeWorkbenchGoogle = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-google" + scalaV)
 
-  val workbenchServiceTestV = "0.10-35e4ee4"
+  val workbenchServiceTestV = "0.13-dc0998e"
   val workbenchServiceTest: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-service-test" % workbenchServiceTestV % "test" classifier "tests" excludeAll (excludeWorkbenchGoogle, excludeWorkbenchModel)
 
   val rootDependencies = Seq(

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/OrchestrationApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/OrchestrationApiSpec.scala
@@ -5,9 +5,10 @@ import java.util.UUID
 
 import akka.http.scaladsl.model.StatusCodes
 import com.google.api.client.googleapis.json.GoogleJsonResponseException
+import com.google.api.services.bigquery.BigqueryScopes
 import com.google.api.services.bigquery.model.{GetQueryResultsResponse, JobReference}
 import org.broadinstitute.dsde.test.OrchConfig
-import org.broadinstitute.dsde.workbench.auth.AuthToken
+import org.broadinstitute.dsde.workbench.auth.{AuthToken, AuthTokenScopes}
 import org.broadinstitute.dsde.workbench.config.{Credentials, UserPool}
 import org.broadinstitute.dsde.workbench.dao.Google.googleBigQueryDAO
 import org.broadinstitute.dsde.workbench.fixture.BillingFixtures
@@ -36,7 +37,7 @@ class OrchestrationApiSpec extends FreeSpec with Matchers with ScalaFutures with
       val role = "bigquery.jobUser"
 
       val user: Credentials = UserPool.chooseStudent
-      val userToken: AuthToken = user.makeAuthToken()
+      val userToken: AuthToken = user.makeAuthToken(AuthTokenScopes.userLoginScopes ++ Seq(BigqueryScopes.BIGQUERY))
       val bigQuery = googleBigQueryDAO(userToken)
 
       // Willy Shakes uses this insult twice

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/OrchestrationApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/OrchestrationApiSpec.scala
@@ -34,11 +34,12 @@ class OrchestrationApiSpec extends FreeSpec with Matchers with ScalaFutures with
       * to that user and watching the BQ job succeed, then removing the role and again seeing the BQ job fail.
       *
       * The funkiness is that:
-      *   - we never execute BQ jobs as the end user
-      *   - to execute a BQ job as the end user, we have to grant the CLOUD_PLATFORM OAuth scope to that user, which
-      *       we also never do in the real app.
+      *   - FireCloud never executes BQ jobs as the end user
+      *   - to execute a BQ job as the end user, FireCloud would have to grant the CLOUD_PLATFORM OAuth scope to that
+      *       user, which we also never do in the real app.
       *
-      *  But beyond this funkiness, the test does check the right things.
+      * HOWEVER, apps outside of FireCloud show activity to this API, so we should continue to maintain and test it.
+      * The test does check the right things, even if FireCloud itself doesn't use it.
       */
     "should grant and remove google role access" in {
       // google roles can take a while to take effect

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/OrchestrationApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/OrchestrationApiSpec.scala
@@ -49,7 +49,7 @@ class OrchestrationApiSpec extends FreeSpec with Matchers with ScalaFutures with
       val role = "bigquery.jobUser"
 
       val user: Credentials = UserPool.chooseStudent
-      val userToken: AuthToken = user.makeAuthToken(AuthTokenScopes.userLoginScopes ++ Seq(BigqueryScopes.CLOUD_PLATFORM))
+      val userToken: AuthToken = user.makeAuthToken(AuthTokenScopes.userLoginScopes :+ BigqueryScopes.CLOUD_PLATFORM)
       val bigQuery = googleBigQueryDAO(userToken)
 
       // Willy Shakes uses this insult twice


### PR DESCRIPTION
update serviceTest version in automation, to pick up this bugfix from workbench-libs:

> bugfix: BillingFixtures.claimGPAllocProject now uses the proper OAuth scopes in the case where GPAlloc did not return a project and therefore the calling test needs to create one on the fly.

-----

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
