### PR TITLE
AS-69: upgrade third-party dependencies [risk: low]

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -52,7 +52,7 @@ object Dependencies {
     "com.sun.mail"                   % "javax.mail"          % "1.5.6",
     "com.univocity"                  % "univocity-parsers"   % "2.4.1",
     "org.ocpsoft.prettytime"         % "prettytime"          % "4.0.1.Final",
-    "org.everit.json"                % "org.everit.json.schema" % "1.4.1",
+    "com.github.everit-org.json-schema" % "org.everit.json.schema" % "1.12.0",
     "com.github.pathikrit"          %% "better-files"        % "2.17.1",
     "org.apache.httpcomponents"      % "httpclient"          % "4.5.3",
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,8 +3,8 @@ import sbt._
 object Dependencies {
   val akkaV = "2.4.19"
   val sprayV = "1.3.4"
-  val jacksonV = "2.9.9"
-  val jacksonHotfixV = "2.9.9.3" // for when only some of the Jackson libs have hotfix releases
+  val jacksonV = "2.10.0"
+  val jacksonHotfixV = "2.10.0" // for when only some of the Jackson libs have hotfix releases
 
   def excludeGuavaJDK5(m: ModuleID): ModuleID = m.exclude("com.google.guava", "guava-jdk5")
 

--- a/project/Merging.scala
+++ b/project/Merging.scala
@@ -1,6 +1,6 @@
 import sbtassembly.{MergeStrategy, PathList}
 
-object  Merging {
+object Merging {
   def customMergeStrategy(oldStrategy: (String) => MergeStrategy):(String => MergeStrategy) = {
     case x if x.endsWith("io.netty.versions.properties") => MergeStrategy.discard
     // we target Java 8, which does not use module-info.class. Some dependencies (Jackson) cause assembly problems on module-info

--- a/project/Merging.scala
+++ b/project/Merging.scala
@@ -1,8 +1,10 @@
 import sbtassembly.{MergeStrategy, PathList}
 
-object Merging {
+object  Merging {
   def customMergeStrategy(oldStrategy: (String) => MergeStrategy):(String => MergeStrategy) = {
     case x if x.endsWith("io.netty.versions.properties") => MergeStrategy.discard
+    // we target Java 8, which does not use module-info.class. Some dependencies (Jackson) cause assembly problems on module-info
+    case x if x.endsWith("module-info.class") => MergeStrategy.discard
     case x => oldStrategy(x)
   }
 }

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -12,7 +12,8 @@ object Settings {
 
   val commonResolvers = List(
     "artifactory-releases" at artifactory + "libs-release",
-    "artifactory-snapshots" at artifactory + "libs-snapshot"
+    "artifactory-snapshots" at artifactory + "libs-snapshot",
+    "jitpack.io" at "https://jitpack.io"
   )
 
   //coreDefaultSettings + defaultConfigs = the now deprecated defaultSettings

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/LibraryServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/LibraryServiceSpec.scala
@@ -619,7 +619,13 @@ class LibraryServiceSpec extends BaseServiceSpec with FreeSpecLike with LibraryS
           validateJsonSchema(sampleData, testSchema)
         }
         assertResult(1){ex.getViolationCount}
-        assert(ex.getCausingExceptions.last.getMessage.contains("library:coverage: foobar is not a valid enum value"))
+        // getSchemaValidationMessages is used at runtime to generate error messages to the user; it recurses through
+        // the exception and its causes.
+        val errMsgs = getSchemaValidationMessages(ex)
+        assert(
+          errMsgs.exists(_.contains("library:coverage: foobar is not a valid enum value")),
+          "did not find expected string 'library:coverage: foobar is not a valid enum value' in error messages"
+        )
       }
       "fails on a string that should be an array" in {
         val testSchema = FileUtils.readAllTextFromResource("library/attribute-definitions.json")


### PR DESCRIPTION
upgrades third-party libraries, based on proactive security advisories from SourceClear.

* upgrading jackson due to advisories on it.
* upgrading json-schema in order to upgrade its transitive dependency BeanUtils, which had advisories.


-----

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
