### PR TITLE
better error message on too-large chunked response [risk: low]

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
@@ -196,4 +196,10 @@ object FireCloudConfig {
     val entityWorkspaceName: Option[String] = if (metrics.hasPath("entityWorkspaceName")) Some(metrics.getString("entityWorkspaceName")) else None
     val libraryNamespaces: List[String] = metrics.getStringList("libraryWorkspaceNamespace").asScala.toList
   }
+
+  object Spray {
+    private val spray = config.getConfig("spray")
+    // grab a copy of this Spray setting to use when displaying an error message
+    lazy val chunkLimit = spray.getString("can.client.response-chunk-aggregation-limit")
+  }
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/HttpClient.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/HttpClient.scala
@@ -24,6 +24,11 @@ object HttpClient {
 
   case class PerformExternalRequest(requestCompression: Boolean, request: HttpRequest)
 
+  lazy val chunkLimitDisplay = FireCloudConfig.Spray.chunkLimit
+    .replace("m", "MB")
+    .replace("k", "KB")
+
+
   def props(requestContext: RequestContext): Props = Props(new HttpClient(requestContext))
 
   def createJsonHttpEntity(json: String) = {
@@ -64,7 +69,7 @@ class HttpClient (requestContext: RequestContext) extends Actor
         log.debug("Got response: " + response)
         context.parent ! RequestComplete(response)
       case Failure(re:RuntimeException) if re.getMessage.startsWith("sendReceive doesn't support chunked responses")  =>
-        val message = s"The response payload was over ${FireCloudConfig.Spray.chunkLimit} and cannot be processed. " +
+        val message = s"The response payload was over ${HttpClient.chunkLimitDisplay} and cannot be processed. " +
                       s"Original request url: ${externalRequest.uri.toString}"
         val customException = new FireCloudException(message, re)
         log.error(message, customException)


### PR DESCRIPTION
DataBiosphere/firecloud-app#83

if orch receives a chunked response from a subsystem, and that response is over the `response-chunk-aggregation-limit` size limit, we previously returned an error message that was confusing to end users: "sendReceive doesn't support chunked responses, try sendTo instead"

This PR attempts to make that error message more understandable.

-----

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [x] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
