### PR TITLE
AS-363: upgrade to ES client 5.6.16 [risk: low]

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,12 +9,14 @@ object Dependencies {
   def excludeGuavaJDK5(m: ModuleID): ModuleID = m.exclude("com.google.guava", "guava-jdk5")
 
   val rootDependencies = Seq(
-    // proactively pull in latest versions of Jackson libs and Netty codec, instead of relying on the versions
+    // proactively pull in latest versions of these libraries, instead of relying on the versions
     // specified as transitive dependencies, due to OWASP DependencyCheck warnings for earlier versions.
     "com.fasterxml.jackson.core"     % "jackson-annotations" % jacksonV,
     "com.fasterxml.jackson.core"     % "jackson-databind"    % jacksonHotfixV,
     "com.fasterxml.jackson.core"     % "jackson-core"        % jacksonV,
     "io.netty"                       % "netty-codec"         % "4.1.46.Final",
+    "org.apache.lucene"              % "lucene-queryparser"  % "6.6.2",
+    // END transitive dependency overrides
 
     "org.apache.logging.log4j"       % "log4j-api"           % "2.8.2", // elasticsearch requires log4j ...
     "org.apache.logging.log4j"       % "log4j-to-slf4j"      % "2.8.2", // ... but we redirect log4j to logback.
@@ -39,7 +41,12 @@ object Dependencies {
     "com.typesafe.akka"             %% "akka-slf4j"                % akkaV,
     "com.typesafe.akka"             %% "akka-stream"               % akkaV,
 
-    "org.elasticsearch.client"       % "transport"           % "5.4.3",
+    "org.elasticsearch.client"       % "transport"           % "5.6.16"
+      exclude("io.netty", "netty-codec")
+      exclude("io.netty", "netty-transport")
+      exclude("io.netty", "netty-resolver")
+      exclude("io.netty", "netty-buffer")
+      exclude("io.netty", "netty-common"),
 
     "com.google.guava"               % "guava"               % "28.1-android",
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
   val jacksonV = "2.10.0"
   val jacksonHotfixV = "2.10.0" // for when only some of the Jackson libs have hotfix releases
 
-  def excludeGuavaJDK5(m: ModuleID): ModuleID = m.exclude("com.google.guava", "guava-jdk5")
+  def excludeGuava(m: ModuleID): ModuleID = m.exclude("com.google.guava", "guava")
 
   val rootDependencies = Seq(
     // proactively pull in latest versions of these libraries, instead of relying on the versions
@@ -16,6 +16,7 @@ object Dependencies {
     "com.fasterxml.jackson.core"     % "jackson-core"        % jacksonV,
     "io.netty"                       % "netty-codec"         % "4.1.46.Final",
     "org.apache.lucene"              % "lucene-queryparser"  % "6.6.2",
+    "com.google.guava"               % "guava"               % "28.1-android",
     // END transitive dependency overrides
 
     "org.apache.logging.log4j"       % "log4j-api"           % "2.8.2", // elasticsearch requires log4j ...
@@ -26,9 +27,10 @@ object Dependencies {
 
     "org.broadinstitute.dsde.vault" %% "vault-common"        % "0.1-19-ca8b927"
       exclude("io.spray", "spray-routing_2.11"),
-    "org.broadinstitute.dsde"       %% "rawls-model"         % "0.1-b9d04a47"
-      exclude("com.typesafe.scala-logging", "scala-logging_2.11") exclude("com.typesafe.akka", "akka-stream_2.11"),
-    "org.broadinstitute.dsde.workbench" %% "workbench-util"  % "0.3-12b7791-SNAP",
+    excludeGuava("org.broadinstitute.dsde"       %% "rawls-model"         % "0.1-b9d04a47")
+      exclude("com.typesafe.scala-logging", "scala-logging_2.11")
+      exclude("com.typesafe.akka", "akka-stream_2.11"),
+    excludeGuava("org.broadinstitute.dsde.workbench" %% "workbench-util"  % "0.3-12b7791-SNAP"),
 
     "io.spray"                      %% "spray-can"                 % sprayV,
     "io.spray"                      %% "spray-json"                % "1.3.3",
@@ -48,14 +50,12 @@ object Dependencies {
       exclude("io.netty", "netty-buffer")
       exclude("io.netty", "netty-common"),
 
-    "com.google.guava"               % "guava"               % "28.1-android",
-
-    excludeGuavaJDK5("com.google.apis"     % "google-api-services-storage"      % "v1-rev20190910-1.30.3"),
-    excludeGuavaJDK5("com.google.apis"     % "google-api-services-sheets"       % "v4-rev20191001-1.30.3"),
-    excludeGuavaJDK5("com.google.apis"     % "google-api-services-cloudbilling" % "v1-rev20191005-1.30.3"),
-    excludeGuavaJDK5("com.google.apis"     % "google-api-services-pubsub"       % "v1-rev20191001-1.30.3"),
-    excludeGuavaJDK5("com.google.auth"     % "google-auth-library-oauth2-http"  % "0.18.0"),
-    excludeGuavaJDK5("com.google.apis"     % "google-api-services-admin-directory"  % "directory_v1-rev110-1.25.0"),
+    excludeGuava("com.google.apis"     % "google-api-services-storage"      % "v1-rev20190910-1.30.3"),
+    excludeGuava("com.google.apis"     % "google-api-services-sheets"       % "v4-rev20191001-1.30.3"),
+    excludeGuava("com.google.apis"     % "google-api-services-cloudbilling" % "v1-rev20191005-1.30.3"),
+    excludeGuava("com.google.apis"     % "google-api-services-pubsub"       % "v1-rev20191001-1.30.3"),
+    excludeGuava("com.google.auth"     % "google-auth-library-oauth2-http"  % "0.18.0"),
+    excludeGuava("com.google.apis"     % "google-api-services-admin-directory"  % "directory_v1-rev110-1.25.0"),
 
     "org.webjars"                    % "swagger-ui"          % "2.2.5",
     "com.pauldijou"                 %% "jwt-core"            % "3.1.0",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -29,7 +29,8 @@ object Dependencies {
       exclude("io.spray", "spray-routing_2.11"),
     excludeGuava("org.broadinstitute.dsde"       %% "rawls-model"         % "0.1-b9d04a47")
       exclude("com.typesafe.scala-logging", "scala-logging_2.11")
-      exclude("com.typesafe.akka", "akka-stream_2.11"),
+      exclude("com.typesafe.akka", "akka-stream_2.11")
+      exclude("com.google.code.findbugs", "jsr305"),
     excludeGuava("org.broadinstitute.dsde.workbench" %% "workbench-util"  % "0.3-12b7791-SNAP"),
 
     "io.spray"                      %% "spray-can"                 % sprayV,


### PR DESCRIPTION
the diff on this looks somewhat large, but a lot of it is renaming/reorganizing. Try reviewing commit-by-commit for an easier view.

This PR does 2 things:
1. Resolves sbt warnings about dependency version conflicts, by applying exclude directives
2. Upgrades the elasticsearch transport client to 5.6.16. Anything after 5.6.1 includes an upgrade to Lucene QueryParsers 6.6.1 (https://www.elastic.co/guide/en/elasticsearch/reference/5.6/release-notes-5.6.1.html). In turn, this allowed me to override the transitive dependency and upgrade to Lucene QueryParsers 6.6.2, which resolves a proactive OSWAP security warning.