### PR TITLE
use Sam getUserIds api inside free credits code [risk: low]

### DIFF
--- a/script/build.sh
+++ b/script/build.sh
@@ -136,7 +136,7 @@ function cleanup()
 {
     echo "cleaning up..."
     if [[ -n $SERVICE_ACCT_KEY_FILE ]]; then
-      gcloud auth revoke
+      gcloud auth revoke && echo 'Token revoke succeeded' || echo 'Token revoke failed -- skipping'
       rm -rf ${CLOUDSDK_CONFIG}
     fi
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpSamDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpSamDAO.scala
@@ -38,10 +38,6 @@ class HttpSamDAO( implicit val system: ActorSystem, implicit val executionContex
     authedRequestToObject[RegistrationInfo](Get(samUserRegistrationUrl), label=Some("HttpSamDAO.getRegistrationStatus"))
   }
 
-  override def adminGetUserByEmail(email: RawlsUserEmail): Future[RegistrationInfo] = {
-    adminAuthedRequestToObject[RegistrationInfo](Get(samAdminUserByEmail.format(email.value)))
-  }
-
   override def getUserIds(email: RawlsUserEmail)(implicit userInfo: WithAccessToken): Future[UserIdInfo] = {
     authedRequestToObject[UserIdInfo](Get(samGetUserIdsUrl.format(email.value)))
   }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpSamDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpSamDAO.scala
@@ -4,7 +4,7 @@ import akka.actor.ActorSystem
 import org.broadinstitute.dsde.firecloud.FireCloudExceptionWithErrorReport
 import org.broadinstitute.dsde.firecloud.model.ErrorReportExtensions.FCErrorReport
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
-import org.broadinstitute.dsde.firecloud.model.{AccessToken, FireCloudManagedGroupMembership, ManagedGroupRoles, RegistrationInfo, UserInfo, WithAccessToken}
+import org.broadinstitute.dsde.firecloud.model.{AccessToken, FireCloudManagedGroupMembership, ManagedGroupRoles, RegistrationInfo, UserIdInfo, UserInfo, WithAccessToken}
 import org.broadinstitute.dsde.workbench.util.health.SubsystemStatus
 import org.broadinstitute.dsde.firecloud.model.ManagedGroupRoles.ManagedGroupRole
 import org.broadinstitute.dsde.firecloud.model.SamResource.UserPolicy
@@ -40,6 +40,10 @@ class HttpSamDAO( implicit val system: ActorSystem, implicit val executionContex
 
   override def adminGetUserByEmail(email: RawlsUserEmail): Future[RegistrationInfo] = {
     adminAuthedRequestToObject[RegistrationInfo](Get(samAdminUserByEmail.format(email.value)))
+  }
+
+  override def getUserIds(email: RawlsUserEmail)(implicit userInfo: WithAccessToken): Future[UserIdInfo] = {
+    authedRequestToObject[UserIdInfo](Get(samGetUserIdsUrl.format(email.value)))
   }
 
   override def isGroupMember(groupName: WorkbenchGroupName, userInfo: UserInfo): Future[Boolean] = {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/SamDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/SamDAO.scala
@@ -27,7 +27,6 @@ trait SamDAO extends LazyLogging with ReportsSubsystemStatus {
 
   val samUserRegistrationUrl = FireCloudConfig.Sam.baseUrl + "/register/user"
   val samStatusUrl = FireCloudConfig.Sam.baseUrl + "/status"
-  val samAdminUserByEmail = FireCloudConfig.Sam.baseUrl + "/api/admin/user/email/%s"
   val samGetUserIdsUrl = FireCloudConfig.Sam.baseUrl + "/api/users/v1/%s"
   val samArbitraryPetTokenUrl = FireCloudConfig.Sam.baseUrl + "/api/google/v1/user/petServiceAccount/token"
 
@@ -52,7 +51,6 @@ trait SamDAO extends LazyLogging with ReportsSubsystemStatus {
   def registerUser(implicit userInfo: WithAccessToken): Future[RegistrationInfo]
   def getRegistrationStatus(implicit userInfo: WithAccessToken): Future[RegistrationInfo]
 
-  def adminGetUserByEmail(email: RawlsUserEmail): Future[RegistrationInfo]
   def getUserIds(email: RawlsUserEmail)(implicit userInfo: WithAccessToken): Future[UserIdInfo]
 
   def listWorkspaceResources(implicit userInfo: WithAccessToken): Future[Seq[UserPolicy]]

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/SamDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/SamDAO.scala
@@ -4,7 +4,7 @@ import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.FireCloudConfig
 import org.broadinstitute.dsde.firecloud.model.ManagedGroupRoles.ManagedGroupRole
 import org.broadinstitute.dsde.firecloud.model.SamResource.UserPolicy
-import org.broadinstitute.dsde.firecloud.model.{AccessToken, FireCloudManagedGroupMembership, RegistrationInfo, UserInfo, WithAccessToken}
+import org.broadinstitute.dsde.firecloud.model.{AccessToken, FireCloudManagedGroupMembership, RegistrationInfo, UserIdInfo, UserInfo, WithAccessToken}
 import org.broadinstitute.dsde.rawls.model.{ErrorReportSource, RawlsUserEmail}
 import org.broadinstitute.dsde.workbench.model.{WorkbenchEmail, WorkbenchGroupName}
 
@@ -28,6 +28,7 @@ trait SamDAO extends LazyLogging with ReportsSubsystemStatus {
   val samUserRegistrationUrl = FireCloudConfig.Sam.baseUrl + "/register/user"
   val samStatusUrl = FireCloudConfig.Sam.baseUrl + "/status"
   val samAdminUserByEmail = FireCloudConfig.Sam.baseUrl + "/api/admin/user/email/%s"
+  val samGetUserIdsUrl = FireCloudConfig.Sam.baseUrl + "/api/users/v1/%s"
   val samArbitraryPetTokenUrl = FireCloudConfig.Sam.baseUrl + "/api/google/v1/user/petServiceAccount/token"
 
   val samManagedGroupsBase: String = FireCloudConfig.Sam.baseUrl + "/api/groups"
@@ -52,6 +53,7 @@ trait SamDAO extends LazyLogging with ReportsSubsystemStatus {
   def getRegistrationStatus(implicit userInfo: WithAccessToken): Future[RegistrationInfo]
 
   def adminGetUserByEmail(email: RawlsUserEmail): Future[RegistrationInfo]
+  def getUserIds(email: RawlsUserEmail)(implicit userInfo: WithAccessToken): Future[UserIdInfo]
 
   def listWorkspaceResources(implicit userInfo: WithAccessToken): Future[Seq[UserPolicy]]
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
@@ -225,6 +225,7 @@ object ModelJsonProtocol extends WorkspaceJsonSupport {
   implicit val impWorkbenchEnabledV2 = jsonFormat3(WorkbenchEnabledV2)
   implicit val impRegistrationInfo = jsonFormat3(RegistrationInfo)
   implicit val impRegistrationInfoV2 = jsonFormat3(RegistrationInfoV2)
+  implicit val impUserIdInfo = jsonFormat3(UserIdInfo)
   implicit val impCurator = jsonFormat1(Curator)
   implicit val impUserImportPermission = jsonFormat2(UserImportPermission)
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/UserInfo.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/UserInfo.scala
@@ -39,6 +39,8 @@ case class OAuthUser(sub: String, email: String)
 case class RegistrationInfo(userInfo: WorkbenchUserInfo, enabled: WorkbenchEnabled, messages:Option[List[String]] = None)
 case class RegistrationInfoV2(userSubjectId: String, userEmail: String, enabled: Boolean)
 
+case class UserIdInfo(userSubjectId: String, userEmail: String, googleSubjectId: String)
+
 case class WorkbenchUserInfo(userSubjectId: String, userEmail: String)
 case class WorkbenchEnabled(google: Boolean, ldap: Boolean, allUsersGroup: Boolean)
 case class WorkbenchEnabledV2(enabled: Boolean, inAllUsersGroup: Boolean, inGoogleProxyGroup: Boolean)

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockSamDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockSamDAO.scala
@@ -23,8 +23,6 @@ class MockSamDAO extends SamDAO {
 
   override def getRegistrationStatus(implicit userInfo: WithAccessToken): Future[RegistrationInfo] = enabledUserInfo
 
-  override def adminGetUserByEmail(email: RawlsUserEmail): Future[RegistrationInfo] = customUserInfo(email.value)
-
   override def getUserIds(email: RawlsUserEmail)(implicit userInfo: WithAccessToken): Future[UserIdInfo] = customUserId(email.value)
 
   override def listWorkspaceResources(implicit userInfo: WithAccessToken): Future[Seq[SamResource.UserPolicy]] = Future.successful(Seq.empty)

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockSamDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockSamDAO.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.firecloud.dataaccess
 
 import org.broadinstitute.dsde.firecloud.FireCloudException
 import org.broadinstitute.dsde.firecloud.model.ManagedGroupRoles.ManagedGroupRole
-import org.broadinstitute.dsde.firecloud.model.{AccessToken, FireCloudManagedGroupMembership, RegistrationInfo, SamResource, UserInfo, WithAccessToken, WorkbenchEnabled, WorkbenchUserInfo}
+import org.broadinstitute.dsde.firecloud.model.{AccessToken, FireCloudManagedGroupMembership, RegistrationInfo, SamResource, UserIdInfo, UserInfo, WithAccessToken, WorkbenchEnabled, WorkbenchUserInfo}
 import org.broadinstitute.dsde.workbench.util.health.SubsystemStatus
 import org.broadinstitute.dsde.rawls.model.RawlsUserEmail
 import org.broadinstitute.dsde.workbench.model.{WorkbenchEmail, WorkbenchGroupName}
@@ -24,6 +24,8 @@ class MockSamDAO extends SamDAO {
   override def getRegistrationStatus(implicit userInfo: WithAccessToken): Future[RegistrationInfo] = enabledUserInfo
 
   override def adminGetUserByEmail(email: RawlsUserEmail): Future[RegistrationInfo] = customUserInfo(email.value)
+
+  override def getUserIds(email: RawlsUserEmail)(implicit userInfo: WithAccessToken): Future[UserIdInfo] = customUserId(email.value)
 
   override def listWorkspaceResources(implicit userInfo: WithAccessToken): Future[Seq[SamResource.UserPolicy]] = Future.successful(Seq.empty)
 
@@ -86,6 +88,10 @@ class MockSamDAO extends SamDAO {
     RegistrationInfo(
       WorkbenchUserInfo(email, email),
       WorkbenchEnabled(google = true, ldap = true, allUsersGroup = true))
+  }
+
+  private def customUserId(email: String) = Future.successful {
+    UserIdInfo(email, email, email)
   }
 
   override def isGroupMember(groupName: WorkbenchGroupName, userInfo: UserInfo): Future[Boolean] = {

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/TrialApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/TrialApiServiceSpec.scala
@@ -585,6 +585,16 @@ final class TrialApiServiceSpec extends BaseServiceSpec with UserApiService with
       }
     }
 
+    override def getUserIds(email: RawlsUserEmail)(implicit userInfo: WithAccessToken): Future[UserIdInfo] = {
+      email.value match {
+        case x if registrationInfoByEmail.keySet.contains(x) =>
+          val regInfo = registrationInfoByEmail(email.value).userInfo
+          val userIdInfo = UserIdInfo(regInfo.userSubjectId, regInfo.userEmail, regInfo.userSubjectId)
+          Future.successful(userIdInfo)
+        case _ => throw new FireCloudExceptionWithErrorReport(ErrorReport(NotFound, ""))
+      }
+    }
+
     private val groupMap = Map(
       "apples" -> Seq("alice"),
       "bananas" -> Seq("bob"),


### PR DESCRIPTION
The free credits termination flow is ignorant of -  and fails for - users who have different subjectids in Sam and Google, due to those users arriving via invite. This PR addresses that case.

See DataBiosphere/firecloud-app#284.

Because this error was found by Onix during the termination process, I have confidence that invited users can progress correctly through enablement and enrollment  for free credits.  It's only once they hit termination that we are seeing a problem. The termination process relied on Sam's admin API to look up user's subjectid based on their email. This returned the Sam-generated  "invite id", while what we actually needed is the user's "google id" in order to query  their state in thurloe.

-----

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
