### PR TITLE
no ticket: upgrade Jackson versions [risk: low]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,13 @@
 jdk:
   - oraclejdk8
 
+sudo: required
+dist: trusty
+
 language: scala
 
 scala:
-  - 2.11.7
+  - 2.11.12
 
 script: AGORA_URL_ROOT='http://localhost:8989' RAWLS_URL_ROOT='http://localhost:8990' THURLOE_URL_ROOT='http://localhost:8991' FIRE_CLOUD_ID='123' sbt coverage test coverageReport
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,8 @@ import sbt._
 object Dependencies {
   val akkaV = "2.4.19"
   val sprayV = "1.3.4"
-  val jacksonV = "2.9.8"
+  val jacksonV = "2.9.9"
+  val jacksonHotfixV = "2.9.9.2" // for when only some of the Jackson libs have hotfix releases
 
   def excludeGuavaJDK5(m: ModuleID): ModuleID = m.exclude("com.google.guava", "guava-jdk5")
 
@@ -11,7 +12,7 @@ object Dependencies {
     // proactively pull in latest versions of Jackson libs, instead of relying on the versions
     // specified as transitive dependencies, due to OWASP DependencyCheck warnings for earlier versions.
     "com.fasterxml.jackson.core"     % "jackson-annotations" % jacksonV,
-    "com.fasterxml.jackson.core"     % "jackson-databind"    % jacksonV,
+    "com.fasterxml.jackson.core"     % "jackson-databind"    % jacksonHotfixV,
     "com.fasterxml.jackson.core"     % "jackson-core"        % jacksonV,
 
     "org.apache.logging.log4j"       % "log4j-api"           % "2.8.2", // elasticsearch requires log4j ...

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ object Dependencies {
   val akkaV = "2.4.19"
   val sprayV = "1.3.4"
   val jacksonV = "2.9.9"
-  val jacksonHotfixV = "2.9.9.2" // for when only some of the Jackson libs have hotfix releases
+  val jacksonHotfixV = "2.9.9.3" // for when only some of the Jackson libs have hotfix releases
 
   def excludeGuavaJDK5(m: ModuleID): ModuleID = m.exclude("com.google.guava", "guava-jdk5")
 


### PR DESCRIPTION
Two changes in this PR:
1. Update Travis configuration to use the same Scala version as the non-Travis build, and to use a supported distro. Without the distro change, Travis builds fail to start. See broadinstitute/agora#280 for a similar change.
2. Upgrade Jackson libs, based on recommendation from SourceClear.

----

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
