### PR TITLE
AS-327: PFB import integration tests [risk: no]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,4 +72,7 @@ crashlytics-build.properties
 *.pid
 .DS_Store
 
-automation/src/test/resources
+
+automation/src/test/resources/**
+!automation/src/test/resources/PFBImportSpec-expected-entities.json
+

--- a/automation/src/test/resources/PFBImportSpec-expected-entities.json
+++ b/automation/src/test/resources/PFBImportSpec-expected-entities.json
@@ -1,0 +1,694 @@
+{
+  "submitted_aligned_reads": {
+    "attributeNames": [
+      "data_category",
+      "data_format",
+      "data_type",
+      "experimental_strategy",
+      "file_format",
+      "file_name",
+      "file_size",
+      "file_state",
+      "file_url",
+      "md5sum",
+      "project_id",
+      "read_group",
+      "state",
+      "submitter_id"
+    ],
+    "count": 1,
+    "idName": "submitted_aligned_reads_id"
+  },
+  "somatic_annotation_workflow": {
+    "attributeNames": [
+      "project_id",
+      "simple_somatic_mutation",
+      "state",
+      "submitter_id",
+      "workflow_end_datetime",
+      "workflow_link",
+      "workflow_start_datetime",
+      "workflow_type",
+      "workflow_version"
+    ],
+    "count": 1,
+    "idName": "somatic_annotation_workflow_id"
+  },
+  "germline_variation_index": {
+    "attributeNames": [
+      "data_category",
+      "data_format",
+      "data_type",
+      "file_format",
+      "file_name",
+      "file_size",
+      "file_state",
+      "file_url",
+      "md5sum",
+      "project_id",
+      "simple_germline_variation",
+      "state",
+      "submitter_id"
+    ],
+    "count": 1,
+    "idName": "germline_variation_index_id"
+  },
+  "participant": {
+    "attributeNames": [
+      "consent_type",
+      "days_to_lost_to_followup",
+      "disease_type",
+      "external_id",
+      "family_id",
+      "index_date",
+      "is_proband",
+      "lost_to_followup",
+      "primary_site",
+      "project_id",
+      "state",
+      "submitter_id"
+    ],
+    "count": 1,
+    "idName": "participant_id"
+  },
+  "read_group": {
+    "attributeNames": [
+      "adapter_name",
+      "adapter_sequence",
+      "aliquot",
+      "base_caller_name",
+      "base_caller_version",
+      "experiment_name",
+      "flow_cell_barcode",
+      "includes_spike_ins",
+      "instrument_model",
+      "is_paired_end",
+      "library_name",
+      "library_preparation_kit_catalog_number",
+      "library_preparation_kit_name",
+      "library_preparation_kit_vendor",
+      "library_preparation_kit_version",
+      "library_selection",
+      "library_strand",
+      "library_strategy",
+      "platform",
+      "project_id",
+      "read_group_name",
+      "read_length",
+      "RIN",
+      "sequencing_center",
+      "sequencing_date",
+      "size_selection_range",
+      "spike_ins_concentration",
+      "spike_ins_fasta",
+      "state",
+      "submitter_id",
+      "target_capture_kit_catalog_number",
+      "target_capture_kit_name",
+      "target_capture_kit_target_region",
+      "target_capture_kit_vendor",
+      "target_capture_kit_version",
+      "to_trim_adapter_sequence"
+    ],
+    "count": 1,
+    "idName": "read_group_id"
+  },
+  "diagnosis": {
+    "attributeNames": [
+      "age_at_event_days",
+      "diagnosis_category",
+      "external_id",
+      "icd_id_diagnosis",
+      "mondo_id_diagnosis",
+      "ncit_id_diagnosis",
+      "participant",
+      "primary_diagnosis",
+      "project_id",
+      "source_text_diagnosis",
+      "source_text_tumor_location",
+      "spatial_descriptor",
+      "state",
+      "submitter_id",
+      "tumor_location",
+      "uberon_id_tumor_location"
+    ],
+    "count": 1,
+    "idName": "diagnosis_id"
+  },
+  "aligned_reads_index": {
+    "attributeNames": [
+      "data_category",
+      "data_format",
+      "data_type",
+      "file_format",
+      "file_name",
+      "file_size",
+      "file_state",
+      "file_url",
+      "md5sum",
+      "project_id",
+      "state",
+      "submitted_aligned_reads",
+      "submitter_id"
+    ],
+    "count": 1,
+    "idName": "aligned_reads_index_id"
+  },
+  "alignment_workflow": {
+    "attributeNames": [
+      "project_id",
+      "state",
+      "submitted_aligned_reads",
+      "submitter_id",
+      "workflow_end_datetime",
+      "workflow_link",
+      "workflow_start_datetime",
+      "workflow_type",
+      "workflow_version"
+    ],
+    "count": 1,
+    "idName": "alignment_workflow_id"
+  },
+  "submitted_unaligned_reads": {
+    "attributeNames": [
+      "data_category",
+      "data_format",
+      "data_type",
+      "experimental_strategy",
+      "file_format",
+      "file_name",
+      "file_size",
+      "file_state",
+      "file_url",
+      "md5sum",
+      "project_id",
+      "read_group",
+      "state",
+      "submitter_id"
+    ],
+    "count": 1,
+    "idName": "submitted_unaligned_reads_id"
+  },
+  "biospecimen_supplement": {
+    "attributeNames": [
+      "data_category",
+      "data_format",
+      "data_type",
+      "file_format",
+      "file_name",
+      "file_size",
+      "file_state",
+      "file_url",
+      "md5sum",
+      "participant",
+      "project_id",
+      "state",
+      "submitter_id"
+    ],
+    "count": 1,
+    "idName": "biospecimen_supplement_id"
+  },
+  "study_file": {
+    "attributeNames": [
+      "data_category",
+      "data_format",
+      "data_type",
+      "file_format",
+      "file_name",
+      "file_size",
+      "file_state",
+      "file_url",
+      "md5sum",
+      "project_id",
+      "state",
+      "submitter_id"
+    ],
+    "count": 1,
+    "idName": "study_file_id"
+  },
+  "outcome": {
+    "attributeNames": [
+      "age_at_event_days",
+      "disease_related",
+      "participant",
+      "project_id",
+      "state",
+      "submitter_id",
+      "vital_status"
+    ],
+    "count": 1,
+    "idName": "outcome_id"
+  },
+  "annotation": {
+    "attributeNames": [
+      "category",
+      "classification",
+      "creator",
+      "legacy_created_datetime",
+      "legacy_updated_datetime",
+      "notes",
+      "participant",
+      "project_id",
+      "state",
+      "status",
+      "submitter_id"
+    ],
+    "count": 1,
+    "idName": "annotation_id"
+  },
+  "annotated_somatic_mutation": {
+    "attributeNames": [
+      "data_category",
+      "data_format",
+      "data_type",
+      "experimental_strategy",
+      "file_format",
+      "file_name",
+      "file_size",
+      "file_state",
+      "file_url",
+      "md5sum",
+      "project_id",
+      "somatic_annotation_workflow",
+      "state",
+      "submitter_id"
+    ],
+    "count": 1,
+    "idName": "annotated_somatic_mutation_id"
+  },
+  "medical_history": {
+    "attributeNames": [
+      "asthma",
+      "coronary_artery_disease",
+      "hypertension",
+      "participant",
+      "project_id",
+      "state",
+      "stroke",
+      "submitter_id"
+    ],
+    "count": 1,
+    "idName": "medical_history_id"
+  },
+  "simple_germline_variation": {
+    "attributeNames": [
+      "data_category",
+      "data_format",
+      "data_type",
+      "experimental_strategy",
+      "file_format",
+      "file_name",
+      "file_size",
+      "file_state",
+      "file_url",
+      "md5sum",
+      "project_id",
+      "state",
+      "submitter_id"
+    ],
+    "count": 1,
+    "idName": "simple_germline_variation_id"
+  },
+  "aligned_reads_metric": {
+    "attributeNames": [
+      "alignment_workflow",
+      "data_category",
+      "data_format",
+      "data_type",
+      "experimental_strategy",
+      "file_format",
+      "file_name",
+      "file_size",
+      "file_state",
+      "file_url",
+      "md5sum",
+      "project_id",
+      "state",
+      "submitter_id"
+    ],
+    "count": 1,
+    "idName": "aligned_reads_metric_id"
+  },
+  "run_metadata": {
+    "attributeNames": [
+      "data_category",
+      "data_format",
+      "data_type",
+      "file_format",
+      "file_name",
+      "file_size",
+      "file_state",
+      "file_url",
+      "md5sum",
+      "project_id",
+      "read_group",
+      "state",
+      "submitter_id"
+    ],
+    "count": 1,
+    "idName": "run_metadata_id"
+  },
+  "demographic": {
+    "attributeNames": [
+      "age_at_last_follow_up_days",
+      "cause_of_death",
+      "ethnicity",
+      "gender",
+      "participant",
+      "project_id",
+      "race",
+      "state",
+      "submitter_id",
+      "vital_status"
+    ],
+    "count": 1,
+    "idName": "demographic_id"
+  },
+  "experiment_metadata": {
+    "attributeNames": [
+      "data_category",
+      "data_format",
+      "data_type",
+      "file_format",
+      "file_name",
+      "file_size",
+      "file_state",
+      "file_url",
+      "md5sum",
+      "project_id",
+      "read_group",
+      "state",
+      "submitter_id"
+    ],
+    "count": 1,
+    "idName": "experiment_metadata_id"
+  },
+  "slide": {
+    "attributeNames": [
+      "number_proliferating_cells",
+      "percent_eosinophil_infiltration",
+      "percent_granulocyte_infiltration",
+      "percent_inflam_infiltration",
+      "percent_lymphocyte_infiltration",
+      "percent_monocyte_infiltration",
+      "percent_necrosis",
+      "percent_neutrophil_infiltration",
+      "percent_normal_cells",
+      "percent_stromal_cells",
+      "percent_tumor_cells",
+      "percent_tumor_nuclei",
+      "project_id",
+      "sample",
+      "section_location",
+      "state",
+      "submitter_id"
+    ],
+    "count": 1,
+    "idName": "slide_id"
+  },
+  "investigator": {
+    "attributeNames": [
+      "institution",
+      "investigator_name",
+      "project_id",
+      "state",
+      "submitter_id"
+    ],
+    "count": 1,
+    "idName": "investigator_id"
+  },
+  "simple_somatic_mutation": {
+    "attributeNames": [
+      "data_category",
+      "data_format",
+      "data_type",
+      "experimental_strategy",
+      "file_format",
+      "file_name",
+      "file_size",
+      "file_state",
+      "file_url",
+      "md5sum",
+      "project_id",
+      "somatic_mutation_calling_workflow",
+      "state",
+      "submitter_id"
+    ],
+    "count": 1,
+    "idName": "simple_somatic_mutation_id"
+  },
+  "somatic_mutation_calling_workflow": {
+    "attributeNames": [
+      "aligned_reads",
+      "project_id",
+      "state",
+      "submitter_id",
+      "workflow_end_datetime",
+      "workflow_link",
+      "workflow_start_datetime",
+      "workflow_type",
+      "workflow_version"
+    ],
+    "count": 1,
+    "idName": "somatic_mutation_calling_workflow_id"
+  },
+  "clinical_supplement": {
+    "attributeNames": [
+      "data_category",
+      "data_format",
+      "data_type",
+      "file_format",
+      "file_name",
+      "file_size",
+      "file_state",
+      "file_url",
+      "md5sum",
+      "participant",
+      "project_id",
+      "state",
+      "submitter_id"
+    ],
+    "count": 1,
+    "idName": "clinical_supplement_id"
+  },
+  "sample": {
+    "attributeNames": [
+      "age_at_event_days",
+      "biospecimen_anatomic_site",
+      "composition",
+      "current_weight",
+      "days_to_collection",
+      "days_to_sample_procurement",
+      "diagnosis_pathologically_confirmed",
+      "external_id",
+      "initial_weight",
+      "intermediate_dimension",
+      "longest_dimension",
+      "method_of_sample_procurement",
+      "ncit_id_anatomical_site",
+      "ncit_id_tissue_type",
+      "participant",
+      "preservation_method",
+      "project_id",
+      "shortest_dimension",
+      "spatial_descriptor",
+      "state",
+      "submitter_id",
+      "time_between_clamping_and_freezing",
+      "time_between_excision_and_freezing",
+      "tissue_type",
+      "tumor_descriptor",
+      "uberon_id_anatomical_site"
+    ],
+    "count": 1,
+    "idName": "sample_id"
+  },
+  "family_relationship": {
+    "attributeNames": [
+      "participant",
+      "project_id",
+      "relative_to_participant_relation",
+      "state",
+      "submitter_id"
+    ],
+    "count": 1,
+    "idName": "family_relationship_id"
+  },
+  "germline_mutation_calling_workflow": {
+    "attributeNames": [
+      "project_id",
+      "state",
+      "submitted_aligned_reads",
+      "submitter_id",
+      "workflow_end_datetime",
+      "workflow_link",
+      "workflow_start_datetime",
+      "workflow_type",
+      "workflow_version"
+    ],
+    "count": 1,
+    "idName": "germline_mutation_calling_workflow_id"
+  },
+  "phenotype": {
+    "attributeNames": [
+      "age_at_event_days",
+      "hpo_id",
+      "observed",
+      "participant",
+      "phenotype",
+      "project_id",
+      "snomed_id_phenotype",
+      "state",
+      "submitter_id"
+    ],
+    "count": 1,
+    "idName": "phenotype_id"
+  },
+  "somatic_mutation_index": {
+    "attributeNames": [
+      "data_category",
+      "data_format",
+      "data_type",
+      "file_format",
+      "file_name",
+      "file_size",
+      "file_state",
+      "file_url",
+      "md5sum",
+      "project_id",
+      "simple_somatic_mutation",
+      "state",
+      "submitter_id"
+    ],
+    "count": 1,
+    "idName": "somatic_mutation_index_id"
+  },
+  "slide_image": {
+    "attributeNames": [
+      "data_category",
+      "data_format",
+      "data_type",
+      "experimental_strategy",
+      "file_format",
+      "file_name",
+      "file_size",
+      "file_state",
+      "file_url",
+      "md5sum",
+      "project_id",
+      "slide",
+      "state",
+      "submitter_id"
+    ],
+    "count": 1,
+    "idName": "slide_image_id"
+  },
+  "aligned_reads": {
+    "attributeNames": [
+      "data_category",
+      "data_format",
+      "data_type",
+      "experimental_strategy",
+      "file_format",
+      "file_name",
+      "file_size",
+      "file_state",
+      "file_url",
+      "md5sum",
+      "platform",
+      "project_id",
+      "state",
+      "submitted_unaligned_reads",
+      "submitter_id"
+    ],
+    "count": 1,
+    "idName": "aligned_reads_id"
+  },
+  "family": {
+    "attributeNames": [
+      "external_id",
+      "project_id",
+      "state",
+      "submitter_id"
+    ],
+    "count": 1,
+    "idName": "family_id"
+  },
+  "analysis_metadata": {
+    "attributeNames": [
+      "data_category",
+      "data_format",
+      "data_type",
+      "file_format",
+      "file_name",
+      "file_size",
+      "file_state",
+      "file_url",
+      "md5sum",
+      "project_id",
+      "state",
+      "submitted_aligned_reads",
+      "submitter_id"
+    ],
+    "count": 1,
+    "idName": "analysis_metadata_id"
+  },
+  "aliquot": {
+    "attributeNames": [
+      "a260_a280_ratio",
+      "aliquot_quantity",
+      "amount",
+      "analyte_quantity",
+      "analyte_type",
+      "concentration",
+      "external_id",
+      "normal_tumor_genotype_snp_match",
+      "project_id",
+      "ribosomal_rna_28s_16s_ratio",
+      "sample",
+      "shipment_date",
+      "shipment_destination",
+      "shipment_origin",
+      "source_center",
+      "spectrophotometer_method",
+      "state",
+      "submitter_id",
+      "volume",
+      "well_number"
+    ],
+    "count": 1,
+    "idName": "aliquot_id"
+  },
+  "read_group_qc": {
+    "attributeNames": [
+      "adapter_content",
+      "basic_statistics",
+      "encoding",
+      "fastq_name",
+      "kmer_content",
+      "overrepresented_sequences",
+      "percent_gc_content",
+      "per_base_n_content",
+      "per_base_sequence_content",
+      "per_base_sequence_quality",
+      "per_sequence_gc_content",
+      "per_sequence_quality_score",
+      "per_tile_sequence_quality",
+      "project_id",
+      "read_group",
+      "sequence_duplication_levels",
+      "sequence_length_distribution",
+      "state",
+      "submitted_aligned_reads",
+      "submitter_id",
+      "total_sequences",
+      "workflow_end_datetime",
+      "workflow_link",
+      "workflow_start_datetime",
+      "workflow_type",
+      "workflow_version"
+    ],
+    "count": 1,
+    "idName": "read_group_qc_id"
+  }
+}

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/PFBImportSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/PFBImportSpec.scala
@@ -61,22 +61,22 @@ class PFBImportSpec extends FreeSpec with Matchers with Eventually
             val importJobId: String = importJobIdValues.head.toString
 
             // poll for completion as owner
-            eventually {
+//            eventually {
               val resp = Orchestration.getRequest( s"${importURL(projectName, workspaceName)}/$importJobId")
               blockForStringBody(resp).parseJson.asJsObject.fields.get("status").value shouldBe "Done"
-            }
+//            }
 
             // inspect data entities and confirm correct import as owner
-            eventually {
-              val resp = Orchestration.getRequest( s"${importURL(projectName, workspaceName)}/entities")
-              blockForStringBody(resp).parseJson shouldBe expectedEntities
-            }
+//            eventually {
+//              val resp = Orchestration.getRequest( s"${importURL(projectName, workspaceName)}/entities")
+//              blockForStringBody(resp).parseJson shouldBe expectedEntities
+//            }
 
           }
         }
       }
 
-      "for writers of a workspace" in {
+      "for writers of a workspace" ignore {
         val writer = UserPool.chooseStudent
         val writerToken = writer.makeAuthToken()
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/PFBImportSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/PFBImportSpec.scala
@@ -149,51 +149,13 @@ class PFBImportSpec extends FreeSpec with Matchers with Eventually
             val errorReport = exception.message.parseJson.convertTo[ErrorReport]
 
             errorReport.statusCode.value shouldBe StatusCodes.BadRequest
-            errorReport.message should include (s"Cannot perform the action write on $projectName/$workspaceName")
+            errorReport.message should include (s"Object expected in field 'url'")
 
           } (ownerAuthToken)
         }
       }
-      "if the PFB does not exist" in {
-        implicit val token: AuthToken = ownerAuthToken
-        withCleanBillingProject(owner) { projectName =>
-          withWorkspace(projectName, prependUUID("reader-pfb-import")) { workspaceName =>
-            // Orchestration.workspaces.waitForBucketReadAccess(projectName, workspaceName)(ownerAuthToken)
-
-            // call importPFB, specifying a PFB that doesn't exist
-            val exception = intercept[RestException] {
-              Orchestration.postRequest(importURL(projectName, workspaceName), Map(
-                "url" -> "https://storage.googleapis.com/fixtures-for-tests/fixtures/public/intentionally-nonexistent.avro"))
-            }
-
-            val errorReport = exception.message.parseJson.convertTo[ErrorReport]
-
-            errorReport.statusCode.value shouldBe StatusCodes.BadRequest
-            errorReport.message should include (s"Cannot perform the action write on $projectName/$workspaceName")
-
-          } (ownerAuthToken)
-        }
-      }
-      "if the PFB is invalid" in {
-        implicit val token: AuthToken = ownerAuthToken
-        withCleanBillingProject(owner) { projectName =>
-          withWorkspace(projectName, prependUUID("reader-pfb-import")) { workspaceName =>
-            // Orchestration.workspaces.waitForBucketReadAccess(projectName, workspaceName)(ownerAuthToken)
-
-            // call importPFB, specifying a .png file instead of a .pfb
-            val exception = intercept[RestException] {
-              Orchestration.postRequest(importURL(projectName, workspaceName), Map(
-                "url" -> "https://storage.googleapis.com/fixtures-for-tests/fixtures/public/broad_logo.png"))
-            }
-
-            val errorReport = exception.message.parseJson.convertTo[ErrorReport]
-
-            errorReport.statusCode.value shouldBe StatusCodes.BadRequest
-            errorReport.message should include (s"Cannot perform the action write on $projectName/$workspaceName")
-
-          } (ownerAuthToken)
-        }
-      }
+      // N.B. other failures, such as an invalid PFB or PFB-not-found, fail asynchronously. Import Service accepts the
+      // job, starts to process it, and then will mark the job as failed. Is that worth testing here?
 
     }
   }

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/PFBImportSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/PFBImportSpec.scala
@@ -5,7 +5,7 @@ import java.util.UUID
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.unmarshalling.Unmarshal
-import akka.stream.{ActorMaterializer, Materializer}
+import akka.stream.{ActorMaterializer, ActorMaterializerSettings, Materializer}
 import org.broadinstitute.dsde.workbench.auth.AuthToken
 import org.broadinstitute.dsde.workbench.config.{Credentials, ServiceTestConfig, UserPool}
 import org.broadinstitute.dsde.workbench.fixture.{BillingFixtures, WorkspaceFixtures}
@@ -30,11 +30,10 @@ class PFBImportSpec extends FreeSpec with Matchers with Eventually
   val owner: Credentials = UserPool.chooseProjectOwner
   val ownerAuthToken: AuthToken = owner.makeAuthToken()
 
-  implicit val system: ActorSystem = ActorSystem("PFBImportSpec")
-  implicit val context: ExecutionContext = system.dispatcher
-  // final implicit val materializer: ActorMaterializer = ActorMaterializer(ActorMaterializerSettings(context.system))
-  implicit val materializer: Materializer = ActorMaterializer()
-  implicit override val patienceConfig: PatienceConfig = PatienceConfig(timeout = scaled(Span(300, Seconds)), interval = scaled(Span(2, Seconds)))
+  final implicit val system: ActorSystem = ActorSystem("PFBImportSpec")
+  final implicit val context: ExecutionContext = system.dispatcher
+  final implicit val materializer: ActorMaterializer = ActorMaterializer(ActorMaterializerSettings(system))
+  final implicit override val patienceConfig: PatienceConfig = PatienceConfig(timeout = scaled(Span(300, Seconds)), interval = scaled(Span(2, Seconds)))
 
   // this test.avro is copied from PyPFB's fixture at https://github.com/uc-cdis/pypfb/tree/master/tests/pfb-data
   val testPayload = Map("url" -> "https://storage.googleapis.com/fixtures-for-tests/fixtures/public/test.avro")
@@ -43,7 +42,7 @@ class PFBImportSpec extends FreeSpec with Matchers with Eventually
   "Orchestration" - {
 
     "should import a PFB file via import service" - {
-      "for the owner of a workspace" in {
+      "for the owner of a workspace" ignore {
         implicit val token: AuthToken = ownerAuthToken
 
         withCleanBillingProject(owner) { projectName =>
@@ -77,7 +76,7 @@ class PFBImportSpec extends FreeSpec with Matchers with Eventually
         }
       }
 
-      "for writers of a workspace" in {
+      "for writers of a workspace" ignore {
         val writer = UserPool.chooseStudent
         val writerToken = writer.makeAuthToken()
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/PFBImportSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/PFBImportSpec.scala
@@ -38,7 +38,7 @@ class PFBImportSpec extends FreeSpec with Matchers with Eventually with ScalaFut
 //  final implicit val context: ExecutionContext = system.dispatcher // for the eventually{} and async testing framework
 //  private val customExecutionContext: ExecutionContext = ExecutionContext.fromExecutor(new ForkJoinPool()) // for the futures being tested
 
-  final implicit override val patienceConfig: PatienceConfig = PatienceConfig(timeout = scaled(Span(60, Seconds)), interval = scaled(Span(2, Seconds)))
+  final implicit override val patienceConfig: PatienceConfig = PatienceConfig(timeout = scaled(Span(300, Seconds)), interval = scaled(Span(2, Seconds)))
 
   // this test.avro is copied from PyPFB's fixture at https://github.com/uc-cdis/pypfb/tree/master/tests/pfb-data
   private val testPayload = Map("url" -> "https://storage.googleapis.com/fixtures-for-tests/fixtures/public/test.avro")

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/PFBImportSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/PFBImportSpec.scala
@@ -27,16 +27,15 @@ import scala.concurrent.ExecutionContext
 import scala.io.Source
 
 class PFBImportSpec extends FreeSpec with Matchers with Eventually
-  with BillingFixtures with WorkspaceFixtures {
+  with BillingFixtures with WorkspaceFixtures with Orchestration {
 
   val owner: Credentials = UserPool.chooseProjectOwner
   val ownerAuthToken: AuthToken = owner.makeAuthToken()
 
-  final implicit val system: ActorSystem = ActorSystem("PFBImportSpec")
-  final implicit val materializer: Materializer = ActorMaterializer(ActorMaterializerSettings(system))
-  final implicit val context: ExecutionContext = system.dispatcher // for the eventually{} and async testing framework
-  private val customExecutionContext: ExecutionContext = ExecutionContext.fromExecutor(new ForkJoinPool()) // for the futures being tested
-
+//  final implicit val system: ActorSystem = ActorSystem("PFBImportSpec")
+//  final implicit val materializer: Materializer = ActorMaterializer(ActorMaterializerSettings(system))
+//  final implicit val context: ExecutionContext = system.dispatcher // for the eventually{} and async testing framework
+//  private val customExecutionContext: ExecutionContext = ExecutionContext.fromExecutor(new ForkJoinPool()) // for the futures being tested
 
   final implicit override val patienceConfig: PatienceConfig = PatienceConfig(timeout = scaled(Span(300, Seconds)), interval = scaled(Span(2, Seconds)))
 
@@ -160,9 +159,10 @@ class PFBImportSpec extends FreeSpec with Matchers with Eventually
   private def prependUUID(suffix: String): String = s"${UUID.randomUUID().toString}-$suffix"
 
   private def blockForStringBody(response: HttpResponse): String = {
-    import akka.http.scaladsl.unmarshalling.PredefinedFromEntityUnmarshallers.stringUnmarshaller
-    implicit val executionContext: ExecutionContext = customExecutionContext
-    Await.result(Unmarshal(response.entity).to[String](um = stringUnmarshaller, ec = executionContext, mat = materializer), 5.seconds)
+    extractResponseString(response)
+//    import akka.http.scaladsl.unmarshalling.PredefinedFromEntityUnmarshallers.stringUnmarshaller
+//    implicit val executionContext: ExecutionContext = customExecutionContext
+//    Await.result(Unmarshal(response.entity).to[String](um = stringUnmarshaller, ec = executionContext, mat = materializer), 5.seconds)
   }
 
   private def importURL(projectName: String, wsName: String): String =

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/PFBImportSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/PFBImportSpec.scala
@@ -69,11 +69,11 @@ class PFBImportSpec extends FreeSpec with Matchers with Eventually with ScalaFut
             logger.warn(s">>>>>>>>>>>>>>>>>>>>>> using job-status url ${importURL(projectName, workspaceName)}/$importJobId")
 
             // poll for completion as owner
-//            eventually {
+            eventually {
               val resp: HttpResponse = Orchestration.getRequest( s"${importURL(projectName, workspaceName)}/$importJobId")
               resp.status shouldBe StatusCodes.OK
-              // blockForStringBody(resp).parseJson.asJsObject.fields.get("status").value shouldBe "Done"
-//            }
+              blockForStringBody(resp).parseJson.asJsObject.fields.get("status").value shouldBe "Done"
+            }
 
             // inspect data entities and confirm correct import as owner
 //            eventually {

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/PFBImportSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/PFBImportSpec.scala
@@ -76,10 +76,10 @@ class PFBImportSpec extends FreeSpec with Matchers with Eventually with ScalaFut
             }
 
             // inspect data entities and confirm correct import as owner
-//            eventually {
-//              val resp = Orchestration.getRequest( s"${importURL(projectName, workspaceName)}/entities")
-//              blockForStringBody(resp).parseJson shouldBe expectedEntities
-//            }
+            eventually {
+              val resp = Orchestration.getRequest( s"${importURL(projectName, workspaceName)}/entities")
+              blockForStringBody(resp).parseJson shouldBe expectedEntities
+            }
 
           }
         }

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/PFBImportSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/PFBImportSpec.scala
@@ -15,7 +15,8 @@ import org.broadinstitute.dsde.workbench.model.ErrorReportJsonSupport.ErrorRepor
 import org.broadinstitute.dsde.workbench.service.{AclEntry, Orchestration, RestException, WorkspaceAccessLevel}
 import org.scalatest.{FreeSpec, Matchers}
 import org.scalatest.OptionValues._
-import org.scalatest.concurrent.Eventually
+import org.scalatest.concurrent.{Eventually, ScalaFutures}
+import org.scalatest.concurrent.PatienceConfiguration.{Interval, Timeout}
 import org.scalatest.time.{Seconds, Span}
 
 import scala.concurrent.Await
@@ -26,7 +27,7 @@ import spray.json._
 import scala.concurrent.ExecutionContext
 import scala.io.Source
 
-class PFBImportSpec extends FreeSpec with Matchers with Eventually
+class PFBImportSpec extends FreeSpec with Matchers with Eventually with ScalaFutures
   with BillingFixtures with WorkspaceFixtures with Orchestration {
 
   val owner: Credentials = UserPool.chooseProjectOwner
@@ -159,7 +160,8 @@ class PFBImportSpec extends FreeSpec with Matchers with Eventually
   private def prependUUID(suffix: String): String = s"${UUID.randomUUID().toString}-$suffix"
 
   private def blockForStringBody(response: HttpResponse): String = {
-    extractResponseString(response)
+//    extractResponseString(response)
+    Unmarshal(response.entity).to[String].futureValue
 //    import akka.http.scaladsl.unmarshalling.PredefinedFromEntityUnmarshallers.stringUnmarshaller
 //    implicit val executionContext: ExecutionContext = customExecutionContext
 //    Await.result(Unmarshal(response.entity).to[String](um = stringUnmarshaller, ec = executionContext, mat = materializer), 5.seconds)

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/PFBImportSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/PFBImportSpec.scala
@@ -16,7 +16,8 @@ class PFBImportSpec extends FreeSpec with Matchers
   val owner: Credentials = UserPool.chooseProjectOwner
   val ownerAuthToken: AuthToken = owner.makeAuthToken()
 
-  // maybe steal the test.avro from https://github.com/uc-cdis/pypfb/tree/master/tests/pfb-data
+  // maybe steal the test.avro from https://github.com/uc-cdis/pypfb/tree/master/tests/pfb-data ?
+  // or do a small export from BDC staging env ?
   val testPayload = Map("url" -> "gs://fixtures-for-tests/example.pfb")
 
   "Orchestration" - {
@@ -67,8 +68,9 @@ class PFBImportSpec extends FreeSpec with Matchers
 
             val exceptionObject = exception.message.parseJson.asJsObject
 
-            exceptionObject.fields("message").convertTo[String] should include (s"insufficient permissions to perform operation on $projectName/$workspaceName")
             exceptionObject.fields("status").convertTo[Int] shouldBe 403
+            exceptionObject.fields("message").convertTo[String] should include (s"Cannot perform the action write on $projectName/$workspaceName")
+
 
           } (ownerAuthToken)
         }

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/PFBImportSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/PFBImportSpec.scala
@@ -68,7 +68,9 @@ class PFBImportSpec extends FreeSpec with Matchers
 
             val exceptionObject = exception.message.parseJson.asJsObject
 
-            exceptionObject.fields("status").convertTo[Int] shouldBe 403
+            // exceptionObject.fields("status").convertTo[Int] shouldBe 403
+
+            exceptionObject.fields.keys should contain theSameElementsAs Seq("status", "message")
             exceptionObject.fields("message").convertTo[String] should include (s"Cannot perform the action write on $projectName/$workspaceName")
 
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/PFBImportSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/PFBImportSpec.scala
@@ -61,7 +61,10 @@ class PFBImportSpec extends FreeSpec with Matchers with Eventually with ScalaFut
             importJobIdValues should have size 1
 
             logger.warn(s">>>>>>>>>>>>>>>>>>>>>> passed importJobId size check")
-            val importJobId: String = importJobIdValues.head.toString
+            val importJobId: String = importJobIdValues.head match {
+              case js:JsString => js.value
+              case x => fail("got in invalid jobId: " + x.toString())
+            }
             logger.warn(s">>>>>>>>>>>>>>>>>>>>>> using importJobId $importJobId")
             logger.warn(s">>>>>>>>>>>>>>>>>>>>>> using job-status url ${importURL(projectName, workspaceName)}/$importJobId")
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/PFBImportSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/PFBImportSpec.scala
@@ -42,7 +42,7 @@ class PFBImportSpec extends FreeSpec with Matchers with Eventually
   "Orchestration" - {
 
     "should import a PFB file via import service" - {
-      "for the owner of a workspace" ignore {
+      "for the owner of a workspace" in {
         implicit val token: AuthToken = ownerAuthToken
 
         withCleanBillingProject(owner) { projectName =>

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/PFBImportSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/PFBImportSpec.scala
@@ -2,7 +2,10 @@ package org.broadinstitute.dsde.test.api.orch
 
 import java.util.UUID
 
+import akka.actor.ActorSystem
 import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.unmarshalling.Unmarshal
+import akka.stream.{ActorMaterializer, Materializer}
 import org.broadinstitute.dsde.workbench.auth.AuthToken
 import org.broadinstitute.dsde.workbench.config.{Credentials, ServiceTestConfig, UserPool}
 import org.broadinstitute.dsde.workbench.fixture.{BillingFixtures, WorkspaceFixtures}
@@ -11,19 +14,32 @@ import org.broadinstitute.dsde.workbench.model.ErrorReportJsonSupport.ErrorRepor
 import org.broadinstitute.dsde.workbench.service.{AclEntry, Orchestration, RestException, WorkspaceAccessLevel}
 import org.scalatest.{FreeSpec, Matchers}
 import org.scalatest.OptionValues._
+import org.scalatest.concurrent.Eventually
+import org.scalatest.time.{Seconds, Span}
+
+import scala.concurrent.duration._
 import spray.json.DefaultJsonProtocol._
 import spray.json._
 
+import scala.concurrent.ExecutionContext
+import scala.io.Source
 
-class PFBImportSpec extends FreeSpec with Matchers
+class PFBImportSpec extends FreeSpec with Matchers with Eventually
   with BillingFixtures with WorkspaceFixtures {
 
   val owner: Credentials = UserPool.chooseProjectOwner
   val ownerAuthToken: AuthToken = owner.makeAuthToken()
 
+  implicit val system: ActorSystem = ActorSystem("PFBImportSpec")
+  implicit val context: ExecutionContext = system.dispatcher
+  // final implicit val materializer: ActorMaterializer = ActorMaterializer(ActorMaterializerSettings(context.system))
+  implicit val materializer: Materializer = ActorMaterializer()
+  implicit override val patienceConfig: PatienceConfig = PatienceConfig(timeout = scaled(Span(300, Seconds)), interval = scaled(Span(2, Seconds)))
+
   // maybe steal the test.avro from https://github.com/uc-cdis/pypfb/tree/master/tests/pfb-data ?
   // or do a small export from BDC staging env ?
-  val testPayload = Map("url" -> "gs://fixtures-for-tests/example.pfb")
+  val testPayload = Map("url" -> "https://storage.googleapis.com/fixtures-for-tests/fixtures/public/test.avro")
+  val expectedEntities: JsValue = Source.fromResource("PFBImportSpec-expected-entities.json").getLines().mkString.parseJson
 
   "Orchestration" - {
 
@@ -35,9 +51,29 @@ class PFBImportSpec extends FreeSpec with Matchers
           withWorkspace(projectName, prependUUID("owner-pfb-import")) { workspaceName =>
             // Orchestration.workspaces.waitForBucketReadAccess(projectName, workspaceName)
 
-            // TODO: call importPFB as owner
-            // TODO: poll for completion as owner
-            // TODO: inspect data entities and confirm correct import as owner
+            // call importPFB as owner
+            val postResponse: String = Orchestration.postRequest(importURL(projectName, workspaceName), testPayload)
+            // expect to get exactly one jobId back
+            val importJobIdValues: Seq[JsValue] = postResponse.parseJson.asJsObject.getFields("jobId")
+            importJobIdValues should have size 1
+            val importJobId: String = importJobIdValues.head.toString
+
+            // poll for completion as owner
+            eventually {
+              val resp = Orchestration.getRequest( s"${importURL(projectName, workspaceName)}/$importJobId")
+              Unmarshal(resp.entity).to[String] map { respString =>
+                respString.parseJson.asJsObject.fields.get("status").value shouldBe "Done"
+              }
+            }
+
+            // inspect data entities and confirm correct import as owner
+            eventually {
+              val resp = Orchestration.getRequest( s"${importURL(projectName, workspaceName)}/entities")
+              Unmarshal(resp.entity).to[String] map { respString =>
+                respString.parseJson shouldBe expectedEntities
+              }
+            }
+
           }
         }
       }
@@ -59,6 +95,7 @@ class PFBImportSpec extends FreeSpec with Matchers
     }
 
     "should return an error when attempting to import a PFB file via import service" - {
+
       "for readers of a workspace" in {
         val reader = UserPool.chooseStudent
 
@@ -79,6 +116,11 @@ class PFBImportSpec extends FreeSpec with Matchers
           } (ownerAuthToken)
         }
       }
+
+      "with an invalid POST payload" ignore {}
+      "if the PFB does not exist" ignore {}
+      "if the PFB is invalid" ignore {}
+
     }
   }
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/PFBImportSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/PFBImportSpec.scala
@@ -1,0 +1,81 @@
+package org.broadinstitute.dsde.test.api.orch
+
+import java.util.UUID
+
+import org.broadinstitute.dsde.workbench.auth.AuthToken
+import org.broadinstitute.dsde.workbench.config.{Credentials, ServiceTestConfig, UserPool}
+import org.broadinstitute.dsde.workbench.fixture.{BillingFixtures, WorkspaceFixtures}
+import org.broadinstitute.dsde.workbench.service.{AclEntry, Orchestration, RestException, WorkspaceAccessLevel}
+import org.scalatest.{FreeSpec, Matchers}
+import spray.json.DefaultJsonProtocol._
+import spray.json._
+
+class PFBImportSpec extends FreeSpec with Matchers
+  with BillingFixtures with WorkspaceFixtures {
+
+  val owner: Credentials = UserPool.chooseProjectOwner
+  val ownerAuthToken: AuthToken = owner.makeAuthToken()
+
+  "Orchestration" - {
+
+    "should import a PFB file via import service" - {
+      "for the owner of a workspace" ignore {
+        implicit val token: AuthToken = ownerAuthToken
+
+        withCleanBillingProject(owner) { projectName =>
+          withWorkspace(projectName, prependUUID("owner-pfb-import")) { workspaceName =>
+            // Orchestration.workspaces.waitForBucketReadAccess(projectName, workspaceName)
+
+            // TODO: call importPFB as owner
+            // TODO: poll for completion as owner
+            // TODO: inspect data entities and confirm correct import as owner
+          }
+        }
+      }
+
+      "for writers of a workspace" ignore {
+        val writer = UserPool.chooseStudent
+
+        withCleanBillingProject(owner) { projectName =>
+          withWorkspace(projectName, prependUUID("writer-pfb-import"), aclEntries = List(AclEntry(writer.email, WorkspaceAccessLevel.Writer))) { workspaceName =>
+            // Orchestration.workspaces.waitForBucketReadAccess(projectName, workspaceName)(ownerAuthToken)
+
+            // TODO: call importPFB as writer
+            // TODO: poll for completion as writer
+            // TODO: inspect data entities and confirm correct import as writer
+
+          } (ownerAuthToken)
+        }
+      }
+    }
+
+    "should return an error when attempting to import a PFB file via import service" - {
+      "for readers of a workspace" in {
+        val reader = UserPool.chooseStudent
+
+        withCleanBillingProject(owner) { projectName =>
+          withWorkspace(projectName, prependUUID("reader-pfb-import"), aclEntries = List(AclEntry(reader.email, WorkspaceAccessLevel.Reader))) { workspaceName =>
+            // Orchestration.workspaces.waitForBucketReadAccess(projectName, workspaceName)(ownerAuthToken)
+
+            // call importPFB as reader
+            val exception = intercept[RestException] {
+              Orchestration.postRequest(importURL(projectName, workspaceName), "{}")(reader.makeAuthToken())
+            }
+
+            val exceptionObject = exception.message.parseJson.asJsObject
+
+            exceptionObject.fields("message").convertTo[String] should contain "insufficient permissions to perform operation on $projectName/$workspaceName"
+            exceptionObject.fields("status").convertTo[Int] shouldBe 403
+
+          } (ownerAuthToken)
+        }
+      }
+    }
+  }
+
+  private def prependUUID(suffix: String): String = s"${UUID.randomUUID().toString}-$suffix"
+
+  private def importURL(projectName: String, wsName: String): String =
+    s"${ServiceTestConfig.FireCloud.orchApiUrl}api/workspaces/$projectName/$wsName/importPFB"
+
+}

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/PFBImportSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/PFBImportSpec.scala
@@ -74,7 +74,7 @@ class PFBImportSpec extends FreeSpec with Matchers with Eventually with ScalaFut
 
             // inspect data entities and confirm correct import as owner
             eventually {
-              val resp = Orchestration.getRequest( s"${importURL(projectName, workspaceName)}/entities")
+              val resp = Orchestration.getRequest( s"${ServiceTestConfig.FireCloud.orchApiUrl}api/workspaces/$projectName/$workspaceName/entities")
               blockForStringBody(resp).parseJson shouldBe expectedEntities
             }
 
@@ -108,7 +108,7 @@ class PFBImportSpec extends FreeSpec with Matchers with Eventually with ScalaFut
 
             // inspect data entities and confirm correct import as writer
             eventually {
-              val resp = Orchestration.getRequest( s"${importURL(projectName, workspaceName)}/entities")(writerToken)
+              val resp = Orchestration.getRequest( s"${ServiceTestConfig.FireCloud.orchApiUrl}api/workspaces/$projectName/$workspaceName/entities")(writerToken)
               blockForStringBody(resp).parseJson shouldBe expectedEntities
             }
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/PFBImportSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/PFBImportSpec.scala
@@ -16,6 +16,9 @@ class PFBImportSpec extends FreeSpec with Matchers
   val owner: Credentials = UserPool.chooseProjectOwner
   val ownerAuthToken: AuthToken = owner.makeAuthToken()
 
+  // maybe steal the test.avro from https://github.com/uc-cdis/pypfb/tree/master/tests/pfb-data
+  val testPayload = Map("url" -> "gs://fixtures-for-tests/example.pfb")
+
   "Orchestration" - {
 
     "should import a PFB file via import service" - {
@@ -59,12 +62,12 @@ class PFBImportSpec extends FreeSpec with Matchers
 
             // call importPFB as reader
             val exception = intercept[RestException] {
-              Orchestration.postRequest(importURL(projectName, workspaceName), "{}")(reader.makeAuthToken())
+              Orchestration.postRequest(importURL(projectName, workspaceName), testPayload)(reader.makeAuthToken())
             }
 
             val exceptionObject = exception.message.parseJson.asJsObject
 
-            exceptionObject.fields("message").convertTo[String] should contain "insufficient permissions to perform operation on $projectName/$workspaceName"
+            exceptionObject.fields("message").convertTo[String] should include (s"insufficient permissions to perform operation on $projectName/$workspaceName")
             exceptionObject.fields("status").convertTo[Int] shouldBe 403
 
           } (ownerAuthToken)


### PR DESCRIPTION
Well it took 24 commits, but all tests are passing now.

```
[info] PFBImportSpec:
[info] Orchestration
[info]   should import a PFB file via import service
[info]   - for the owner of a workspace (1 minute, 34 seconds)
[info]   - for writers of a workspace (1 minute, 20 seconds)
[info]   should asynchronously result in an error when attempting to import a PFB file via import service
[info]   - if the file to be imported is invalid (12 seconds, 773 milliseconds)
[info]   should synchronously return an error when attempting to import a PFB file via import service
[info]   - for readers of a workspace (12 seconds, 11 milliseconds)
[info]   - with an invalid POST payload (11 seconds, 91 milliseconds)
```

also, what are you talking about, Coveralls? Coverage decreased? All this PR does is add tests. Grr.

---

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
