### PR TITLE
DDO-641 Fix swatomation pipeline breakage by removing JVM flag that disables SNI extension

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -5,7 +5,7 @@ echo $SBT_CMD
 
 set -o pipefail
 
-sbt -batch -Djsse.enableSNIExtension=false -Dheadless=true "${SBT_CMD}"
+sbt -batch -Dheadless=true "${SBT_CMD}"
 TEST_EXIT_CODE=$?
 sbt clean
 


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/DDO-641

Details in the ticket, but in short, this flag is breaking the swatomation pipeline. Removing it fixes the build so that firecloud-orchestration's tests actually run: https://fc-jenkins.dsp-techops.broadinstitute.org/job/sam-fiab-test-runner/24150/

This change should only impact Jenkins test runs, not the app itself.

---
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
