### PR TITLE
AS-47: tsv entity import is now lenient to trailing delimiter-only lines [risk: low]

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/utils/TSVParser.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/utils/TSVParser.scala
@@ -42,11 +42,12 @@ object TSVParser {
         val tsvData = t.zipWithIndex.map { case (line, idx) => parseLine(line, idx, h.length) }
         // for user-friendliness, we are lenient and ignore any lines that are either just a newline,
         // or consist only of delimiters (tabs) but have no data.
-        // we implement this by checking if the line is empty or if all values in the line are the empty string.
+        // we implement this by checking to see if any of the line's values is non-empty.  If the line
+        // consists only of delimiters, all values will be empty.
         // NB: CsvParserSettings.setSkipEmptyLines, setIgnoreTrailingWhitespaces, and setIgnoreLeadingWhitespaces
         // do not help with this use case, so we write our own implementation.
         val validData =  tsvData.collect {
-          case hasValues if hasValues.nonEmpty && hasValues.forall(_.nonEmpty) =>
+          case hasValues if hasValues.exists(_.nonEmpty) =>
             hasValues
         }
         TSVLoadFile(h.head, h.toList, validData)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/utils/TSVParser.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/utils/TSVParser.scala
@@ -47,8 +47,7 @@ object TSVParser {
         // NB: CsvParserSettings.setSkipEmptyLines, setIgnoreTrailingWhitespaces, and setIgnoreLeadingWhitespaces
         // do not help with this use case, so we write our own implementation.
         val validData =  tsvData.collect {
-          case hasValues if hasValues.exists(_.nonEmpty) =>
-            hasValues
+          case hasValues if hasValues.exists(_.nonEmpty) => hasValues
         }
         TSVLoadFile(h.head, h.toList, validData)
       case _ => throw new RuntimeException("TSV parsing error: no header")

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/utils/TSVParser.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/utils/TSVParser.scala
@@ -34,12 +34,22 @@ object TSVParser {
     val allRows = makeParser.parseAll(new StringReader(tsvString)).asScala
       // The CsvParser returns null for missing fields, however the application expects the
       // empty string. This replaces all nulls with the empty string.
+      // someday, consider trying CsvParserSettings.setEmptyValue("") instead of doing this ourselves
       .map(_.map(s => Option(s).getOrElse("")))
       .toList
     allRows match {
       case h :: t =>
         val tsvData = t.zipWithIndex.map { case (line, idx) => parseLine(line, idx, h.length) }
-        TSVLoadFile(h.head, h.toList, tsvData)
+        // for user-friendliness, we are lenient and ignore any lines that are either just a newline,
+        // or consist only of delimiters (tabs) but have no data.
+        // we implement this by checking if the line is empty or if all values in the line are the empty string.
+        // NB: CsvParserSettings.setSkipEmptyLines, setIgnoreTrailingWhitespaces, and setIgnoreLeadingWhitespaces
+        // do not help with this use case, so we write our own implementation.
+        val validData =  tsvData.collect {
+          case hasValues if hasValues.nonEmpty && hasValues.forall(_.nonEmpty) =>
+            hasValues
+        }
+        TSVLoadFile(h.head, h.toList, validData)
       case _ => throw new RuntimeException("TSV parsing error: no header")
     }
   }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockTSV.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockTSV.scala
@@ -101,6 +101,22 @@ object MockTSVStrings {
     List("sset_01", "sample_01").tabbed,
     List("sset_01", "sample_02").tabbed).newlineSeparated
 
+  val membershipValidWithMultipleNewlines = List(
+    List("membership:sample_set_id", "sample").tabbed,
+    List("sset_01", "sample_01").tabbed,
+    List("sset_01", "sample_02").tabbed,
+    List().tabbed,
+    List().tabbed,
+    List().tabbed).newlineSeparated
+
+  val membershipValidWithMultipleDelimiterOnlylines = List(
+    List("membership:sample_set_id", "sample").tabbed,
+    List("sset_01", "sample_01").tabbed,
+    List("sset_01", "sample_02").tabbed,
+    List("", "").tabbed,
+    List("", "").tabbed,
+    List("", "").tabbed).newlineSeparated
+
   val defaultMembershipValid = List(
     List("sample_set_id", "sample").tabbed,
     List("sset_01", "sample_01").tabbed,
@@ -139,6 +155,22 @@ object MockTSVStrings {
     List("entity:sample_id", "participant").tabbed,
     List("sample_01", "part_01").tabbed,
     List("sample_02", "part_02").tabbed).newlineSeparated
+
+  val entityUpdateWithMultipleNewlines = List(
+    List("entity:sample_id", "participant").tabbed,
+    List("sample_01", "part_01").tabbed,
+    List("sample_02", "part_02").tabbed,
+    List().tabbed,
+    List().tabbed,
+    List().tabbed).newlineSeparated
+
+  val entityUpdateWithMultipleDelimiterOnlylines = List(
+    List("entity:sample_id", "participant").tabbed,
+    List("sample_01", "part_01").tabbed,
+    List("sample_02", "part_02").tabbed,
+    List("","").tabbed,
+    List("","").tabbed,
+    List("","").tabbed).newlineSeparated
 
   val defaultUpdateWithRequiredAttrs = List(
     List("sample_id", "participant").tabbed,
@@ -289,6 +321,8 @@ object MockTSVFormData {
   val membershipMissingMembersHeader = wrapInMultipart("entities", MockTSVStrings.membershipMissingMembersHeader)
   val membershipExtraAttributes = wrapInMultipart("entities", MockTSVStrings.membershipExtraAttributes)
   val membershipValid = wrapInMultipart("entities", MockTSVStrings.membershipValid)
+  val membershipValidWithMultipleNewlines = wrapInMultipart("entities", MockTSVStrings.membershipValidWithMultipleNewlines)
+  val membershipValidWithMultipleDelimiterOnlylines = wrapInMultipart("entities", MockTSVStrings.membershipValidWithMultipleDelimiterOnlylines)
 
   val entityUnknownFirstColumnHeader = wrapInMultipart("entities", MockTSVStrings.entityNonModelFirstColumnHeader)
   val entityHasDupes = wrapInMultipart("entities", MockTSVStrings.entityHasDupes)
@@ -296,6 +330,8 @@ object MockTSVFormData {
   val entityHasNoRows = wrapInMultipart("entities", MockTSVStrings.entityHasNoRows)
   val entityUpdateMissingRequiredAttrs = wrapInMultipart("entities", MockTSVStrings.entityUpdateMissingRequiredAttrs)
   val entityUpdateWithRequiredAttrs = wrapInMultipart("entities", MockTSVStrings.entityUpdateWithRequiredAttrs)
+  val entityUpdateWithMultipleNewlines = wrapInMultipart("entities", MockTSVStrings.entityUpdateWithMultipleNewlines)
+  val entityUpdateWithMultipleDelimiterOnlylines = wrapInMultipart("entities", MockTSVStrings.entityUpdateWithMultipleDelimiterOnlylines)
   val entityUpdateWithRequiredAndOptionalAttrs = wrapInMultipart("entities", MockTSVStrings.entityUpdateWithRequiredAndOptionalAttrs)
 
   val updateNonModelFirstColumnHeader = wrapInMultipart("entities", MockTSVStrings.updateNonModelFirstColumnHeader)

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceApiServiceSpec.scala
@@ -761,6 +761,24 @@ class WorkspaceApiServiceSpec extends BaseServiceSpec with WorkspaceApiService w
               status should equal(OK)
             }
           }
+
+          "should 200 OK if it has the correct headers and valid internals followed by multiple newlines" in {
+            stubRawlsService(HttpMethods.POST, batchUpsertPath, NoContent)
+            (Post(tsvImportPath, MockTSVFormData.membershipValidWithMultipleNewlines)
+              ~> dummyUserIdHeaders(dummyUserId)
+              ~> sealRoute(workspaceRoutes)) ~> check {
+              status should equal(OK)
+            }
+          }
+
+          "should 200 OK if it has the correct headers and valid internals followed by multiple delimiter-only lines" in {
+            stubRawlsService(HttpMethods.POST, batchUpsertPath, NoContent)
+            (Post(tsvImportPath, MockTSVFormData.membershipValidWithMultipleDelimiterOnlylines)
+              ~> dummyUserIdHeaders(dummyUserId)
+              ~> sealRoute(workspaceRoutes)) ~> check {
+              status should equal(OK)
+            }
+          }
         }
 
         "an entity-type TSV" - {
@@ -820,6 +838,24 @@ class WorkspaceApiServiceSpec extends BaseServiceSpec with WorkspaceApiService w
           "should 200 OK if it has the full set of required attribute headers" in {
             stubRawlsService(HttpMethods.POST, batchUpsertPath, NoContent)
             (Post(tsvImportPath, MockTSVFormData.entityUpdateWithRequiredAttrs)
+              ~> dummyUserIdHeaders(dummyUserId)
+              ~> sealRoute(workspaceRoutes)) ~> check {
+              status should equal(OK)
+            }
+          }
+
+          "should 200 OK if it has valid rows followed by multiple newlines" in {
+            stubRawlsService(HttpMethods.POST, batchUpsertPath, NoContent)
+            (Post(tsvImportPath, MockTSVFormData.entityUpdateWithMultipleNewlines)
+              ~> dummyUserIdHeaders(dummyUserId)
+              ~> sealRoute(workspaceRoutes)) ~> check {
+              status should equal(OK)
+            }
+          }
+
+          "should 200 OK if it has valid rows followed by multiple delimiter-only lines" in {
+            stubRawlsService(HttpMethods.POST, batchUpsertPath, NoContent)
+            (Post(tsvImportPath, MockTSVFormData.entityUpdateWithMultipleDelimiterOnlylines)
               ~> dummyUserIdHeaders(dummyUserId)
               ~> sealRoute(workspaceRoutes)) ~> check {
               status should equal(OK)


### PR DESCRIPTION
User attempts to import a TSV file, where the TSV contains multiple trailing delimiter-only lines, e.g.:
```
entity:some_id\tcol1\tcol2
id1\tVal1\tVal2
id2\tVal1\tVal2
\t\t
\t\t
\t\t
```
this can occur when exporting a TSV from Excel, etc.

**Expected**: the TSV imports successfully.
**Actual**: import fails with an error message "Duplicated attribute keys are not allowed"

Before this PR, the code would parse each line, extract the empty string as the entity id for the trailing lines, and fail because it believed the TSV to contain multiple rows with the same id (of the empty string)

After this PR, the TSV parser ignores any lines that consist purely of delimiters and therefore have no value.

-----

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
