### PR TITLE
Storage Cost Estimate API tests

### DIFF
--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -12,11 +12,11 @@ object Dependencies {
   val excludeWorkbenchModel = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-model_" + scalaV)
 
 
-  val workbenchGoogleV = "0.16-847c3ff"
+  val workbenchGoogleV = "0.18-9e165e2-SNAP"
   val workbenchGoogle: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-google" % workbenchGoogleV excludeAll excludeWorkbenchModel
   val excludeWorkbenchGoogle = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-google" + scalaV)
 
-  val workbenchServiceTestV = "0.16-ff865e0"
+  val workbenchServiceTestV = "0.16-0131efa-SNAP"
   val workbenchServiceTest: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-service-test" % workbenchServiceTestV % "test" classifier "tests" excludeAll (excludeWorkbenchGoogle, excludeWorkbenchModel)
 
   val rootDependencies = Seq(

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -16,7 +16,7 @@ object Dependencies {
   val workbenchGoogle: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-google" % workbenchGoogleV excludeAll excludeWorkbenchModel
   val excludeWorkbenchGoogle = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-google" + scalaV)
 
-  val workbenchServiceTestV = "0.16-0131efa-SNAP"
+  val workbenchServiceTestV = "0.16-407095c-SNAP"
   val workbenchServiceTest: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-service-test" % workbenchServiceTestV % "test" classifier "tests" excludeAll (excludeWorkbenchGoogle, excludeWorkbenchModel)
 
   val rootDependencies = Seq(

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -12,11 +12,11 @@ object Dependencies {
   val excludeWorkbenchModel = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-model_" + scalaV)
 
 
-  val workbenchGoogleV = "0.18-9e165e2-SNAP"
+  val workbenchGoogleV = "0.16-847c3ff"
   val workbenchGoogle: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-google" % workbenchGoogleV excludeAll excludeWorkbenchModel
   val excludeWorkbenchGoogle = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-google" + scalaV)
 
-  val workbenchServiceTestV = "0.16-407095c-SNAP"
+  val workbenchServiceTestV = "0.16-4503607"
   val workbenchServiceTest: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-service-test" % workbenchServiceTestV % "test" classifier "tests" excludeAll (excludeWorkbenchGoogle, excludeWorkbenchModel)
 
   val rootDependencies = Seq(

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/WorkspaceApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/WorkspaceApiSpec.scala
@@ -1,0 +1,71 @@
+package org.broadinstitute.dsde.test.api.orch
+
+import java.time.Instant
+import java.util.UUID
+
+import org.broadinstitute.dsde.workbench.auth.AuthToken
+import org.broadinstitute.dsde.workbench.config.{Credentials, UserPool}
+import org.broadinstitute.dsde.workbench.fixture.{BillingFixtures, WorkspaceFixtures}
+import org.broadinstitute.dsde.workbench.service.{AclEntry, Orchestration, RestException, WorkspaceAccessLevel}
+import org.scalatest.concurrent.{Eventually, ScalaFutures}
+import org.scalatest.time.{Minutes, Span}
+import org.scalatest.{FreeSpec, Matchers}
+import spray.json._
+import DefaultJsonProtocol._
+
+class WorkspaceApiSpec extends FreeSpec with Matchers with ScalaFutures with Eventually
+  with BillingFixtures with WorkspaceFixtures {
+
+  implicit override val patienceConfig: PatienceConfig = PatienceConfig(timeout = scaled(Span(1, Minutes)))
+
+  implicit val StorageCostEstimateFormat = jsonFormat1(StorageCostEstimate)
+  final case class StorageCostEstimate(estimate: String)
+
+  "Orchestration" - {
+    val owner: Credentials = UserPool.chooseProjectOwner
+    val ownerAuthToken: AuthToken = owner.makeAuthToken()
+
+    "should return a storage cost estimate" - {
+      "for the owner of a workspace" in {
+        implicit val token: AuthToken = ownerAuthToken
+
+        withCleanBillingProject(owner) { projectName =>
+          withWorkspace(projectName, prependUUID("owner-storage-cost")) { workspaceName =>
+            val storageCostEstimate = Orchestration.workspaces.getStorageCostEstimate(projectName, workspaceName).parseJson.convertTo[StorageCostEstimate]
+            storageCostEstimate.estimate should be ("$0.00")
+          }
+        }
+      }
+
+      "for writers of a workspace" in {
+        val writer = UserPool.chooseStudent
+
+        withCleanBillingProject(owner) { projectName =>
+          withWorkspace(projectName, prependUUID("writer-storage-cost"), aclEntries = List(AclEntry(writer.email, WorkspaceAccessLevel.Writer))) { workspaceName =>
+            val storageCostEstimate = Orchestration.workspaces.getStorageCostEstimate(projectName, workspaceName)(writer.makeAuthToken()).parseJson.convertTo[StorageCostEstimate]
+            storageCostEstimate.estimate should be ("$0.00")
+          } (ownerAuthToken)
+        }
+      }
+    }
+
+    "should not return a storage cost estimate" - {
+      "for readers of a workspace" in {
+        val reader = UserPool.chooseStudent
+
+        withCleanBillingProject(owner) { projectName =>
+          withWorkspace(projectName, prependUUID("reader-storage-cost"), aclEntries = List(AclEntry(reader.email, WorkspaceAccessLevel.Reader))) { workspaceName =>
+            val exception = intercept[RestException] {
+              Orchestration.workspaces.getStorageCostEstimate(projectName, workspaceName)(reader.makeAuthToken())
+            }
+            val exceptionMessage = exception.message.parseJson.asJsObject.fields("message").convertTo[String]
+
+            exceptionMessage should be (s"insufficient permissions to perform operation on $projectName/$workspaceName")
+          } (ownerAuthToken)
+        }
+      }
+    }
+  }
+
+  private def prependUUID(suffix: String): String = s"${UUID.randomUUID().toString}-$suffix"
+}

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/WorkspaceApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/WorkspaceApiSpec.scala
@@ -24,6 +24,8 @@ class WorkspaceApiSpec extends FreeSpec with Matchers
 
         withCleanBillingProject(owner) { projectName =>
           withWorkspace(projectName, prependUUID("owner-storage-cost")) { workspaceName =>
+            Orchestration.workspaces.waitForBucketReadAccess(projectName, workspaceName)
+
             val storageCostEstimate = Orchestration.workspaces.getStorageCostEstimate(projectName, workspaceName).parseJson.convertTo[StorageCostEstimate]
             storageCostEstimate.estimate should be ("$0.00")
           }
@@ -35,6 +37,8 @@ class WorkspaceApiSpec extends FreeSpec with Matchers
 
         withCleanBillingProject(owner) { projectName =>
           withWorkspace(projectName, prependUUID("writer-storage-cost"), aclEntries = List(AclEntry(writer.email, WorkspaceAccessLevel.Writer))) { workspaceName =>
+            Orchestration.workspaces.waitForBucketReadAccess(projectName, workspaceName)(ownerAuthToken)
+
             val storageCostEstimate = Orchestration.workspaces.getStorageCostEstimate(projectName, workspaceName)(writer.makeAuthToken()).parseJson.convertTo[StorageCostEstimate]
             storageCostEstimate.estimate should be ("$0.00")
           } (ownerAuthToken)
@@ -48,6 +52,8 @@ class WorkspaceApiSpec extends FreeSpec with Matchers
 
         withCleanBillingProject(owner) { projectName =>
           withWorkspace(projectName, prependUUID("reader-storage-cost"), aclEntries = List(AclEntry(reader.email, WorkspaceAccessLevel.Reader))) { workspaceName =>
+            Orchestration.workspaces.waitForBucketReadAccess(projectName, workspaceName)(ownerAuthToken)
+
             val exception = intercept[RestException] {
               Orchestration.workspaces.getStorageCostEstimate(projectName, workspaceName)(reader.makeAuthToken())
             }


### PR DESCRIPTION
Tests for [QA-481](https://broadworkbench.atlassian.net/browse/QA-481) and [QA-487](https://broadworkbench.atlassian.net/browse/QA-487).
I also added a test that makes sure that a workspace reader can't see the storage cost estimate. This test falls out of the scope of either ticket and I believe Terra handles this without calling Orch, but it was minimal extra effort.

Dependent on [Workbench-Libs PR #222](https://github.com/broadinstitute/workbench-libs/pull/222)

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [x] Get two thumbsworth of review and PO signoff if necessary
- [x] Verify all tests go green
- [x] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
