### PR TITLE
Preferences API extensibility [no ticket; risk: low]

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/RegisterService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/RegisterService.scala
@@ -86,8 +86,16 @@ class RegisterService(val rawlsDao: RawlsDAO, val samDao: SamDAO, val thurloeDao
     }
   }
 
+  /*  utility method to determine if a preferences key headed to Thurloe is valid for user input.
+      Add whitelist logic here if you need to allow more keys.
+      If we find we update this logic frequently, I suggest moving the predicates to a config file!
+   */
+  private def isValidPreferenceKey(key: String): Boolean = {
+    key.startsWith("notifications/")
+  }
+
   private def updateProfilePreferences(userInfo: UserInfo, preferences: Map[String, String]): Future[PerRequestMessage] = {
-    if (preferences.forall(_._1.startsWith("notifications/"))) {
+    if (preferences.keys.forall(isValidPreferenceKey)) {
       thurloeDao.saveKeyValues(userInfo, preferences).map(_ => RequestComplete(StatusCodes.NoContent))
     } else {
       throw new FireCloudExceptionWithErrorReport(ErrorReport(StatusCodes.BadRequest, "illegal preference key"))

--- a/src/test/resources/reference.conf
+++ b/src/test/resources/reference.conf
@@ -1,7 +1,7 @@
 include "src/main/resources/reference.conf"
 
 akka {
-  loglevel = "ERROR"
+  loglevel = "OFF"
 }
 
 auth {

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/RegisterApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/RegisterApiServiceSpec.scala
@@ -1,0 +1,86 @@
+package org.broadinstitute.dsde.firecloud.webservice
+
+import org.broadinstitute.dsde.firecloud.dataaccess.MockThurloeDAO
+import org.broadinstitute.dsde.firecloud.model.UserInfo
+import org.broadinstitute.dsde.firecloud.service.{BaseServiceSpec, RegisterService}
+import spray.http.StatusCodes.{BadRequest, NoContent}
+import spray.http.StatusCode
+import spray.httpx.SprayJsonSupport
+import spray.json.DefaultJsonProtocol
+
+import scala.concurrent.Future
+import scala.util.Success
+
+final class RegisterApiServiceSpec extends BaseServiceSpec with RegisterApiService
+  with DefaultJsonProtocol with SprayJsonSupport {
+
+  def actorRefFactory = system
+
+  val registerServiceConstructor:() => RegisterService =
+    RegisterService.constructor(app.copy(thurloeDAO = new RegisterApiServiceSpecThurloeDAO))
+
+  "RegisterApiService" - {
+    "update-preferences API" - {
+
+      "should succeed with a single notifications key" in {
+        val payload = Map(
+          "notifications/foo" -> "yes"
+        )
+        assertPreferencesUpdate(payload, NoContent)
+      }
+
+      "should succeed with multiple notifications keys" in {
+        val payload = Map(
+          "notifications/foo" -> "yes",
+          "notifications/bar" ->  "no",
+          "notifications/baz" -> "astring"
+        )
+        assertPreferencesUpdate(payload, NoContent)
+      }
+
+      "should refuse with a single non-whitelisted key" in {
+        val payload = Map(
+          "abadkey" -> "astring"
+        )
+        assertPreferencesUpdate(payload, BadRequest)
+      }
+
+      "should refuse with mixed notifications and non-whitelisted keys" in {
+        val payload = Map(
+          "notifications/foo" -> "yes",
+          "notifications/bar" ->  "no",
+          "secretsomething" -> "astring"
+        )
+        assertPreferencesUpdate(payload, BadRequest)
+      }
+
+      "should refuse with the string 'notifications/' in the middle of a key" in {
+        val payload = Map(
+          "notifications/foo" -> "yes",
+          "notifications/bar" ->  "no",
+          "substring/notifications/arebad" -> "true"
+        )
+        assertPreferencesUpdate(payload, BadRequest)
+      }
+
+      "should succeed with an empty payload" in {
+        val payload = Map.empty[String, String]
+        assertPreferencesUpdate(payload, NoContent)
+      }
+
+    }
+  }
+
+  private def assertPreferencesUpdate(payload: Map[String, String], expectedStatus: StatusCode): Unit = {
+    Post("/profile/preferences", payload) ~> dummyUserIdHeaders("RegisterApiServiceSpec") ~> sealRoute(profileRoutes) ~> check {
+      status should be(expectedStatus)
+    }
+  }
+
+  // for purposes of these tests, we treat Thurloe as if it is always successful.
+  final class RegisterApiServiceSpecThurloeDAO extends MockThurloeDAO {
+    override def saveKeyValues(userInfo: UserInfo, keyValues: Map[String, String])= Future.successful(Success(()))
+  }
+
+}
+


### PR DESCRIPTION
This PR has no functional changes to the end user!!!

It adds a few unit tests and refactors the code around the `/api/profile/preferences` endpoint to be easily extensible.

Currently, that API is whitelisted to only allow Thurloe keys that start with "notifications/". We do this for security - there are some Thurloe keys that end users should not modify at will. However, we also want an easily extensible way to whitelist new keys. This PR (hopefully) makes it such that it is easier for developers to add new whitelisted keys, and add new unit tests for those keys.

-----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
