### PR TITLE
set email only on user registration, not profile update

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpThurloeDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpThurloeDAO.scala
@@ -80,7 +80,7 @@ class HttpThurloeDAO ( implicit val system: ActorSystem, implicit val executionC
   }
 
   override def saveProfile(userInfo: UserInfo, profile: BasicProfile): Future[Unit] = {
-    val profilePropertyMap = profile.propertyValueMap ++ Map("email" -> userInfo.userEmail)
+    val profilePropertyMap = profile.propertyValueMap
     saveKeyValues(userInfo, profilePropertyMap).map(_ => ())
   }
   /**


### PR DESCRIPTION
when users create a google account with an external email they have the ability to later change that email. If they do that then update their profile the new email address is saved in thurloe but this is then out of sync with the rest of the system. This PR stops the update, email is only set when user first registers.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [x] Get two thumbsworth of review and PO signoff if necessary
- [x] Verify all tests go green
- [x] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [x] Test this change deployed correctly and works on dev environment after deployment
