### PR TITLE
encode uri for workflow metadata passthrough

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/SubmissionService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/SubmissionService.scala
@@ -50,7 +50,7 @@ trait SubmissionService extends HttpService with PerRequestCreator with FireClou
             pathEnd {
               get {
                 extract(_.request.uri.query) { query =>
-                  passthrough(Uri(s"$workspacesUrl/$namespace/$name/submissions/$submissionId/workflows/$workflowId").withQuery(query), GET)
+                  passthrough(Uri(encodeUri(s"$workspacesUrl/$namespace/$name/submissions/$submissionId/workflows/$workflowId")).withQuery(query), GET)
                 }
               }
             } ~

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockWorkspaceServer.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockWorkspaceServer.scala
@@ -34,6 +34,21 @@ object MockWorkspaceServer {
     false //locked
   )
 
+  val mockSpacedWorkspace = Workspace(
+    "spacey",
+    "this  workspace has spaces",
+    Set.empty,
+    "workspace_id",
+    "buckety_bucket",
+    DateTime.now(),
+    DateTime.now(),
+    "my_workspace_creator",
+    Map(), //attributes
+    Map(), //acls
+    Map(), //realm acls
+    false //locked
+  )
+
   val mockValidId = randomPositiveInt()
   val mockInvalidId = randomPositiveInt()
 
@@ -206,6 +221,20 @@ object MockWorkspaceServer {
           .withMethod("GET")
           .withPath(s"${workspaceBasePath}/%s/%s/submissions/%s/workflows/%s"
             .format(mockValidWorkspace.namespace, mockValidWorkspace.name, mockValidId, mockValidId))
+          .withHeader(authHeader))
+      .respond(
+        response()
+          .withHeaders(header)
+          .withStatusCode(OK.intValue)
+          .withBody(mockValidSubmission.toJson.prettyPrint)
+      )
+
+    MockWorkspaceServer.workspaceServer
+      .when(
+        request()
+          .withMethod("GET")
+          .withPath(s"${workspaceBasePath}/%s/%s/submissions/%s/workflows/%s"
+            .format(mockSpacedWorkspace.namespace, mockSpacedWorkspace.name, mockValidId, mockValidId))
           .withHeader(authHeader))
       .respond(
         response()

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/SubmissionServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/SubmissionServiceSpec.scala
@@ -6,6 +6,7 @@ import org.broadinstitute.dsde.firecloud.model.SubmissionRequest
 import spray.http.StatusCodes._
 import spray.httpx.SprayJsonSupport._
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
+import spray.http.Uri
 
 final class SubmissionServiceSpec extends ServiceSpec with SubmissionService {
 
@@ -40,6 +41,12 @@ final class SubmissionServiceSpec extends ServiceSpec with SubmissionService {
   val localSubmissionWorkflowIdPath = FireCloudConfig.Rawls.submissionsWorkflowIdPath.format(
     MockWorkspaceServer.mockValidWorkspace.namespace,
     MockWorkspaceServer.mockValidWorkspace.name,
+    MockWorkspaceServer.mockValidId,
+    MockWorkspaceServer.mockValidId)
+
+  val localSpacedWorkspaceWorkflowIdPath = FireCloudConfig.Rawls.submissionsWorkflowIdPath.format(
+    MockWorkspaceServer.mockSpacedWorkspace.namespace,
+    MockWorkspaceServer.mockSpacedWorkspace.name,
     MockWorkspaceServer.mockValidId,
     MockWorkspaceServer.mockValidId)
 
@@ -175,6 +182,15 @@ final class SubmissionServiceSpec extends ServiceSpec with SubmissionService {
     "when calling GET on the /workspaces/*/*/submissions/*/workflows/* path" - {
       "with a valid id, OK response is returned" in {
         Get(localSubmissionWorkflowIdPath) ~> dummyAuthHeaders ~> sealRoute(routes) ~> check {
+          status should equal(OK)
+        }
+      }
+
+      "with a valid id and a space in the workspace name, OK response is returned" in {
+        // the request inbound to orchestration should encoded, so we replace spaces with  %20 in the test below.
+        // this test really verifies that the runtime orch code can accept an encoded URI and maintain the encoding
+        // when it passes through the request to rawls - i.e. it doesn't decode the request at any point.
+        Get(Uri(localSpacedWorkspaceWorkflowIdPath.replace(" ","%20"))) ~> dummyAuthHeaders ~> sealRoute(routes) ~> check {
           status should equal(OK)
         }
       }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/SubmissionServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/SubmissionServiceSpec.scala
@@ -6,7 +6,6 @@ import org.broadinstitute.dsde.firecloud.model.SubmissionRequest
 import spray.http.StatusCodes._
 import spray.httpx.SprayJsonSupport._
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
-import spray.http.Uri
 
 final class SubmissionServiceSpec extends ServiceSpec with SubmissionService {
 
@@ -190,7 +189,7 @@ final class SubmissionServiceSpec extends ServiceSpec with SubmissionService {
         // the request inbound to orchestration should encoded, so we replace spaces with  %20 in the test below.
         // this test really verifies that the runtime orch code can accept an encoded URI and maintain the encoding
         // when it passes through the request to rawls - i.e. it doesn't decode the request at any point.
-        Get(Uri(localSpacedWorkspaceWorkflowIdPath.replace(" ","%20"))) ~> dummyAuthHeaders ~> sealRoute(routes) ~> check {
+        Get(localSpacedWorkspaceWorkflowIdPath.replace(" ","%20")) ~> dummyAuthHeaders ~> sealRoute(routes) ~> check {
           status should equal(OK)
         }
       }


### PR DESCRIPTION
DataBiosphere/firecloud-app#227

viewing metadata for a workflow fails if the workspace has a space in its name. This is a regression from #684. See that other PR to understand the change that introduced the regression, compare to this PR for the fix.

-----

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
