### PR TITLE
revert last 2 commits to dev [risk: no, no ticket]

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/utils/TSVFormatter.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/utils/TSVFormatter.scala
@@ -48,7 +48,7 @@ object TSVFormatter {
   private def makeRow(entity: Entity, headerValues: IndexedSeq[String]): IndexedSeq[String] = {
     val rowMap: Map[Int, String] =  entity.attributes map {
       case (attributeName, attribute) =>
-        val columnPosition = headerValues.indexOf(AttributeName.toDelimitedName(attributeName))
+        val columnPosition = headerValues.indexOf(attributeName.name)
         val cellValue = AttributeStringifier(attribute)
         columnPosition -> cellValue
     }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockRawlsDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockRawlsDAO.scala
@@ -106,19 +106,6 @@ object MockRawlsDAO {
     Entity("PB&J", "pair", Map(AttributeName.withDefaultNS("names") -> AttributeValueList(Seq(AttributeString("PeanutButter"), AttributeString("Jelly")))))
   )
 
-  val namespacedEntities = List(
-    Entity("first", "study", Map(
-      AttributeName.withDefaultNS("foo") -> AttributeString("default-foovalue"),
-      AttributeName.fromDelimitedName("tag:study_id") -> AttributeString("first-id"),
-      AttributeName.fromDelimitedName("tag:foo") -> AttributeString("namespaced-foovalue")
-    )),
-    Entity("second", "study", Map(
-      AttributeName.withDefaultNS("foo") -> AttributeString("default-bar"),
-      AttributeName.fromDelimitedName("tag:study_id") -> AttributeString("second-id"),
-      AttributeName.fromDelimitedName("tag:foo") -> AttributeString("namespaced-bar")
-    ))
-  )
-
   val nonModelBigQueryMetadata = Map(
     "bigQuery" -> EntityTypeMetadata(
       count = 2,
@@ -136,12 +123,6 @@ object MockRawlsDAO {
       count = 2,
       idName = "pair_id",
       attributeNames = Seq("names")))
-
-  val namespacedMetadata = Map(
-    "study" -> EntityTypeMetadata(
-      count = 2,
-      idName = "study_id",
-      attributeNames = Seq("foo", "tag:foo", "tag:study_id")))
 
 }
 
@@ -363,13 +344,6 @@ class MockRawlsDAO extends RawlsDAO {
         results = nonModelPairEntities
       )
       Future.successful(queryResponse)
-    } else if (workspaceName == "namespacedEntities") {
-      val queryResponse: EntityQueryResponse = EntityQueryResponse(
-        parameters = query,
-        resultMetadata = EntityQueryResultMetadata(unfilteredCount = 2, filteredCount = 2, filteredPageCount = 1),
-        results = namespacedEntities
-      )
-      Future.successful(queryResponse)
     } else {
       val queryResponse: EntityQueryResponse = EntityQueryResponse(
         parameters = query,
@@ -395,8 +369,6 @@ class MockRawlsDAO extends RawlsDAO {
       Future.successful(nonModelBigQuerySetMetadata)
     } else if (workspaceName == "nonModelPair") {
       Future.successful(nonModelPairMetadata)
-    } else if (workspaceName == "namespacedEntities") {
-      Future.successful(namespacedMetadata)
     } else {
       Future.successful(validEntitiesMetadata)
     }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockTSV.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockTSV.scala
@@ -257,12 +257,6 @@ object MockTSVStrings {
     List("baz".quoted, List("this", "has", "tabs").tabbed.quoted).tabbed
   ).newlineSeparated
 
-  val namespacedAttributes = List(
-    List("foo", "tag:foo", "bar", "tag:bar").tabbed,
-    List("1", "2", "3", "4").tabbed,
-    List("5", "6", "7", "8").tabbed
-  ).newlineSeparated
-
   val windowsNewline = List(
     List("foo", "bar").tabbed,
     List("baz", "biz").tabbed
@@ -307,7 +301,6 @@ object MockTSVLoadFiles {
   val validRemoveAddAttribute = TSVLoadFile("workspace", Seq("a1", "a2"), Seq(Seq("__DELETE__", "v2")))
   val validQuotedValues = TSVLoadFile("foo", Seq("foo", "bar"), Seq(Seq("baz", "biz")))
   val validQuotedValuesWithTabs = TSVLoadFile("foo", Seq("foo", "bar"), Seq(Seq("baz", "this\thas\ttabs")))
-  val validNamespacedAttributes = TSVLoadFile("foo", Seq("foo", "tag:foo", "bar", "tag:bar"), Seq(Seq("1","2","3","4"), Seq("5","6","7","8")))
   val missingFields1 = TSVLoadFile("foo", Seq("foo", "bar", "baz"), Seq(Seq("biz", "", "buz")))
   val missingFields2 = TSVLoadFile("foo", Seq("foo", "bar", "baz"), Seq(Seq("", "", "buz"), Seq("abc", "123", "")))
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/utils/TSVParserSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/utils/TSVParserSpec.scala
@@ -71,13 +71,6 @@ class TSVParserSpec extends FlatSpec {
     }
   }
 
-  it should "handle attributes in namespaces" in {
-    val expected = MockTSVLoadFiles.validNamespacedAttributes
-    assertResult(expected) {
-      TSVParser.parse(MockTSVStrings.namespacedAttributes)
-    }
-  }
-
   it should "handle windows newline separators" in {
     val expected = MockTSVLoadFiles.validQuotedValues
     assertResult(expected) {


### PR DESCRIPTION
This reverts the last two commits that I mistakenly pushed to develop without a PR. Ack that was bad of me!

Compare to the last commit that had a proper PR: https://github.com/broadinstitute/firecloud-orchestration/compare/82a1ce4fa354f7eb9864eb4675adfeefe36cd416...da_revertCommits

----


I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
