### PR TITLE
Fix for AoU RW-2776: Add Calhoun Passthrough Endpoint (Orch)

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -2355,6 +2355,8 @@ paths:
     post:
       x-passthrough: true
       x-passthrough-target: calhoun
+      produces:
+        - text/html
       tags:
         - Static Notebooks
       operationId: convertNotebook

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/FireCloudDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/FireCloudDirectives.scala
@@ -26,7 +26,7 @@ trait FireCloudDirectives extends spray.routing.Directives with PerRequestCreato
   def passthrough(unencodedPath: String, methods: HttpMethod*): Route = {
     passthrough(Uri(unencodedPath), methods: _*)
   }
-  
+
   // Danger: it is a common mistake to pass in a URI that omits the query parameters included in the original request to Orch.
   // To preserve the query, extract it and attach it to the passthrough URI using `.withQuery(query)`.
   def passthrough(uri: Uri, methods: HttpMethod*): Route = methods map { inMethod =>

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/FireCloudDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/FireCloudDirectives.scala
@@ -26,7 +26,7 @@ trait FireCloudDirectives extends spray.routing.Directives with PerRequestCreato
   def passthrough(unencodedPath: String, methods: HttpMethod*): Route = {
     passthrough(Uri(unencodedPath), methods: _*)
   }
-
+  
   // Danger: it is a common mistake to pass in a URI that omits the query parameters included in the original request to Orch.
   // To preserve the query, extract it and attach it to the passthrough URI using `.withQuery(query)`.
   def passthrough(uri: Uri, methods: HttpMethod*): Route = methods map { inMethod =>

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/StaticNotebooksApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/StaticNotebooksApiService.scala
@@ -3,8 +3,8 @@ package org.broadinstitute.dsde.firecloud.webservice
 import org.broadinstitute.dsde.firecloud.FireCloudConfig
 import org.broadinstitute.dsde.firecloud.service._
 import org.broadinstitute.dsde.firecloud.utils.StandardUserInfoDirectives
-import spray.http.HttpMethods
 import spray.routing._
+import spray.http.MediaTypes.`text/html`
 
 trait StaticNotebooksApiService extends HttpService
   with FireCloudDirectives
@@ -13,12 +13,16 @@ trait StaticNotebooksApiService extends HttpService
   private implicit val executionContext = actorRefFactory.dispatcher
 
   val calhounStaticNotebooksRoot: String = FireCloudConfig.StaticNotebooks.baseUrl
+  val calhounStaticNotebooksURL: String = s"$calhounStaticNotebooksRoot/api/convert"
 
   val staticNotebooksRoutes: Route = {
     path("staticNotebooks" / "convert") {
       requireUserInfo() { _ =>
         post {
-          passthrough(s"$calhounStaticNotebooksRoot/api/convert", HttpMethods.POST)
+          respondWithMediaType(`text/html`) {
+            requestContext =>
+              externalHttpPerRequest(requestContext, Post(calhounStaticNotebooksURL, requestContext.request.entity))
+          }
         }
       }
     }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/StaticNotebooksApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/StaticNotebooksApiService.scala
@@ -21,7 +21,10 @@ trait StaticNotebooksApiService extends HttpService
         post {
           respondWithMediaType(`text/html`) {
             requestContext =>
-              externalHttpPerRequest(requestContext, Post(calhounStaticNotebooksURL, requestContext.request.entity))
+              // call Calhoun and pass its response back to our own caller
+              // can't use passthrough() here because that demands a JSON response
+              externalHttpPerRequest(requestContext,
+                Post(calhounStaticNotebooksURL, requestContext.request.entity))
           }
         }
       }


### PR DESCRIPTION
Followup to #735 after some testing with stricter clients on the AoU side.

Swagger and Spray now correctly report that the content they're passing along from Calhoun is `text/html` rather than JSON.  

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
