### PR TITLE
get-workspace allows querystrings [no ticket; risk: low]

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiService.scala
@@ -79,7 +79,9 @@ trait WorkspaceApiService extends HttpService with FireCloudRequestBuilding
           pathEnd {
             get {
               requireUserInfo() { _ =>
-                passthrough(workspacePath, HttpMethods.GET)
+                extract(_.request.uri.query) { query =>
+                  passthrough(Uri(workspacePath).withQuery(query), HttpMethods.GET)
+                }
               }
             } ~
             delete {


### PR DESCRIPTION
This PR modifies the get workspace API passthrough to pass querystrings through to Rawls. Previously the querystring was dropped.

This is in support of broadinstitute/rawls#1132.

I am *NOT* updating any swagger docs in this PR. This is intentional, as until broadinstitute/rawls#1132 is merged, the query parameters may change. My goal with this PR  is that, by updating the passthrough, any API consumers would be able to immediately take advantage of broadinstitute/rawls#1132 as soon as it is merged, and we could take our time releasing swagger doc updates.

----

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
