### PR TITLE
enable Travis caching for sbt [no ticket; risk: low]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,15 @@ after_success: sbt coveralls
 
 notifications:
   email: false
+
+# https://www.scala-sbt.org/1.x/docs/Travis-CI-with-sbt.html describes how to enable caches for sbt dependencies
+before_cache:
+  - rm -fv $HOME/.ivy2/.sbt.ivy.lock
+  - find $HOME/.ivy2/cache -name "ivydata-*.properties" -print -delete
+  - find $HOME/.sbt        -name "*.lock"               -print -delete
+
+cache:
+  directories:
+    - $HOME/.cache/coursier
+    - $HOME/.ivy2/cache
+    - $HOME/.sbt


### PR DESCRIPTION
I spent too long getting  #777 to pass Travis tests, because Travis was being flaky about sbt dependencies. Enable Travis caching for these.

I ran the Travis jobs twice on this PR, and could see the cache take effect on the second run.

---

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
