### PR TITLE
GAWB-4014: TSV download filename should be .tsv

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/ExportEntitiesByTypeActor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/ExportEntitiesByTypeActor.scala
@@ -149,7 +149,7 @@ class ExportEntitiesByTypeActor(rawlsDAO: RawlsDAO,
     */
   private def streamSingularType(entityQueries: Seq[EntityQuery], metadata: EntityTypeMetadata, headers: IndexedSeq[String]): Future[Done] = {
     // The output to the user
-    val streamingActorRef = context.actorOf(StreamingActor.props(ctx, ContentTypes.`text/plain`, entityType + ".txt"))
+    val streamingActorRef = context.actorOf(StreamingActor.props(ctx, ContentType(MediaTypes.`text/tab-separated-values`, HttpCharsets.`UTF-8`), entityType + ".tsv"))
 
     // The Source
     val entityQuerySource = Source(entityQueries.toStream)

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/ExportEntitiesByTypeServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/ExportEntitiesByTypeServiceSpec.scala
@@ -73,7 +73,8 @@ class ExportEntitiesByTypeServiceSpec extends BaseServiceSpec with ExportEntitie
           entity shouldNot be(empty) // Entity is the first line of content as output by StreamingActor
           chunks shouldNot be(empty) // Chunks has all of the rest of the content, as output by StreamingActor
           headers.contains(HttpHeaders.Connection("Keep-Alive")) should be(true)
-          headers.contains(HttpHeaders.`Content-Disposition`.apply("attachment", Map("filename" -> "sample.txt"))) should be(true)
+          headers should contain(HttpHeaders.`Content-Disposition`.apply("attachment", Map("filename" -> "sample.tsv")))
+          contentType shouldEqual ContentType(MediaTypes.`text/tab-separated-values`, HttpCharsets.`UTF-8`)
           validateLineCount(chunks, MockRawlsDAO.largeSampleSize)
           entity.asString.startsWith("update:") should be(true)
           validateProps(entity)
@@ -89,7 +90,8 @@ class ExportEntitiesByTypeServiceSpec extends BaseServiceSpec with ExportEntitie
           entity shouldNot be(empty) // Entity is the first line of content as output by StreamingActor
           chunks shouldNot be(empty) // Chunks has all of the rest of the content, as output by StreamingActor
           headers.contains(HttpHeaders.Connection("Keep-Alive")) should be(true)
-          headers.contains(HttpHeaders.`Content-Disposition`.apply("attachment", Map("filename" -> "bigQuery.txt"))) should be(true)
+          headers should contain(HttpHeaders.`Content-Disposition`.apply("attachment", Map("filename" -> "bigQuery.tsv")))
+          contentType shouldEqual ContentType(MediaTypes.`text/tab-separated-values`, HttpCharsets.`UTF-8`)
           validateLineCount(chunks, 2)
           entity.asString.contains("query_str") should be(true)
         }
@@ -110,7 +112,8 @@ class ExportEntitiesByTypeServiceSpec extends BaseServiceSpec with ExportEntitie
           entity shouldNot be(empty) // Entity is the first line of content as output by StreamingActor
           chunks shouldNot be(empty) // Chunks has all of the rest of the content, as output by StreamingActor
           headers.contains(HttpHeaders.Connection("Keep-Alive")) should be(true)
-          headers.contains(HttpHeaders.`Content-Disposition`.apply("attachment", Map("filename" -> "pair.txt"))) should be(true)
+          headers should contain(HttpHeaders.`Content-Disposition`.apply("attachment", Map("filename" -> "pair.tsv")))
+          contentType shouldEqual ContentType(MediaTypes.`text/tab-separated-values`, HttpCharsets.`UTF-8`)
           validateLineCount(chunks, 2)
           entity.asString.startsWith("entity:") should be(true)
           entity.asString.contains("names") should be(true)
@@ -135,7 +138,8 @@ class ExportEntitiesByTypeServiceSpec extends BaseServiceSpec with ExportEntitie
           entity shouldNot be(empty) // Entity is the first line of content as output by StreamingActor
           chunks shouldNot be(empty) // Chunks has all of the rest of the content, as output by StreamingActor
           headers.contains(HttpHeaders.Connection("Keep-Alive")) should be(true)
-          headers.contains(HttpHeaders.`Content-Disposition`.apply("attachment", Map("filename" -> "sample.txt"))) should be(true)
+          headers should contain(HttpHeaders.`Content-Disposition`.apply("attachment", Map("filename" -> "sample.tsv")))
+          contentType shouldEqual ContentType(MediaTypes.`text/tab-separated-values`, HttpCharsets.`UTF-8`)
           validateLineCount(chunks, MockRawlsDAO.largeSampleSize)
         }
       }
@@ -160,7 +164,8 @@ class ExportEntitiesByTypeServiceSpec extends BaseServiceSpec with ExportEntitie
           status should be(OK)
           entity shouldNot be(empty)
           headers.contains(HttpHeaders.Connection("Keep-Alive")) should be(true)
-          headers.contains(HttpHeaders.`Content-Disposition`.apply("attachment", Map("filename" -> "sample_set.zip"))) should be(true)
+          headers should contain(HttpHeaders.`Content-Disposition`.apply("attachment", Map("filename" -> "sample_set.zip")))
+          contentType shouldEqual ContentTypes.`application/octet-stream`
         }
       }
     }
@@ -172,7 +177,8 @@ class ExportEntitiesByTypeServiceSpec extends BaseServiceSpec with ExportEntitie
           status should be(OK)
           entity shouldNot be(empty)
           headers.contains(HttpHeaders.Connection("Keep-Alive")) should be(true)
-          headers.contains(HttpHeaders.`Content-Disposition`.apply("attachment", Map("filename" -> "sample.txt"))) should be(true)
+          headers should contain(HttpHeaders.`Content-Disposition`.apply("attachment", Map("filename" -> "sample.tsv")))
+          contentType shouldEqual ContentType(MediaTypes.`text/tab-separated-values`, HttpCharsets.`UTF-8`)
         }
       }
     }
@@ -237,7 +243,8 @@ class ExportEntitiesByTypeServiceSpec extends BaseServiceSpec with ExportEntitie
           entity shouldNot be(empty) // Entity is the first line of content as output by StreamingActor
           chunks shouldNot be(empty) // Chunks has all of the rest of the content, as output by StreamingActor
           headers.contains(HttpHeaders.Connection("Keep-Alive")) should be(true)
-          headers.contains(HttpHeaders.`Content-Disposition`.apply("attachment", Map("filename" -> "sample.txt"))) should be(true)
+          headers should contain(HttpHeaders.`Content-Disposition`.apply("attachment", Map("filename" -> "sample.tsv")))
+          contentType shouldEqual ContentType(MediaTypes.`text/tab-separated-values`, HttpCharsets.`UTF-8`)
           validateLineCount(chunks, MockRawlsDAO.largeSampleSize)
           validateProps(entity)
         }
@@ -251,7 +258,8 @@ class ExportEntitiesByTypeServiceSpec extends BaseServiceSpec with ExportEntitie
           status should be(OK)
           entity shouldNot be(empty)
           headers.contains(HttpHeaders.Connection("Keep-Alive")) should be(true)
-          headers.contains(HttpHeaders.`Content-Disposition`.apply("attachment", Map("filename" -> "sample.txt"))) should be(true)
+          headers should contain(HttpHeaders.`Content-Disposition`.apply("attachment", Map("filename" -> "sample.tsv")))
+          contentType shouldEqual ContentType(MediaTypes.`text/tab-separated-values`, HttpCharsets.`UTF-8`)
         }
       }
     }
@@ -275,7 +283,8 @@ class ExportEntitiesByTypeServiceSpec extends BaseServiceSpec with ExportEntitie
           status should be(OK)
           entity shouldNot be(empty)
           headers.contains(HttpHeaders.Connection("Keep-Alive")) should be(true)
-          headers.contains(HttpHeaders.`Content-Disposition`.apply("attachment", Map("filename" -> "sample.txt"))) should be(true)
+          headers should contain(HttpHeaders.`Content-Disposition`.apply("attachment", Map("filename" -> "sample.tsv")))
+          contentType shouldEqual ContentType(MediaTypes.`text/tab-separated-values`, HttpCharsets.`UTF-8`)
         }
       }
     }
@@ -301,7 +310,7 @@ class ExportEntitiesByTypeServiceSpec extends BaseServiceSpec with ExportEntitie
 
     "when calling PUT, PATCH, DELETE on export path" - {
       "MethodNotAllowed response is returned" in {
-        List(HttpMethods.PUT, HttpMethods.DELETE, HttpMethods.PATCH) map { method =>
+        List(HttpMethods.PUT, HttpMethods.DELETE, HttpMethods.PATCH) foreach { method =>
           new RequestBuilder(method)(invalidCookieFireCloudEntitiesParticipantSetTSVPath) ~> sealRoute(cookieAuthedRoutes) ~> check {
             handled should be(true)
             withClue(s"Method $method:") {
@@ -323,7 +332,8 @@ class ExportEntitiesByTypeServiceSpec extends BaseServiceSpec with ExportEntitie
             entity shouldNot be(empty) // Entity is the first line of content as output by StreamingActor
             chunks shouldNot be(empty) // Chunks has all of the rest of the content, as output by StreamingActor
             headers.contains(HttpHeaders.Connection("Keep-Alive")) should be(true)
-            headers.contains(HttpHeaders.`Content-Disposition`.apply("attachment", Map("filename" -> "sample.txt"))) should be(true)
+            headers should contain(HttpHeaders.`Content-Disposition`.apply("attachment", Map("filename" -> "sample.tsv")))
+            contentType shouldEqual ContentType(MediaTypes.`text/tab-separated-values`, HttpCharsets.`UTF-8`)
             validateLineCount(chunks, MockRawlsDAO.largeSampleSize)
             validateProps(entity)
           }
@@ -338,8 +348,8 @@ class ExportEntitiesByTypeServiceSpec extends BaseServiceSpec with ExportEntitie
 
   private def validateProps(entity: HttpEntity): Unit = {
     val entityHeaderString = entity.asString
-    filterProps.map { h => entityHeaderString.contains(h) should be(true) }
-    missingProps.map { h => entityHeaderString.contains(h) should be(false) }
+    filterProps.foreach { h => entityHeaderString.contains(h) should be(true) }
+    missingProps.foreach { h => entityHeaderString.contains(h) should be(false) }
   }
 
   private def validateErrorInLastChunk(chunks: List[MessageChunk], message: String): Unit = {


### PR DESCRIPTION
Changes TSV filename to have `.tsv` extension instead of `.txt`. Also changes content-type to `text/tab-separated-values` instead of `text/plain`.

This is a bug fix. It could also be interpreted as a breaking API change. Let me know if you object to this change as-is and if you have any suggestions for making it backward-compatible. One thought I had was to only apply this change if the request has `text/tab-separated-values` in its `Accept` header.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
