### PR TITLE
Resiliency/debugging in free credit spreadsheet update [risk: low]

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchTrialDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchTrialDAO.scala
@@ -282,7 +282,7 @@ class ElasticSearchTrialDAO(client: TransportClient, indexName: String, refreshM
       .prepareSearch(indexName)
       .setQuery(Ready)
       .addSort("name.keyword", SortOrder.ASC)
-      .setSize(1000)
+      .setSize(5000) // we should loop and make paginated requests; this will have to suffice for now
 
     val reportProjectResponse = executeESRequest[SearchRequest, SearchResponse, SearchRequestBuilder](reportProjectRequest)
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/Profile.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/Profile.scala
@@ -88,7 +88,7 @@ object Profile {
     }).toMap
 
     requiredKeys foreach {req =>
-      assert(mappedKVPs.contains(req), s"Profile must contain a key-value entry for $req")
+      assert(mappedKVPs.contains(req), s"Profile for user ${wrapper.userId} must contain a key-value entry for $req")
     }
 
     new Profile(

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/Profile.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/Profile.scala
@@ -79,23 +79,30 @@ object Profile {
   // increment this number every time you make a change to the user-provided profile fields
   val currentVersion:Int = 3
 
-  def apply(wrapper: ProfileWrapper) = {
+  val requiredKeys = List("firstName", "lastName", "title", "institute", "institutionalProgram", "programLocationCity",
+                          "programLocationState", "programLocationCountry", "pi", "nonProfitStatus")
 
-    val mappedKVPs:Map[String,String] = (wrapper.keyValuePairs map {
-      fckv:FireCloudKeyValue => (fckv.key.get -> fckv.value.get) }).toMap
+  def apply(wrapper: ProfileWrapper): Profile = {
+    val mappedKVPs: Map[String, String] = (wrapper.keyValuePairs collect {
+      case fckv: FireCloudKeyValue if fckv.key.nonEmpty && fckv.value.nonEmpty => fckv.key.get -> fckv.value.get
+    }).toMap
+
+    requiredKeys foreach {req =>
+      assert(mappedKVPs.contains(req), s"Profile must contain a key-value entry for $req")
+    }
 
     new Profile(
-      firstName = mappedKVPs.get("firstName").get,
-      lastName = mappedKVPs.get("lastName").get,
-      title = mappedKVPs.get("title").get,
+      firstName = mappedKVPs("firstName"),
+      lastName = mappedKVPs("lastName"),
+      title = mappedKVPs("title"),
       contactEmail = mappedKVPs.get("contactEmail"),
-      institute = mappedKVPs.get("institute").get,
-      institutionalProgram = mappedKVPs.get("institutionalProgram").get,
-      programLocationCity = mappedKVPs.get("programLocationCity").get,
-      programLocationState = mappedKVPs.get("programLocationState").get,
-      programLocationCountry = mappedKVPs.get("programLocationCountry").get,
-      pi = mappedKVPs.get("pi").get,
-      nonProfitStatus = mappedKVPs.get("nonProfitStatus").get,
+      institute = mappedKVPs("institute"),
+      institutionalProgram = mappedKVPs("institutionalProgram"),
+      programLocationCity = mappedKVPs("programLocationCity"),
+      programLocationState = mappedKVPs("programLocationState"),
+      programLocationCountry = mappedKVPs("programLocationCountry"),
+      pi = mappedKVPs("pi"),
+      nonProfitStatus = mappedKVPs("nonProfitStatus"),
       linkedNihUsername = mappedKVPs.get("linkedNihUsername"),
       linkExpireTime = mappedKVPs.get("linkExpireTime") match {
         case Some(time) => Some(time.toLong)
@@ -103,6 +110,7 @@ object Profile {
       }
     )
   }
+
 }
 
 case class NihLink(linkedNihUsername: String, linkExpireTime: Long) extends mappedPropVals {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/TrialService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/TrialService.scala
@@ -506,7 +506,7 @@ final class TrialService
         case Failure(e) =>
           e match {
             case g: GoogleJsonResponseException =>
-              logger.error(s"Unable to update spreadsheet [$spreadsheetId]: ${g.getDetails.getMessage}")
+              logger.error(s"Unable to update spreadsheet [$spreadsheetId]: ${g.getDetails.getMessage}", e)
               val code = StatusCodes.getForKey(g.getDetails.getCode).getOrElse(StatusCodes.InternalServerError)
               throw new FireCloudExceptionWithErrorReport(ErrorReport(code, e.getMessage))
             case _ => throw e
@@ -514,7 +514,7 @@ final class TrialService
       }
     }.recoverWith {
       case e: Throwable =>
-        logger.error(s"Unable to update google spreadsheet [$spreadsheetId]: ${e.getMessage}")
+        logger.error(s"Unable to update google spreadsheet [$spreadsheetId]: ${e.getMessage}", e)
         throw new FireCloudExceptionWithErrorReport(ErrorReport(StatusCodes.InternalServerError, e.getMessage))
     }
   }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/TrialServiceSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/TrialServiceSupport.scala
@@ -45,7 +45,7 @@ trait TrialServiceSupport extends LazyLogging {
   }
 
   def errorValues(subjectIdInError: String) = {
-    List(subjectIdInError) ++ List.fill(headers.size() - 2)("ERROR")
+    List(subjectIdInError) ++ List.fill(headers.size() - 2)("ERROR IN FIRECLOUD")
   }
 
   def makeSpreadsheetValues(managerInfo: WithAccessToken, trialDAO: TrialDAO, thurloeDAO: ThurloeDAO, majorDimension: String, range: String)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/TrialServiceSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/TrialServiceSupport.scala
@@ -35,7 +35,6 @@ trait TrialServiceSupport extends LazyLogging {
   // the default set of values to use if a project has no users; one fewer than # of columns
   private val defaultValues = List.fill(headers.size() - 1)("")
 
-
   def makeSpreadsheetResponse(spreadsheetId: String): SpreadsheetResponse = {
     SpreadsheetResponse(s"https://docs.google.com/spreadsheets/d/$spreadsheetId")
   }
@@ -45,12 +44,19 @@ trait TrialServiceSupport extends LazyLogging {
     new SpreadsheetProperties().setTitle(s"$title: $dateString")
   }
 
+  def errorValues(subjectIdInError: String) = {
+    List(subjectIdInError) ++ List.fill(headers.size() - 2)("ERROR")
+  }
+
   def makeSpreadsheetValues(managerInfo: WithAccessToken, trialDAO: TrialDAO, thurloeDAO: ThurloeDAO, majorDimension: String, range: String)
     (implicit executionContext: ExecutionContext): Future[ValueRange] = {
 
     // get the list of projects from ES
     val projects: Seq[TrialProject] = trialDAO.projectReport
+    logger.info(s"makeSpreadsheetValues processing ${projects.length} projects ...")
+
     // find the Thurloe KVPs for any users referenced in those projects
+    // TODO: this should switch to using Thurloe's bulk endpoint, so we're not making a large burst of requests.
     val profileWrappers:Future[Seq[ProfileWrapper]] = Future.sequence(projects.filter(p => p.user.isDefined).map { p =>
       thurloeDAO.getAllKVPs(p.user.get.userSubjectId, managerInfo) map { kvpOption =>
         kvpOption.getOrElse(ProfileWrapper(p.user.get.userSubjectId, List.empty[FireCloudKeyValue]))
@@ -59,13 +65,19 @@ trait TrialServiceSupport extends LazyLogging {
 
     // resolve the Thurloe KVPs future
     profileWrappers.map { wrappers =>
+      logger.info(s"makeSpreadsheetValues processing ${wrappers.length} profiles ...")
       // cache a map of subjectId -> ProfileWrapper for efficient lookups later
       val userKVPMap: Map[String, ProfileWrapper] = wrappers.map(pw => pw.userId -> pw).toMap
 
       // loop over all projects (including those that have no defined user) and build spreadsheet rows
       val rows: List[util.List[AnyRef]] = projects.map { trialProject =>
         val rowStrings = trialProject.user match {
-          case Some(user) => getTrialUserInformation(user, userKVPMap).toSpreadsheetValues
+          case Some(user) => Try(getTrialUserInformation(user, userKVPMap).toSpreadsheetValues) match {
+            case Success(s) => s
+            case Failure(x) =>
+              logger.error(s"Failure during getTrialUserInformation for user ${user.userSubjectId} ${user.userEmail} in project ${trialProject.name.value}: ${x.getMessage}", x)
+              errorValues(user.userSubjectId)
+          }
           case None => defaultValues
         }
 


### PR DESCRIPTION
As of Friday 18th, FireCloud started getting errors during its scheduled/automatic updates to the free credits tracking spreadsheet. A Sentry issue exists for this error: 556815659.

Unfortunately the pre-existing error logging in this area is insufficient to fully diagnose this problem. My hypothesis is that some user is missing one or more Thurloe keys that we normally require. From code inspection, I think we are vulnerable to this condition.

This PR:
* adds more logs and adds more error details to existing logs
* adds a `Try` around a potential trouble spot, with additional logging in case of error, and the ability to continue processing instead of fully breaking on error
* increases a hardcoded limit that I know we have already overflowed

This may not be the final fix, but I'd like to get this additional logging into place as soon as possible so we CAN get to the final fix.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
