### PR TITLE
AS-155: PFB endpoints talk to import service, not arrow [risk: low]

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -3527,6 +3527,38 @@ paths:
           description: Internal Error
 
   /api/workspaces/{workspaceNamespace}/{workspaceName}/importPFB:
+    get:
+      x-passthrough: false
+      tags:
+        - Entities
+      operationId: listImportPFBJobs
+      summary: List PFB import jobs in this workspace
+      description: >
+        Lists all imports for this workspace, optionally filtered to only those imports currently in progress
+      produces:
+        - application/json
+      parameters:
+        - $ref: '#/parameters/workspaceNamespaceParam'
+        - $ref: '#/parameters/workspaceNameParam'
+        - in: query
+          description: When true, filters to only those imports currently in progress
+          name: running_only
+          required: false
+          type: boolean
+          default: false
+      responses:
+        200:
+          description: Successful Request
+        400:
+          description: Bad Request
+        401:
+          description: Unauthorized access to Workspace
+        403:
+          description: Forbidden access to Workspace
+        404:
+          description: Workspace not found
+        500:
+          description: Internal Error
     post:
       x-passthrough: false
       tags:

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -3549,12 +3549,12 @@ paths:
       responses:
         200:
           description: Successful Request
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/PFBStatusResponse'
         400:
           description: Bad Request
-        401:
-          description: Unauthorized access to Workspace
-        403:
-          description: Forbidden access to Workspace
         404:
           description: Workspace not found
         500:
@@ -6853,15 +6853,9 @@ definitions:
       message:
         type: string
         description: extended explanation for the import job.
-      timestamp:
-        type: integer
-        format: int64
-        description: time of the response
     required:
       - jobId
       - status
-      - message
-      - timestamp
 
   Profile:
     type: object

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -3621,7 +3621,7 @@ paths:
           schema:
             $ref: '#/definitions/PFBStatusResponse'
         404:
-          description: job ID not found
+          description: workspace or job ID not found
         500:
           description: Internal Error
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/EntityClient.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/EntityClient.scala
@@ -367,20 +367,6 @@ class EntityClient(requestContext: RequestContext, modelSchema: ModelSchema, goo
     }
   }
 
-  // ask Rawls if we have permission on this workspace. For writes, Rawls will also check if the workspace is locked.
-  private def validateUpsertPermissions(userInfo: UserInfo, workspaceNamespace: String, workspaceName: String, action: String = "read"): Future[Boolean] = {
-    val pipeline: WithTransformerConcatenation[HttpRequest, Future[HttpResponse]] = authHeaders(requestContext) ~> sendRec
-
-    def enc(s: String) = java.net.URLEncoder.encode(s, "utf-8")
-
-    val checkUrl = s"${Rawls.workspacesUrl}/${enc(workspaceNamespace)}/${enc(workspaceName)}/checkIamActionWithLock/$action"
-
-    userAuthedRequest(Get(checkUrl))(userInfo: UserInfo) map {
-      case resp if resp.status == NoContent => true
-      case resp => throw new FireCloudExceptionWithErrorReport(ErrorReport(resp.status, resp.entity.asString)) // bubble up errors
-    }
-  }
-
   def importPFB(workspaceNamespace: String, workspaceName: String, pfbRequest: PfbImportRequest, userInfo: UserInfo): Future[PerRequestMessage] = {
 
     def enc(str: String) = java.net.URLEncoder.encode(str, "utf-8")

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/EntityClient.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/EntityClient.scala
@@ -387,7 +387,7 @@ class EntityClient(requestContext: RequestContext, modelSchema: ModelSchema, goo
 
     // the payload to Import Service sends "path" and filetype.  Here, we force-hardcode filetype because this API
     // should only be used for PFBs.
-    val importServicePayload: ImportServiceRequest = ImportServiceRequest(path = pfbRequest.url, filetype = "pfb")
+    val importServicePayload: ImportServiceRequest = ImportServiceRequest(path = pfbRequest.url.getOrElse(""), filetype = "pfb")
 
     val importServiceUrl = s"${FireCloudConfig.ImportService.server}/${enc(workspaceNamespace)}/${enc(workspaceName)}/imports"
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/EntityClient.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/EntityClient.scala
@@ -41,11 +41,6 @@ import scala.util.{Failure, Success, Try}
 
 object EntityClient {
 
-  // TODO: AS-155: update these as necessray
-  lazy val arrowRoot: String = FireCloudConfig.Arrow.baseUrl
-  lazy val arrowAppName: String = FireCloudConfig.Arrow.appName
-  lazy val avroToRawlsURL: String = s"$arrowRoot/$arrowAppName"
-
   case class ImportEntitiesFromTSV(workspaceNamespace: String,
                                    workspaceName: String,
                                    tsvString: String)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/EntityClient.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/EntityClient.scala
@@ -416,6 +416,7 @@ class EntityClient(requestContext: RequestContext, modelSchema: ModelSchema, goo
           case resp if resp.status == Created =>
             val importServiceResponse = unmarshal[ImportServiceResponse].apply(resp)
             // for backwards compatibility, we return Accepted(202), even though import service returns Created(201)
+            // TODO: AS-155: this returns "id", not "jobId" as in the status endpoint
             RequestComplete(Accepted, importServiceResponse)
           case otherResp =>
             RequestCompleteWithErrorReport(otherResp.status, otherResp.toString)
@@ -434,11 +435,7 @@ class EntityClient(requestContext: RequestContext, modelSchema: ModelSchema, goo
           val importServiceResponse = unmarshal[ImportServiceResponse].apply(resp)
 
           // for backwards compatibility, we return a different model than import service does
-          val responsePayload = JsObject(
-            "status" -> JsString(importServiceResponse.status),
-            "message" -> JsString(importServiceResponse.status),
-            "jobId" -> JsString(importServiceResponse.id.toString)
-          )
+          val responsePayload = ImportStatusResponse.apply(importServiceResponse)
 
           RequestComplete(OK, responsePayload)
         case otherResp =>

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/EntityClient.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/EntityClient.scala
@@ -380,9 +380,7 @@ class EntityClient(requestContext: RequestContext, modelSchema: ModelSchema, goo
 
     userAuthedRequest(Get(checkUrl))(userInfo: UserInfo) flatMap {
       case resp if resp.status == NoContent => op(true)
-      case resp =>
-        logger.warn(s"****** workspace permissions failed with ${resp.status.intValue} ${resp.status.defaultMessage}: ${resp}")
-        Future(RequestComplete(resp)) // bubble up errors
+      case resp => Future(RequestComplete(resp)) // bubble up errors
     }
   }
 
@@ -417,7 +415,7 @@ class EntityClient(requestContext: RequestContext, modelSchema: ModelSchema, goo
         userAuthedRequest(Post(importServiceUrl, importServicePayload))(userInfo) map {
           case resp if resp.status == Created =>
             val importServiceResponse = unmarshal[ImportServiceResponse].apply(resp)
-            // for backwards compatibility, we return Accepted(202), not Created(201)
+            // for backwards compatibility, we return Accepted(202), even though import service returns Created(201)
             RequestComplete(Accepted, importServiceResponse)
           case otherResp =>
             RequestCompleteWithErrorReport(otherResp.status, otherResp.toString)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/EntityClient.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/EntityClient.scala
@@ -422,7 +422,8 @@ class EntityClient(requestContext: RequestContext, modelSchema: ModelSchema, goo
         userAuthedRequest(Post(importServiceUrl, importServicePayload))(userInfo) map {
           case resp if resp.status == Created =>
             val importServiceResponse = unmarshal[ImportServiceResponse].apply(resp)
-            RequestComplete(Created, importServiceResponse)
+            // for backwards compatibility, we return Accepted(202), not Created(201)
+            RequestComplete(Accepted, importServiceResponse)
           case otherResp =>
             RequestCompleteWithErrorReport(otherResp.status, otherResp.toString)
         }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/EntityClient.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/EntityClient.scala
@@ -383,10 +383,10 @@ class EntityClient(requestContext: RequestContext, modelSchema: ModelSchema, goo
         // for backwards compatibility, we return Accepted(202), even though import service returns Created(201),
         // and we return a different response payload than what import service returns.
 
-        val responsePayload:PfbImportRequest = pfbRequest.copy(
-          jobId = Some(importServiceResponse.jobId),
-          user = None,
-          workspace = Some(WorkspaceName(workspaceNamespace, workspaceName))
+        val responsePayload:PfbImportResponse = PfbImportResponse(
+          jobId = importServiceResponse.jobId,
+          url = pfbRequest.url.getOrElse(""),
+          workspace = WorkspaceName(workspaceNamespace, workspaceName)
         )
 
         RequestComplete(Accepted, responsePayload)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
@@ -235,4 +235,9 @@ object FireCloudConfig {
     val baseUrl: String = arrow.getString("baseUrl")
     val bucketName: String = arrow.getString("bucketName")
   }
+
+  object ImportService {
+    lazy val server: String = if (config.hasPath("importService.server")) config.getString("importService.server") else ""
+  }
+
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
@@ -229,13 +229,6 @@ object FireCloudConfig {
     val baseUrl: String = staticNotebooks.getString("baseUrl")
   }
 
-  object Arrow {
-    private val arrow = config.getConfig("arrow")
-    val appName: String = if (arrow.hasPath("appName")) arrow.getString("appName") else "avro-import"
-    val baseUrl: String = arrow.getString("baseUrl")
-    val bucketName: String = arrow.getString("bucketName")
-  }
-
   object ImportService {
     lazy val server: String = if (config.hasPath("importService.server")) config.getString("importService.server") else ""
   }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/GoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/GoogleServicesDAO.scala
@@ -24,6 +24,7 @@ trait GoogleServicesDAO extends ReportsSubsystemStatus {
   implicit val errorReportSource = ErrorReportSource(GoogleServicesDAO.serviceName)
 
   def getAdminUserAccessToken: String
+  @deprecated("currently unused and targeted for deletion", "2020-03-06")
   def getAdminIdentityToken: String
   def getTrialBillingManagerAccessToken: String
   def getTrialBillingManagerEmail: String

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/GoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/GoogleServicesDAO.scala
@@ -24,8 +24,6 @@ trait GoogleServicesDAO extends ReportsSubsystemStatus {
   implicit val errorReportSource = ErrorReportSource(GoogleServicesDAO.serviceName)
 
   def getAdminUserAccessToken: String
-  @deprecated("currently unused and targeted for deletion", "2020-03-06")
-  def getAdminIdentityToken: String
   def getTrialBillingManagerAccessToken: String
   def getTrialBillingManagerEmail: String
   def getTrialSpreadsheetAccessToken: String

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
@@ -138,7 +138,7 @@ object HttpGoogleServicesDAO extends GoogleServicesDAO with FireCloudRequestBuil
   @deprecated("currently unused and targeted for deletion", "2020-03-06")
   override def getAdminIdentityToken: String = {
     getScopedServiceAccountCredentials(firecloudAdminSACreds, Seq("openid", "email"))
-      .idTokenWithAudience(EntityClient.avroToRawlsURL, List()).getTokenValue
+      .idTokenWithAudience("DEPRECATED", List()).getTokenValue
   }
 
   def getTrialBillingManagerAccessToken = {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
@@ -135,6 +135,7 @@ object HttpGoogleServicesDAO extends GoogleServicesDAO with FireCloudRequestBuil
       .refreshAccessToken().getTokenValue
   }
 
+  @deprecated("currently unused and targeted for deletion", "2020-03-06")
   override def getAdminIdentityToken: String = {
     getScopedServiceAccountCredentials(firecloudAdminSACreds, Seq("openid", "email"))
       .idTokenWithAudience(EntityClient.avroToRawlsURL, List()).getTokenValue

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
@@ -135,12 +135,6 @@ object HttpGoogleServicesDAO extends GoogleServicesDAO with FireCloudRequestBuil
       .refreshAccessToken().getTokenValue
   }
 
-  @deprecated("currently unused and targeted for deletion", "2020-03-06")
-  override def getAdminIdentityToken: String = {
-    getScopedServiceAccountCredentials(firecloudAdminSACreds, Seq("openid", "email"))
-      .idTokenWithAudience("DEPRECATED", List()).getTokenValue
-  }
-
   def getTrialBillingManagerAccessToken = {
     getScopedServiceAccountCredentials(trialBillingSACreds, authScopes ++ billingScope)
       .refreshAccessToken().getTokenValue

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
@@ -227,7 +227,8 @@ object ModelJsonProtocol extends WorkspaceJsonSupport {
   implicit val impUserImportPermission = jsonFormat2(UserImportPermission)
 
   implicit val impBagitImportRequest = jsonFormat2(BagitImportRequest)
-  implicit val impPfbImportRequest = jsonFormat4(PfbImportRequest)
+  implicit val impPfbImportRequest = jsonFormat1(PfbImportRequest)
+  implicit val impPfbImportResponse = jsonFormat3(PfbImportResponse)
   implicit val impImportServiceRequest = jsonFormat2(ImportServiceRequest)
   implicit val impImportServiceResponse = jsonFormat3(ImportServiceResponse)
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
@@ -230,7 +230,6 @@ object ModelJsonProtocol extends WorkspaceJsonSupport {
   implicit val impPfbImportRequest = jsonFormat4(PfbImportRequest)
   implicit val impImportServiceRequest = jsonFormat2(ImportServiceRequest)
   implicit val impImportServiceResponse = jsonFormat3(ImportServiceResponse)
-  implicit val impImportStatusResponse = jsonFormat3(ImportStatusResponse.apply)
 
   implicit val impWorkspaceStorageCostEstimate = jsonFormat1(WorkspaceStorageCostEstimate)
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
@@ -229,7 +229,8 @@ object ModelJsonProtocol extends WorkspaceJsonSupport {
   implicit val impBagitImportRequest = jsonFormat2(BagitImportRequest)
   implicit val impPfbImportRequest = jsonFormat4(PfbImportRequest)
   implicit val impImportServiceRequest = jsonFormat2(ImportServiceRequest)
-  implicit val impImportServiceResponse = jsonFormat2(ImportServiceResponse)
+  implicit val impImportServiceResponse = jsonFormat3(ImportServiceResponse)
+  implicit val impImportStatusResponse = jsonFormat3(ImportStatusResponse.apply)
 
   implicit val impWorkspaceStorageCostEstimate = jsonFormat1(WorkspaceStorageCostEstimate)
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
@@ -228,6 +228,8 @@ object ModelJsonProtocol extends WorkspaceJsonSupport {
 
   implicit val impBagitImportRequest = jsonFormat2(BagitImportRequest)
   implicit val impPfbImportRequest = jsonFormat4(PfbImportRequest)
+  implicit val impImportServiceRequest = jsonFormat2(ImportServiceRequest)
+  implicit val impImportServiceResponse = jsonFormat2(ImportServiceResponse)
 
   implicit val impWorkspaceStorageCostEstimate = jsonFormat1(WorkspaceStorageCostEstimate)
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/Workspace.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/Workspace.scala
@@ -39,24 +39,9 @@ case class ImportServiceRequest(
   filetype: String)
 
 case class ImportServiceResponse(
-  id: String,
+  jobId: String,
   status: String,
-  error_message: Option[String])
-
-object ImportStatusResponse {
-  def apply(importServiceResponse: ImportServiceResponse): ImportStatusResponse = {
-    new ImportStatusResponse(
-      jobId = importServiceResponse.id,
-      status = importServiceResponse.status,
-      message = importServiceResponse.error_message)
-  }
-}
-
-case class ImportStatusResponse(
-   jobId: String,
-   status: String,
-   message: Option[String])
-
+  message: Option[String])
 
 case class MethodConfigurationId(
   name: Option[String] = None,

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/Workspace.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/Workspace.scala
@@ -34,6 +34,14 @@ case class PfbImportRequest(
   workspace: Option[WorkspaceName] = None,
   user: Option[WorkbenchUserInfo] = None)
 
+case class ImportServiceRequest(
+  path: String,
+  filetype: String)
+
+case class ImportServiceResponse(
+  id: String,
+  status: String)
+
 case class MethodConfigurationId(
   name: Option[String] = None,
   namespace: Option[String] = None,

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/Workspace.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/Workspace.scala
@@ -29,7 +29,7 @@ case class EntityId(entityType: String, entityName: String)
 case class BagitImportRequest(bagitURL: String, format: String)
 
 case class PfbImportRequest(
-  url: String,
+  url: Option[String],
   jobId: Option[String] = None,
   workspace: Option[WorkspaceName] = None,
   user: Option[WorkbenchUserInfo] = None)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/Workspace.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/Workspace.scala
@@ -40,7 +40,23 @@ case class ImportServiceRequest(
 
 case class ImportServiceResponse(
   id: String,
-  status: String)
+  status: String,
+  error_message: Option[String])
+
+object ImportStatusResponse {
+  def apply(importServiceResponse: ImportServiceResponse): ImportStatusResponse = {
+    new ImportStatusResponse(
+      jobId = importServiceResponse.id,
+      status = importServiceResponse.status,
+      message = importServiceResponse.error_message)
+  }
+}
+
+case class ImportStatusResponse(
+   jobId: String,
+   status: String,
+   message: Option[String])
+
 
 case class MethodConfigurationId(
   name: Option[String] = None,

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/Workspace.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/Workspace.scala
@@ -28,11 +28,11 @@ case class EntityId(entityType: String, entityName: String)
 
 case class BagitImportRequest(bagitURL: String, format: String)
 
-case class PfbImportRequest(
-  url: Option[String],
-  jobId: Option[String] = None,
-  workspace: Option[WorkspaceName] = None,
-  user: Option[WorkbenchUserInfo] = None)
+case class PfbImportRequest(url: Option[String])
+
+case class PfbImportResponse(url: String,
+                             jobId: String,
+                             workspace: WorkspaceName)
 
 case class ImportServiceRequest(
   path: String,

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiService.scala
@@ -165,7 +165,6 @@ trait WorkspaceApiService extends HttpService with FireCloudRequestBuilding
             get {
               requireUserInfo() { _ =>
                 extract(_.request.uri.query) { query =>
-                  // TODO: AS-155: simple passthrough is nice, but it retuns a payload inconsistent with the other PFB endpoints
                   passthrough(Uri(s"${FireCloudConfig.ImportService.server}/$workspaceNamespace/$workspaceName/imports").withQuery(query), HttpMethods.GET)
                 }
               }
@@ -174,10 +173,7 @@ trait WorkspaceApiService extends HttpService with FireCloudRequestBuilding
           path("importPFB" / Segment) { jobId =>
             get {
               requireUserInfo() { userInfo =>
-                respondWithJSON { requestContext =>
-                  perRequest(requestContext, EntityClient.props(entityClientConstructor, requestContext, FlexibleModelSchema),
-                    EntityClient.PFBImportStatus(workspaceNamespace, workspaceName, jobId, userInfo))
-                }
+                  passthrough(Uri(s"${FireCloudConfig.ImportService.server}/$workspaceNamespace/$workspaceName/imports/$jobId"), HttpMethods.GET)
               }
             }
           } ~

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiService.scala
@@ -165,6 +165,7 @@ trait WorkspaceApiService extends HttpService with FireCloudRequestBuilding
             get {
               requireUserInfo() { _ =>
                 extract(_.request.uri.query) { query =>
+                  // TODO: AS-155: simple passthrough is nice, but it retuns a payload inconsistent with the other PFB endpoints
                   passthrough(Uri(s"${FireCloudConfig.ImportService.server}/$workspaceNamespace/$workspaceName/imports").withQuery(query), HttpMethods.GET)
                 }
               }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiService.scala
@@ -161,6 +161,13 @@ trait WorkspaceApiService extends HttpService with FireCloudRequestBuilding
                   }
                 }
               }
+            } ~
+            get {
+              requireUserInfo() { _ =>
+                extract(_.request.uri.query) { query =>
+                  passthrough(Uri(s"${FireCloudConfig.ImportService.server}/$workspaceNamespace/$workspaceName/imports").withQuery(query), HttpMethods.GET)
+                }
+              }
             }
           } ~
           path("importPFB" / Segment) { jobId =>

--- a/src/test/resources/reference.conf
+++ b/src/test/resources/reference.conf
@@ -114,7 +114,11 @@ notification {
 }
 
 arrow {
-  baseUrl = "http://localhost:9394"
+  baseUrl = "DEPRECATED"
   appName = "avro-import"
   bucketName = "unit-test-arrow-bucket"
+}
+
+importService {
+  server = "http://localhost:9394"
 }

--- a/src/test/resources/reference.conf
+++ b/src/test/resources/reference.conf
@@ -113,12 +113,6 @@ notification {
   fullyQualifiedNotificationTopic = "dummy"
 }
 
-arrow {
-  baseUrl = "DEPRECATED"
-  appName = "avro-import"
-  bucketName = "unit-test-arrow-bucket"
-}
-
 importService {
   server = "http://localhost:9394"
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockGoogleServicesDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockGoogleServicesDAO.scala
@@ -74,6 +74,7 @@ class MockGoogleServicesDAO extends GoogleServicesDAO {
   val pubsubMessages = new LinkedBlockingQueue[String]()
 
   override def getAdminUserAccessToken: String = "adminUserAccessToken"
+  @deprecated("currently unused and targeted for deletion", "2020-03-06")
   override def getAdminIdentityToken: String = "adminIdentityToken"
   override def getTrialBillingManagerAccessToken: String = "billingManagerAccessToken"
   override def getTrialBillingManagerEmail: String = "mock-trial-billing-mgr-email"

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockGoogleServicesDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockGoogleServicesDAO.scala
@@ -74,8 +74,6 @@ class MockGoogleServicesDAO extends GoogleServicesDAO {
   val pubsubMessages = new LinkedBlockingQueue[String]()
 
   override def getAdminUserAccessToken: String = "adminUserAccessToken"
-  @deprecated("currently unused and targeted for deletion", "2020-03-06")
-  override def getAdminIdentityToken: String = "adminIdentityToken"
   override def getTrialBillingManagerAccessToken: String = "billingManagerAccessToken"
   override def getTrialBillingManagerEmail: String = "mock-trial-billing-mgr-email"
   override def getTrialSpreadsheetAccessToken: String = "trialSpreadsheetAccessToken"

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockUtils.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockUtils.scala
@@ -22,7 +22,7 @@ object MockUtils {
   val cromiamServerPort = 8995
   val searchServerPort = 9292
   val bagitServerPort = 9393
-  val arrowServerPort = 9394
+  val importServerPort = 9394
 
    def randomPositiveInt(): Int = {
      scala.util.Random.nextInt(9) + 1

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockUtils.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockUtils.scala
@@ -22,7 +22,7 @@ object MockUtils {
   val cromiamServerPort = 8995
   val searchServerPort = 9292
   val bagitServerPort = 9393
-  val importServerPort = 9394
+  val importServiceServerPort = 9394
 
    def randomPositiveInt(): Int = {
      scala.util.Random.nextInt(9) + 1

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceApiServiceSpec.scala
@@ -1068,10 +1068,9 @@ class WorkspaceApiServiceSpec extends BaseServiceSpec with WorkspaceApiService w
 
         val importSvcResponsePayload = ImportServiceResponse(jobId = jobId, status = "Pending", message = None)
 
-        val orchExpectedPayload = PfbImportRequest(url = Some(pfbPath),
-                                                   jobId = Some(jobId),
-                                                   workspace = Some(WorkspaceName(workspace.namespace, workspace.name)),
-                                                   user = None)
+        val orchExpectedPayload = PfbImportResponse(url = pfbPath,
+                                                   jobId = jobId,
+                                                   workspace = WorkspaceName(workspace.namespace, workspace.name))
 
         importServiceServer
           .when(request()

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceApiServiceSpec.scala
@@ -1351,12 +1351,6 @@ class WorkspaceApiServiceSpec extends BaseServiceSpec with WorkspaceApiService w
 
     }
 
-    // TODO: AS-155: new tests needed:
-    /*
-      - get job listing
-      - job listing passes query param
-     */
-
     "Workspace updateAttributes tests" - {
       "when calling any method other than PATCH on workspaces/*/*/updateAttributes path" - {
         "should receive a MethodNotAllowed error" in {

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceApiServiceSpec.scala
@@ -1239,7 +1239,7 @@ class WorkspaceApiServiceSpec extends BaseServiceSpec with WorkspaceApiService w
         }
       }
 
-      "should 200 (OK) if everything validated and import request was accepted" in {
+      "should 200 (OK) if everything validated and we return import status" in {
 
         val jobId = UUID.randomUUID().toString
 
@@ -1251,8 +1251,7 @@ class WorkspaceApiServiceSpec extends BaseServiceSpec with WorkspaceApiService w
         // for backwards compatibiilty reasons, orch returns a different payload than import service
         val expectedOrchResponsePayload = JsObject(
           ("jobId", JsString(jobId)),
-          ("status", JsString("Running")),
-          ("message", JsString("Running"))
+          ("status", JsString("Running"))
         )
 
         importServiceServer

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceApiServiceSpec.scala
@@ -1055,7 +1055,7 @@ class WorkspaceApiServiceSpec extends BaseServiceSpec with WorkspaceApiService w
           .when(request().withMethod("POST").withPath(s"/${workspace.namespace}/${workspace.name}/imports"))
           .respond(org.mockserver.model.HttpResponse.response()
             .withStatusCode(UnavailableForLegalReasons.intValue)
-            .withBody(UnavailableForLegalReasons.defaultMessage))
+            .withBody("import service message"))
 
         stubRawlsService(HttpMethods.GET, s"$workspacesPath/checkIamActionWithLock/write", NoContent)
 
@@ -1063,7 +1063,7 @@ class WorkspaceApiServiceSpec extends BaseServiceSpec with WorkspaceApiService w
           ~> dummyUserIdHeaders(dummyUserId)
           ~> sealRoute(workspaceRoutes)) ~> check {
           status should equal(UnavailableForLegalReasons)
-          body.asString should include (UnavailableForLegalReasons.defaultMessage)
+          body.asString should include ("import service message")
         }
       }
 
@@ -1092,13 +1092,13 @@ class WorkspaceApiServiceSpec extends BaseServiceSpec with WorkspaceApiService w
             .withStatusCode(Created.intValue)
             .withBody("""{"id":"123","status":"RUNNING"}"""))
 
-        stubRawlsService(HttpMethods.GET, s"$workspacesPath/checkIamActionWithLock/write", Forbidden, body = Some(Forbidden.defaultMessage))
+        stubRawlsService(HttpMethods.GET, s"$workspacesPath/checkIamActionWithLock/write", Forbidden, body = Some("import service message"))
 
         (Post(pfbImportPath, HttpEntity(MediaTypes.`application/json`, s"""{"url":"https://good.avro"}"""))
           ~> dummyUserIdHeaders(dummyUserId)
           ~> sealRoute(workspaceRoutes)) ~> check {
             status should equal(Forbidden)
-            body.asString should be (Forbidden.defaultMessage)
+            body.asString should include ("import service message")
           }
       }
 
@@ -1186,13 +1186,13 @@ class WorkspaceApiServiceSpec extends BaseServiceSpec with WorkspaceApiService w
             .withStatusCode(Created.intValue)
             .withBody("""{"id":"123","status":"RUNNING"}"""))
 
-        stubRawlsService(HttpMethods.GET, s"$workspacesPath/checkIamActionWithLock/read", Forbidden, body = Some(Forbidden.defaultMessage))
+        stubRawlsService(HttpMethods.GET, s"$workspacesPath/checkIamActionWithLock/read", Forbidden, body = Some("import service message"))
 
         (Get(s"$pfbImportPath/$jobId")
           ~> dummyUserIdHeaders(dummyUserId)
           ~> sealRoute(workspaceRoutes)) ~> check {
           status should equal(Forbidden)
-          body.asString should be (Forbidden.defaultMessage)
+          body.asString should include ("import service message")
         }
       }
 
@@ -1229,7 +1229,7 @@ class WorkspaceApiServiceSpec extends BaseServiceSpec with WorkspaceApiService w
           .when(request().withMethod("GET").withPath(s"/${workspace.namespace}/${workspace.name}/imports/$jobId"))
           .respond(org.mockserver.model.HttpResponse.response()
             .withStatusCode(UnavailableForLegalReasons.intValue)
-            .withBody(UnavailableForLegalReasons.defaultMessage))
+            .withBody("import service message"))
 
         stubRawlsService(HttpMethods.GET, s"$workspacesPath/checkIamActionWithLock/read", NoContent)
 
@@ -1237,7 +1237,7 @@ class WorkspaceApiServiceSpec extends BaseServiceSpec with WorkspaceApiService w
           ~> dummyUserIdHeaders(dummyUserId)
           ~> sealRoute(workspaceRoutes)) ~> check {
           status should equal(UnavailableForLegalReasons)
-          body.asString should include (UnavailableForLegalReasons.defaultMessage)
+          body.asString should include ("import service message")
         }
       }
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceApiServiceSpec.scala
@@ -255,7 +255,7 @@ class WorkspaceApiServiceSpec extends BaseServiceSpec with WorkspaceApiService w
   override def beforeAll(): Unit = {
     rawlsServer = startClientAndServer(MockUtils.workspaceServerPort)
     bagitServer = startClientAndServer(MockUtils.bagitServerPort)
-    importServiceServer = startClientAndServer(MockUtils.importServerPort)
+    importServiceServer = startClientAndServer(MockUtils.importServiceServerPort)
   }
 
   override def afterAll(): Unit = {


### PR DESCRIPTION
**DO NOT MERGE until ready to cut over to new import service.**

Use the new import service for create-import and get-import-status endpoints.

When this PR merges, we will no longer talk to the Arrow cloud function; we will only talk to the new import service. This means that users will not be able to query for status of Arrow-based jobs. I think this is a fair tradeoff given low usage, but feel free to push back. The alternative is to keep all the Arrow config in the codebase,  and have the status endpoint first query import service, then fall back to querying Arrow if import service returns a 404.

I've left some follow-on work for future PRs to keep this one small. Still left to do:
* new endpoint for listing import jobs in a workspace
* remove Arrow from configs in firecloud-develop
* ensure that spaces in workspace names work properly

-----

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
