### PR TITLE
gawb-3840: data library tab will show workspaces user already has read access to

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
@@ -101,6 +101,7 @@ object FireCloudConfig {
   object Sam {
     private val sam = config.getConfig("sam")
     val baseUrl = sam.getString("baseUrl")
+    val allUsersGroupRef = WorkbenchEmail(sam.getString("allUsersGroupEmail"))
   }
 
   object Thurloe {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
@@ -101,7 +101,6 @@ object FireCloudConfig {
   object Sam {
     private val sam = config.getConfig("sam")
     val baseUrl = sam.getString("baseUrl")
-    val allUsersGroupRef = WorkbenchEmail(sam.getString("allUsersGroupEmail"))
   }
 
   object Thurloe {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchDAO.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.firecloud.dataaccess
 
 import org.broadinstitute.dsde.firecloud.{FireCloudConfig, FireCloudException}
 import org.broadinstitute.dsde.firecloud.model.Metrics.{LogitMetric, NumSubjects}
-import org.broadinstitute.dsde.firecloud.model.SamResource.AccessPolicyName
+import org.broadinstitute.dsde.firecloud.model.SamResource.{AccessPolicyName, UserPolicy}
 import org.broadinstitute.dsde.firecloud.model._
 import org.broadinstitute.dsde.firecloud.service.LibraryService
 import org.broadinstitute.dsde.workbench.util.health.SubsystemStatus
@@ -119,12 +119,12 @@ class ElasticSearchDAO(client: TransportClient, indexName: String, researchPurpo
     }
   }
 
-  override def findDocuments(criteria: LibrarySearchParams, groups: Seq[String], workspaceIdAccessMap: Map[String, String]): Future[LibrarySearchResponse] = {
-    findDocumentsWithAggregateInfo(client, indexName, criteria, groups, workspaceIdAccessMap, researchPurposeSupport)
+  override def findDocuments(criteria: LibrarySearchParams, groups: Seq[String], workspacePolicyMap: Map[String, UserPolicy]): Future[LibrarySearchResponse] = {
+    findDocumentsWithAggregateInfo(client, indexName, criteria, groups, workspacePolicyMap, researchPurposeSupport)
   }
 
-  override def suggestionsFromAll(criteria: LibrarySearchParams, groups: Seq[String], workspaceIdAccessMap: Map[String, String]): Future[LibrarySearchResponse] = {
-    autocompleteSuggestions(client, indexName, criteria, groups, workspaceIdAccessMap, researchPurposeSupport)
+  override def suggestionsFromAll(criteria: LibrarySearchParams, groups: Seq[String], workspacePolicyMap: Map[String, UserPolicy]): Future[LibrarySearchResponse] = {
+    autocompleteSuggestions(client, indexName, criteria, groups, workspacePolicyMap, researchPurposeSupport)
   }
 
   override def suggestionsForFieldPopulate(field: String, text: String): Future[Seq[String]] = {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchDAO.scala
@@ -119,12 +119,12 @@ class ElasticSearchDAO(client: TransportClient, indexName: String, researchPurpo
     }
   }
 
-  override def findDocuments(criteria: LibrarySearchParams, groups: Seq[String], workspaceIds: Seq[String]): Future[LibrarySearchResponse] = {
-    findDocumentsWithAggregateInfo(client, indexName, criteria, groups, workspaceIds, researchPurposeSupport)
+  override def findDocuments(criteria: LibrarySearchParams, groups: Seq[String], workspaceIdAccessMap: Map[String, String]): Future[LibrarySearchResponse] = {
+    findDocumentsWithAggregateInfo(client, indexName, criteria, groups, workspaceIdAccessMap, researchPurposeSupport)
   }
 
-  override def suggestionsFromAll(criteria: LibrarySearchParams, groups: Seq[String], workspaceIds: Seq[String]): Future[LibrarySearchResponse] = {
-    autocompleteSuggestions(client, indexName, criteria, groups, workspaceIds, researchPurposeSupport)
+  override def suggestionsFromAll(criteria: LibrarySearchParams, groups: Seq[String], workspaceIdAccessMap: Map[String, String]): Future[LibrarySearchResponse] = {
+    autocompleteSuggestions(client, indexName, criteria, groups, workspaceIdAccessMap, researchPurposeSupport)
   }
 
   override def suggestionsForFieldPopulate(field: String, text: String): Future[Seq[String]] = {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchDAO.scala
@@ -119,8 +119,8 @@ class ElasticSearchDAO(client: TransportClient, indexName: String, researchPurpo
     }
   }
 
-  override def findDocuments(criteria: LibrarySearchParams, groups: Seq[String], workspaceAccessMap: Map[String, AccessPolicyName]): Future[LibrarySearchResponse] = {
-    findDocumentsWithAggregateInfo(client, indexName, criteria, groups, workspaceAccessMap, researchPurposeSupport)
+  override def findDocuments(criteria: LibrarySearchParams, groups: Seq[String], workspaceIds: Seq[String]): Future[LibrarySearchResponse] = {
+    findDocumentsWithAggregateInfo(client, indexName, criteria, groups, workspaceIds, researchPurposeSupport)
   }
 
   override def suggestionsFromAll(criteria: LibrarySearchParams, groups: Seq[String], workspaceIds: Seq[String]): Future[LibrarySearchResponse] = {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchDAO.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.dsde.firecloud.dataaccess
 
 import org.broadinstitute.dsde.firecloud.{FireCloudConfig, FireCloudException}
 import org.broadinstitute.dsde.firecloud.model.Metrics.{LogitMetric, NumSubjects}
+import org.broadinstitute.dsde.firecloud.model.SamResource.AccessPolicyName
 import org.broadinstitute.dsde.firecloud.model._
 import org.broadinstitute.dsde.firecloud.service.LibraryService
 import org.broadinstitute.dsde.workbench.util.health.SubsystemStatus
@@ -118,12 +119,12 @@ class ElasticSearchDAO(client: TransportClient, indexName: String, researchPurpo
     }
   }
 
-  override def findDocuments(criteria: LibrarySearchParams, groups: Seq[String]): Future[LibrarySearchResponse] = {
-    findDocumentsWithAggregateInfo(client, indexName, criteria, groups, researchPurposeSupport)
+  override def findDocuments(criteria: LibrarySearchParams, groups: Seq[String], workspaceAccessMap: Map[String, AccessPolicyName]): Future[LibrarySearchResponse] = {
+    findDocumentsWithAggregateInfo(client, indexName, criteria, groups, workspaceAccessMap, researchPurposeSupport)
   }
 
-  override def suggestionsFromAll(criteria: LibrarySearchParams, groups: Seq[String]): Future[LibrarySearchResponse] = {
-    autocompleteSuggestions(client, indexName, criteria, groups, researchPurposeSupport)
+  override def suggestionsFromAll(criteria: LibrarySearchParams, groups: Seq[String], workspaceIds: Seq[String]): Future[LibrarySearchResponse] = {
+    autocompleteSuggestions(client, indexName, criteria, groups, workspaceIds, researchPurposeSupport)
   }
 
   override def suggestionsForFieldPopulate(field: String, text: String): Future[Seq[String]] = {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchDAOQuerySupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchDAOQuerySupport.scala
@@ -105,9 +105,10 @@ trait ElasticSearchDAOQuerySupport extends ElasticSearchDAOSupport {
     if (groups.nonEmpty) {
       groupsQuery.should(termsQuery(fieldDiscoverableByGroups, groups.asJavaCollection))
     }
-    groupsQuery.should(termsQuery(fieldWorkspaceId+".keyword" , workspaceIds.asJavaCollection))
+    if (workspaceIds.nonEmpty) {
+      groupsQuery.should(termsQuery(fieldWorkspaceId + ".keyword", workspaceIds.asJavaCollection))
+    }
     query.filter(groupsQuery)
-
     query
   }
 
@@ -203,6 +204,8 @@ trait ElasticSearchDAOQuerySupport extends ElasticSearchDAOSupport {
     }
   }
 
+  // TODO: we might want to keep a cache of workspaceIds that have been published so we can intersect with the workspaces
+  // the user has access to before adding them to the filter criteria
   def findDocumentsWithAggregateInfo(client: TransportClient, indexname: String, criteria: LibrarySearchParams, groups: Seq[String], workspacePolicyMap: Map[String, UserPolicy], researchPurposeSupport: ResearchPurposeSupport): Future[LibrarySearchResponse] = {
     val workspaceIds = workspacePolicyMap.keys.toSeq
     val searchQuery = buildSearchQuery(client, indexname, criteria, groups, workspaceIds, researchPurposeSupport)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpSamDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpSamDAO.scala
@@ -7,6 +7,7 @@ import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
 import org.broadinstitute.dsde.firecloud.model.{AccessToken, FireCloudManagedGroupMembership, ManagedGroupRoles, RegistrationInfo, UserInfo, WithAccessToken}
 import org.broadinstitute.dsde.workbench.util.health.SubsystemStatus
 import org.broadinstitute.dsde.firecloud.model.ManagedGroupRoles.ManagedGroupRole
+import org.broadinstitute.dsde.firecloud.model.SamResource.UserPolicy
 import org.broadinstitute.dsde.firecloud.utils.RestJsonClient
 import org.broadinstitute.dsde.rawls.model.{ManagedRoles, RawlsUserEmail}
 import org.broadinstitute.dsde.workbench.model.WorkbenchIdentityJsonSupport._
@@ -91,6 +92,11 @@ class HttpSamDAO( implicit val system: ActorSystem, implicit val executionContex
   override def requestGroupAccess(groupName: WorkbenchGroupName)(implicit userInfo: WithAccessToken): Future[Unit] = {
     userAuthedRequestToUnit(Post(samManagedGroupRequestAccess(groupName)))
   }
+
+  override def listResourcesByType(resourceTypeName: String)(implicit userInfo: WithAccessToken): Future[Seq[UserPolicy]] ={
+    authedRequestToObject[List[UserPolicy]](Get(samListResources(resourceTypeName)))
+  }
+
 
   private def userAuthedRequestToUnit(request: HttpRequest)(implicit userInfo: WithAccessToken): Future[Unit] = {
     userAuthedRequest(request).map { resp =>

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpSamDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpSamDAO.scala
@@ -7,6 +7,7 @@ import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
 import org.broadinstitute.dsde.firecloud.model.{AccessToken, FireCloudManagedGroupMembership, ManagedGroupRoles, RegistrationInfo, UserInfo, WithAccessToken}
 import org.broadinstitute.dsde.workbench.util.health.SubsystemStatus
 import org.broadinstitute.dsde.firecloud.model.ManagedGroupRoles.ManagedGroupRole
+import org.broadinstitute.dsde.firecloud.model.SamResource.UserPolicy
 import org.broadinstitute.dsde.firecloud.utils.RestJsonClient
 import org.broadinstitute.dsde.rawls.model.{ManagedRoles, RawlsUserEmail}
 import org.broadinstitute.dsde.workbench.model.WorkbenchIdentityJsonSupport._
@@ -24,6 +25,10 @@ import scala.concurrent.{ExecutionContext, Future}
   */
 class HttpSamDAO( implicit val system: ActorSystem, implicit val executionContext: ExecutionContext )
   extends SamDAO with RestJsonClient {
+
+  override def listWorkspaceResources(implicit userInfo: WithAccessToken): Future[Seq[UserPolicy]] = {
+    authedRequestToObject[Seq[UserPolicy]](Get(samListResources("workspace")))
+  }
 
   override def registerUser(implicit userInfo: WithAccessToken): Future[RegistrationInfo] = {
     authedRequestToObject[RegistrationInfo](Post(samUserRegistrationUrl), label=Some("HttpSamDAO.registerUser"))

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpSamDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpSamDAO.scala
@@ -7,7 +7,6 @@ import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
 import org.broadinstitute.dsde.firecloud.model.{AccessToken, FireCloudManagedGroupMembership, ManagedGroupRoles, RegistrationInfo, UserInfo, WithAccessToken}
 import org.broadinstitute.dsde.workbench.util.health.SubsystemStatus
 import org.broadinstitute.dsde.firecloud.model.ManagedGroupRoles.ManagedGroupRole
-import org.broadinstitute.dsde.firecloud.model.SamResource.UserPolicy
 import org.broadinstitute.dsde.firecloud.utils.RestJsonClient
 import org.broadinstitute.dsde.rawls.model.{ManagedRoles, RawlsUserEmail}
 import org.broadinstitute.dsde.workbench.model.WorkbenchIdentityJsonSupport._
@@ -92,11 +91,6 @@ class HttpSamDAO( implicit val system: ActorSystem, implicit val executionContex
   override def requestGroupAccess(groupName: WorkbenchGroupName)(implicit userInfo: WithAccessToken): Future[Unit] = {
     userAuthedRequestToUnit(Post(samManagedGroupRequestAccess(groupName)))
   }
-
-  override def listResourcesByType(resourceTypeName: String)(implicit userInfo: WithAccessToken): Future[Seq[UserPolicy]] ={
-    authedRequestToObject[List[UserPolicy]](Get(samListResources(resourceTypeName)))
-  }
-
 
   private def userAuthedRequestToUnit(request: HttpRequest)(implicit userInfo: WithAccessToken): Future[Unit] = {
     userAuthedRequest(request).map { resp =>

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpSamDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpSamDAO.scala
@@ -27,7 +27,7 @@ class HttpSamDAO( implicit val system: ActorSystem, implicit val executionContex
   extends SamDAO with RestJsonClient {
 
   override def listWorkspaceResources(implicit userInfo: WithAccessToken): Future[Seq[UserPolicy]] = {
-    authedRequestToObject[Seq[UserPolicy]](Get(samListResources("workspace")))
+    authedRequestToObject[Seq[UserPolicy]](Get(samListResources("workspace")), label=Some("HttpSamDAO.listWorkspaceResources"))
   }
 
   override def registerUser(implicit userInfo: WithAccessToken): Future[RegistrationInfo] = {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/SamDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/SamDAO.scala
@@ -3,6 +3,7 @@ package org.broadinstitute.dsde.firecloud.dataaccess
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.FireCloudConfig
 import org.broadinstitute.dsde.firecloud.model.ManagedGroupRoles.ManagedGroupRole
+import org.broadinstitute.dsde.firecloud.model.SamResource.UserPolicy
 import org.broadinstitute.dsde.firecloud.model.{AccessToken, FireCloudManagedGroupMembership, RegistrationInfo, UserInfo, WithAccessToken}
 import org.broadinstitute.dsde.rawls.model.{ErrorReportSource, RawlsUserEmail}
 import org.broadinstitute.dsde.workbench.model.{WorkbenchEmail, WorkbenchGroupName}
@@ -43,6 +44,10 @@ trait SamDAO extends LazyLogging with ReportsSubsystemStatus {
   def samResourcePolicy(resourceTypeName: String, resourceId: String, policyName: String): String = samResourcePolicies(resourceTypeName, resourceId) + s"/$policyName"
   def samResourcePolicyAlterMember(resourceTypeName: String, resourceId: String, policyName: String, email: WorkbenchEmail): String = samResourcePolicy(resourceTypeName, resourceId, policyName) + s"/$email"
 
+
+  val samResourcesBase: String = FireCloudConfig.Sam.baseUrl + s"/api/resources"
+  def samListResources(resourceTypeName: String): String = samResourcesBase + s"/$resourceTypeName"
+
   def registerUser(implicit userInfo: WithAccessToken): Future[RegistrationInfo]
   def getRegistrationStatus(implicit userInfo: WithAccessToken): Future[RegistrationInfo]
 
@@ -58,6 +63,7 @@ trait SamDAO extends LazyLogging with ReportsSubsystemStatus {
   def removeGroupMember(groupName: WorkbenchGroupName, role: ManagedGroupRole, email: WorkbenchEmail)(implicit userInfo: WithAccessToken): Future[Unit]
   def overwriteGroupMembers(groupName: WorkbenchGroupName, role: ManagedGroupRole, memberList: List[WorkbenchEmail])(implicit userInfo: WithAccessToken): Future[Unit]
   def requestGroupAccess(groupName: WorkbenchGroupName)(implicit userInfo: WithAccessToken): Future[Unit]
+  def listResourcesByType(resourceTypeName: String)(implicit userInfo: WithAccessToken): Future[Seq[UserPolicy]]
 
   def addPolicyMember(resourceTypeName: String, resourceId: String, policyName: String, email: WorkbenchEmail)(implicit userInfo: WithAccessToken): Future[Unit]
   def setPolicyPublic(resourceTypeName: String, resourceId: String, policyName: String, public: Boolean)(implicit userInfo: WithAccessToken): Future[Unit]

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/SamDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/SamDAO.scala
@@ -63,7 +63,6 @@ trait SamDAO extends LazyLogging with ReportsSubsystemStatus {
   def removeGroupMember(groupName: WorkbenchGroupName, role: ManagedGroupRole, email: WorkbenchEmail)(implicit userInfo: WithAccessToken): Future[Unit]
   def overwriteGroupMembers(groupName: WorkbenchGroupName, role: ManagedGroupRole, memberList: List[WorkbenchEmail])(implicit userInfo: WithAccessToken): Future[Unit]
   def requestGroupAccess(groupName: WorkbenchGroupName)(implicit userInfo: WithAccessToken): Future[Unit]
-  def listResourcesByType(resourceTypeName: String)(implicit userInfo: WithAccessToken): Future[Seq[UserPolicy]]
 
   def addPolicyMember(resourceTypeName: String, resourceId: String, policyName: String, email: WorkbenchEmail)(implicit userInfo: WithAccessToken): Future[Unit]
   def setPolicyPublic(resourceTypeName: String, resourceId: String, policyName: String, public: Boolean)(implicit userInfo: WithAccessToken): Future[Unit]

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/SamDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/SamDAO.scala
@@ -45,13 +45,15 @@ trait SamDAO extends LazyLogging with ReportsSubsystemStatus {
   def samResourcePolicyAlterMember(resourceTypeName: String, resourceId: String, policyName: String, email: WorkbenchEmail): String = samResourcePolicy(resourceTypeName, resourceId, policyName) + s"/$email"
 
 
-  val samResourcesBase: String = FireCloudConfig.Sam.baseUrl + s"/api/resources"
+  val samResourcesBase: String = FireCloudConfig.Sam.baseUrl + s"/api/resources/v1"
   def samListResources(resourceTypeName: String): String = samResourcesBase + s"/$resourceTypeName"
 
   def registerUser(implicit userInfo: WithAccessToken): Future[RegistrationInfo]
   def getRegistrationStatus(implicit userInfo: WithAccessToken): Future[RegistrationInfo]
 
   def adminGetUserByEmail(email: RawlsUserEmail): Future[RegistrationInfo]
+
+  def listWorkspaceResources(implicit userInfo: WithAccessToken): Future[Seq[UserPolicy]]
 
   def createGroup(groupName: WorkbenchGroupName)(implicit userInfo: WithAccessToken): Future[Unit]
   def deleteGroup(groupName: WorkbenchGroupName)(implicit userInfo: WithAccessToken): Future[Unit]

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/SearchDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/SearchDAO.scala
@@ -4,7 +4,7 @@ import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.model.Metrics.LogitMetric
 import org.broadinstitute.dsde.firecloud.model._
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
-import org.broadinstitute.dsde.firecloud.model.SamResource.AccessPolicyName
+import org.broadinstitute.dsde.firecloud.model.SamResource.{AccessPolicyName, UserPolicy}
 import org.broadinstitute.dsde.rawls.model.ErrorReportSource
 
 import scala.concurrent.Future
@@ -26,8 +26,8 @@ trait SearchDAO extends LazyLogging with ReportsSubsystemStatus {
   def bulkIndex(docs: Seq[Document], refresh:Boolean = false): LibraryBulkIndexResponse
   def indexDocument(doc: Document): Unit
   def deleteDocument(id: String): Unit
-  def findDocuments(criteria: LibrarySearchParams, groups: Seq[String], workspaceIds: Map[String, String]): Future[LibrarySearchResponse]
-  def suggestionsFromAll(criteria: LibrarySearchParams, groups: Seq[String], workspaceIds: Map[String, String]): Future[LibrarySearchResponse]
+  def findDocuments(criteria: LibrarySearchParams, groups: Seq[String], workspacePolicyMap: Map[String, UserPolicy]): Future[LibrarySearchResponse]
+  def suggestionsFromAll(criteria: LibrarySearchParams, groups: Seq[String], workspacePolicyMap: Map[String, UserPolicy]): Future[LibrarySearchResponse]
   def suggestionsForFieldPopulate(field: String, text: String): Future[Seq[String]]
 
   def statistics: LogitMetric

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/SearchDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/SearchDAO.scala
@@ -26,7 +26,7 @@ trait SearchDAO extends LazyLogging with ReportsSubsystemStatus {
   def bulkIndex(docs: Seq[Document], refresh:Boolean = false): LibraryBulkIndexResponse
   def indexDocument(doc: Document): Unit
   def deleteDocument(id: String): Unit
-  def findDocuments(criteria: LibrarySearchParams, groups: Seq[String], workspaceAccessMap: Map[String, AccessPolicyName]): Future[LibrarySearchResponse]
+  def findDocuments(criteria: LibrarySearchParams, groups: Seq[String], workspaceIds: Seq[String]): Future[LibrarySearchResponse]
   def suggestionsFromAll(criteria: LibrarySearchParams, groups: Seq[String], workspaceIds: Seq[String]): Future[LibrarySearchResponse]
   def suggestionsForFieldPopulate(field: String, text: String): Future[Seq[String]]
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/SearchDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/SearchDAO.scala
@@ -4,6 +4,7 @@ import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.model.Metrics.LogitMetric
 import org.broadinstitute.dsde.firecloud.model._
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
+import org.broadinstitute.dsde.firecloud.model.SamResource.AccessPolicyName
 import org.broadinstitute.dsde.rawls.model.ErrorReportSource
 
 import scala.concurrent.Future
@@ -25,8 +26,8 @@ trait SearchDAO extends LazyLogging with ReportsSubsystemStatus {
   def bulkIndex(docs: Seq[Document], refresh:Boolean = false): LibraryBulkIndexResponse
   def indexDocument(doc: Document): Unit
   def deleteDocument(id: String): Unit
-  def findDocuments(criteria: LibrarySearchParams, groups: Seq[String]): Future[LibrarySearchResponse]
-  def suggestionsFromAll(criteria: LibrarySearchParams, groups: Seq[String]): Future[LibrarySearchResponse]
+  def findDocuments(criteria: LibrarySearchParams, groups: Seq[String], workspaceAccessMap: Map[String, AccessPolicyName]): Future[LibrarySearchResponse]
+  def suggestionsFromAll(criteria: LibrarySearchParams, groups: Seq[String], workspaceIds: Seq[String]): Future[LibrarySearchResponse]
   def suggestionsForFieldPopulate(field: String, text: String): Future[Seq[String]]
 
   def statistics: LogitMetric

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/SearchDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/SearchDAO.scala
@@ -26,8 +26,8 @@ trait SearchDAO extends LazyLogging with ReportsSubsystemStatus {
   def bulkIndex(docs: Seq[Document], refresh:Boolean = false): LibraryBulkIndexResponse
   def indexDocument(doc: Document): Unit
   def deleteDocument(id: String): Unit
-  def findDocuments(criteria: LibrarySearchParams, groups: Seq[String], workspaceIds: Seq[String]): Future[LibrarySearchResponse]
-  def suggestionsFromAll(criteria: LibrarySearchParams, groups: Seq[String], workspaceIds: Seq[String]): Future[LibrarySearchResponse]
+  def findDocuments(criteria: LibrarySearchParams, groups: Seq[String], workspaceIds: Map[String, String]): Future[LibrarySearchResponse]
+  def suggestionsFromAll(criteria: LibrarySearchParams, groups: Seq[String], workspaceIds: Map[String, String]): Future[LibrarySearchResponse]
   def suggestionsForFieldPopulate(field: String, text: String): Future[Seq[String]]
 
   def statistics: LogitMetric

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ElasticSearch.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ElasticSearch.scala
@@ -12,6 +12,7 @@ object ElasticSearch {
   final val fieldAll = "_all"
   final val fieldSuggest = "_suggest"
   final val fieldDiscoverableByGroups = "_discoverableByGroups"
+  final val fieldWorkspaceId = "workspaceId"
   final val fieldOntologyParents = "parents"
   final val fieldOntologyParentsOrder = "order"
   final val fieldOntologyParentsLabel = "label"

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
@@ -8,6 +8,7 @@ import spray.http.StatusCode
 import spray.http.StatusCodes.BadRequest
 import org.broadinstitute.dsde.firecloud.model.MethodRepository._
 import org.broadinstitute.dsde.firecloud.model.Ontology.{ESTermParent, TermParent, TermResource}
+import org.broadinstitute.dsde.firecloud.model.SamResource.{AccessPolicyName, ResourceId, UserPolicy}
 import org.broadinstitute.dsde.firecloud.model.ShareLog.{Share, ShareType}
 import org.broadinstitute.dsde.firecloud.model.Trial.ProjectRoles.ProjectRole
 import org.broadinstitute.dsde.firecloud.model.Trial._
@@ -241,6 +242,13 @@ object ModelJsonProtocol extends WorkspaceJsonSupport {
 
   implicit val impFireCloudManagedGroup = jsonFormat3(FireCloudManagedGroup)
   implicit val impFireCloudManagedGroupMembership = jsonFormat3(FireCloudManagedGroupMembership)
+
+  implicit val impResourceId = jsonFormat1(ResourceId)
+  implicit val impAccessPolicyName = jsonFormat1(AccessPolicyName)
+//  implicit val impWorkbenchGroupName = jsonFormat1(WorkbenchGroupName)
+  implicit val impUserPolicy = jsonFormat4(UserPolicy)
+
+
 
   implicit val AttributeDetailFormat: RootJsonFormat[AttributeDetail] = rootFormat(lazyFormat(jsonFormat5(AttributeDetail)))
   implicit val AttributeDefinitionFormat = jsonFormat1(AttributeDefinition)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
@@ -245,8 +245,7 @@ object ModelJsonProtocol extends WorkspaceJsonSupport {
 
   implicit val impResourceId = jsonFormat1(ResourceId)
   implicit val impAccessPolicyName = jsonFormat1(AccessPolicyName)
-//  implicit val impWorkbenchGroupName = jsonFormat1(WorkbenchGroupName)
-  implicit val impUserPolicy = jsonFormat4(UserPolicy)
+  implicit val impUserPolicy = jsonFormat5(UserPolicy)
 
 
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
@@ -17,6 +17,7 @@ import spray.routing.{MalformedRequestContentRejection, RejectionHandler}
 import spray.routing.directives.RouteDirectives.complete
 import org.broadinstitute.dsde.rawls.model.UserModelJsonSupport._
 import org.broadinstitute.dsde.rawls.model.WorkspaceACLJsonSupport.WorkspaceAccessLevelFormat
+import org.broadinstitute.dsde.workbench.model.ValueObjectFormat
 import org.broadinstitute.dsde.workbench.model.google.GoogleModelJsonSupport.InstantFormat
 import org.broadinstitute.dsde.workbench.model.WorkbenchIdentityJsonSupport._
 
@@ -243,8 +244,8 @@ object ModelJsonProtocol extends WorkspaceJsonSupport {
   implicit val impFireCloudManagedGroup = jsonFormat3(FireCloudManagedGroup)
   implicit val impFireCloudManagedGroupMembership = jsonFormat3(FireCloudManagedGroupMembership)
 
-  implicit val impResourceId = jsonFormat1(ResourceId)
-  implicit val impAccessPolicyName = jsonFormat1(AccessPolicyName)
+  implicit val impResourceId = ValueObjectFormat(ResourceId)
+  implicit val impAccessPolicyName = ValueObjectFormat(AccessPolicyName)
   implicit val impUserPolicy = jsonFormat5(UserPolicy)
 
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/SamResource.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/SamResource.scala
@@ -1,0 +1,10 @@
+package org.broadinstitute.dsde.firecloud.model
+
+import org.broadinstitute.dsde.workbench.model.WorkbenchGroupName
+
+object SamResource {
+
+  case class ResourceId(value: String)
+  case class AccessPolicyName(value: String)
+  case class UserPolicy(resourceId: ResourceId, accessPolicyName: AccessPolicyName, authDomains: Set[WorkbenchGroupName], missingAuthDomains: Set[WorkbenchGroupName])
+}

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/SamResource.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/SamResource.scala
@@ -6,5 +6,5 @@ object SamResource {
 
   case class ResourceId(value: String)
   case class AccessPolicyName(value: String)
-  case class UserPolicy(resourceId: ResourceId, accessPolicyName: AccessPolicyName, authDomains: Set[WorkbenchGroupName], missingAuthDomains: Set[WorkbenchGroupName])
+  case class UserPolicy(resourceId: ResourceId, public: Boolean, accessPolicyName: AccessPolicyName, missingAuthDomainGroups: Seq[WorkbenchGroupName], authDomainGroups: Seq[WorkbenchGroupName])
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/SamResource.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/SamResource.scala
@@ -1,10 +1,10 @@
 package org.broadinstitute.dsde.firecloud.model
 
-import org.broadinstitute.dsde.workbench.model.WorkbenchGroupName
+import org.broadinstitute.dsde.workbench.model.{ValueObject, WorkbenchGroupName}
 
 object SamResource {
 
-  case class ResourceId(value: String)
-  case class AccessPolicyName(value: String)
-  case class UserPolicy(resourceId: ResourceId, public: Boolean, accessPolicyName: AccessPolicyName, missingAuthDomainGroups: Seq[WorkbenchGroupName], authDomainGroups: Seq[WorkbenchGroupName])
+  case class ResourceId(value: String) extends ValueObject
+  case class AccessPolicyName(value: String) extends ValueObject
+  case class UserPolicy(resourceId: ResourceId, public: Boolean, accessPolicyName: AccessPolicyName, missingAuthDomainGroups: Set[WorkbenchGroupName], authDomainGroups: Set[WorkbenchGroupName])
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/LibraryService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/LibraryService.scala
@@ -225,48 +225,26 @@ class LibraryService (protected val argUserInfo: UserInfo,
     }
   }
 
-//  def searchFor(criteria: LibrarySearchParams, searchMethod:()=>LibrarySearchResponse): Future[PerRequestMessage] ={
-//    val workspaces: Future[Seq[WorkspaceListResponse]] = rawlsDAO.getWorkspaces
-//    workspaces flatMap { workspaceList =>
-//      val wsIds = workspaceList map { workspace =>
-//        workspace.workspace.workspaceId
-//      }
-//      getEffectiveDiscoverGroups(samDao) map { userGroups =>
-//        // we want docsFuture and ids to be parallelized - so declare them here, outside
-//        // of the for-yield.
-//        searchMethod(criteria, userGroups, wsIds)
-//      } map (RequestComplete(_))
-//    }
-//
-//  }
-
-
-  def findDocuments(criteria: LibrarySearchParams): Future[PerRequestMessage] = {
-//    searchFor(criteria, searchDAO.findDocuments)
+  def searchFor(criteria: LibrarySearchParams, searchMethod:(LibrarySearchParams, Seq[String], Map[String, String])=>Future[LibrarySearchResponse]): Future[PerRequestMessage] ={
     val workspaces: Future[Seq[WorkspaceListResponse]] = rawlsDAO.getWorkspaces
     workspaces flatMap { workspaceList =>
-      val wsIds = workspaceList map { workspace =>
-        workspace.workspace.workspaceId
-      }
+      val workspaceIdAccessMap = (workspaceList map { workspace =>
+        (workspace.workspace.workspaceId, workspace.accessLevel.toString)
+      }).toMap
       getEffectiveDiscoverGroups(samDao) map { userGroups =>
         // we want docsFuture and ids to be parallelized - so declare them here, outside
         // of the for-yield.
-        searchDAO.findDocuments(criteria, userGroups, wsIds)
+        searchMethod(criteria, userGroups, workspaceIdAccessMap)
       } map (RequestComplete(_))
     }
   }
 
+  def findDocuments(criteria: LibrarySearchParams): Future[PerRequestMessage] = {
+    searchFor(criteria, searchDAO.findDocuments)
+  }
 
   def suggest(criteria: LibrarySearchParams): Future[PerRequestMessage] = {
-    val workspaces: Future[Seq[WorkspaceListResponse]] = rawlsDAO.getWorkspaces
-    workspaces flatMap { workspaceList =>
-      val wsIds = workspaceList map { workspace =>
-        workspace.workspace.workspaceId
-      }
-      getEffectiveDiscoverGroups(samDao) map { userGroups =>
-        searchDAO.suggestionsFromAll(criteria, userGroups, wsIds)
-      } map (RequestComplete(_))
-    }
+    searchFor(criteria, searchDAO.suggestionsFromAll)
   }
 
   def populateSuggest(field: String, text: String): Future[PerRequestMessage] = {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/LibraryService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/LibraryService.scala
@@ -225,24 +225,46 @@ class LibraryService (protected val argUserInfo: UserInfo,
     }
   }
 
+//  def searchFor(criteria: LibrarySearchParams, searchMethod:()=>LibrarySearchResponse): Future[PerRequestMessage] ={
+//    val workspaces: Future[Seq[WorkspaceListResponse]] = rawlsDAO.getWorkspaces
+//    workspaces flatMap { workspaceList =>
+//      val wsIds = workspaceList map { workspace =>
+//        workspace.workspace.workspaceId
+//      }
+//      getEffectiveDiscoverGroups(samDao) map { userGroups =>
+//        // we want docsFuture and ids to be parallelized - so declare them here, outside
+//        // of the for-yield.
+//        searchMethod(criteria, userGroups, wsIds)
+//      } map (RequestComplete(_))
+//    }
+//
+//  }
+
+
   def findDocuments(criteria: LibrarySearchParams): Future[PerRequestMessage] = {
-    val policies = samDao.listResourcesByType("workspace")
-    policies flatMap { workspacePolicies =>
-      val accessMap = createAccessMap(workspacePolicies)
+//    searchFor(criteria, searchDAO.findDocuments)
+    val workspaces: Future[Seq[WorkspaceListResponse]] = rawlsDAO.getWorkspaces
+    workspaces flatMap { workspaceList =>
+      val wsIds = workspaceList map { workspace =>
+        workspace.workspace.workspaceId
+      }
       getEffectiveDiscoverGroups(samDao) map { userGroups =>
         // we want docsFuture and ids to be parallelized - so declare them here, outside
         // of the for-yield.
-        searchDAO.findDocuments(criteria, userGroups, accessMap)
+        searchDAO.findDocuments(criteria, userGroups, wsIds)
       } map (RequestComplete(_))
     }
   }
 
+
   def suggest(criteria: LibrarySearchParams): Future[PerRequestMessage] = {
-    val policies = samDao.listResourcesByType("workspace")
-    policies flatMap { workspacePolicies =>
-      val accessMap = createAccessMap(workspacePolicies)
+    val workspaces: Future[Seq[WorkspaceListResponse]] = rawlsDAO.getWorkspaces
+    workspaces flatMap { workspaceList =>
+      val wsIds = workspaceList map { workspace =>
+        workspace.workspace.workspaceId
+      }
       getEffectiveDiscoverGroups(samDao) map { userGroups =>
-        searchDAO.suggestionsFromAll(criteria, userGroups, accessMap.keys.toSeq)
+        searchDAO.suggestionsFromAll(criteria, userGroups, wsIds)
       } map (RequestComplete(_))
     }
   }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/LibraryServiceSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/LibraryServiceSupport.scala
@@ -171,8 +171,6 @@ trait LibraryServiceSupport extends DataUseRestrictionSupport with LazyLogging {
     samDAO.listGroups(userInfo) map {FireCloudConfig.ElasticSearch.discoverGroupNames intersect _}
   }
 
-  val accessible = Seq(AccessPolicyName("reader"), AccessPolicyName("writer"), AccessPolicyName("owner"))
-
   // this method will determine if the user is making a change to discoverableByGroups
   // if the attribute does not exist on the workspace, it is the same as the empty list
   def isDiscoverableDifferent(workspaceResponse: WorkspaceResponse, userAttrs: AttributeMap): Boolean = {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/LibraryServiceSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/LibraryServiceSupport.scala
@@ -173,14 +173,6 @@ trait LibraryServiceSupport extends DataUseRestrictionSupport with LazyLogging {
 
   val accessible = Seq(AccessPolicyName("reader"), AccessPolicyName("writer"), AccessPolicyName("owner"))
 
-  def createAccessMap(policies: Seq[UserPolicy]): Map[String,AccessPolicyName] = {
-    (policies groupBy (_.resourceId.value) map {
-      case (id, pollist) => (id, (pollist map (_.accessPolicyName) filter (accessible contains _)).sortBy(accessible.indexOf(_)).lastOption)
-    }).collect  {
-      case (k, Some(v)) => (k, v)
-    }
-  }
-  
   // this method will determine if the user is making a change to discoverableByGroups
   // if the attribute does not exist on the workspace, it is the same as the empty list
   def isDiscoverableDifferent(workspaceResponse: WorkspaceResponse, userAttrs: AttributeMap): Boolean = {

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockSamDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockSamDAO.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.firecloud.dataaccess
 
 import org.broadinstitute.dsde.firecloud.FireCloudException
 import org.broadinstitute.dsde.firecloud.model.ManagedGroupRoles.ManagedGroupRole
-import org.broadinstitute.dsde.firecloud.model.{AccessToken, FireCloudManagedGroupMembership, RegistrationInfo, UserInfo, WithAccessToken, WorkbenchEnabled, WorkbenchUserInfo}
+import org.broadinstitute.dsde.firecloud.model.{AccessToken, FireCloudManagedGroupMembership, RegistrationInfo, SamResource, UserInfo, WithAccessToken, WorkbenchEnabled, WorkbenchUserInfo}
 import org.broadinstitute.dsde.workbench.util.health.SubsystemStatus
 import org.broadinstitute.dsde.rawls.model.RawlsUserEmail
 import org.broadinstitute.dsde.workbench.model.{WorkbenchEmail, WorkbenchGroupName}
@@ -24,6 +24,8 @@ class MockSamDAO extends SamDAO {
   override def getRegistrationStatus(implicit userInfo: WithAccessToken): Future[RegistrationInfo] = enabledUserInfo
 
   override def adminGetUserByEmail(email: RawlsUserEmail): Future[RegistrationInfo] = customUserInfo(email.value)
+
+  override def listWorkspaceResources(implicit userInfo: WithAccessToken): Future[Seq[SamResource.UserPolicy]] = Future.successful(Seq.empty)
 
   override def status: Future[SubsystemStatus] = Future.successful(SubsystemStatus(ok = true, messages = None))
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockSearchDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockSearchDAO.scala
@@ -1,6 +1,7 @@
 package org.broadinstitute.dsde.firecloud.dataaccess
 
 import org.broadinstitute.dsde.firecloud.model.Metrics.{LogitMetric, NumSubjects}
+import org.broadinstitute.dsde.firecloud.model.SamResource.UserPolicy
 import org.broadinstitute.dsde.firecloud.model._
 import org.broadinstitute.dsde.workbench.util.health.SubsystemStatus
 import spray.json.JsValue
@@ -35,12 +36,12 @@ class MockSearchDAO extends SearchDAO {
     deleteDocumentInvoked = true
   }
 
-  override def findDocuments(librarySearchParams: LibrarySearchParams, groups: Seq[String]): Future[LibrarySearchResponse] = {
+  override def findDocuments(librarySearchParams: LibrarySearchParams, groups: Seq[String], workspacePolicyMap: Map[String, UserPolicy]): Future[LibrarySearchResponse] = {
     findDocumentsInvoked = true
     Future(LibrarySearchResponse(librarySearchParams, 0, Seq[JsValue](), Seq[LibraryAggregationResponse]()))
   }
 
-  override def suggestionsFromAll(librarySearchParams: LibrarySearchParams, groups: Seq[String]): Future[LibrarySearchResponse] = {
+  override def suggestionsFromAll(librarySearchParams: LibrarySearchParams, groups: Seq[String], workspacePolicyMap: Map[String, UserPolicy]): Future[LibrarySearchResponse] = {
     autocompleteInvoked = true
     Future(LibrarySearchResponse(librarySearchParams, 0, Seq[JsValue](), Seq[LibraryAggregationResponse]()))
   }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/AutoSuggestSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/AutoSuggestSpec.scala
@@ -105,7 +105,7 @@ class AutoSuggestSpec extends FreeSpec with Matchers with BeforeAndAfterAll with
   val dur = Duration(2, MINUTES)
   private def suggestionsFor(txt:String) = {
     val criteria = emptyCriteria.copy(searchString = Some(txt))
-    Await.result(searchDAO.suggestionsFromAll(criteria, Seq.empty[String]), dur)
+    Await.result(searchDAO.suggestionsFromAll(criteria, Seq.empty[String], Map.empty), dur)
   }
 
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/DataUseRestrictionSearchSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/DataUseRestrictionSearchSpec.scala
@@ -191,7 +191,7 @@ class DataUseRestrictionSearchSpec extends FreeSpec with SearchResultValidation 
     val criteria = emptyCriteria.copy(
       searchString = Some(text),
       size = datasets.size)
-    Await.result(searchDAO.findDocuments(criteria, Seq.empty[String]), dur)
+    Await.result(searchDAO.findDocuments(criteria, Seq.empty[String], Map.empty), dur)
   }
 
   private def getDataUseRestrictions(searchResponse: LibrarySearchResponse): Seq[DataUseRestriction] = {

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/FilterLimitsSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/FilterLimitsSpec.scala
@@ -1,0 +1,42 @@
+package org.broadinstitute.dsde.firecloud.integrationtest
+
+import com.typesafe.scalalogging.LazyLogging
+import org.broadinstitute.dsde.firecloud.integrationtest.ESIntegrationSupport.searchDAO
+import org.broadinstitute.dsde.firecloud.model.SamResource.{AccessPolicyName, ResourceId, UserPolicy}
+import org.broadinstitute.dsde.rawls.model.WorkspaceAccessLevels
+import org.scalatest.{BeforeAndAfterAll, FreeSpec, Matchers}
+
+import scala.concurrent.duration.{Duration, MINUTES}
+
+class FilterLimitsSpec extends FreeSpec with Matchers with SearchResultValidation with BeforeAndAfterAll with LazyLogging {
+
+  override def beforeAll = {
+    // use re-create here, since instantiating the DAO will create it in the first place
+    searchDAO.recreateIndex()
+    // make sure we specify refresh=true here; otherwise, the documents may not be available in the index by the
+    // time the tests start, leading to test failures.
+    logger.info("indexing fixtures ...")
+    searchDAO.bulkIndex(IntegrationTestFixtures.fixtureRestrictedDocs, refresh = true)
+    logger.info("... fixtures indexed.")
+  }
+
+  override def afterAll = {
+    searchDAO.deleteIndex()
+  }
+
+  "Library integration" - {
+    "search with 100000 filter criteria" - {
+      "returns 1 result without error " in {
+        val wsMatchesMap = Map("testing123" -> UserPolicy(ResourceId("testing123"), false, AccessPolicyName(WorkspaceAccessLevels.Read.toString), Seq.empty.toSet, Seq.empty.toSet))
+        val wsMap = 0.to(100000).map { num =>
+          (num.toString -> UserPolicy(ResourceId(num.toString), false, AccessPolicyName(WorkspaceAccessLevels.Read.toString), Seq.empty.toSet, Seq.empty.toSet))
+        }.toMap
+        val searchResponse = searchWithFilter(wsMap ++ wsMatchesMap)
+        assertResult(wsMatchesMap.size) {
+          searchResponse.total
+        }
+      }
+    }
+  }
+
+}

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/IntegrationTestFixtures.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/IntegrationTestFixtures.scala
@@ -1,7 +1,7 @@
 package org.broadinstitute.dsde.firecloud.integrationtest
 
 import org.broadinstitute.dsde.firecloud.model.Document
-import org.broadinstitute.dsde.rawls.model.{AttributeName, AttributeNumber, AttributeString}
+import org.broadinstitute.dsde.rawls.model.{AttributeName, AttributeNumber, AttributeString, AttributeValueList}
 
 /**
   * Created by davidan on 2/22/17.
@@ -46,6 +46,18 @@ object IntegrationTestFixtures {
         AttributeName("library","indication") -> AttributeString(phenotype),
         AttributeName("library","datasetOwner") -> AttributeString(phenotype),
         AttributeName("library","numSubjects") -> AttributeNumber(count)
+      ))
+  }
+
+  val fixtureRestrictedDocs:Seq[Document] = datasetTuples map {
+    case (name, phenotype, count) =>
+      Document(name, Map(
+        AttributeName("library","datasetName") -> AttributeString(name),
+        AttributeName("library","indication") -> AttributeString(phenotype),
+        AttributeName("library","datasetOwner") -> AttributeString(phenotype),
+        AttributeName("library","numSubjects") -> AttributeNumber(count),
+        AttributeName.withDefaultNS("workspaceId") -> AttributeString(name),
+        AttributeName.withDefaultNS("_discoverableByGroups") -> AttributeValueList(Seq(AttributeString("no_one")))
       ))
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/SearchResultValidation.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/SearchResultValidation.scala
@@ -19,7 +19,7 @@ trait SearchResultValidation {
 
   def searchFor(txt:String) = {
     val criteria = emptyCriteria.copy(searchString = Some(txt))
-    Await.result(searchDAO.findDocuments(criteria, Seq.empty[String]), dur)
+    Await.result(searchDAO.findDocuments(criteria, Seq.empty[String], Map.empty), dur)
   }
 
   def searchWithPurpose(researchPurpose: Option[ResearchPurpose], term:Option[String], filters:Option[Map[String, Seq[String]]]): LibrarySearchResponse = {
@@ -29,7 +29,7 @@ trait SearchResultValidation {
       filters = filters.getOrElse(Map.empty[String, Seq[String]])
     )
     // set size to 100 to make sure we return all results for testing comparisons
-    Await.result(searchDAO.findDocuments(criteria.copy(size=100), Seq.empty[String]), dur)
+    Await.result(searchDAO.findDocuments(criteria.copy(size=100), Seq.empty[String], Map.empty), dur)
   }
 
   def searchWithPurpose(researchPurpose: ResearchPurpose): LibrarySearchResponse =
@@ -46,7 +46,7 @@ trait SearchResultValidation {
       searchString = Some(term),
       researchPurpose = Some(researchPurpose))
     // set size to 100 to make sure we return all results for testing comparisons
-    Await.result(searchDAO.suggestionsFromAll(criteria.copy(size=100), Seq.empty[String]), dur)
+    Await.result(searchDAO.suggestionsFromAll(criteria.copy(size=100), Seq.empty[String], Map.empty), dur)
   }
 
   /**

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/SearchResultValidation.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/SearchResultValidation.scala
@@ -4,6 +4,7 @@ import org.broadinstitute.dsde.firecloud.dataaccess.{ElasticSearchDAO, MockResea
 import org.broadinstitute.dsde.firecloud.integrationtest.ESIntegrationSupport._
 import org.broadinstitute.dsde.firecloud.model.DataUse.ResearchPurpose
 import org.broadinstitute.dsde.firecloud.model.LibrarySearchResponse
+import org.broadinstitute.dsde.firecloud.model.SamResource.UserPolicy
 import org.elasticsearch.action.search.{SearchRequest, SearchRequestBuilder, SearchResponse}
 import org.elasticsearch.index.query.BoolQueryBuilder
 import org.scalatest.Assertions._
@@ -62,6 +63,10 @@ trait SearchResultValidation {
     val elasticSearchDAO = new ElasticSearchDAO(client, itTestIndexName, new MockResearchPurposeSupport)
     val searchRequest = elasticSearchDAO.createESSearchRequest(client, itTestIndexName, boolQuery, 0, 10)
     elasticSearchDAO.executeESRequest[SearchRequest, SearchResponse, SearchRequestBuilder](searchRequest)
+  }
+
+  def searchWithFilter(workspacePolicyMap: Map[String, UserPolicy]) = {
+    Await.result(searchDAO.findDocuments(emptyCriteria, Seq.empty[String], workspacePolicyMap), dur)
   }
 
   def validateResultNames(expectedNames:Set[String], response:LibrarySearchResponse) = {

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/SortSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/SortSpec.scala
@@ -123,7 +123,7 @@ class SortSpec extends FreeSpec with Matchers with BeforeAndAfterAll with LazyLo
   }
 
   private def searchFor(criteria: LibrarySearchParams) = {
-    Await.result(searchDAO.findDocuments(criteria, Seq.empty[String]), dur)
+    Await.result(searchDAO.findDocuments(criteria, Seq.empty[String], Map.empty), dur)
   }
 
   private def validateFirstResult(field: String, expectedValue: String, response: LibrarySearchResponse): Unit = {

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/model/SamResourceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/model/SamResourceSpec.scala
@@ -1,0 +1,58 @@
+package org.broadinstitute.dsde.firecloud.model
+
+import org.broadinstitute.dsde.firecloud.model.SamResource.{AccessPolicyName, ResourceId, UserPolicy}
+import org.scalatest.{FreeSpec, Matchers}
+import spray.json._
+import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
+import spray.json.DefaultJsonProtocol._
+
+import scala.util.parsing.json.JSONFormat
+
+class SamResourceSpec extends FreeSpec with Matchers {
+
+  val userPolicyJSON =     """
+    |  {
+    |    "resourceId": "8011932d-d76e-4c5d-9f66-1538d86a683b",
+    |    "public": true,
+    |    "accessPolicyName": "reader",
+    |    "missingAuthDomainGroups": [],
+    |    "authDomainGroups": []
+    |    }
+    """.stripMargin
+
+  val userPolicyListJSON =
+    """
+    |  [{
+    |    "resourceId": "8011932d-d76e-4c5d-9f66-1538d86a683b",
+    |    "public": true,
+    |    "accessPolicyName": "reader",
+    |    "missingAuthDomainGroups": [],
+    |    "authDomainGroups": []
+    |  },
+    |  {
+    |    "resourceId": "195feff3-d4b0-43df-9d0d-d49eda2036eb",
+    |    "public": false,
+    |    "accessPolicyName": "owner",
+    |    "missingAuthDomainGroups": [],
+    |    "authDomainGroups": []
+    |  },
+    |  {
+    |    "resourceId": "a2e2a933-76ed-4679-a3c1-fcec146441b5",
+    |    "public": false,
+    |    "accessPolicyName": "owner",
+    |    "missingAuthDomainGroups": [],
+    |    "authDomainGroups": []
+    |  }]
+  """.stripMargin
+
+  "UserPolicy JSON" - {
+
+    "should should convert to UserPolicy object" in {
+      val jsobj: JsValue = JsonParser(userPolicyJSON)
+      val userPolicy: UserPolicy = jsobj.convertTo[UserPolicy]
+      assert(userPolicy.public)
+      assertResult("reader"){ userPolicy.accessPolicyName.value }
+      }
+    }
+
+  }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/model/SamResourceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/model/SamResourceSpec.scala
@@ -47,7 +47,7 @@ class SamResourceSpec extends FreeSpec with Matchers {
 
   "UserPolicy JSON" - {
 
-    "should should convert to UserPolicy object" in {
+    "should convert to UserPolicy object" in {
       val jsobj: JsValue = JsonParser(userPolicyJSON)
       val userPolicy: UserPolicy = jsobj.convertTo[UserPolicy]
       assert(userPolicy.public)

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/LibraryServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/LibraryServiceSpec.scala
@@ -23,33 +23,7 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.util.Try
 
-class LibraryServiceSpec extends BaseServiceSpec with FreeSpecLike with LibraryServiceSupport with AttributeSupport with ElasticSearchDAOSupport {
-  def toName(s:String) = AttributeName.fromDelimitedName(s)
-
-  implicit val userToken: WithAccessToken = AccessToken("LibraryServiceSpec")
-
-  val libraryAttributePredicate = (k: AttributeName) => k.namespace == AttributeName.libraryNamespace && k.name != LibraryService.publishedFlag.name
-
-  val existingLibraryAttrs = Map("library:keyone"->"valone", "library:keytwo"->"valtwo", "library:keythree"->"valthree", "library:keyfour"->"valfour").toJson.convertTo[AttributeMap]
-  val existingMixedAttrs = Map("library:keyone"->"valone", "library:keytwo"->"valtwo", "keythree"->"valthree", "keyfour"->"valfour").toJson.convertTo[AttributeMap]
-  val existingPublishedAttrs = Map("library:published"->"true", "library:keytwo"->"valtwo", "keythree"->"valthree", "keyfour"->"valfour").toJson.convertTo[AttributeMap]
-
-  val testUUID = UUID.randomUUID()
-
-  val testGroup1Ref = ManagedGroupRef(RawlsGroupName("test-group1"))
-  val testGroup2Ref = ManagedGroupRef(RawlsGroupName("test-group2"))
-
-  val testWorkspace = new WorkspaceDetails(workspaceId=testUUID.toString,
-    namespace="testWorkspaceNamespace",
-    name="testWorkspaceName",
-    authorizationDomain=Set(testGroup1Ref, testGroup2Ref),
-    isLocked=false,
-    createdBy="createdBy",
-    createdDate=DateTime.now(),
-    lastModified=DateTime.now(),
-    attributes=Map.empty,
-    bucketName="bucketName")
-
+object LibraryServiceSpec {
   val testLibraryMetadata =
     """
       |{
@@ -81,6 +55,35 @@ class LibraryServiceSpec extends BaseServiceSpec with FreeSpecLike with LibraryS
     """.stripMargin
   val testLibraryMetadataJsObject = testLibraryMetadata.parseJson.asJsObject
 
+}
+class LibraryServiceSpec extends BaseServiceSpec with FreeSpecLike with LibraryServiceSupport with AttributeSupport with ElasticSearchDAOSupport {
+  def toName(s:String) = AttributeName.fromDelimitedName(s)
+
+  implicit val userToken: WithAccessToken = AccessToken("LibraryServiceSpec")
+
+  val libraryAttributePredicate = (k: AttributeName) => k.namespace == AttributeName.libraryNamespace && k.name != LibraryService.publishedFlag.name
+
+  val existingLibraryAttrs = Map("library:keyone"->"valone", "library:keytwo"->"valtwo", "library:keythree"->"valthree", "library:keyfour"->"valfour").toJson.convertTo[AttributeMap]
+  val existingMixedAttrs = Map("library:keyone"->"valone", "library:keytwo"->"valtwo", "keythree"->"valthree", "keyfour"->"valfour").toJson.convertTo[AttributeMap]
+  val existingPublishedAttrs = Map("library:published"->"true", "library:keytwo"->"valtwo", "keythree"->"valthree", "keyfour"->"valfour").toJson.convertTo[AttributeMap]
+
+  val testUUID = UUID.randomUUID()
+
+  val testGroup1Ref = ManagedGroupRef(RawlsGroupName("test-group1"))
+  val testGroup2Ref = ManagedGroupRef(RawlsGroupName("test-group2"))
+
+  val testWorkspace = new WorkspaceDetails(workspaceId = testUUID.toString,
+    namespace = "testWorkspaceNamespace",
+    name = "testWorkspaceName",
+    authorizationDomain = Set(testGroup1Ref, testGroup2Ref),
+    isLocked = false,
+    createdBy = "createdBy",
+    createdDate = DateTime.now(),
+    lastModified = DateTime.now(),
+    attributes = Map.empty,
+    bucketName = "bucketName")
+
+
   val DULAdditionalJsObject =
     """
       |{
@@ -96,8 +99,8 @@ class LibraryServiceSpec extends BaseServiceSpec with FreeSpecLike with LibraryS
       |  "library:IRB"  : false
       |}
     """.stripMargin.parseJson.asJsObject
-  val DULfields = (testLibraryMetadataJsObject.fields-"library:orsp") ++ DULAdditionalJsObject.fields
-  val testLibraryDULMetadata = testLibraryMetadataJsObject.copy(DULfields).compactPrint
+  val DULfields = (LibraryServiceSpec.testLibraryMetadataJsObject.fields-"library:orsp") ++ DULAdditionalJsObject.fields
+  val testLibraryDULMetadata = LibraryServiceSpec.testLibraryMetadataJsObject.copy(DULfields).compactPrint
 
   val dur = Duration(2, MINUTES)
 
@@ -569,7 +572,7 @@ class LibraryServiceSpec extends BaseServiceSpec with FreeSpecLike with LibraryS
       }
       "fails with one missing key" in {
         val testSchema = FileUtils.readAllTextFromResource("library/attribute-definitions.json")
-        val defaultData = testLibraryMetadata.parseJson.asJsObject
+        val defaultData = LibraryServiceSpec.testLibraryMetadata.parseJson.asJsObject
         val sampleData = defaultData.copy(defaultData.fields-"library:datasetName").compactPrint
         val ex = intercept[ValidationException] {
           validateJsonSchema(sampleData, testSchema)
@@ -579,7 +582,7 @@ class LibraryServiceSpec extends BaseServiceSpec with FreeSpecLike with LibraryS
       }
       "fails with two missing keys" in {
         val testSchema = FileUtils.readAllTextFromResource("library/attribute-definitions.json")
-        val defaultData = testLibraryMetadata.parseJson.asJsObject
+        val defaultData = LibraryServiceSpec.testLibraryMetadata.parseJson.asJsObject
         val sampleData = defaultData.copy(defaultData.fields-"library:datasetName"-"library:datasetOwner").compactPrint
         val ex = intercept[ValidationException] {
           validateJsonSchema(sampleData, testSchema)
@@ -588,7 +591,7 @@ class LibraryServiceSpec extends BaseServiceSpec with FreeSpecLike with LibraryS
       }
       "fails on a string that should be a number" in {
         val testSchema = FileUtils.readAllTextFromResource("library/attribute-definitions.json")
-        val defaultData = testLibraryMetadata.parseJson.asJsObject
+        val defaultData = LibraryServiceSpec.testLibraryMetadata.parseJson.asJsObject
         val sampleData = defaultData.copy(defaultData.fields.updated("library:numSubjects", JsString("isString"))).compactPrint
         val ex = intercept[ValidationException] {
           validateJsonSchema(sampleData, testSchema)
@@ -598,7 +601,7 @@ class LibraryServiceSpec extends BaseServiceSpec with FreeSpecLike with LibraryS
       }
       "fails on a number out of bounds" in {
         val testSchema = FileUtils.readAllTextFromResource("library/attribute-definitions.json")
-        val defaultData = testLibraryMetadata.parseJson.asJsObject
+        val defaultData = LibraryServiceSpec.testLibraryMetadata.parseJson.asJsObject
         val sampleData = defaultData.copy(defaultData.fields.updated("library:numSubjects", JsNumber(-1))).compactPrint
         val ex = intercept[ValidationException] {
           validateJsonSchema(sampleData, testSchema)
@@ -608,7 +611,7 @@ class LibraryServiceSpec extends BaseServiceSpec with FreeSpecLike with LibraryS
       }
       "fails on a value outside its enum" in {
         val testSchema = FileUtils.readAllTextFromResource("library/attribute-definitions.json")
-        val defaultData = testLibraryMetadata.parseJson.asJsObject
+        val defaultData = LibraryServiceSpec.testLibraryMetadata.parseJson.asJsObject
         val sampleData = defaultData.copy(defaultData.fields.updated("library:coverage", JsString("foobar"))).compactPrint
         val ex = intercept[ValidationException] {
           validateJsonSchema(sampleData, testSchema)
@@ -618,7 +621,7 @@ class LibraryServiceSpec extends BaseServiceSpec with FreeSpecLike with LibraryS
       }
       "fails on a string that should be an array" in {
         val testSchema = FileUtils.readAllTextFromResource("library/attribute-definitions.json")
-        val defaultData = testLibraryMetadata.parseJson.asJsObject
+        val defaultData = LibraryServiceSpec.testLibraryMetadata.parseJson.asJsObject
         val sampleData = defaultData.copy(defaultData.fields.updated("library:institute", JsString("isString"))).compactPrint
         val ex = intercept[ValidationException] {
           validateJsonSchema(sampleData, testSchema)
@@ -628,7 +631,7 @@ class LibraryServiceSpec extends BaseServiceSpec with FreeSpecLike with LibraryS
       }
       "fails with missing ORSP key" in {
         val testSchema = FileUtils.readAllTextFromResource("library/attribute-definitions.json")
-        val defaultData = testLibraryMetadata.parseJson.asJsObject
+        val defaultData = LibraryServiceSpec.testLibraryMetadata.parseJson.asJsObject
         val sampleData = defaultData.copy(defaultData.fields-"library:orsp").compactPrint
         val ex = intercept[ValidationException] {
           validateJsonSchema(sampleData, testSchema)
@@ -638,7 +641,7 @@ class LibraryServiceSpec extends BaseServiceSpec with FreeSpecLike with LibraryS
       }
       "validates on a complete metadata packet with ORSP key" in {
         val testSchema = FileUtils.readAllTextFromResource("library/attribute-definitions.json")
-        validateJsonSchema(testLibraryMetadata, testSchema)
+        validateJsonSchema(LibraryServiceSpec.testLibraryMetadata, testSchema)
       }
       "fails with one missing key from the DUL set" in {
         val testSchema = FileUtils.readAllTextFromResource("library/attribute-definitions.json")
@@ -665,7 +668,7 @@ class LibraryServiceSpec extends BaseServiceSpec with FreeSpecLike with LibraryS
 
       "has error messages for top-level missing keys" in {
         val testSchema = FileUtils.readAllTextFromResource("library/attribute-definitions.json")
-        val defaultData = testLibraryMetadata.parseJson.asJsObject
+        val defaultData = LibraryServiceSpec.testLibraryMetadata.parseJson.asJsObject
         val sampleData = defaultData.copy(defaultData.fields-"library:datasetName"-"library:datasetOwner").compactPrint
         val ex = intercept[ValidationException] {
           validateJsonSchema(sampleData, testSchema)
@@ -794,32 +797,6 @@ class LibraryServiceSpec extends BaseServiceSpec with FreeSpecLike with LibraryS
         assert(testJson.contains(ElasticSearch.fieldDiscoverableByGroups))
       }
     }
-//    "when finding documents" - {
-//      val params = LibrarySearchParams(Some("test"), Map(), None, Map())
-//      "don't add workspaceAccess to document if can't find workspace id for a document" in {
-//        val doc = LibrarySearchResponse(params, 1, Seq(testLibraryMetadataJsObject: JsValue), Seq())
-//        assertResult(doc) {
-//          updateAccess(doc, Seq())
-//        }
-//      }
-//      "set workspaceAccess to No Access if workspace is not returned from workspace list" in {
-//        val result = testLibraryMetadataJsObject.copy(testLibraryMetadataJsObject.fields.updated("workspaceId", JsString("no.access.to.workspace.id")))
-//        val expectedResult: JsValue = result.copy(result.fields.updated("workspaceAccess", JsString(WorkspaceAccessLevels.NoAccess.toString)))
-//        val doc = LibrarySearchResponse(params, 1, Seq(result: JsValue), Seq())
-//        assertResult(doc.copy(results=Seq(expectedResult))) {
-//          updateAccess(doc, Seq())
-//        }
-//      }
-//      "set workspaceAccess to workspace access level if workspace is returned from workspace list" in {
-//        val workspaceList = Seq(WorkspaceListResponse(WorkspaceAccessLevels.Owner, testWorkspace, WorkspaceSubmissionStats(None, None, 0), false))
-//        val result = testLibraryMetadataJsObject.copy(testLibraryMetadataJsObject.fields.updated("workspaceId", JsString(testUUID.toString)))
-//        val expectedResult: JsValue = result.copy(result.fields.updated("workspaceAccess", JsString(WorkspaceAccessLevels.Owner.toString)))
-//        val doc = LibrarySearchResponse(params, 1, Seq(result: JsValue), Seq())
-//        assertResult(doc.copy(results=Seq(expectedResult))) {
-//          updateAccess(doc, workspaceList)
-//        }
-//      }
-//    }
     "when finding unique string attributes in a Seq of Workspaces" - {
 
       def makeWorkspacesWithAttributes(attrMaps: Seq[AttributeMap]): Seq[WorkspaceDetails] = {

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/LibraryServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/LibraryServiceSpec.scala
@@ -794,32 +794,32 @@ class LibraryServiceSpec extends BaseServiceSpec with FreeSpecLike with LibraryS
         assert(testJson.contains(ElasticSearch.fieldDiscoverableByGroups))
       }
     }
-    "when finding documents" - {
-      val params = LibrarySearchParams(Some("test"), Map(), None, Map())
-      "don't add workspaceAccess to document if can't find workspace id for a document" in {
-        val doc = LibrarySearchResponse(params, 1, Seq(testLibraryMetadataJsObject: JsValue), Seq())
-        assertResult(doc) {
-          updateAccess(doc, Seq())
-        }
-      }
-      "set workspaceAccess to No Access if workspace is not returned from workspace list" in {
-        val result = testLibraryMetadataJsObject.copy(testLibraryMetadataJsObject.fields.updated("workspaceId", JsString("no.access.to.workspace.id")))
-        val expectedResult: JsValue = result.copy(result.fields.updated("workspaceAccess", JsString(WorkspaceAccessLevels.NoAccess.toString)))
-        val doc = LibrarySearchResponse(params, 1, Seq(result: JsValue), Seq())
-        assertResult(doc.copy(results=Seq(expectedResult))) {
-          updateAccess(doc, Seq())
-        }
-      }
-      "set workspaceAccess to workspace access level if workspace is returned from workspace list" in {
-        val workspaceList = Seq(WorkspaceListResponse(WorkspaceAccessLevels.Owner, testWorkspace, WorkspaceSubmissionStats(None, None, 0), false))
-        val result = testLibraryMetadataJsObject.copy(testLibraryMetadataJsObject.fields.updated("workspaceId", JsString(testUUID.toString)))
-        val expectedResult: JsValue = result.copy(result.fields.updated("workspaceAccess", JsString(WorkspaceAccessLevels.Owner.toString)))
-        val doc = LibrarySearchResponse(params, 1, Seq(result: JsValue), Seq())
-        assertResult(doc.copy(results=Seq(expectedResult))) {
-          updateAccess(doc, workspaceList)
-        }
-      }
-    }
+//    "when finding documents" - {
+//      val params = LibrarySearchParams(Some("test"), Map(), None, Map())
+//      "don't add workspaceAccess to document if can't find workspace id for a document" in {
+//        val doc = LibrarySearchResponse(params, 1, Seq(testLibraryMetadataJsObject: JsValue), Seq())
+//        assertResult(doc) {
+//          updateAccess(doc, Seq())
+//        }
+//      }
+//      "set workspaceAccess to No Access if workspace is not returned from workspace list" in {
+//        val result = testLibraryMetadataJsObject.copy(testLibraryMetadataJsObject.fields.updated("workspaceId", JsString("no.access.to.workspace.id")))
+//        val expectedResult: JsValue = result.copy(result.fields.updated("workspaceAccess", JsString(WorkspaceAccessLevels.NoAccess.toString)))
+//        val doc = LibrarySearchResponse(params, 1, Seq(result: JsValue), Seq())
+//        assertResult(doc.copy(results=Seq(expectedResult))) {
+//          updateAccess(doc, Seq())
+//        }
+//      }
+//      "set workspaceAccess to workspace access level if workspace is returned from workspace list" in {
+//        val workspaceList = Seq(WorkspaceListResponse(WorkspaceAccessLevels.Owner, testWorkspace, WorkspaceSubmissionStats(None, None, 0), false))
+//        val result = testLibraryMetadataJsObject.copy(testLibraryMetadataJsObject.fields.updated("workspaceId", JsString(testUUID.toString)))
+//        val expectedResult: JsValue = result.copy(result.fields.updated("workspaceAccess", JsString(WorkspaceAccessLevels.Owner.toString)))
+//        val doc = LibrarySearchResponse(params, 1, Seq(result: JsValue), Seq())
+//        assertResult(doc.copy(results=Seq(expectedResult))) {
+//          updateAccess(doc, workspaceList)
+//        }
+//      }
+//    }
     "when finding unique string attributes in a Seq of Workspaces" - {
 
       def makeWorkspacesWithAttributes(attrMaps: Seq[AttributeMap]): Seq[WorkspaceDetails] = {


### PR DESCRIPTION
This PR is for both gawb-3840 and gawb-3842

it calls sam to get the workspaces the user has access to and adds this as filter criteria for matching published data sets. it also changes the way we determine whether the user has access to the underlying workspace. 


Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
