### PR TITLE
Add query param passthrough to CromIAM endpoints [BA-5670]

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/FireCloudDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/FireCloudDirectives.scala
@@ -27,7 +27,7 @@ trait FireCloudDirectives extends spray.routing.Directives with PerRequestCreato
     passthrough(Uri(unencodedPath), methods: _*)
   }
 
-  // Danger: it is a common mistake to pass in a URI that ommits the query parameters included in the original request to Orch.
+  // Danger: it is a common mistake to pass in a URI that omits the query parameters included in the original request to Orch.
   // To preserve the query, extract it and attach it to the passthrough URI using `.withQuery(query)`.
   def passthrough(uri: Uri, methods: HttpMethod*): Route = methods map { inMethod =>
     generateExternalHttpPerRequestForMethod(uri, inMethod)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/FireCloudDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/FireCloudDirectives.scala
@@ -27,6 +27,8 @@ trait FireCloudDirectives extends spray.routing.Directives with PerRequestCreato
     passthrough(Uri(unencodedPath), methods: _*)
   }
 
+  // Danger: it is a common mistake to pass in a URI that ommits the query parameters included in the original request to Orch.
+  // To preserve the query, extract it and attach it to the passthrough URI using `.withQuery(query)`.
   def passthrough(uri: Uri, methods: HttpMethod*): Route = methods map { inMethod =>
     generateExternalHttpPerRequestForMethod(uri, inMethod)
   } reduce (_ ~ _)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/CromIamApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/CromIamApiService.scala
@@ -1,7 +1,5 @@
 package org.broadinstitute.dsde.firecloud.webservice
 
-
-import akka.http.scaladsl.server.PathMatchers._
 import org.broadinstitute.dsde.firecloud.FireCloudConfig
 import org.broadinstitute.dsde.firecloud.service.{FireCloudDirectives, FireCloudRequestBuilding}
 import org.broadinstitute.dsde.firecloud.utils.StandardUserInfoDirectives

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/CromIamApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/CromIamApiService.scala
@@ -5,7 +5,7 @@ import akka.http.scaladsl.server.PathMatchers._
 import org.broadinstitute.dsde.firecloud.FireCloudConfig
 import org.broadinstitute.dsde.firecloud.service.{FireCloudDirectives, FireCloudRequestBuilding}
 import org.broadinstitute.dsde.firecloud.utils.StandardUserInfoDirectives
-import spray.http.HttpMethods
+import spray.http.{HttpMethods, Uri}
 import spray.routing.Route
 import spray.routing.HttpService
 
@@ -25,7 +25,9 @@ trait CromIamApiService extends HttpService with FireCloudRequestBuilding with F
       path("query") {
         pathEnd {
           get {
-            passthrough(s"$workflowRoot/query", HttpMethods.GET)
+            extract(_.request.uri.query) { query =>
+              passthrough(Uri(s"$workflowRoot/query").withQuery(query), HttpMethods.GET)
+            }
           } ~
           post {
             passthrough(s"$workflowRoot/query", HttpMethods.POST)
@@ -43,7 +45,9 @@ trait CromIamApiService extends HttpService with FireCloudRequestBuilding with F
         path("metadata") {
           pathEnd {
             get {
-              passthrough(s"$workflowRoot/$workflowId/metadata", HttpMethods.GET)
+              extract(_.request.uri.query) { query =>
+                passthrough(Uri(s"$workflowRoot/$workflowId/metadata").withQuery(query), HttpMethods.GET)
+              }
             }
           }
         } ~

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/CromIamApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/CromIamApiServiceSpec.scala
@@ -2,20 +2,14 @@ package org.broadinstitute.dsde.firecloud.webservice
 
 import akka.actor.ActorRefFactory
 import org.broadinstitute.dsde.firecloud.mock.MockUtils
-import org.broadinstitute.dsde.firecloud.service.{BaseServiceSpec, ServiceSpec}
+import org.broadinstitute.dsde.firecloud.service.BaseServiceSpec
 import org.mockserver.integration.ClientAndServer
 import org.mockserver.integration.ClientAndServer._
-import org.mockserver.model.HttpRequest.request
-import spray.http.StatusCodes.OK
 import spray.http.{HttpMethods, Uri}
 import spray.httpx.SprayJsonSupport
 
 class CromIamApiServiceSpec extends BaseServiceSpec with CromIamApiService with SprayJsonSupport {
 
-
-  // The route tests pass without the mock server, but we attempt to contact `http://localhost:8995`
-  // and print out a hideous stacktrace if nothing is running there. If there is a smarter way to do
-  // this, please speak up! (AEN 2019-02-04)
   var cromiamServer: ClientAndServer = _
 
   override def beforeAll(): Unit = {

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/CromIamApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/CromIamApiServiceSpec.scala
@@ -100,11 +100,11 @@ class CromIamApiServiceSpec extends BaseServiceSpec with CromIamApiService with 
           .withStatusCode(200)
           .withBody("We got all of your includeKeys")
 
-        cromiamServer.when(request)
-                     .respond(response)
+        cromiamServer
+          .when(request)
+          .respond(response)
 
         Get(Uri(endpoint).withQuery("includeKey=hit&includeKey=hitFailure")) ~> dummyUserIdHeaders("1234") ~> sealRoute(cromIamApiServiceRoutes) ~> check {
-
           cromiamServer.verify(request)
 
           status.intValue should equal(200)
@@ -173,11 +173,11 @@ class CromIamApiServiceSpec extends BaseServiceSpec with CromIamApiService with 
           .withStatusCode(200)
           .withBody("Got a query with start and end values")
 
-        cromiamServer.when(request)
+        cromiamServer
+          .when(request)
           .respond(response)
 
         Get(Uri(endpoint).withQuery("start=start%20value&end=end%20value")) ~> dummyUserIdHeaders("1234") ~> sealRoute(cromIamApiServiceRoutes) ~> check {
-
           cromiamServer.verify(request)
 
           status.intValue should equal(200)


### PR DESCRIPTION
This functionality should have been here all along, we missed it during the JM rush to production.

Job Manager uses the `POST` version of `/query` rather than `GET`, so there was no impact on JM users - only the rare person who tried using Swagger.

Dropping query params on `/metadata` caused unnecessary metadata to be returned, which affected performance but not correctness.

---

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
