### PR TITLE
add single whitelist sync endpoint

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/NihService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/NihService.scala
@@ -48,10 +48,10 @@ object NihStatus {
 
 object NihService {
   sealed trait ServiceMessage
-  case class GetNihStatus(userInfo: UserInfo) extends ServiceMessage
-  case class UpdateNihLinkAndSyncSelf(userInfo: UserInfo, nihLink: NihLink) extends ServiceMessage
+  final case class GetNihStatus(userInfo: UserInfo) extends ServiceMessage
+  final case class UpdateNihLinkAndSyncSelf(userInfo: UserInfo, nihLink: NihLink) extends ServiceMessage
   case object SyncAllWhitelists extends ServiceMessage
-  case class SyncWhitelist(whitelistName: String) extends ServiceMessage
+  final case class SyncWhitelist(whitelistName: String) extends ServiceMessage
 
   def props(service: () => NihServiceActor): Props = {
     Props(service())
@@ -106,7 +106,6 @@ trait NihService extends LazyLogging {
   }
 
   def syncWhitelistAllUsers(whitelistName: String): Future[PerRequestMessage] = {
-    println(s"foo $nihWhitelists")
     nihWhitelists.find(_.name.equals(whitelistName)) match {
       case Some(whitelist) =>
         val whitelistSyncResults = syncNihWhitelistAllUsers(whitelist)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/NihService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/NihService.scala
@@ -7,7 +7,7 @@ import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.{Application, FireCloudConfig, FireCloudException, FireCloudExceptionWithErrorReport}
 import org.broadinstitute.dsde.firecloud.dataaccess.{GoogleServicesDAO, RawlsDAO, SamDAO, ThurloeDAO}
 import org.broadinstitute.dsde.firecloud.model._
-import org.broadinstitute.dsde.firecloud.service.NihService.{GetNihStatus, SyncWhitelist, UpdateNihLinkAndSyncSelf}
+import org.broadinstitute.dsde.firecloud.service.NihService.{GetNihStatus, SyncAllWhitelists, SyncWhitelist, UpdateNihLinkAndSyncSelf}
 import org.broadinstitute.dsde.firecloud.service.PerRequest.{PerRequestMessage, RequestComplete}
 import org.broadinstitute.dsde.firecloud.utils.DateUtils
 import org.broadinstitute.dsde.rawls.model.ErrorReport
@@ -50,7 +50,8 @@ object NihService {
   sealed trait ServiceMessage
   case class GetNihStatus(userInfo: UserInfo) extends ServiceMessage
   case class UpdateNihLinkAndSyncSelf(userInfo: UserInfo, nihLink: NihLink) extends ServiceMessage
-  case object SyncWhitelist extends ServiceMessage
+  case object SyncAllWhitelists extends ServiceMessage
+  case class SyncWhitelist(whitelistName: String) extends ServiceMessage
 
   def props(service: () => NihServiceActor): Props = {
     Props(service())
@@ -66,7 +67,8 @@ class NihServiceActor(val samDao: SamDAO, val rawlsDao: RawlsDAO, val thurloeDao
   override def receive = {
     case GetNihStatus(userInfo: UserInfo) => getNihStatus(userInfo) pipeTo sender
     case UpdateNihLinkAndSyncSelf(userInfo: UserInfo, nihLink: NihLink) => updateNihLinkAndSyncSelf(userInfo: UserInfo, nihLink: NihLink) pipeTo sender
-    case SyncWhitelist => syncAllNihWhitelistsAllUsers pipeTo sender
+    case SyncAllWhitelists => syncAllNihWhitelistsAllUsers pipeTo sender
+    case SyncWhitelist(whitelistName) => syncWhitelistAllUsers(whitelistName) pipeTo sender
   }
 }
 
@@ -101,6 +103,17 @@ trait NihService extends LazyLogging {
     val usersList = Source.fromInputStream(googleDao.getBucketObjectAsInputStream(FireCloudConfig.Nih.whitelistBucket, whitelist.fileName))
 
     usersList.getLines().toSet
+  }
+
+  def syncWhitelistAllUsers(whitelistName: String): Future[PerRequestMessage] = {
+    println(s"foo $nihWhitelists")
+    nihWhitelists.find(_.name.equals(whitelistName)) match {
+      case Some(whitelist) =>
+        val whitelistSyncResults = syncNihWhitelistAllUsers(whitelist)
+        whitelistSyncResults map { _ => RequestComplete(NoContent) }
+
+      case None => Future.successful(RequestComplete(NotFound))
+    }
   }
 
   // This syncs all of the whitelists for all of the users

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/NihApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/NihApiService.scala
@@ -19,11 +19,15 @@ trait NihApiService extends HttpService with PerRequestCreator with FireCloudDir
   val nihServiceConstructor: () => NihServiceActor
 
   val syncRoute: Route =
-    path("sync_whitelist") {
+    path("sync_whitelist" / Segment) { whitelistName =>
       post { requestContext =>
-        NihService.SyncWhitelist
         perRequest(requestContext, NihService.props(nihServiceConstructor),
-          NihService.SyncWhitelist)
+          NihService.SyncWhitelist(whitelistName))
+      }
+    } ~ path("sync_whitelist") {
+      post { requestContext =>
+        perRequest(requestContext, NihService.props(nihServiceConstructor),
+          NihService.SyncAllWhitelists)
       }
     }
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/NihApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/NihApiServiceSpec.scala
@@ -146,4 +146,17 @@ class NihApiServiceSpec extends ApiServiceSpec {
       assertSameElements(Set(services.thurloeDao.TCGA_AND_TARGET_LINKED, services.thurloeDao.TARGET_LINKED), services.rawlsDao.groups(targetDbGaPAuthorized).map(_.value))
     }
   }
+
+  it should "return NoContent and properly sync a single whitelist" in withDefaultApiServices { services =>
+    Post("/sync_whitelist/TCGA") ~> sealRoute(services.syncRoute) ~> check {
+      status should equal(NoContent)
+      assertSameElements(Set(services.thurloeDao.TCGA_AND_TARGET_LINKED, services.thurloeDao.TCGA_LINKED), services.samDao.groups(tcgaDbGaPAuthorized).map(_.value))
+    }
+  }
+
+  it should "return NotFound for unknown whitelist" in withDefaultApiServices { services =>
+    Post("/sync_whitelist/foobar") ~> sealRoute(services.syncRoute) ~> check {
+      status should equal(NotFound)
+    }
+  }
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/NihApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/NihApiServiceSpec.scala
@@ -150,7 +150,7 @@ class NihApiServiceSpec extends ApiServiceSpec {
   it should "return NoContent and properly sync a single whitelist" in withDefaultApiServices { services =>
     Post("/sync_whitelist/TCGA") ~> sealRoute(services.syncRoute) ~> check {
       status should equal(NoContent)
-      assertSameElements(Set(services.thurloeDao.TCGA_AND_TARGET_LINKED, services.thurloeDao.TCGA_LINKED), services.samDao.groups(tcgaDbGaPAuthorized).map(_.value))
+      assertSameElements(Set(services.thurloeDao.TCGA_AND_TARGET_LINKED, services.thurloeDao.TCGA_LINKED), services.rawlsDao.groups(tcgaDbGaPAuthorized).map(_.value))
     }
   }
 


### PR DESCRIPTION
in prep for 60 some whitelists from AnVIL changing the sync process to be an api call per whiltelist

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
