### PR TITLE
logging for ontology autocomplete to help debug tests [risk: low]

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchOntologyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchOntologyDAO.scala
@@ -48,7 +48,11 @@ class ElasticSearchOntologyDAO(client: TransportClient, indexName: String) exten
     val autocompleteResults = executeESRequest[SearchRequest, SearchResponse, SearchRequestBuilder](searchRequest)
 
     val allHits = autocompleteResults.getHits.getHits
-    allHits.map(_.getSourceAsString.parseJson.convertTo[TermResource]).toList
+    val termResources = allHits.map(_.getSourceAsString.parseJson.convertTo[TermResource]).toList
+
+    logger.info(s"autocomplete for input [$term] resulted in: ${termResources.map(_.label)}")
+
+    termResources
   }
 
   private def indexExists: Boolean = {


### PR DESCRIPTION
DO NOT MERGE: this is probably unnecessary, given broadinstitute/firecloud-ui#1460. Leaving this open for another day or two to track test failures, then will close.

-----

https://broadworkbench.atlassian.net/browse/WB-88

adds some logging to the ontology autocomplete DAO. We see intermittent test failures on autocomplete, and in those test failures the screenshots show search results that don't match the input. I hope this logging will expose details of what's happening under the covers.

-----

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
