### PR TITLE
skip tests: update swagger responses for create and clone workspace [AS-100; risk: low]

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -2627,10 +2627,12 @@ paths:
           schema:
             $ref: '#/definitions/WorkspaceIngest'
       responses:
-        200:
-          description: No response was specified
         201:
           description: Successful Request
+          schema:
+            $ref: '#/definitions/CreateWorkspaceResponse'
+        400:
+          description: Bad request
         403:
           description: Unable to create bucket for workspace
         409:
@@ -2929,6 +2931,8 @@ paths:
       responses:
         201:
           description: Successful Request
+          schema:
+            $ref: '#/definitions/CreateWorkspaceResponse'
         400:
           description: Unable to create resources for workspace
         404:
@@ -5620,6 +5624,59 @@ definitions:
       servicePerimeter:
         type: string
         description: The fully qualified name of the GCP service perimeter to put this project into in the form accessPolicies/[POLICY NUMBER]/servicePerimeters/[NAME]. Caller must have the add_project action for this service perimeter in Sam.
+
+  CreateWorkspaceResponse:
+    description: payload returned from create- or clone-workspace
+    required:
+      - attributes
+      - authorizationDomain
+      - bucketName
+      - createdBy
+      - createdDate
+      - isLocked
+      - lastModified
+      - name
+      - namespace
+      - workspaceId
+    type: object
+    properties:
+      attributes:
+        type: object
+        description: Map[String, Attribute]
+      authorizationDomain:
+        type: array
+        items:
+          $ref: '#/definitions/ManagedGroupRef'
+        description: The list of groups to form the Authorization Domain (empty if no Authorization Domain is set)
+      bucketName:
+        type: string
+        description: The name of the bucket associated with the workspace
+      createdBy:
+        type: string
+        description: The user who created the workspace
+      createdDate:
+        type: string
+        format: date-time
+        description: 'The date the workspace was created in yyyy-MM-ddTHH:mm:ss.SSSZZ format'
+      isLocked:
+        type: boolean
+        description: Can the Workspace currently be modified?
+      lastModified:
+        type: string
+        format: date-time
+        description: 'The date the workspace was last modified in yyyy-MM-ddTHH:mm:ss.SSSZZ format'
+      name:
+        type: string
+        description: The name of the workspace
+      namespace:
+        type: string
+        description: The namespace the workspace belongs to
+      workflowCollectionName:
+        type: string
+        description: Workflow collection name
+      workspaceId:
+        type: string
+        description: A UUID associated with the workspace
 
   CuratorStatus:
     description: is the user a curator?

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -1010,8 +1010,18 @@ paths:
           required: false
           type: file
           in: formData
-        - $ref: '#/parameters/workflowTypeParam'
-        - $ref: '#/parameters/workflowTypeVersionParam'
+        - name: workflowType
+          type: string
+          description: The workflow language for the file you submitted. Cromwell currently supports WDL and CWL.
+          enum: [WDL, CWL]
+          required: false
+          in: formData
+        - name: workflowTypeVersion
+          description: The specification version for the workflow language being used. For WDL, Cromwell currently supports draft-2 and 1.0. For CWL, Cromwell currently supports v1.0.
+          required: false
+          type: string
+          enum: ["draft-2", "1.0", "v1.0"]
+          in: formData
       responses:
         '200':
           description: Workflow description.
@@ -5008,20 +5018,6 @@ paths:
 ## PARAMETERS
 ##########################################################################################
 parameters:
-  workflowTypeParam:
-    name: workflowType
-    type: string
-    description: The workflow language for the file you submitted. Cromwell currently supports WDL and CWL.
-    enum: [WDL, CWL]
-    required: false
-    in: formData
-  workflowTypeVersionParam:
-    name: workflowTypeVersion
-    description: The specification version for the workflow language being used. For WDL, Cromwell currently supports draft-2 and 1.0. For CWL, Cromwell currently supports v1.0.
-    required: false
-    type: string
-    enum: ["draft-2", "1.0", "v1.0"]
-    in: formData
   versionParam:
     name: version
     description: Cromwell API Version


### PR DESCRIPTION
updates response codes and payloads for create- and clone-workspace. Especially important for  anyone generating stubs for these API calls.

-----


Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
