### PR TITLE
AS-120 followup: not-quite-exhaustive handling of discardEntityBytes

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/EntityService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/EntityService.scala
@@ -7,6 +7,7 @@ import java.util.zip.{ZipEntry, ZipFile}
 
 import akka.http.scaladsl.model.StatusCodes._
 import akka.http.scaladsl.model.{HttpResponse, StatusCodes}
+import akka.stream.Materializer
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.EntityService._
 import org.broadinstitute.dsde.firecloud.FireCloudConfig.Rawls
@@ -29,7 +30,7 @@ import scala.util.{Failure, Success, Try}
 
 object EntityService {
 
-  def constructor(app: Application)(modelSchema: ModelSchema)(implicit executionContext: ExecutionContext) =
+  def constructor(app: Application)(modelSchema: ModelSchema)(implicit executionContext: ExecutionContext, materializer: Materializer) =
     new EntityService(app.rawlsDAO, app.importServiceDAO, modelSchema)
 
   def colNamesToAttributeNames(headers: Seq[String], requiredAttributes: Map[String, String]): Seq[(String, Option[String])] = {
@@ -98,7 +99,7 @@ object EntityService {
 
 }
 
-class EntityService(rawlsDAO: RawlsDAO, importServiceDAO: ImportServiceDAO, modelSchema: ModelSchema)(implicit val executionContext: ExecutionContext)
+class EntityService(rawlsDAO: RawlsDAO, importServiceDAO: ImportServiceDAO, modelSchema: ModelSchema)(implicit val executionContext: ExecutionContext, val materializer: Materializer)
   extends TSVFileSupport with LazyLogging {
 
   val format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZZ")

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/EntityService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/EntityService.scala
@@ -211,6 +211,7 @@ class EntityService(rawlsDAO: RawlsDAO, importServiceDAO: ImportServiceDAO, mode
     response map { response =>
       response.status match {
         case NoContent =>
+          response.discardEntityBytes()
           logger.debug("OK response")
           RequestComplete(OK, entityType)
         case _ =>

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
@@ -356,6 +356,7 @@ class HttpGoogleServicesDAO(implicit val system: ActorSystem, implicit val mater
                   val extReq = Get(gcsApiUrl)
 
                   userAuthedRequest(extReq)(userAuthToken).map { proxyResponse =>
+                    proxyResponse.discardEntityBytes()
                     proxyResponse.header[`Content-Type`] match {
                       case Some(ct) =>
                         RequestCompleteWithHeaders(proxyResponse, `Content-Type`(ct.contentType))

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
@@ -366,6 +366,7 @@ class HttpGoogleServicesDAO(implicit val system: ActorSystem, implicit val mater
                   // object is too large to proxy; try to make a signed url.
                   // now make a final request to see if our service account has access, so it can sign a URL
                   objectAccessCheck(bucketName, objectKey, AccessToken(getRawlsServiceAccountAccessToken)) map { serviceAccountResponse =>
+                    serviceAccountResponse.discardEntityBytes()
                     serviceAccountResponse.status match {
                       case OK =>
                         // the service account can read the object too. We are safe to sign a url.

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpRawlsDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpRawlsDAO.scala
@@ -98,6 +98,7 @@ class HttpRawlsDAO(implicit val system: ActorSystem, implicit val materializer: 
         }
       }
       else {
+        response.discardEntityBytes()
         logger.info(s"body of reindex error response: ${response.entity}")
         throw new FireCloudExceptionWithErrorReport(ErrorReport(StatusCodes.InternalServerError, "Could not unmarshal: " + response.entity))
       }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpRawlsDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpRawlsDAO.scala
@@ -39,6 +39,7 @@ class HttpRawlsDAO(implicit val system: ActorSystem, implicit val materializer: 
 
   override def isAdmin(userInfo: UserInfo): Future[Boolean] = {
     userAuthedRequest(Get(rawlsAdminUrl))(userInfo) flatMap { response =>
+      response.discardEntityBytes()
       response.status match {
         case OK => Future.successful(true)
         case NotFound => Future.successful(false)
@@ -53,6 +54,7 @@ class HttpRawlsDAO(implicit val system: ActorSystem, implicit val materializer: 
 
   override def isLibraryCurator(userInfo: UserInfo): Future[Boolean] = {
     userAuthedRequest(Get(rawlsCuratorUrl))(userInfo) flatMap { response =>
+      response.discardEntityBytes()
       response.status match {
         case OK => Future.successful(true)
         case NotFound => Future.successful(false)
@@ -162,6 +164,7 @@ class HttpRawlsDAO(implicit val system: ActorSystem, implicit val materializer: 
     val url = editBillingMembershipURL(projectId, role, email)
 
     userAuthedRequest(Put(url), true) flatMap { resp =>
+      resp.discardEntityBytes()
       if (resp.status.isSuccess) {
         Future.successful(true)
       } else {
@@ -176,6 +179,7 @@ class HttpRawlsDAO(implicit val system: ActorSystem, implicit val materializer: 
     val url = editBillingMembershipURL(projectId, role, email)
 
     userAuthedRequest(Delete(url), true) flatMap { resp =>
+      resp.discardEntityBytes()
       if (resp.status.isSuccess) {
         Future.successful(true)
       } else {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpSamDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpSamDAO.scala
@@ -106,6 +106,7 @@ class HttpSamDAO( implicit val system: ActorSystem, val materializer: Materializ
 
   private def userAuthedRequestToUnit(request: HttpRequest)(implicit userInfo: WithAccessToken): Future[Unit] = {
     userAuthedRequest(request).map { resp =>
+      resp.discardEntityBytes()
       if(resp.status.isSuccess) Future.successful(())
       else {
         FCErrorReport(resp).flatMap { errorReport =>

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ErrorReport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ErrorReport.scala
@@ -30,14 +30,6 @@ object ErrorReportExtensions {
           val fallbackMessage = Try(response.toString()).toOption.getOrElse("Unexpected error")
           Future.successful(new ErrorReport(ers.source, fallbackMessage, Option(response.status), Seq.empty, Seq.empty, None))
       }
-//
-//      Unmarshal(response).to[ErrorReport].map { re =>
-//        new ErrorReport(ers.source, re.message, Option(response.status), Seq(re), Seq.empty, None)
-//      } recoverWith {
-//        case _ => Unmarshal(response).to[String].map { message =>
-//          new ErrorReport(ers.source, message, Option(response.status), Seq.empty, Seq.empty, None)
-//        }
-//      }
     }
   }
 }


### PR DESCRIPTION
I have not yet determined if `requestContext.complete(response)` properly consumes `response`....there are a few places that still do that. This takes care of all of the other places, I believe

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
