### PR TITLE
correct cleanup order

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/PublishedWorkspaceSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/PublishedWorkspaceSpec.scala
@@ -59,23 +59,25 @@ class PublishedWorkspaceSpec extends FreeSpec with WorkspaceFixtures with Billin
 
           withCleanBillingProject(curatorUser) { billingProject =>
             withWorkspace(billingProject, "PublishedWorkspaceSpec_workspace") { workspaceName =>
+              withCleanUp {
 
-              val data = LibraryData.metadataBasic + ("library:datasetName" -> workspaceName)
-              Orchestration.library.setLibraryAttributes(billingProject, workspaceName, data)
-              Orchestration.library.publishWorkspace(billingProject, workspaceName)
+                val data = LibraryData.metadataBasic + ("library:datasetName" -> workspaceName)
+                Orchestration.library.setLibraryAttributes(billingProject, workspaceName, data)
+                Orchestration.library.publishWorkspace(billingProject, workspaceName)
 
-              val clonedWorkspaceName = uuidWithPrefix("cloneWorkspace")
+                val clonedWorkspaceName = uuidWithPrefix("cloneWorkspace")
 
-              register cleanUp Orchestration.workspaces.delete(billingProject, clonedWorkspaceName)
-              Orchestration.workspaces.clone(billingProject, workspaceName, billingProject, clonedWorkspaceName)
-              // check cloned workspace does not have published status in workspace detail: "library:published": false
-              val response = Rawls.workspaces.getWorkspaceDetails(billingProject, clonedWorkspaceName)
-              response should include(""""library:published":false""")
+                register cleanUp Orchestration.workspaces.delete(billingProject, clonedWorkspaceName)
+                Orchestration.workspaces.clone(billingProject, workspaceName, billingProject, clonedWorkspaceName)
+                // check cloned workspace does not have published status in workspace detail: "library:published": false
+                val response = Rawls.workspaces.getWorkspaceDetails(billingProject, clonedWorkspaceName)
+                response should include(""""library:published":false""")
 
-              // check cloned workspace is not visible in library
-              withClue("a cloned workspace should not be visible in library.") {
-                eventually {
-                  isVisibleInLibrary(clonedWorkspaceName) shouldBe false
+                // check cloned workspace is not visible in library
+                withClue("a cloned workspace should not be visible in library.") {
+                  eventually {
+                    isVisibleInLibrary(clonedWorkspaceName) shouldBe false
+                  }
                 }
               }
             }
@@ -89,22 +91,24 @@ class PublishedWorkspaceSpec extends FreeSpec with WorkspaceFixtures with Billin
 
           withCleanBillingProject(curatorUser) { billingProject =>
             withWorkspace(billingProject, "PublishedWorkspaceSpec_workspace") { workspaceName =>
+              withCleanUp {
 
-              val data = LibraryData.metadataBasic + ("library:datasetName" -> workspaceName)
-              Orchestration.library.setLibraryAttributes(billingProject, workspaceName, data)
-              Orchestration.library.setDiscoverableGroups(billingProject, workspaceName, List("all_broad_users"))
-              Orchestration.library.publishWorkspace(billingProject, workspaceName)
+                val data = LibraryData.metadataBasic + ("library:datasetName" -> workspaceName)
+                Orchestration.library.setLibraryAttributes(billingProject, workspaceName, data)
+                Orchestration.library.setDiscoverableGroups(billingProject, workspaceName, List("all_broad_users"))
+                Orchestration.library.publishWorkspace(billingProject, workspaceName)
 
-              val clonedWorkspaceName = workspaceName + "_clone"
-              register cleanUp Orchestration.workspaces.delete(billingProject, clonedWorkspaceName)
-              Orchestration.workspaces.clone(billingProject, workspaceName, billingProject, clonedWorkspaceName)
+                val clonedWorkspaceName = workspaceName + "_clone"
+                register cleanUp Orchestration.workspaces.delete(billingProject, clonedWorkspaceName)
+                Orchestration.workspaces.clone(billingProject, workspaceName, billingProject, clonedWorkspaceName)
 
-              //Verify default group "All users"
-              //In swagger you make sure that getDiscoverableGroup endpoint shows []
-              withClue(s"Get api/library/${billingProject}/${clonedWorkspaceName}/discoverableGroups endpoint shows []") {
-                eventually {
-                  val accessGroup: Seq[String] = Orchestration.library.getDiscoverableGroups(billingProject, clonedWorkspaceName)
-                  accessGroup.size shouldBe 0
+                //Verify default group "All users"
+                //In swagger you make sure that getDiscoverableGroup endpoint shows []
+                withClue(s"Get api/library/${billingProject}/${clonedWorkspaceName}/discoverableGroups endpoint shows []") {
+                  eventually {
+                    val accessGroup: Seq[String] = Orchestration.library.getDiscoverableGroups(billingProject, clonedWorkspaceName)
+                    accessGroup.size shouldBe 0
+                  }
                 }
               }
             }


### PR DESCRIPTION
Postgres is much more sensitive to missing or out of order cleanup steps. This PR fixes a few problems.

Hide whitespace changes when reviewing.


Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
