### PR TITLE
AS-107: google oauth lib upgrade

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -27,7 +27,7 @@ object Dependencies {
       exclude("com.typesafe.scala-logging", "scala-logging_2.11") exclude("com.typesafe.akka", "akka-stream_2.11"),
     "org.broadinstitute.dsde.workbench" %% "workbench-util"  % "0.3-12b7791-SNAP",
 
-  "io.spray"                      %% "spray-can"                 % sprayV,
+    "io.spray"                      %% "spray-can"                 % sprayV,
     "io.spray"                      %% "spray-json"                % "1.3.3",
     "io.spray"                      %% "spray-client"              % sprayV,
     "io.spray"                      %% "spray-routing-shapeless23" % sprayV,
@@ -40,13 +40,13 @@ object Dependencies {
 
     "org.elasticsearch.client"       % "transport"           % "5.4.3",
 
-    "com.google.guava"               % "guava"               % "28.0-jre",
+    "com.google.guava"               % "guava"               % "28.1-android",
 
-    excludeGuavaJDK5("com.google.apis"                % "google-api-services-storage" % "v1-rev20190910-1.30.3"),
-    excludeGuavaJDK5("com.google.apis"                % "google-api-services-sheets"  % "v4-rev494-1.23.0"),
-    excludeGuavaJDK5("com.google.apis"                % "google-api-services-cloudbilling" % "v1-rev14-1.23.0"),
-    excludeGuavaJDK5("com.google.apis"                % "google-api-services-pubsub"       % "v1-rev357-1.22.0"),
-    excludeGuavaJDK5("com.google.auth"                % "google-auth-library-oauth2-http" % "0.18.0"),
+    excludeGuavaJDK5("com.google.apis"     % "google-api-services-storage"      % "v1-rev20190910-1.30.3"),
+    excludeGuavaJDK5("com.google.apis"     % "google-api-services-sheets"       % "v4-rev20191001-1.30.3"),
+    excludeGuavaJDK5("com.google.apis"     % "google-api-services-cloudbilling" % "v1-rev20191005-1.30.3"),
+    excludeGuavaJDK5("com.google.apis"     % "google-api-services-pubsub"       % "v1-rev20191001-1.30.3"),
+    excludeGuavaJDK5("com.google.auth"     % "google-auth-library-oauth2-http"  % "0.18.0"),
 
     "org.webjars"                    % "swagger-ui"          % "2.2.5",
     "com.pauldijou"                 %% "jwt-core"            % "3.1.0",

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
@@ -17,13 +17,16 @@ object FireCloudConfig {
     private val auth = config.getConfig("auth")
     val googleClientId = auth.getString("googleClientId")
     val googleSecretJson = auth.getString("googleSecretsJson")
-    val pemFile = auth.getString("pemFile")
-    val pemFileClientId = auth.getString("pemFileClientId")
-    val firecloudAccountJsonFile = auth.getString("jsonFile")
-    val rawlsPemFile = auth.getString("rawlsPemFile")
-    val rawlsPemFileClientId = auth.getString("rawlsPemFileClientId")
-    val trialBillingPemFile = auth.getString("trialBillingPemFile")
-    val trialBillingPemFileClientId = auth.getString("trialBillingPemFileClientId")
+
+    // credentials for orchestration's "firecloud" service account, used for admin duties
+    val firecloudAdminSAJsonFile = auth.getString("firecloudAdminSA")
+
+    // credentials for the rawls service account, used for signing GCS urls
+    val rawlsSAJsonFile = auth.getString("rawlsSA")
+
+    // credentials for the trial billing service account, used for free trial duties
+    val trialBillingSAJsonFile = auth.getString("trialBillingSA")
+
     val swaggerRealm = auth.getString("swaggerRealm")
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/GoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/GoogleServicesDAO.scala
@@ -41,7 +41,7 @@ trait GoogleServicesDAO extends ReportsSubsystemStatus {
   def getObjectContentsAsRawlsSA(bucketName: String, objectKey: String): String
 
   def fetchPriceList(implicit actorRefFactory: ActorRefFactory, executionContext: ExecutionContext): Future[GooglePriceList]
-  def updateSpreadsheet(withAccessToken: WithAccessToken, spreadsheetId: String, content: ValueRange): JsObject
+  def updateSpreadsheet(spreadsheetId: String, content: ValueRange): JsObject
 
   def trialBillingManagerRemoveBillingAccount(projectName: String, targetUserEmail: String): Boolean
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
@@ -137,7 +137,7 @@ object HttpGoogleServicesDAO extends GoogleServicesDAO with FireCloudRequestBuil
   def getTrialBillingManagerEmail = trialBillingSACreds.getClientEmail
 
   def getCloudBillingManager(credential: ServiceAccountCredentials): Cloudbilling = {
-    new Cloudbilling.Builder(httpTransport, jsonFactory, new HttpCredentialsAdapter(credential)).setApplicationName(appName).build()
+    new Cloudbilling.Builder(httpTransport, jsonFactory, new HttpCredentialsAdapter(credential.createScoped(authScopes ++ billingScope))).setApplicationName(appName).build()
   }
 
   private lazy val pubSub = {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
@@ -423,7 +423,7 @@ object HttpGoogleServicesDAO extends GoogleServicesDAO with FireCloudRequestBuil
     */
   def updateSpreadsheet(spreadsheetId: String, newContent: ValueRange): JsObject = {
 
-    val service = new Sheets.Builder(httpTransport, jsonFactory, new HttpCredentialsAdapter(trialBillingSACreds)).setApplicationName("FireCloud").build()
+    val service = new Sheets.Builder(httpTransport, jsonFactory, new HttpCredentialsAdapter(trialBillingSACreds.createScoped(spreadsheetScopes))).setApplicationName("FireCloud").build()
 
     // Retrieve existing records
     val getExisting: Sheets#Spreadsheets#Values#Get = service.spreadsheets().values.get(spreadsheetId, "Sheet1")

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/TrialService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/TrialService.scala
@@ -501,7 +501,7 @@ final class TrialService
     val majorDimension: String = "ROWS"
     val range: String = "Sheet1!A1"
     makeSpreadsheetValues(saToken, trialDao, thurloeDao, majorDimension, range).map { content =>
-      Try (googleDAO.updateSpreadsheet(saToken, spreadsheetId, content)) match {
+      Try (googleDAO.updateSpreadsheet(spreadsheetId, content)) match {
         case Success(updatedSheet) =>
           logger.info(s"Successfully updated spreadsheet [$spreadsheetId].")
           makeSpreadsheetResponse(spreadsheetId)

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockGoogleServicesDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockGoogleServicesDAO.scala
@@ -101,7 +101,7 @@ class MockGoogleServicesDAO extends GoogleServicesDAO {
   override def fetchPriceList(implicit actorRefFactory: ActorRefFactory, executionContext: ExecutionContext): Future[GooglePriceList] = {
     Future.successful(GooglePriceList(GooglePrices(UsPriceItem(BigDecimal(0.01)), UsTieredPriceItem(Map(1024L -> BigDecimal(0.12)))), "v0", "18-November-2016"))
   }
-  override def updateSpreadsheet(withAccessToken: WithAccessToken, spreadsheetId: String, content: ValueRange): JsObject = spreadsheetUpdateJson
+  override def updateSpreadsheet(spreadsheetId: String, content: ValueRange): JsObject = spreadsheetUpdateJson
 
 
   override def trialBillingManagerRemoveBillingAccount(projectName: String, targetUserEmail: String): Boolean = false

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/TrialApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/TrialApiServiceSpec.scala
@@ -639,7 +639,7 @@ final class TrialApiServiceSpec extends BaseServiceSpec with UserApiService with
 
   final class TrialApiServiceSpecGoogleDAO extends MockGoogleServicesDAO {
 
-    override def updateSpreadsheet(withAccessToken: WithAccessToken, spreadsheetId: String, content: ValueRange): JsObject = {
+    override def updateSpreadsheet(spreadsheetId: String, content: ValueRange): JsObject = {
       spreadsheetId match {
         case "invalid" =>
           // A lot of java overhead to generate the right exception...


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AS-107

Standardizes `HttpGoogleServicesDAO` to use the  `google-auth-library-oauth2-http` library for all its various *Credentials classes,  getting access/identity tokens, etc.

Before this PR, as of #760, we were using both `google-auth-library-oauth2-http` and the `google-oauth-client` it supersedes.

As a nice benefit, after this PR merges we can simplify orch's config to remove .pem files, as we will be relying solely on .json files. I'll do this as a follow-on PR.

TODOs:
- [x] test and verify that each `HttpCredentialsAdapter` has the proper scopes
- [x] test and verify that each change is still working

-----

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
