### PR TITLE
skip tests: AS-106: document userDetailsOnly for /me endpoint [risk: no]

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -4897,7 +4897,7 @@ paths:
       summary: Returns registration and activation status for the current user
       parameters:
         - in: query
-          description: when set to true does not check the various enabled status of the user
+          description: when set to true does not check the various enabled statuses of the user
           name: userDetailsOnly
           required: false
           type: boolean

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -4895,6 +4895,13 @@ paths:
         - Profile
       operationId: me
       summary: Returns registration and activation status for the current user
+      parameters:
+        - in: query
+          description: when set to true does not check the various enabled status of the user
+          name: userDetailsOnly
+          required: false
+          type: boolean
+          default: false
       responses:
         200:
           description: OK


### PR DESCRIPTION
skipping tests because this is a swagger-only change.

the `userDetailsOnly` query param works correctly at runtime, but was undocumented. Add it to swagger.

-----

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
