### PR TITLE
AS-465: integration test for security-related http headers

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/HttpHeaderSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/HttpHeaderSpec.scala
@@ -1,0 +1,58 @@
+package org.broadinstitute.dsde.test.api.orch
+
+import akka.http.scaladsl.model.HttpHeader
+import org.broadinstitute.dsde.test.OrchConfig.Users
+import org.broadinstitute.dsde.workbench.auth.AuthToken
+import org.broadinstitute.dsde.workbench.service.Orchestration
+import org.broadinstitute.dsde.workbench.config.{Credentials, UserPool}
+import org.broadinstitute.dsde.workbench.fixture.BillingFixtures
+import org.broadinstitute.dsde.workbench.service.{Sam, Thurloe}
+import org.scalatest.concurrent.{Eventually, ScalaFutures}
+import org.scalatest.tagobjects.Retryable
+import org.scalatest.time.{Seconds, Span}
+import org.scalatest.{BeforeAndAfterAll, FreeSpec, Matchers, OptionValues}
+
+class HttpHeaderSpec extends FreeSpec with Matchers with OptionValues {
+
+  // these headers and values should be added by the Apache proxy
+  val expectedHeaders: Seq[HttpHeader] = Seq(
+    HttpHeader.parse("X-Frame-Options", "SAMEORIGIN"),
+    HttpHeader.parse("X-XSS-Protection", "1; mode=block"),
+    HttpHeader.parse("X-Content-Type-Options", "nosniff"),
+    HttpHeader.parse("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
+  ).collect{
+    case HttpHeader.ParsingResult.Ok(hdr, errs) if errs.isEmpty => hdr
+  }
+
+  "Expected security-related HTTP headers" - {
+
+    "parsed correctly during test suite setup" in {
+      expectedHeaders.size shouldBe 4
+    }
+
+    def executeHeaderTests(getUrl: String): Unit = {
+      expectedHeaders foreach { hdr =>
+        s"'${hdr.name()}: ${hdr.value()}' should be returned from the $getUrl endpoint" in {
+          val creds = UserPool.userConfig.Students.getRandomCredentials(1).head
+          implicit val authToken: AuthToken = creds.makeAuthToken()
+
+          val resp = Orchestration.getRequest(getUrl)
+          val actualHeader = resp.headers.find(_.lowercaseName() == hdr.lowercaseName())
+          actualHeader.value.lowercaseName() shouldBe hdr.lowercaseName() // we just did a `find` on this, it should always be true
+          actualHeader.value.value() shouldBe hdr.value()
+        }
+      }
+    }
+
+    // unauthenticated endpoint
+    executeHeaderTests("/status")
+
+    // authenticated + registered endpoint
+    executeHeaderTests("/api/profile/terra")
+
+    // authenticated but registration not required endpoint
+    executeHeaderTests("/register/profile")
+
+  }
+
+}

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/HttpHeaderSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/HttpHeaderSpec.scala
@@ -1,16 +1,10 @@
 package org.broadinstitute.dsde.test.api.orch
 
 import akka.http.scaladsl.model.HttpHeader
-import org.broadinstitute.dsde.test.OrchConfig.Users
 import org.broadinstitute.dsde.workbench.auth.AuthToken
+import org.broadinstitute.dsde.workbench.config.{ServiceTestConfig, UserPool}
 import org.broadinstitute.dsde.workbench.service.Orchestration
-import org.broadinstitute.dsde.workbench.config.{Credentials, ServiceTestConfig, UserPool}
-import org.broadinstitute.dsde.workbench.fixture.BillingFixtures
-import org.broadinstitute.dsde.workbench.service.{Sam, Thurloe}
-import org.scalatest.concurrent.{Eventually, ScalaFutures}
-import org.scalatest.tagobjects.Retryable
-import org.scalatest.time.{Seconds, Span}
-import org.scalatest.{BeforeAndAfterAll, FreeSpec, Matchers, OptionValues}
+import org.scalatest.{FreeSpec, Matchers, OptionValues}
 
 class HttpHeaderSpec extends FreeSpec with Matchers with OptionValues {
 
@@ -27,7 +21,7 @@ class HttpHeaderSpec extends FreeSpec with Matchers with OptionValues {
   "Expected security-related HTTP headers" - {
 
     "should be parsed correctly during test suite setup" in {
-      expectedHeaders.size shouldBe 4
+      expectedHeaders should have length 4
     }
 
     def executeHeaderTests(getUrl: String): Unit = {

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/HttpHeaderSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/HttpHeaderSpec.scala
@@ -26,13 +26,13 @@ class HttpHeaderSpec extends FreeSpec with Matchers with OptionValues {
 
   "Expected security-related HTTP headers" - {
 
-    "parsed correctly during test suite setup" in {
+    "should be parsed correctly during test suite setup" in {
       expectedHeaders.size shouldBe 4
     }
 
     def executeHeaderTests(getUrl: String): Unit = {
       expectedHeaders foreach { hdr =>
-        s"'${hdr.name()}: ${hdr.value()}' should be returned from the $getUrl endpoint" in {
+        s"should return '${hdr.name()}: ${hdr.value()}' from the /$getUrl endpoint" in {
           val creds = UserPool.userConfig.Students.getRandomCredentials(1).head
           implicit val authToken: AuthToken = creds.makeAuthToken()
 
@@ -44,15 +44,17 @@ class HttpHeaderSpec extends FreeSpec with Matchers with OptionValues {
       }
     }
 
-    // unauthenticated endpoint
-    executeHeaderTests("status")
+    "on an unauthenticated endpoint" - {
+      executeHeaderTests("status")
+    }
 
-    // authenticated + registered endpoint
-    executeHeaderTests("api/profile/terra")
+    "on an authenticated and registered endpoint" - {
+      executeHeaderTests("api/profile/terra")
+    }
 
-    // authenticated but registration not required endpoint
-    executeHeaderTests("register/profile")
-
+    "on an authenticated but registration-not-required endpoint" - {
+      executeHeaderTests("register/profile")
+    }
   }
 
 }

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/HttpHeaderSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/HttpHeaderSpec.scala
@@ -4,7 +4,7 @@ import akka.http.scaladsl.model.HttpHeader
 import org.broadinstitute.dsde.test.OrchConfig.Users
 import org.broadinstitute.dsde.workbench.auth.AuthToken
 import org.broadinstitute.dsde.workbench.service.Orchestration
-import org.broadinstitute.dsde.workbench.config.{Credentials, UserPool}
+import org.broadinstitute.dsde.workbench.config.{Credentials, ServiceTestConfig, UserPool}
 import org.broadinstitute.dsde.workbench.fixture.BillingFixtures
 import org.broadinstitute.dsde.workbench.service.{Sam, Thurloe}
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
@@ -36,7 +36,7 @@ class HttpHeaderSpec extends FreeSpec with Matchers with OptionValues {
           val creds = UserPool.userConfig.Students.getRandomCredentials(1).head
           implicit val authToken: AuthToken = creds.makeAuthToken()
 
-          val resp = Orchestration.getRequest(getUrl)
+          val resp = Orchestration.getRequest(ServiceTestConfig.FireCloud.orchApiUrl + getUrl)
           val actualHeader = resp.headers.find(_.lowercaseName() == hdr.lowercaseName())
           actualHeader.value.lowercaseName() shouldBe hdr.lowercaseName() // we just did a `find` on this, it should always be true
           actualHeader.value.value() shouldBe hdr.value()
@@ -45,13 +45,13 @@ class HttpHeaderSpec extends FreeSpec with Matchers with OptionValues {
     }
 
     // unauthenticated endpoint
-    executeHeaderTests("/status")
+    executeHeaderTests("status")
 
     // authenticated + registered endpoint
-    executeHeaderTests("/api/profile/terra")
+    executeHeaderTests("api/profile/terra")
 
     // authenticated but registration not required endpoint
-    executeHeaderTests("/register/profile")
+    executeHeaderTests("register/profile")
 
   }
 


### PR DESCRIPTION
followup to broadinstitute/firecloud-develop#2251, which addresses [AS-465](https://broadworkbench.atlassian.net/browse/AS-465).

Reviewer(s):
* are these tests worth it? We'd have to add these tests to every service I updated (i.e. agora, orchestration, rawls, sam, thurloe, leo, job manager). Even then, we could really only test at the load balancer level, and not test each individual instance. Note that our security scans will scan every instance as well as the load balancers, so our scans and our tests would not match.
* do our security scans equate to test coverage? They run weekly, and will notify us if these headers are missing. They scan production, so if we rely solely on scans and there is any regression to headers, we'd be reactive instead of proactive; the regression would have already made it to prod.

My opinion is we should just rely on the security scans, not add integration tests, as the cost:benefit of integration tests is not worth it.