### PR TITLE
move storage cost estimate keys to config, change egress key [risk: low; no ticket]

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -50,7 +50,10 @@ userprofile {
 }
 
 googlecloud {
-  priceListUrl: "https://cloudpricingcalculator.appspot.com/static/data/pricelist.json"
+  priceListUrl = "https://cloudpricingcalculator.appspot.com/static/data/pricelist.json"
+  # egress key previouly was "CP-COMPUTEENGINE-INTERNET-EGRESS-NA-NA"
+  priceListEgressKey = "CP-INTERNET-EGRESS-PREMIUM-TIER-TO-NA-FROM-NA"
+  priceListStorageKey = "CP-BIGSTORE-STORAGE"
 }
 
 trial {

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -52,7 +52,7 @@ userprofile {
 googlecloud {
   priceListUrl = "https://cloudpricingcalculator.appspot.com/static/data/pricelist.json"
   # egress key previouly was "CP-COMPUTEENGINE-INTERNET-EGRESS-NA-NA"
-  priceListEgressKey = "CP-INTERNET-EGRESS-PREMIUM-TIER-TO-NA-FROM-NA"
+  priceListEgressKey = "CP-INTERNET-EGRESS-STANDARD-TIER-FROM-NA"
   priceListStorageKey = "CP-BIGSTORE-STORAGE"
 }
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
@@ -181,6 +181,8 @@ object FireCloudConfig {
   object GoogleCloud {
     private val googlecloud = config.getConfig("googlecloud")
     val priceListUrl = googlecloud.getString("priceListUrl")
+    val priceListEgressKey = googlecloud.getString("priceListEgressKey")
+    val priceListStorageKey = googlecloud.getString("priceListStorageKey")
   }
 
   object Duos {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
@@ -74,7 +74,7 @@ object GooglePriceListJsonProtocol extends DefaultJsonProtocol {
       case x => throw new DeserializationException("invalid value: " + x)
     }
   }
-  implicit val GooglePricesFormat = jsonFormat(GooglePrices, "CP-BIGSTORE-STORAGE", "CP-COMPUTEENGINE-INTERNET-EGRESS-NA-NA")
+  implicit val GooglePricesFormat = jsonFormat(GooglePrices, FireCloudConfig.GoogleCloud.priceListStorageKey, FireCloudConfig.GoogleCloud.priceListEgressKey)
   implicit val GooglePriceListFormat = jsonFormat(GooglePriceList, "gcp_price_list", "version", "updated")
 }
 import org.broadinstitute.dsde.firecloud.dataaccess.GooglePriceListJsonProtocol._


### PR DESCRIPTION
The `storageCostEstimate` API works by doing the following:
1. Retrieve the Google price list from https://cloudpricingcalculator.appspot.com/static/data/pricelist.json (see https://github.com/broadinstitute/firecloud-orchestration/blob/develop/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala#L435)
2. Deserialize the Google JSON into a convenient `GooglePrices` object by extracting a couple keys we care about (see https://github.com/broadinstitute/firecloud-orchestration/blob/develop/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala#L77)
3. do math based on size of the bucket x values in `GooglePrices`

In step 2, we are looking for a specific key `CP-COMPUTEENGINE-INTERNET-EGRESS-NA-NA`. However, that key has disappeared from the price list. The price list does have a key `CP-INTERNET-EGRESS-STANDARD-TIER-FROM-NA`, but I'm not sure if that's equivalent.

This PR moves the name of the target key to config, to make it easier to update on the fly if we need to. It also changes the code to ask for `CP-INTERNET-EGRESS-STANDARD-TIER-FROM-NA`.



Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
