### PR TITLE
ignore direct-download storage test [no ticket; risk: no]

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/StorageApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/StorageApiSpec.scala
@@ -145,7 +145,16 @@ class StorageApiSpec extends FreeSpec with StorageApiSpecSupport with Matchers w
       }
     }
 
-    "should redirect to a direct-download url when SA doesn't have signing permissions for large (>8MB) files " in {
+    /*  David An 30-Sep-19: disabling this test. We recently re-evaluated our SA permissions, removing many that were
+        unnecessary. SA now has storage-admin, which means this test is failing, since the SA *does* have permission
+        to sign the URL.
+
+        End-user functionality remains fine. The test is faulty. The test will need to be rewritten such that after
+        it grants the student access to the file, it removes the SA's permission.
+
+        TODO: rewrite/refactor/re-enable
+     */
+    "should redirect to a direct-download url when SA doesn't have signing permissions for large (>8MB) files " ignore {
       implicit val authToken: AuthToken = student.makeAuthToken()
       withLargeFile { largeFile =>
         setStudentOnly(largeFile, student)


### PR DESCRIPTION
ignores an integration test until we can rethink/rewrite it

-----

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
