### PR TITLE
upgrade automation sbt and docker baseimage

### DIFF
--- a/automation/Dockerfile-tests
+++ b/automation/Dockerfile-tests
@@ -1,4 +1,4 @@
-FROM iflavoursbv/sbt-openjdk-8-alpine
+FROM hseeberger/scala-sbt:8u181_2.12.6_1.2.3
 
 COPY src /app/src
 COPY test.sh /app

--- a/automation/project/Settings.scala
+++ b/automation/project/Settings.scala
@@ -40,7 +40,7 @@ object Settings {
   val commonSettings =
     commonBuildSettings ++ testSettings ++ List(
     organization  := "org.broadinstitute.dsde.firecloud",
-    scalaVersion  := "2.12.6",
+    scalaVersion  := "2.12.10",
     resolvers ++= commonResolvers,
     scalacOptions ++= commonCompilerSettings
   )

--- a/automation/project/build.properties
+++ b/automation/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.17
+sbt.version = 1.2.3

--- a/automation/project/build.properties
+++ b/automation/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.2.3
+sbt.version = 1.3.7


### PR DESCRIPTION
targeting https://broadworkbench.atlassian.net/browse/QA-1051: failures downloading sbt during automation tests.

This PR changes the version of sbt specified by automation tests from 0.13.17 to 1.3.7, the version of scala from 2.12.6 to 2.12.10, and changes the automation docker base image to `hseeberger/scala-sbt:8u242_1.3.7_2.12.10` (~702MB), which already contains sbt 1.3.7. Goal is to avoid downloads since the sbt version already exists.

See also #775, which is less of a change but requires an sbt downgrade; it hurts to downgrade.



-----

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
