### PR TITLE
AS-249: downgrade automation sbt to match docker image [risk: low]

### DIFF
--- a/automation/project/build.properties
+++ b/automation/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.17
+sbt.version = 0.13.15


### PR DESCRIPTION
targeting https://broadworkbench.atlassian.net/browse/QA-1051 / https://broadworkbench.atlassian.net/browse/AS-249: failures downloading sbt during automation tests.

This PR changes the version of sbt specified by automation tests from 0.13.17 to 0.13.15. The automation docker image is based off `iflavoursbv/sbt-openjdk-8-alpine` (~319MB), which contains 0.13.15 already; goal of the PR is to avoid downloads since the sbt version already exists.

------


Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
