### PR TITLE
NIH link status api should not require full user profile [risk: low]

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/Profile.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/Profile.scala
@@ -5,6 +5,7 @@ import org.broadinstitute.dsde.firecloud.utils.DateUtils
 import spray.json.DefaultJsonProtocol._
 
 import scala.language.postfixOps
+import scala.util.Try
 
 case class FireCloudKeyValue(
   key: Option[String] = None,
@@ -126,6 +127,17 @@ object ProfileValidator {
     case Some(x) if x.isEmpty => true
     case Some(x) if emailRegex.findFirstMatchIn(x).isDefined => true
     case _ => false
+  }
+}
+
+object ProfileUtils {
+  def getString(key: String, profileWrapper: ProfileWrapper): Option[String] = {
+    profileWrapper.keyValuePairs.collectFirst {
+      case fckv if fckv.key.contains(key) => fckv.value
+    }.flatten
+  }
+  def getLong(key: String, profileWrapper: ProfileWrapper): Option[Long] = {
+    getString(key, profileWrapper).flatMap(x => Try(x.toLong).toOption)
   }
 }
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/NihService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/NihService.scala
@@ -36,14 +36,6 @@ case class NihDatasetPermission(name: String, authorized: Boolean)
 object NihStatus {
   implicit val impNihDatasetPermission = jsonFormat2(NihDatasetPermission)
   implicit val impNihStatus = jsonFormat3(NihStatus.apply)
-
-  def apply(profile: Profile, whitelistAccess: Set[NihDatasetPermission]): NihStatus = {
-    new NihStatus(
-      profile.linkedNihUsername,
-      whitelistAccess,
-      profile.linkExpireTime
-    )
-  }
 }
 
 object NihService {
@@ -83,14 +75,15 @@ trait NihService extends LazyLogging {
   val nihWhitelists: Set[NihWhitelist] = FireCloudConfig.Nih.whitelists
 
   def getNihStatus(userInfo: UserInfo): Future[PerRequestMessage] = {
-    thurloeDao.getProfile(userInfo) flatMap {
-      case Some(profile) =>
-        profile.linkedNihUsername match {
-          case Some(_) =>
+    thurloeDao.getAllKVPs(userInfo.id, userInfo) flatMap {
+      case Some(profileWrapper) =>
+        profileWrapper.keyValuePairs.find(_.key.contains("linkedNihUsername")).flatMap(_.value) match {
+          case Some(linkedNihUsername) =>
             Future.traverse(nihWhitelists) { whitelistDef =>
               samDao.isGroupMember(whitelistDef.groupToSync, userInfo).map(isMember => NihDatasetPermission(whitelistDef.name, isMember))
             }.map { whitelistMembership =>
-              RequestComplete(NihStatus(profile, whitelistMembership))
+              val linkExpireTime = Try(profileWrapper.keyValuePairs.find(_.key.contains("linkExpireTime")).flatMap(_.value.map(_.toLong))).toOption.flatten
+              RequestComplete(NihStatus(Some(linkedNihUsername), whitelistMembership, linkExpireTime))
             }
           case None => Future.successful(RequestComplete(NotFound))
         }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/NihService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/NihService.scala
@@ -88,6 +88,8 @@ trait NihService extends LazyLogging {
           case None => Future.successful(RequestComplete(NotFound))
         }
       case None => Future.successful(RequestComplete(NotFound))
+    } recover {
+      case e:Exception => RequestCompleteWithErrorReport(InternalServerError, e.getMessage, e)
     }
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockThurloeDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockThurloeDAO.scala
@@ -114,8 +114,14 @@ class MockThurloeDAO extends ThurloeDAO {
     )
 
 
-  override def getAllKVPs(forUserId: String, callerToken: WithAccessToken): Future[Option[ProfileWrapper]] =
-    Future.successful(None)
+  override def getAllKVPs(forUserId: String, callerToken: WithAccessToken): Future[Option[ProfileWrapper]] = {
+    val profileWrapper = try {
+      Option(ProfileWrapper(forUserId, mockKeyValues(forUserId).toList))
+    } catch {
+      case e:NoSuchElementException => None
+    }
+    Future.successful(profileWrapper)
+  }
 
   override def getProfile(userInfo: UserInfo): Future[Option[Profile]] = {
     val profileWrapper = try {

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/model/ProfileSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/model/ProfileSpec.scala
@@ -117,4 +117,74 @@ class ProfileSpec extends FreeSpec with Matchers {
 
   }
 
+  "ProfileUtils" - {
+
+    val pw = ProfileWrapper("123", List(
+      FireCloudKeyValue(Some("imastring"), Some("hello")),
+      FireCloudKeyValue(Some("imalong"), Some("1556724034")),
+      FireCloudKeyValue(Some("imnotalong"), Some("not-a-long")),
+      FireCloudKeyValue(Some("imnothing"), None)
+    ))
+
+    "getString" - {
+      "returns None if key doesn't exist" - {
+        val targetKey = "nonexistent"
+        // assert key does not exist in sample data
+        pw.keyValuePairs.find(_.key.contains(targetKey)) shouldBe None
+        // and therefore getString returns None
+        val actual = ProfileUtils.getString(targetKey, pw)
+        actual shouldBe None
+      }
+      "returns None if key exists but value doesn't" - {
+        val targetKey = "imnothing"
+        // assert key exists in sample data with no value
+        val targetKV = pw.keyValuePairs.find(_.key.contains(targetKey))
+        targetKV.isDefined shouldBe true
+        targetKV.get.value shouldBe None
+
+        val actual = ProfileUtils.getString(targetKey, pw)
+        actual shouldBe None
+      }
+      "returns Some(String) if key and value exist" - {
+        val targetKey = "imastring"
+        val actual = ProfileUtils.getString(targetKey, pw)
+        actual shouldBe Some("hello")
+      }
+    }
+    "getLong" - {
+      "returns None if key doesn't exist" - {
+        val targetKey = "nonexistent"
+        // assert key does not exist in sample data
+        pw.keyValuePairs.find(_.key.contains(targetKey)) shouldBe None
+        // and therefore getString returns None
+        val actual = ProfileUtils.getLong(targetKey, pw)
+        actual shouldBe None
+
+      }
+      "returns None if key exists but value doesn't" - {
+        val targetKey = "imnothing"
+        // assert key exists in sample data with no value
+        val targetKV = pw.keyValuePairs.find(_.key.contains(targetKey))
+        targetKV.isDefined shouldBe true
+        targetKV.get.value shouldBe None
+
+        val actual = ProfileUtils.getLong(targetKey, pw)
+        actual shouldBe None
+      }
+      "returns None if key and value exist but value is not a Long" - {
+        val targetKey = "imnotalong"
+        // assert the key exists
+        ProfileUtils.getString(targetKey, pw) shouldBe Some("not-a-long")
+        // but can't be parsed as a Long
+        val actual = ProfileUtils.getLong(targetKey, pw)
+        actual shouldBe None
+      }
+      "returns Some(Long) if key and value exist and value is Long-able" - {
+        val targetKey = "imalong"
+        val actual = ProfileUtils.getLong(targetKey, pw)
+        actual shouldBe Some(1556724034L)
+      }
+    }
+  }
+
 }


### PR DESCRIPTION
The NIH link status API - `GET /api/nih/status` - requires a full user profile, including e.g. `firstName`, `institute` keys in Thurloe. This is because:
* the API internally relied on `ThurloeDao.getProfile`
* which relies on `Profile.apply`
* which has assertions on the existence of all the relevant keys

Terra UI, as compared to FireCloud UI, does not enforce that a user must complete a full profile. Therefore, any new users in Terra who have not visited FireCloud UI will not have a profile and will be unable to successfully call `GET /api/nih/status`,  in turn preventing proper linking.

This PR changes this. Instead of relying on `ThurloeDao.getProfile`, we'll rely on `ThurloeDao.getAllKVPs`, which does not have assertions.

Additionally, I've added a `recover` to the API so that in the case of error, we have better/clearer messages.

-----

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
