### PR TITLE
AS-501: support namespaced entity attributes in TSV export [risk: low]

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/utils/TSVFormatter.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/utils/TSVFormatter.scala
@@ -48,7 +48,7 @@ object TSVFormatter {
   private def makeRow(entity: Entity, headerValues: IndexedSeq[String]): IndexedSeq[String] = {
     val rowMap: Map[Int, String] =  entity.attributes map {
       case (attributeName, attribute) =>
-        val columnPosition = headerValues.indexOf(attributeName.name)
+        val columnPosition = headerValues.indexOf(AttributeName.toDelimitedName(attributeName))
         val cellValue = AttributeStringifier(attribute)
         columnPosition -> cellValue
     }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockRawlsDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockRawlsDAO.scala
@@ -106,6 +106,19 @@ object MockRawlsDAO {
     Entity("PB&J", "pair", Map(AttributeName.withDefaultNS("names") -> AttributeValueList(Seq(AttributeString("PeanutButter"), AttributeString("Jelly")))))
   )
 
+  val namespacedEntities = List(
+    Entity("first", "study", Map(
+      AttributeName.withDefaultNS("foo") -> AttributeString("default-foovalue"),
+      AttributeName.fromDelimitedName("tag:study_id") -> AttributeString("first-id"),
+      AttributeName.fromDelimitedName("tag:foo") -> AttributeString("namespaced-foovalue")
+    )),
+    Entity("second", "study", Map(
+      AttributeName.withDefaultNS("foo") -> AttributeString("default-bar"),
+      AttributeName.fromDelimitedName("tag:study_id") -> AttributeString("second-id"),
+      AttributeName.fromDelimitedName("tag:foo") -> AttributeString("namespaced-bar")
+    ))
+  )
+
   val nonModelBigQueryMetadata = Map(
     "bigQuery" -> EntityTypeMetadata(
       count = 2,
@@ -123,6 +136,12 @@ object MockRawlsDAO {
       count = 2,
       idName = "pair_id",
       attributeNames = Seq("names")))
+
+  val namespacedMetadata = Map(
+    "study" -> EntityTypeMetadata(
+      count = 2,
+      idName = "study_id",
+      attributeNames = Seq("foo", "tag:foo", "tag:study_id")))
 
 }
 
@@ -344,6 +363,13 @@ class MockRawlsDAO extends RawlsDAO {
         results = nonModelPairEntities
       )
       Future.successful(queryResponse)
+    } else if (workspaceName == "namespacedEntities") {
+      val queryResponse: EntityQueryResponse = EntityQueryResponse(
+        parameters = query,
+        resultMetadata = EntityQueryResultMetadata(unfilteredCount = 2, filteredCount = 2, filteredPageCount = 1),
+        results = namespacedEntities
+      )
+      Future.successful(queryResponse)
     } else {
       val queryResponse: EntityQueryResponse = EntityQueryResponse(
         parameters = query,
@@ -369,6 +395,8 @@ class MockRawlsDAO extends RawlsDAO {
       Future.successful(nonModelBigQuerySetMetadata)
     } else if (workspaceName == "nonModelPair") {
       Future.successful(nonModelPairMetadata)
+    } else if (workspaceName == "namespacedEntities") {
+      Future.successful(namespacedMetadata)
     } else {
       Future.successful(validEntitiesMetadata)
     }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockTSV.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockTSV.scala
@@ -257,6 +257,12 @@ object MockTSVStrings {
     List("baz".quoted, List("this", "has", "tabs").tabbed.quoted).tabbed
   ).newlineSeparated
 
+  val namespacedAttributes = List(
+    List("foo", "tag:foo", "bar", "tag:bar").tabbed,
+    List("1", "2", "3", "4").tabbed,
+    List("5", "6", "7", "8").tabbed
+  ).newlineSeparated
+
   val windowsNewline = List(
     List("foo", "bar").tabbed,
     List("baz", "biz").tabbed
@@ -301,6 +307,7 @@ object MockTSVLoadFiles {
   val validRemoveAddAttribute = TSVLoadFile("workspace", Seq("a1", "a2"), Seq(Seq("__DELETE__", "v2")))
   val validQuotedValues = TSVLoadFile("foo", Seq("foo", "bar"), Seq(Seq("baz", "biz")))
   val validQuotedValuesWithTabs = TSVLoadFile("foo", Seq("foo", "bar"), Seq(Seq("baz", "this\thas\ttabs")))
+  val validNamespacedAttributes = TSVLoadFile("foo", Seq("foo", "tag:foo", "bar", "tag:bar"), Seq(Seq("1","2","3","4"), Seq("5","6","7","8")))
   val missingFields1 = TSVLoadFile("foo", Seq("foo", "bar", "baz"), Seq(Seq("biz", "", "buz")))
   val missingFields2 = TSVLoadFile("foo", Seq("foo", "bar", "baz"), Seq(Seq("", "", "buz"), Seq("abc", "123", "")))
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/ExportEntitiesByTypeServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/ExportEntitiesByTypeServiceSpec.scala
@@ -35,6 +35,7 @@ class ExportEntitiesByTypeServiceSpec extends BaseServiceSpec with ExportEntitie
   val nonModelEntitiesBigQueryTSVPath = "/api/workspaces/broad-dsde-dev/nonModel/entities/bigQuery/tsv"
   val nonModelEntitiesBigQuerySetTSVPath = "/api/workspaces/broad-dsde-dev/nonModelSet/entities/bigQuery_set/tsv"
   val nonModelEntitiesPairTSVPath = "/api/workspaces/broad-dsde-dev/nonModelPair/entities/pair/tsv"
+  val namespacedEntitiesTSVPath = "/api/workspaces/broad-dsde-dev/namespacedEntities/entities/study/tsv"
 
   // Pick the first few headers from the list of available sample headers:
   val filterProps: Seq[String] = MockRawlsDAO.largeSampleHeaders.take(5).map(_.name)
@@ -117,6 +118,33 @@ class ExportEntitiesByTypeServiceSpec extends BaseServiceSpec with ExportEntitie
           validateLineCount(chunks, 2)
           entity.asString.startsWith("entity:") should be(true)
           entity.asString.contains("names") should be(true)
+        }
+      }
+    }
+
+    "when calling GET on exporting a non-FC model entity type with namespaced attributes" - {
+      "OK response is returned and file is entity type when model is flexible" in {
+        Get(namespacedEntitiesTSVPath + "?model=flexible") ~> dummyUserIdHeaders("1234") ~> sealRoute(exportEntitiesRoutes) ~> check {
+          handled should be(true)
+          status should be(OK)
+          entity shouldNot be(empty) // Entity is the first line of content as output by StreamingActor
+          chunks shouldNot be(empty) // Chunks has all of the rest of the content, as output by StreamingActor
+          headers.contains(HttpHeaders.Connection("Keep-Alive")) should be(true)
+          headers should contain(HttpHeaders.`Content-Disposition`.apply("attachment", Map("filename" -> "study.tsv")))
+          contentType shouldEqual ContentType(MediaTypes.`text/tab-separated-values`, HttpCharsets.`UTF-8`)
+          validateLineCount(chunks, MockRawlsDAO.namespacedEntities.length)
+
+          // confirm headers
+          entity.asString.trim.split('\t') should contain theSameElementsAs(List("entity:study_id") ++ MockRawlsDAO.namespacedMetadata("study").attributeNames)
+
+          // columns are returned in a deterministic but not easily-predictable order (hashmaps are involved deep inside).
+          // so it's very difficult for this unit test to check ordering of TSV values. If this test starts failing myseteriously,
+          // it is possible a Java- or Scala- internal ordering changed. To be more lenient, use theSameElementsAs instead of
+          // theSameElementsInOrderAs in the following assertions.
+          val bodyLines = asStringBody(chunks)
+          bodyLines.length shouldBe MockRawlsDAO.namespacedEntities.length // effecively the same assertion as validateLineCount
+          bodyLines.head.split("\t") should contain theSameElementsInOrderAs(List("first", "default-foovalue", "namespaced-foovalue", "first-id"))
+          bodyLines.tail.head.split("\t") should contain theSameElementsInOrderAs(List("second", "default-bar", "namespaced-bar", "second-id"))
         }
       }
     }
@@ -339,6 +367,10 @@ class ExportEntitiesByTypeServiceSpec extends BaseServiceSpec with ExportEntitie
           }
       }
     }
+  }
+
+  private def asStringBody(chunks: List[MessageChunk]): List[String] = {
+    chunks.flatMap(c => scala.io.Source.fromString(c.data.asString).getLines())
   }
 
   private def validateLineCount(chunks: List[MessageChunk], count: Int): Unit = {

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/utils/TSVParserSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/utils/TSVParserSpec.scala
@@ -71,6 +71,13 @@ class TSVParserSpec extends FlatSpec {
     }
   }
 
+  it should "handle attributes in namespaces" in {
+    val expected = MockTSVLoadFiles.validNamespacedAttributes
+    assertResult(expected) {
+      TSVParser.parse(MockTSVStrings.namespacedAttributes)
+    }
+  }
+
   it should "handle windows newline separators" in {
     val expected = MockTSVLoadFiles.validQuotedValues
     assertResult(expected) {


### PR DESCRIPTION
TSV download should now respect attribute namespaces.

-----

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
