### PR TITLE
Free credits spreadsheet-update refactor  [risk: low]

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudServiceActor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudServiceActor.scala
@@ -109,10 +109,10 @@ class FireCloudServiceActor extends HttpServiceActor with FireCloudDirectives
   val managedGroupServiceConstructor: (WithAccessToken) => ManagedGroupService = ManagedGroupService.constructor(app)
 
   if (FireCloudConfig.Trial.spreadsheetId.nonEmpty && FireCloudConfig.Trial.spreadsheetUpdateFrequencyMinutes > 0) {
-    val freq = FireCloudConfig.Trial.spreadsheetUpdateFrequencyMinutes
+    val freq = 2 // TODO: should be: FireCloudConfig.Trial.spreadsheetUpdateFrequencyMinutes
     val scheduledTrialService = system.actorOf(TrialService.props(trialServiceConstructor), "trial-spreadsheet-actor")
     // use a randomized startup delay to avoid multiple instances of this app executing on the same cycle
-    val initialDelay = 1 + scala.util.Random.nextInt(freq/2)
+    val initialDelay = 0 // TODO: should be: 1 + scala.util.Random.nextInt(freq/2)
     logger.info(s"Free credits spreadsheet updates are enabled: every $freq minutes, starting $initialDelay minutes from now.")
     system.scheduler.schedule(initialDelay.minutes, freq.minutes, scheduledTrialService, UpdateBillingReport(FireCloudConfig.Trial.spreadsheetId))
   } else {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudServiceActor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudServiceActor.scala
@@ -109,10 +109,10 @@ class FireCloudServiceActor extends HttpServiceActor with FireCloudDirectives
   val managedGroupServiceConstructor: (WithAccessToken) => ManagedGroupService = ManagedGroupService.constructor(app)
 
   if (FireCloudConfig.Trial.spreadsheetId.nonEmpty && FireCloudConfig.Trial.spreadsheetUpdateFrequencyMinutes > 0) {
-    val freq = 2 // TODO: should be: FireCloudConfig.Trial.spreadsheetUpdateFrequencyMinutes
+    val freq = FireCloudConfig.Trial.spreadsheetUpdateFrequencyMinutes
     val scheduledTrialService = system.actorOf(TrialService.props(trialServiceConstructor), "trial-spreadsheet-actor")
     // use a randomized startup delay to avoid multiple instances of this app executing on the same cycle
-    val initialDelay = 0 // TODO: should be: 1 + scala.util.Random.nextInt(freq/2)
+    val initialDelay = 1 + scala.util.Random.nextInt(freq/2)
     logger.info(s"Free credits spreadsheet updates are enabled: every $freq minutes, starting $initialDelay minutes from now.")
     system.scheduler.schedule(initialDelay.minutes, freq.minutes, scheduledTrialService, UpdateBillingReport(FireCloudConfig.Trial.spreadsheetId))
   } else {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchTrialDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchTrialDAO.scala
@@ -342,7 +342,7 @@ class ElasticSearchTrialDAO(client: TransportClient, indexName: String, refreshM
     val (scrollId, accum) = startScroll // initial query
     val (_, finalAccum) = nextScroll(scrollId, startCount = 0, accum)
 
-    finalAccum
+    finalAccum.sortBy(_.name.value)
   }
 
   private def indexExists: Boolean = {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchTrialDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchTrialDAO.scala
@@ -287,6 +287,15 @@ class ElasticSearchTrialDAO(client: TransportClient, indexName: String, refreshM
   }
 
   private def startScroll: (String, List[TrialProject]) = {
+    /* Start an Elasticsearch scroll request. This allows us to retrieve all records in the index,
+        in batches of N records.
+
+        We currently have N set to 250.
+
+        Dear future engineer: if you find that you ever need to change this value, even
+        just to experiment with other values, or to use different values in different environments,
+        please move it to config so that it is easier to tweak.
+    */
     val startScrollRequest = client
       .prepareSearch(indexName)
       .setQuery(Ready)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpThurloeDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpThurloeDAO.scala
@@ -122,7 +122,7 @@ class HttpThurloeDAO ( implicit val system: ActorSystem, implicit val executionC
     val userIdParams:List[(String,String)] = userIds.map(("userId", _))
     val keyParams:List[(String,String)] = keySelection.map(("key", _))
 
-    val allQueryParams = userIdParams ++ keyParams
+    val allQueryParams = keyParams ++ userIdParams
 
     val queryUri = Uri(UserApiService.remoteGetQueryURL).withQuery(allQueryParams:_*)
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ThurloeDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ThurloeDAO.scala
@@ -62,6 +62,7 @@ trait ThurloeDAO extends LazyLogging with ReportsSubsystemStatus {
     */
   def saveTrialStatus(forUserId: String, callerToken: WithAccessToken, trialStatus: UserTrialStatus): Future[Try[Unit]]
 
+  def bulkUserQuery(userIds: List[String], keySelection: List[String]): Future[List[ProfileWrapper]]
 
   override def serviceName:String = ThurloeDAO.serviceName
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
@@ -211,6 +211,7 @@ object ModelJsonProtocol extends WorkspaceJsonSupport {
   implicit val impBasicProfile = jsonFormat11(BasicProfile)
   implicit val impProfile = jsonFormat13(Profile.apply)
   implicit val impProfileWrapper = jsonFormat2(ProfileWrapper)
+  implicit val impProfileKVP = jsonFormat2(ProfileKVP)
   implicit val impTerraPreference = jsonFormat2(TerraPreference)
 
   implicit val impTokenResponse = jsonFormat6(OAuthTokens.apply)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/Profile.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/Profile.scala
@@ -21,6 +21,8 @@ case class ThurloeKeyValues(
 
 case class ProfileWrapper(userId: String, keyValuePairs: List[FireCloudKeyValue])
 
+case class ProfileKVP(userId: String, keyValuePair: FireCloudKeyValue)
+
 case class BasicProfile (
     firstName: String,
     lastName: String,

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/TrialServiceSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/TrialServiceSupport.scala
@@ -11,7 +11,7 @@ import org.broadinstitute.dsde.firecloud.{FireCloudConfig, FireCloudException}
 import org.broadinstitute.dsde.firecloud.dataaccess.{SamDAO, ThurloeDAO, TrialDAO}
 import org.broadinstitute.dsde.firecloud.model.Trial.TrialStates.{Disabled, Enabled, TrialState}
 import org.broadinstitute.dsde.firecloud.model.Trial.{SpreadsheetResponse, TrialProject, UserTrialStatus}
-import org.broadinstitute.dsde.firecloud.model.{FireCloudKeyValue, Profile, ProfileWrapper, UserInfo, WithAccessToken, WorkbenchUserInfo}
+import org.broadinstitute.dsde.firecloud.model.{FireCloudKeyValue, Profile, ProfileUtils, ProfileWrapper, UserInfo, WithAccessToken, WorkbenchUserInfo}
 
 import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future}
@@ -31,6 +31,11 @@ trait TrialServiceSupport extends LazyLogging {
   private val headers = List("Project Name", "User Subject Id", "Status", "Login Email", "Contact Email",
     "Enrollment Date", "Terminated Date", "Expiration Date", "User Agreement", "User Agreement Date",
     "First Name", "Last Name", "Organization", "City", "State", "Country").map(_.asInstanceOf[AnyRef]).asJava
+
+  // keys to retrieve from Thurloe to populate spreadsheet
+  private val thurloeKeys = List("trialState", "trialEnrolledDate", "trialTerminatedDate", "trialExpirationDate",
+    "userAgreed", "trialEnrolledDate", "firstName", "lastName", "contactEmail", "institute", "programLocationCity",
+    "programLocationState", "programLocationCountry")
 
   // default value to use if user has no entry for a field in their profile
   private val defaultProfileField = ""
@@ -57,13 +62,19 @@ trait TrialServiceSupport extends LazyLogging {
     val projects: Seq[TrialProject] = trialDAO.projectReport
     logger.info(s"makeSpreadsheetValues processing ${projects.length} projects ...")
 
-    // find the Thurloe KVPs for any users referenced in those projects
-    // TODO: this should switch to using Thurloe's bulk endpoint, so we're not making a large burst of requests.
-    val profileWrappers:Future[Seq[ProfileWrapper]] = Future.sequence(projects.filter(p => p.user.isDefined).map { p =>
-      thurloeDAO.getAllKVPs(p.user.get.userSubjectId, managerInfo) map { kvpOption =>
-        kvpOption.getOrElse(ProfileWrapper(p.user.get.userSubjectId, List.empty[FireCloudKeyValue]))
+    // from the list of projects, get assigned userids
+    val assignedUsers:List[String] = projects.toList.filter(p => p.user.isDefined).flatMap(_.user.map(_.userSubjectId))
+    logger.info(s"makeSpreadsheetValues found ${assignedUsers.length} users assigned to projects ...")
+
+    // split users into chunks of size N for efficient querying to Thurloe
+    val profileQueries = assignedUsers
+      .grouped(100) // tweak chunk size here!
+      .map{ userChunk =>
+        thurloeDAO.bulkUserQuery(userChunk, thurloeKeys)
       }
-    })
+
+    // TODO: make this sequential instead of parallel, to reduce load? Would have to not start them eagerly above.
+    val profileWrappers:Future[Seq[ProfileWrapper]] = Future.sequence(profileQueries).map(_.flatten.toSeq)
 
     // resolve the Thurloe KVPs future
     profileWrappers.map { wrappers =>
@@ -103,17 +114,7 @@ trait TrialServiceSupport extends LazyLogging {
 
     val status = UserTrialStatus(profileWrapper)
 
-    // profile may be incomplete - especially for users coming in via Terra
-    val maybeProfile  = Try(Profile(profileWrapper))
-
-    val List(firstName, lastName, contactEmail, institute,
-          programLocationCity, programLocationState, programLocationCountry) =  maybeProfile match {
-      case Success(profile) =>
-        List(profile.firstName, profile.lastName, profile.contactEmail.getOrElse(user.userEmail),
-          profile.institute, profile.programLocationCity, profile.programLocationState, profile.programLocationCountry)
-      case Failure(ex) =>
-        List.fill(7)(defaultProfileField)
-    }
+    def fromProfileWrapper(key: String) = ProfileUtils.getString(key, profileWrapper).getOrElse(defaultProfileField)
 
     SpreadsheetRow(
       userSubjectId = status.userId,
@@ -124,13 +125,13 @@ trait TrialServiceSupport extends LazyLogging {
       expiredDate = status.expirationDate,
       userAgreed = status.userAgreed,
       userAgreedDate = status.enrolledDate, // TODO: should be separate date
-      firstName = firstName,
-      lastName = lastName,
-      contactEmail = contactEmail,
-      institute = institute,
-      programLocationCity = programLocationCity,
-      programLocationState = programLocationState,
-      programLocationCountry = programLocationCountry
+      firstName = fromProfileWrapper("firstName"),
+      lastName = fromProfileWrapper("lastName"),
+      contactEmail = fromProfileWrapper("contactEmail"),
+      institute = fromProfileWrapper("institute"),
+      programLocationCity = fromProfileWrapper("programLocationCity"),
+      programLocationState = fromProfileWrapper("programLocationState"),
+      programLocationCountry = fromProfileWrapper("programLocationCountry")
     )
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/TrialServiceSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/TrialServiceSupport.scala
@@ -68,10 +68,8 @@ trait TrialServiceSupport extends LazyLogging {
 
     // split users into chunks of size N for efficient querying to Thurloe
     val profileQueries = assignedUsers
-      .grouped(100) // tweak chunk size here!
-      .map{ userChunk =>
-        thurloeDAO.bulkUserQuery(userChunk, thurloeKeys)
-      }
+      .grouped(40) // tweak chunk size here!
+      .map{ userChunk => thurloeDAO.bulkUserQuery(userChunk, thurloeKeys) }
 
     // TODO: make this sequential instead of parallel, to reduce load? Would have to not start them eagerly above.
     val profileWrappers:Future[Seq[ProfileWrapper]] = Future.sequence(profileQueries).map(_.flatten.toSeq)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/TrialServiceSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/TrialServiceSupport.scala
@@ -66,7 +66,13 @@ trait TrialServiceSupport extends LazyLogging {
     val assignedUsers:List[String] = projects.toList.filter(p => p.user.isDefined).flatMap(_.user.map(_.userSubjectId))
     logger.info(s"makeSpreadsheetValues found ${assignedUsers.length} users assigned to projects ...")
 
-    // split users into chunks of size N for efficient querying to Thurloe
+    /* split users into chunks of size N for efficient querying to Thurloe
+        based on empirical perf/scale testing, the most efficient value for N is ~40.
+
+        Dear future engineer: if you find that you ever need to change this value, even
+        just to experiment with other values, or to use different values in different environments,
+        please move it to config so that it is easier to tweak.
+     */
     val profileQueries = assignedUsers
       .grouped(40) // tweak chunk size here!
       .map{ userChunk => thurloeDAO.bulkUserQuery(userChunk, thurloeKeys) }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockThurloeDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockThurloeDAO.scala
@@ -169,4 +169,17 @@ class MockThurloeDAO extends ThurloeDAO {
 
   override def saveTrialStatus(forUserId: String, callerToken: WithAccessToken, trialStatus: UserTrialStatus): Future[Try[Unit]] =
     Future.successful(Success(()))
+
+  override def bulkUserQuery(userIds: List[String], keySelection: List[String]): Future[List[ProfileWrapper]] = {
+
+    val mockdata = userIds.map { forUserId =>
+      if (mockKeyValues.contains(forUserId)) {
+        val kvps = mockKeyValues(forUserId).filter(kvp => kvp.key.isDefined && keySelection.contains(kvp.key.get))
+        Some(ProfileWrapper(forUserId, kvps.toList))
+      } else {
+        None
+      }
+    }
+    Future.successful(mockdata.flatten)
+  }
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/ElasticSearchDAOQuerySupportSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/ElasticSearchDAOQuerySupportSpec.scala
@@ -300,7 +300,9 @@ class ElasticSearchDAOQuerySupportSpec extends FreeSpec with ElasticSearchDAOQue
               case _ => Unit
             }
             // assertResult(expectedNoDiscoverableGroups, "group criteria should be just the must-not-exists") {groupbool}
+          case x => throw new Exception(s"unmatched case for  ${x.getClass.getName}: ${x.toString()}")
       }
+      case x => throw new Exception(s"unmatched case for  ${x.getClass.getName}: ${x.toString()}")
     }
   }
 
@@ -373,7 +375,9 @@ class ElasticSearchDAOQuerySupportSpec extends FreeSpec with ElasticSearchDAOQue
             boolMap.fields("should") match {
               case shouldArray:JsArray =>
                 shouldArray
+              case x => throw new Exception(s"unmatched case for  ${x.getClass.getName}: ${x.toString()}")
             }
+          case x => throw new Exception(s"unmatched case for  ${x.getClass.getName}: ${x.toString()}")
         }
       case _ => fail("must clause should be a JsArray")
     }


### PR DESCRIPTION
The scheduled task to update the free-credits spreadsheet was not performant. For reference: https://docs.google.com/document/d/12pwsl_xT1THr-e2K-Dcx35s3baWk_11QQ02VG3eEg2E/edit?usp=sharing (access allowed to Broad internal only)

This PR changes it such that:
* instead of one big query to Elasticsearch (hardcoded limit: 5000 documents), we make multiple paginated [scroll queries](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html) to get all documents.
* instead of N small queries to Thurloe, where N=number of free trial users, we batch the queries to Thurloe into groups of 100 users.
* more resilience to/error-handling of missing data when generating the spreadsheet cells

Some rough analysis of how this would change query load in production:

service | Before  PR | After PR
--- | ---------- | ---------- |
Elasticsearch |  1 query, returning 1649 documents | 7 queries, returning up to 250 documents
Thurloe | 1579 queries, 1 user per query | 40 queries, up to 40 users per query
 Thurloe | all keys per user, roughly 20 | 13 keys per  user

-----
Changes since this PR was approved (8dd899080eeabb704275a1cfc23317579e175e30):
1. Changed the order of `key` and `userid` query params in the request to Thurloe. This is purely cosmetic: since we expect the `key`s to be the same for all requests but the `userid`s to  change, I  wanted the static params to come first.
2. Changed the batch size from 100 to 40. It was necessary to reduce this below  ~50 to address url-length restrictions (I originally miscalculated when choosing 100). From empirical perf testing, 40 seemed the sweet spot.
3. Ran a bunch of perf tests at multiple levels of concurrency and multiple query batch sizes. Landed on 40 as the best batch size. I have this data if anyone wants to review.
4. Stood up this version of orch in perf and watched the spreadsheet-update process repeatedly at a batch size of 40. It performed well and the requests to Thurloe were all fast - most under 100ms with a few outliers.

-----

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
