### PR TITLE
apis to set terra ui vs legacy view preference [risk: low]

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -6483,9 +6483,12 @@ definitions:
   TerraPreference:
     description: Current user's choice of UI views.
     properties:
-      PreferTerra:
+      preferTerra:
         type: boolean
         description: When true, prefer Terra UI; when false, prefer Legacy FireCloud UI.
+      preferTerraLastUpdated:
+        type: number
+        description: Epoch timestamp representing when the Terra Preference was last saved.
 
   ToolClass:
     description: Describes a class (type) of tool allowing us to categorize workflows, tools, and maybe even other entities (such as services) separately

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -2100,6 +2100,44 @@ paths:
         500:
           description: Internal Server Error
 
+  /api/profile/terra:
+    get:
+      tags:
+        - Profile
+      operationId: setTerraPreference
+      summary: Returns the current user's preference for Terra UI vs. Legacy view
+      responses:
+        200:
+          description: Success
+          schema:
+            $ref: '#/definitions/TerraPreference'
+        500:
+          description: Internal Server Error
+    post:
+      tags:
+        - Profile
+      operationId: setTerraPreference
+      summary: Sets the current user's preference to use Terra UI, not Legacy view
+      responses:
+        200:
+          description: Success
+          schema:
+            $ref: '#/definitions/TerraPreference'
+        500:
+          description: Internal Server Error
+    delete:
+      tags:
+        - Profile
+      operationId: setTerraPreference
+      summary: Sets the current user's preference to use Legacy view, not Terra UI
+      responses:
+        200:
+          description: Success
+          schema:
+            $ref: '#/definitions/TerraPreference'
+        500:
+          description: Internal Server Error
+
   /api/profile/trial:
     post:
       tags:
@@ -6441,6 +6479,13 @@ definitions:
       inputName:
         type: string
         description: name of input
+
+  TerraPreference:
+    description: Current user's choice of UI views.
+    properties:
+      PreferTerra:
+        type: boolean
+        description: When true, prefer Terra UI; when false, prefer Legacy FireCloud UI.
 
   ToolClass:
     description: Describes a class (type) of tool allowing us to categorize workflows, tools, and maybe even other entities (such as services) separately

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudServiceActor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudServiceActor.scala
@@ -104,7 +104,7 @@ class FireCloudServiceActor extends HttpServiceActor with FireCloudDirectives
   val statusServiceConstructor: () => StatusService = StatusService.constructor(healthMonitor)
   val permissionReportServiceConstructor: (UserInfo) => PermissionReportService = PermissionReportService.constructor(app)
   val trialServiceConstructor: () => TrialService = TrialService.constructor(app, trialProjectManager)
-  val userServiceConstructor: (WithAccessToken) => UserService = UserService.constructor(app)
+  val userServiceConstructor: (UserInfo) => UserService = UserService.constructor(app)
   val shareLogServiceConstructor: () => ShareLogService = ShareLogService.constructor(app)
   val managedGroupServiceConstructor: (WithAccessToken) => ManagedGroupService = ManagedGroupService.constructor(app)
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
@@ -211,6 +211,7 @@ object ModelJsonProtocol extends WorkspaceJsonSupport {
   implicit val impBasicProfile = jsonFormat11(BasicProfile)
   implicit val impProfile = jsonFormat13(Profile.apply)
   implicit val impProfileWrapper = jsonFormat2(ProfileWrapper)
+  implicit val impTerraPreference = jsonFormat2(TerraPreference)
 
   implicit val impTokenResponse = jsonFormat6(OAuthTokens.apply)
   implicit val impRawlsToken = jsonFormat1(RawlsToken)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/Profile.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/Profile.scala
@@ -142,3 +142,5 @@ trait mappedPropVals {
     } toMap
   }
 }
+
+case class TerraPreference(preferTerra: Boolean, preferTerraLastUpdated: Long)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/UserService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/UserService.scala
@@ -4,39 +4,49 @@ import akka.actor.{Actor, Props}
 import akka.pattern._
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.Application
-import org.broadinstitute.dsde.firecloud.dataaccess.RawlsDAO
+import org.broadinstitute.dsde.firecloud.dataaccess.{RawlsDAO, ThurloeDAO}
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol.impUserImportPermission
 import org.broadinstitute.dsde.firecloud.model.Trial.CreationStatuses
-import org.broadinstitute.dsde.firecloud.model.{UserImportPermission, WithAccessToken}
+import org.broadinstitute.dsde.firecloud.model.{FireCloudKeyValue, RequestCompleteWithErrorReport, UserImportPermission, UserInfo}
 import org.broadinstitute.dsde.firecloud.service.PerRequest.{PerRequestMessage, RequestComplete}
-import org.broadinstitute.dsde.firecloud.service.UserService.ImportPermission
+import org.broadinstitute.dsde.firecloud.service.UserService.{DeleteTerraPreference, GetTerraPreference, ImportPermission, SetTerraPreference}
 import org.broadinstitute.dsde.rawls.model.WorkspaceAccessLevels
 import spray.http.StatusCodes
 import spray.httpx.SprayJsonSupport
+import spray.json.DefaultJsonProtocol
 
 import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success, Try}
 
 object UserService {
   sealed trait UserServiceMessage
 
-  case object ImportPermission extends UserServiceMessage
+  val TerraPreferenceKey = "PreferTerra"
 
-  def props(userService: (WithAccessToken) => UserService, userInfo: WithAccessToken): Props = {
+  case object ImportPermission extends UserServiceMessage
+  case object GetTerraPreference extends UserServiceMessage
+  case object SetTerraPreference extends UserServiceMessage
+  case object DeleteTerraPreference extends UserServiceMessage
+
+  def props(userService: (UserInfo) => UserService, userInfo: UserInfo): Props = {
     Props(userService(userInfo))
   }
 
-  def constructor(app: Application)(userInfo: WithAccessToken)(implicit executionContext: ExecutionContext) =
-    new UserService(app.rawlsDAO, userInfo)
+  def constructor(app: Application)(userInfo: UserInfo)(implicit executionContext: ExecutionContext) =
+    new UserService(app.rawlsDAO, app.thurloeDAO, userInfo)
 }
 
-class UserService(rawlsDAO: RawlsDAO, userToken: WithAccessToken)(implicit protected val executionContext: ExecutionContext)
-  extends Actor with LazyLogging with SprayJsonSupport {
+class UserService(rawlsDAO: RawlsDAO, thurloeDAO: ThurloeDAO, userToken: UserInfo)(implicit protected val executionContext: ExecutionContext)
+  extends Actor with LazyLogging with SprayJsonSupport with DefaultJsonProtocol {
 
   override def receive = {
     case ImportPermission => importPermission(userToken) pipeTo sender
+    case GetTerraPreference => getTerraPreference(userToken) pipeTo sender
+    case SetTerraPreference => setTerraPreference(userToken) pipeTo sender
+    case DeleteTerraPreference => deleteTerraPreference(userToken) pipeTo sender
   }
 
-  def importPermission(implicit userToken: WithAccessToken): Future[PerRequestMessage] = {
+  def importPermission(implicit userToken: UserInfo): Future[PerRequestMessage] = {
     // start two requests, in parallel, to fire off workspace list and billing project list
     val billingProjects = rawlsDAO.getProjects
     val workspaces = rawlsDAO.getWorkspaces
@@ -54,4 +64,34 @@ class UserService(rawlsDAO: RawlsDAO, userToken: WithAccessToken)(implicit prote
         writableWorkspace = hasWorkspace))
   }
 
+  def getTerraPreference(implicit userToken: UserInfo): Future[PerRequestMessage] = {
+    // so, so many nested Options ...
+    val maybeValue:Future[Option[Long]] = thurloeDAO.getAllKVPs(userToken.id, userToken) map { // .getAllKVPs returns Option[ProfileWrapper]
+      case None => None
+      case Some(wrapper) => wrapper.keyValuePairs
+        .find(_.key.contains(UserService.TerraPreferenceKey)) // .find returns Option[FireCloudKeyValue]
+        .flatMap(_.value.map(_.toLong)) // .value returns Option[String]
+    }
+    maybeValue map { v =>
+      val pref:Boolean = v.getOrElse(0L) >= 0 // if user no key, or the key has no value, default to 0
+      RequestComplete(Map(UserService.TerraPreferenceKey -> pref))
+    }
+  }
+
+  def setTerraPreference(userToken: UserInfo): Future[PerRequestMessage] = {
+    writeTerraPreference(userToken, System.currentTimeMillis())
+  }
+
+
+  def deleteTerraPreference(userToken: UserInfo): Future[PerRequestMessage] = {
+    writeTerraPreference(userToken, System.currentTimeMillis() * -1)
+  }
+
+  private def writeTerraPreference(userToken: UserInfo, prefValue: Long): Future[PerRequestMessage] = {
+    thurloeDAO.saveKeyValues(userToken, Map(UserService.TerraPreferenceKey -> prefValue.toString)) flatMap {
+      case Failure(exception) => Future(RequestCompleteWithErrorReport(StatusCodes.InternalServerError,
+        "could not save preference", exception))
+      case Success(_) => getTerraPreference(userToken)
+    }
+  }
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/UserApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/UserApiService.scala
@@ -4,7 +4,7 @@ import org.broadinstitute.dsde.firecloud.FireCloudConfig
 import org.broadinstitute.dsde.firecloud.dataaccess.HttpGoogleServicesDAO
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
 import org.broadinstitute.dsde.firecloud.model._
-import org.broadinstitute.dsde.firecloud.service.UserService.ImportPermission
+import org.broadinstitute.dsde.firecloud.service.UserService.{DeleteTerraPreference, GetTerraPreference, ImportPermission, SetTerraPreference}
 import org.broadinstitute.dsde.firecloud.service._
 import org.broadinstitute.dsde.firecloud.utils.StandardUserInfoDirectives
 import org.broadinstitute.dsde.rawls.model.ErrorReport
@@ -64,7 +64,7 @@ trait UserApiService extends HttpService with PerRequestCreator with FireCloudRe
   lazy val log = LoggerFactory.getLogger(getClass)
 
   val trialServiceConstructor: () => TrialService
-  val userServiceConstructor: (WithAccessToken) => UserService
+  val userServiceConstructor: (UserInfo) => UserService
 
   val userServiceRoutes =
     path("me") {
@@ -117,6 +117,23 @@ trait UserApiService extends HttpService with PerRequestCreator with FireCloudRe
         get {
           requireUserInfo() { userInfo => requestContext =>
             perRequest(requestContext, UserService.props(userServiceConstructor, userInfo), ImportPermission)
+          }
+        }
+      } ~
+      path("profile" / "terra") {
+        get {
+          requireUserInfo() { userInfo => requestContext =>
+            perRequest(requestContext, UserService.props(userServiceConstructor, userInfo), GetTerraPreference)
+          }
+        } ~
+        post {
+          requireUserInfo() { userInfo => requestContext =>
+            perRequest(requestContext, UserService.props(userServiceConstructor, userInfo), SetTerraPreference)
+          }
+        } ~
+        delete {
+          requireUserInfo() { userInfo => requestContext =>
+            perRequest(requestContext, UserService.props(userServiceConstructor, userInfo), DeleteTerraPreference)
           }
         }
       } ~

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/UserApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/UserApiServiceSpec.scala
@@ -23,7 +23,7 @@ class UserApiServiceSpec extends BaseServiceSpec with RegisterApiService with Us
 
   val registerServiceConstructor:() => RegisterService = RegisterService.constructor(app)
   val trialServiceConstructor:() => TrialService = TrialService.constructor(app, trialProjectManager)
-  val userServiceConstructor:(WithAccessToken) => UserService = UserService.constructor(app)
+  val userServiceConstructor:(UserInfo) => UserService = UserService.constructor(app)
   var workspaceServer: ClientAndServer = _
   var profileServer: ClientAndServer = _
   var samServer: ClientAndServer = _

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/ImportPermissionApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/ImportPermissionApiServiceSpec.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.firecloud.webservice
 
 import org.broadinstitute.dsde.firecloud.{FireCloudException, FireCloudExceptionWithErrorReport}
 import org.broadinstitute.dsde.firecloud.dataaccess.MockRawlsDAO
-import org.broadinstitute.dsde.firecloud.model.{Trial, UserImportPermission, WithAccessToken}
+import org.broadinstitute.dsde.firecloud.model.{Trial, UserImportPermission, UserInfo, WithAccessToken}
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol.impUserImportPermission
 import org.broadinstitute.dsde.firecloud.model.Trial.{CreationStatuses, ProjectRoles, RawlsBillingProjectMembership}
 import org.broadinstitute.dsde.firecloud.service.{BaseServiceSpec, TrialService, UserService}
@@ -23,7 +23,7 @@ class ImportPermissionApiServiceSpec extends BaseServiceSpec with UserApiService
 
   val trialProjectManager = system.actorOf(ProjectManager.props(testApp.rawlsDAO, testApp.trialDAO, testApp.googleServicesDAO), "trial-project-manager")
   val trialServiceConstructor:() => TrialService = TrialService.constructor(testApp, trialProjectManager)
-  val userServiceConstructor:(WithAccessToken) => UserService = UserService.constructor(testApp)
+  val userServiceConstructor:(UserInfo) => UserService = UserService.constructor(testApp)
 
   "UserService /api/profile/importstatus endpoint tests" - {
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/TrialApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/TrialApiServiceSpec.scala
@@ -55,7 +55,7 @@ final class TrialApiServiceSpec extends BaseServiceSpec with UserApiService with
         rawlsDAO = localRawlsDao,
         googleServicesDAO = localGoogleDao),
       trialProjectManager)
-  val userServiceConstructor:(WithAccessToken) => UserService = UserService.constructor(app)
+  val userServiceConstructor:(UserInfo) => UserService = UserService.constructor(app)
 
   var localThurloeServer: ClientAndServer = _
 


### PR DESCRIPTION
three new APIs in orchestration that get/set the "Terra Preference" - a well-known KVP in Thurloe that Terra UI and FireCloud UI will look at in order to honor the user's choice of which UI they prefer.

each of the three endpoints returns a json a la:
```
{
  "preferTerra": false,
  "preferTerraLastUpdated": 1555519882001
}
```

"preferTerra" is true if the user should be redirected from FCUI to Terra. This is the default if the user has not explicitly set a preference.
"preferTerraLastUpdated" is the epoch timestamp of when the user last set their preference. This defaults to 0 if the user has not explicitly set a preference.

We are intentionally storing this preference in Thurloe, and tracking a timestamp, because Thurloe is connected to our analytics warehouse and thus we can report on these  preferences.

The new endpoints are:
* GET /api/profile/terra - returns the user's current preference.
* POST /api/profile/terra - explicitly sets the user's preference to `true` and returns the same payload as GET, after writing the preference
* DELETE /api/profile/terra - explicitly sets the user's preference to `false` and returns the same payload as GET, after writing the preference

After some discussion, I am choosing to leave the `POST` and  `DELETE` as separate endpoints so they are logged separately and we have easy access to analytics on those request logs.

If clients (UIs) would prefer to read this preference from the pre-existing /register/profile endpoint and consolidate ajax calls, they should:
* look for the `preferTerra` key
* be resilient to `preferTerra` not existing in profile
* default `preferTerra` to true if it is missing or otherwise has a value that cannot be converted to boolean
* expect `preferTerra` to contain a string, and parse that string into a boolean

-----

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
