### PR TITLE
skip tests: swagger doc for get-workspace fields [PERF-47; risk: low]

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -2644,6 +2644,8 @@ paths:
       responses:
         200:
           description: Successful Request
+        400:
+          description: Unrecognized query parameters
         404:
           description: Workspace does not exist
         500:

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -2626,6 +2626,21 @@ paths:
       parameters:
         - $ref: '#/parameters/workspaceNamespaceParam'
         - $ref: '#/parameters/workspaceNameParam'
+        - name: fields
+          description: >
+            When specified, include only these keys in the response payload and exclude other keys.
+            Accepts a comma-delimited list of values. To include a nested key, specify the key's path
+            using a dot delimiter; for example, to include {"workspace": {"attributes": {}}}, specify
+            "workspace.attributes". Legal values are any first-level key in the response, any first-level key
+            inside the {"workspace": {}} object, and any first-level key inside the {"workspace": {"attributes": {}}}
+            object.
+            If omitted, will return the full response payload.
+          required: false
+          type: array
+          items:
+            type: string
+          collectionFormat: csv
+          in: query
       responses:
         200:
           description: Successful Request


### PR DESCRIPTION
catches orch up to broadinstitute/rawls#1132, which just merged.

-----

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
