### PR TITLE
changed default timeout for passthrough requests to 120 seconds

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/HttpClient.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/HttpClient.scala
@@ -16,6 +16,9 @@ import spray.http._
 import spray.routing.RequestContext
 import spray.http.StatusCodes._
 
+import scala.concurrent.duration._
+import akka.util.Timeout
+
 import org.broadinstitute.dsde.firecloud.HttpClient.PerformExternalRequest
 import org.broadinstitute.dsde.firecloud.service.FireCloudRequestBuilding
 import org.broadinstitute.dsde.firecloud.service.PerRequest.RequestComplete
@@ -57,6 +60,9 @@ class HttpClient (requestContext: RequestContext) extends Actor
       requestCompression: Boolean,
       requestContext: RequestContext,
       externalRequest: HttpRequest): Unit = {
+
+    implicit val requestTimeout = Timeout(120 seconds)
+
     val pipeline: HttpRequest => Future[HttpResponse] =
       requestCompression match {
         case true =>


### PR DESCRIPTION

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
