### PR TITLE
rename consentCodes library title to Data Use Limitations [risk: no]

### DIFF
--- a/src/main/resources/library/attribute-definitions.json
+++ b/src/main/resources/library/attribute-definitions.json
@@ -208,7 +208,7 @@
       "typeahead": "populate"
     },
     "library:consentCodes" : {
-      "title": "Consent Codes",
+      "title": "Data Use Limitations",
       "type": "array",
       "items": { "type": "string" },
       "renderHint": { "type": "tag" }


### PR DESCRIPTION
DataBiosphere/firecloud-app#237

renames a Library column from "Consent Codes" to "Data Use Limitations".

This value appears to only be used when displaying the column header in FC UI's Library table. Since it is display-only, I don't feel that the `attribute-definitions.json` file needs a version bump, nor do we need to change anything about the browser's local storage of Library display preferences.


-----

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
