### PR TITLE
[CA-738] add privateIpGoogleAccess to swagger

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -5921,6 +5921,9 @@ definitions:
       enableFlowLogs:
         type: boolean
         description: Optional, false if not specified. If true, enable flow logs within the high security network. Requires highSecurityNetwork = true.
+      privateIpGoogleAccess:
+        type: boolean
+        description: Optional, false if not specified. If true, it configures the VPC network to only allow access to GCP APIs that are protected by the project's service perimeter and routes all allowed API traffic through a narrow IP range. Requires highSecurityNetwork = true.
       servicePerimeter:
         type: string
         description: The fully qualified name of the GCP service perimeter to put this project into in the form accessPolicies/[POLICY NUMBER]/servicePerimeters/[NAME]. Caller must have the add_project action for this service perimeter in Sam.

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -5920,10 +5920,10 @@ definitions:
         description: Optional, false if not specified. If true, spin up all compute in a VPC network.
       enableFlowLogs:
         type: boolean
-        description: Optional, false if not specified. If true, enable flow logs within the high security network. Requires highSecurityNetwork = true.
+        description: Requires highSecurityNetwork = true. Optional, false if not specified. If true, enable flow logs within the high security network.
       privateIpGoogleAccess:
         type: boolean
-        description: Optional, false if not specified. If true, it configures the VPC network to only allow access to GCP APIs that are protected by the project's service perimeter and routes all allowed API traffic through a narrow IP range. Requires highSecurityNetwork = true.
+        description: Requires highSecurityNetwork = true. Optional, false if not specified. If true, it configures the VPC network to only allow access to GCP APIs that are protected by the project's service perimeter and routes all allowed API traffic through a narrow IP range.
       servicePerimeter:
         type: string
         description: The fully qualified name of the GCP service perimeter to put this project into in the form accessPolicies/[POLICY NUMBER]/servicePerimeters/[NAME]. Caller must have the add_project action for this service perimeter in Sam.


### PR DESCRIPTION
Update swagger to show privateIpGoogleAccess optional parameter when creating projects.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
