### PR TITLE
[CA-864] Swagger changes from https://github.com/broadinstitute/rawls/pull/1286 for creating/cloning workspaces with noWorkspaceOwner

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -9438,6 +9438,10 @@ components:
         attributes:
           type: object
           properties: {}
+        noWorkspaceOwner:
+          type: boolean
+          description: Optional, false if not specified. If true, the workspace is created with a Billing Project owner but no workspace owner. Requires being a Billing Project owner.
+          default: false
       description: ""
     WorkspaceRequestClone:
       required:
@@ -9465,6 +9469,10 @@ components:
           type: string
           description: Used for clone operations only; the prefix for files to copy
             between source and destination workspace buckets
+        noWorkspaceOwner:
+          type: boolean
+          description: Optional, false if not specified. If true, the workspace is created with a Billing Project owner but no workspace owner. Requires being a Billing Project owner.
+          default: false
       description: ""
     WorkspaceResponse:
       type: object


### PR DESCRIPTION
\<your comments for this PR go here\>

Copying swagger changes from: https://github.com/broadinstitute/rawls/pull/1286


Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [x] Get two thumbsworth of review and PO signoff if necessary
- [x] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
