### PR TITLE
use jwt-core instead of authentikat-jwt [no ticket; risk: low]

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -50,8 +50,7 @@ object Dependencies {
     excludeGuavaJDK5("com.google.apis"                % "google-api-services-pubsub"       % "v1-rev357-1.22.0"),
 
     "org.webjars"                    % "swagger-ui"          % "2.2.5",
-    "com.jason-goodwin"             %% "authentikat-jwt"     % "0.4.5"
-      exclude("com.fasterxml.jackson.core", "jackson-databind"),
+    "com.pauldijou"                 %% "jwt-core"            % "3.1.0",
     "com.sun.mail"                   % "javax.mail"          % "1.5.6",
     "com.univocity"                  % "univocity-parsers"   % "2.4.1",
     "org.ocpsoft.prettytime"         % "prettytime"          % "4.0.1.Final",

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/NihApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/NihApiService.scala
@@ -1,15 +1,17 @@
 package org.broadinstitute.dsde.firecloud.webservice
 
-import authentikat.jwt._
 import org.broadinstitute.dsde.firecloud.FireCloudConfig
 import org.broadinstitute.dsde.firecloud.model._
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
 import org.broadinstitute.dsde.firecloud.service.{FireCloudDirectives, NihService, NihServiceActor, PerRequestCreator}
 import org.broadinstitute.dsde.firecloud.utils.{DateUtils, StandardUserInfoDirectives}
 import org.slf4j.LoggerFactory
+import pdi.jwt.{Jwt, JwtAlgorithm}
 import spray.http.StatusCodes
 import spray.httpx.SprayJsonSupport._
 import spray.routing._
+
+import scala.util.{Failure, Success}
 
 trait NihApiService extends HttpService with PerRequestCreator with FireCloudDirectives with StandardUserInfoDirectives {
 
@@ -42,32 +44,34 @@ trait NihApiService extends HttpService with PerRequestCreator with FireCloudDir
               // get the token from the json wrapper
               val jwt = jwtWrapper.jwt
 
-              // validate the token
-              val isValid = JsonWebToken.validate(jwt, FireCloudConfig.Shibboleth.signingKey)
+              // validate the token.
+              // the NIH JWT is nonstandard. The claims portion of the token *should* be json, but is in fact
+              // a simple string. So, use decodeRaw here:
+              val decodeAttempt = Jwt.decodeRawAll(jwt, FireCloudConfig.Shibboleth.signingKey, Seq(JwtAlgorithm.HS256))
 
-              if (!isValid) {
-                requestContext.complete(StatusCodes.BadRequest)
-              } else {
-                // the NIH JWT is nonstandard. The claims portion of the token *should* be json, but is in fact
-                // a simple string. So, libraries tend to fail when working with it. Extract it manually.
-                // we shouldn't have to check for bad/missing parts of the token, because we've already validated it.
-                val claim = jwt.split("\\.")(1)
+              decodeAttempt match {
+                case Success((_, linkedNihUsername, _)) =>
+                  // The entirety of the claims portion of the jwt is the NIH username.
 
-                // decode it
-                val decoded = java.util.Base64.getDecoder.decode(claim)
+                  // JWT standard uses epoch time for dates, so we'll follow that convention here.
+                  val linkExpireTime = DateUtils.nowPlus30Days
 
-                // the entirety of the claims portion of the jwt is the NIH username.
-                val linkedNihUsername = new String(decoded)
-                // JWT standard uses epoch time for dates, so we'll follow that convention here.
-                val linkExpireTime = DateUtils.nowPlus30Days
+                  val nihLink = NihLink(linkedNihUsername, linkExpireTime)
 
-                val nihLink = NihLink(linkedNihUsername, linkExpireTime)
-
-                // update this user's dbGaP access in rawls, assuming the user exists in the whitelist
-                // and save the NIH link keys into Thurloe
-                perRequest(requestContext, NihService.props(nihServiceConstructor),
-                  NihService.UpdateNihLinkAndSyncSelf(userInfo, nihLink))
-
+                  // update this user's dbGaP access in rawls, assuming the user exists in the whitelist
+                  // and save the NIH link keys into Thurloe
+                  perRequest(requestContext, NihService.props(nihServiceConstructor),
+                    NihService.UpdateNihLinkAndSyncSelf(userInfo, nihLink))
+                case Failure(_) =>
+                  // The exception's error message contains the raw JWT. For an abundance of security, don't
+                  // log the error message - even though if we reached this point, the JWT is invalid. It could
+                  // still contain sensitive info.
+                  log.error(s"Failed to decode JWT")
+                  requestContext.complete(StatusCodes.BadRequest)
+                case _ =>
+                  // this should never happen: decodeAttempt returned a type it shouldn't.
+                  log.error("Unexpected error decoding JWT")
+                  requestContext.complete(StatusCodes.BadRequest)
               }
             }
           }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/RegisterApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/RegisterApiService.scala
@@ -1,14 +1,10 @@
 package org.broadinstitute.dsde.firecloud.webservice
 
-import akka.actor.Props
-import authentikat.jwt._
-import org.broadinstitute.dsde.firecloud.FireCloudConfig
-import org.broadinstitute.dsde.firecloud.model._
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
+import org.broadinstitute.dsde.firecloud.model._
 import org.broadinstitute.dsde.firecloud.service.{FireCloudDirectives, PerRequestCreator, RegisterService}
-import org.broadinstitute.dsde.firecloud.utils.{DateUtils, StandardUserInfoDirectives}
+import org.broadinstitute.dsde.firecloud.utils.StandardUserInfoDirectives
 import org.slf4j.LoggerFactory
-import spray.http.StatusCodes
 import spray.httpx.SprayJsonSupport._
 import spray.json.DefaultJsonProtocol._
 import spray.routing._


### PR DESCRIPTION
We have a medium-priority recommendation from SourceClear to upgrade or replace the `authentikat-jwt` library. That library looks abandoned - the repo says they are "looking for maintainer" and its readme recommends we use something else.

So, I've replaced `authentikat-jwt` with `jwt-core`. As a bonus, `jwt-core` is better about decoding our non-standard JWTs, so I've refactored/simplified the code a bit.


---

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
