### PR TITLE
remove unused ThurloeDAO.getProfile [risk: low]

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpThurloeDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpThurloeDAO.scala
@@ -38,9 +38,6 @@ class HttpThurloeDAO ( implicit val system: ActorSystem, implicit val executionC
     }
   }
 
-  override def getProfile(userInfo: UserInfo): Future[Option[Profile]] =
-    getAllKVPs(userInfo.id, userInfo) map { optionalWrapper => optionalWrapper map (Profile(_)) }
-
   override def getAllUserValuesForKey(key: String): Future[Map[String, String]] = {
     val queryUri = Uri(UserApiService.remoteGetQueryURL).withQuery(Map("key"->key))
     wrapExceptions {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ThurloeDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ThurloeDAO.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.firecloud.dataaccess
 
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.model.Trial.UserTrialStatus
-import org.broadinstitute.dsde.firecloud.model.{BasicProfile, Profile, ProfileWrapper, UserInfo, WithAccessToken}
+import org.broadinstitute.dsde.firecloud.model.{BasicProfile, ProfileWrapper, UserInfo, WithAccessToken}
 import org.broadinstitute.dsde.rawls.model.ErrorReportSource
 
 import scala.concurrent.Future
@@ -20,8 +20,6 @@ trait ThurloeDAO extends LazyLogging with ReportsSubsystemStatus {
   implicit val errorReportSource = ErrorReportSource(ThurloeDAO.serviceName)
 
   def getAllKVPs(forUserId: String, callerToken: WithAccessToken): Future[Option[ProfileWrapper]]
-
-  def getProfile(userInfo: UserInfo): Future[Option[Profile]]
   def getAllUserValuesForKey(key: String): Future[Map[String, String]]
   def saveProfile(userInfo: UserInfo, profile: BasicProfile): Future[Unit]
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockThurloeDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockThurloeDAO.scala
@@ -4,13 +4,13 @@ import java.util.NoSuchElementException
 
 import org.broadinstitute.dsde.firecloud.dataaccess.MockThurloeDAO._
 import org.broadinstitute.dsde.firecloud.model.Trial.{TrialStates, UserTrialStatus}
-import org.broadinstitute.dsde.firecloud.model.{BasicProfile, FireCloudKeyValue, Profile, ProfileWrapper, Trial, UserInfo, WithAccessToken}
+import org.broadinstitute.dsde.firecloud.model.{BasicProfile, FireCloudKeyValue, ProfileWrapper, UserInfo, WithAccessToken}
 import org.broadinstitute.dsde.firecloud.utils.DateUtils
 import org.broadinstitute.dsde.workbench.util.health.SubsystemStatus
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
-import scala.util.{Failure, Success, Try}
+import scala.util.{Success, Try}
 
 /**
  * Created by mbemis on 10/25/16.
@@ -117,15 +117,6 @@ class MockThurloeDAO extends ThurloeDAO {
   override def getAllKVPs(forUserId: String, callerToken: WithAccessToken): Future[Option[ProfileWrapper]] = {
     val profileWrapper = try {
       Option(ProfileWrapper(forUserId, mockKeyValues(forUserId).toList))
-    } catch {
-      case e:NoSuchElementException => None
-    }
-    Future.successful(profileWrapper)
-  }
-
-  override def getProfile(userInfo: UserInfo): Future[Option[Profile]] = {
-    val profileWrapper = try {
-      Option(Profile(ProfileWrapper(userInfo.id, mockKeyValues(userInfo.id).toList)))
     } catch {
       case e:NoSuchElementException => None
     }


### PR DESCRIPTION
As of #726, `ThurloeDAO.getProfile` is unused ... let's delete it.

#726 removed the last call to `getProfile` because it is prone to errors. If the calling user did not have all of the required keys in the `Profile` object, the entire call would fail.

-----

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
