### PR TITLE
Cromwell metadata params [risk: low]

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -3251,6 +3251,33 @@ paths:
         - $ref: '#/parameters/workspaceNameParam'
         - $ref: '#/parameters/submissionIdParam'
         - $ref: '#/parameters/workflowIdParam'
+        - name: includeKey
+          description: >
+            When specified key(s) to include from the metadata. Matches any key starting with the value. May not be
+            used with excludeKey. This applies to all keys in the response, including within nested blocks.
+          required: false
+          type: array
+          items:
+            type: string
+          collectionFormat: multi
+          in: query
+        - name: excludeKey
+          description: >
+            When specified key(s) to exclude from the metadata. Matches any key starting with the value. May not be
+            used with includeKey. This applies to all keys in the response, including within nested blocks.
+          required: false
+          type: array
+          items:
+            type: string
+          collectionFormat: multi
+          in: query
+        - name: expandSubWorkflows
+          description: >
+            When true, metadata for sub workflows will be fetched and inserted automatically in the metadata response.
+          required: false
+          type: boolean
+          default: false
+          in: query
 
   /api/workspaces/{workspaceNamespace}/{workspaceName}/submissions/{submissionId}/workflows/{workflowId}/outputs:
     get:

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -3253,8 +3253,8 @@ paths:
         - $ref: '#/parameters/workflowIdParam'
         - name: includeKey
           description: >
-            When specified key(s) to include from the metadata. Matches any key starting with the value. May not be
-            used with excludeKey. This applies to all keys in the response, including within nested blocks.
+            When specified, return only these keys in the response. Matches any key in the response, including within
+            nested blocks. May not be used with excludeKey.
           required: false
           type: array
           items:
@@ -3263,8 +3263,8 @@ paths:
           in: query
         - name: excludeKey
           description: >
-            When specified key(s) to exclude from the metadata. Matches any key starting with the value. May not be
-            used with includeKey. This applies to all keys in the response, including within nested blocks.
+            When specified, omit these keys from the response. Matches any key in the response, including within
+            nested blocks. May not be used with includeKey.
           required: false
           type: array
           items:

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/SubmissionService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/SubmissionService.scala
@@ -4,6 +4,7 @@ import akka.actor.Actor
 import spray.http.HttpMethods.{GET, POST}
 import spray.routing.{HttpService, Route}
 import org.broadinstitute.dsde.firecloud.FireCloudConfig.Rawls._
+import spray.http.Uri
 
 abstract class SubmissionServiceActor extends Actor with SubmissionService {
   def actorRefFactory = context
@@ -48,7 +49,9 @@ trait SubmissionService extends HttpService with PerRequestCreator with FireClou
           pathPrefix("workflows" / Segment) { workflowId =>
             pathEnd {
               get {
-                passthrough(encodeUri(s"$workspacesUrl/$namespace/$name/submissions/$submissionId/workflows/$workflowId"), GET)
+                extract(_.request.uri.query) { query =>
+                  passthrough(Uri(s"$workspacesUrl/$namespace/$name/submissions/$submissionId/workflows/$workflowId").withQuery(query), GET)
+                }
               }
             } ~
             pathPrefix("outputs") {


### PR DESCRIPTION
DataBiosphere/firecloud-app#212. Requires broadinstitute/rawls#1008.

Pass through the querystring on the workflow metadata endpoint to Rawls. Rawls, in broadinstitute/rawls#1008, will send the `includeKey`, `excludeKey`, and `expandSubWorkflows` query params on to Cromwell. This capability will allow apps (e.g FireCloud UI) to optimize what they request from Cromwell. In turn, this will improve end user performance and eliminate a few timeouts.

Will require updates to the FireCloud UI to really take advantage of this, but need to get the apis working first.

---

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
