### PR TITLE
AoU RW-3627: Expose Rawls DELETE /api/user/billing/{projectName}

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -329,8 +329,7 @@ paths:
   /api/user/billing/{projectName}:
     delete:
       tags:
-        - billing
-        - users
+        - Billing
       summary: delete billing project
       description: delete billing project
       operationId: deleteBillingProject

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -326,6 +326,48 @@ paths:
             - profile
       x-passthrough: true
       x-passthrough-target: rawls
+  /api/user/billing/{projectName}:
+    delete:
+      tags:
+        - billing
+        - users
+      summary: delete billing project
+      description: delete billing project
+      operationId: deleteBillingProject
+      parameters:
+        - name: projectName
+          in: path
+          description: Name of the billing project
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: Successfully delete billing project
+          content: {}
+        400:
+          description: Project cannot be deleted because it contains workspaces.
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        403:
+          description: You must be a project owner to delete billing project
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        500:
+          description: Rawls Internal Error
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+      security:
+        - authorization:
+            - openid
+            - email
+            - profile
   /api/configurations:
     get:
       tags:

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/BillingService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/BillingService.scala
@@ -6,7 +6,8 @@ import spray.routing._
 
 trait BillingService extends HttpService with PerRequestCreator with FireCloudDirectives {
   private val billingUrl = FireCloudConfig.Rawls.authUrl + "/billing"
-  
+  private val userBillingUrl = FireCloudConfig.Rawls.authUrl + "/user/billing"
+
   val routes: Route =
     pathPrefix("billing") {
       pathEnd {
@@ -36,5 +37,10 @@ trait BillingService extends HttpService with PerRequestCreator with FireCloudDi
           }
         }
       }
-    }
+    } ~
+      path("user" / "billing" / Segment) { projectId =>
+        delete {
+          passthrough(s"$userBillingUrl/$projectId", DELETE)
+        }
+      }
 }


### PR DESCRIPTION
AoU RW wants to do a better job of cleaning up our resources.  We have a one-workspace-per-project paradigm, so it's safe to delete our projects after we delete the associated workspace.  Until now, we have used a batch cleanup job to do this.

With https://precisionmedicineinitiative.atlassian.net/browse/RW-3627 (please let me know if you need access) we will now be calling the Terra delete-project endpoint after calling Terra's delete-workspace whenever we delete an AoU RW workspace.  We prefer to call FC-Orch instead of Rawls directly for abstraction reasons - we don't currently make any Rawls calls.

This PR adds the Rawls call we need (implemented for https://broadworkbench.atlassian.net/browse/CA-540) to Orchestration.

Tested on a FIAB:
* created a few billing projects in FC-UI
* hit the Rawls endpoint with the same user to delete one
* hit the new Orch endpoint with the same user to delete another
* observed that the billing projects were no longer present in FC-UI 

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
