### PR TITLE
AS-120 followup: akka-http fixes related to discarding entity bytes

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/utils/RestJsonClient.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/utils/RestJsonClient.scala
@@ -121,6 +121,8 @@ trait RestJsonClient extends FireCloudRequestBuilding with PerformanceLogging {
           }
         case f => {
           FCErrorReport(response).map { errorReport =>
+            //we never consume the response body in this case, so we must discard the bytes here
+            response.discardEntityBytes()
             throw new FireCloudExceptionWithErrorReport(errorReport)
           }
         }


### PR DESCRIPTION
I've traced a bunch of log warnings in orch back to not discarding entity bytes in these locations. This may improve test stability, not sure, but this code is very close to where the most recent swatomation failures occurred

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
