### PR TITLE
support fields param for list-workspaces [PERF-238; risk: low]

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -2583,12 +2583,30 @@ paths:
       operationId: listWorkspaces
       summary: |
         Lists workspaces.
+      parameters:
+        - name: fields
+          description: >
+            When specified, include only these keys in the response payload and exclude other keys.
+            Accepts a comma-delimited list of values. To include a nested key, specify the key's path
+            using a dot delimiter; for example, to include {"workspace": {"attributes": {}}}, specify
+            "workspace.attributes". Legal values are any first-level key in the response, any first-level key
+            inside the {"workspace": {}} object, and any first-level key inside the {"workspace": {"attributes": {}}}
+            object.
+            If omitted, will return the full response payload.
+          required: false
+          type: array
+          items:
+            type: string
+          collectionFormat: csv
+          in: query
       produces:
         - application/json
         - text/plain
       responses:
         200:
           description: List of workspaces.
+        400:
+          description: Unrecognized query parameters
     post:
       x-passthrough: true
       x-passthrough-target: rawls

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiService.scala
@@ -57,7 +57,9 @@ trait WorkspaceApiService extends HttpService with FireCloudRequestBuilding
       pathPrefix("workspaces") {
         pathEnd {
           requireUserInfo() { _ =>
-            passthrough(rawlsWorkspacesRoot, HttpMethods.GET, HttpMethods.POST)
+            extract(_.request.uri.query) { query =>
+              passthrough(Uri(rawlsWorkspacesRoot).withQuery(query), HttpMethods.GET, HttpMethods.POST)
+            }
           }
         } ~
         pathPrefix("tags") {


### PR DESCRIPTION
in support of broadinstitute/rawls#1138  - adds swagger doc for the `fields` query param on list-workspaces and passes the query param through to Rawls.

-----

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
