### PR TITLE
Add useReferenceDisks as passthrough for SubmissionRequest [CROM-6662]

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -8553,6 +8553,9 @@ components:
           type: boolean
           description: Whether or not to delete intermediate output files when the
             workflow completes. See Cromwell docs for more information.
+        useReferenceDisks:
+          type: boolean
+          description: Whether or not to use pre-built disks for common genome references
         workflowFailureMode:
           type: string
           description: What happens after a task fails. Choose from ContinueWhilePossible

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
@@ -201,7 +201,7 @@ object ModelJsonProtocol extends WorkspaceJsonSupport with SprayJsonSupport {
 
   implicit val impEntityMetadata = jsonFormat3(EntityMetadata)
   implicit val impModelSchema = jsonFormat1(EntityModel)
-  implicit val impSubmissionRequest = jsonFormat8(SubmissionRequest)
+  implicit val impSubmissionRequest = jsonFormat9(SubmissionRequest)
 
   implicit val impEntityUpdateDefinition = jsonFormat3(EntityUpdateDefinition)
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/Workspace.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/Workspace.scala
@@ -91,6 +91,7 @@ case class SubmissionRequest(
   expression: Option[String],
   useCallCache: Option[Boolean],
   deleteIntermediateOutputFiles: Option[Boolean],
+  useReferenceDisks: Option[Boolean],
   workflowFailureMode: Option[String])
 
 case class RawlsGroupMemberList(

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockWorkspaceServer.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockWorkspaceServer.scala
@@ -62,9 +62,10 @@ object MockWorkspaceServer {
     expression = Option(randomAlpha()),
     useCallCache = Option(randomBoolean()),
     deleteIntermediateOutputFiles = Option(randomBoolean()),
+    useReferenceDisks = Option(randomBoolean()),
     workflowFailureMode = Option(randomElement(List("ContinueWhilePossible", "NoNewCalls")))
-  ) 
-  
+  )
+
   val mockInvalidSubmission = SubmissionRequest(
     methodConfigurationNamespace = Option.empty,
     methodConfigurationName = Option.empty,

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockWorkspaceServer.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockWorkspaceServer.scala
@@ -74,6 +74,7 @@ object MockWorkspaceServer {
     expression = Option.empty,
     useCallCache = Option.empty,
     deleteIntermediateOutputFiles = Option.empty,
+    useReferenceDisks = Option.empty,
     workflowFailureMode = Option.empty
   )
 


### PR DESCRIPTION
\<your comments for this PR go here\>

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [x] Get two thumbsworth of review and PO signoff if necessary
- [x] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
