### PR TITLE
AS-541: upgrade to sbt 1.4.4 [risk: low]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ config/
 
 # sbt specific
 .sbtopts
+.bsp/
 .cache/
 .history/
 .lib/

--- a/build.sbt
+++ b/build.sbt
@@ -8,8 +8,6 @@ lazy val root = project.in(file("."))
 
 enablePlugins(RevolverPlugin)
 
-//Revolver.settings.settings
-
 Revolver.enableDebugging(port = 5051, suspend = false)
 
 // When JAVA_OPTS are specified in the environment, they are usually meant for the application

--- a/build.sbt
+++ b/build.sbt
@@ -1,12 +1,14 @@
 import Settings._
 import Testing._
-import spray.revolver.RevolverPlugin.Revolver
+import spray.revolver.RevolverPlugin
 
 lazy val root = project.in(file("."))
   .settings(rootSettings:_*)
   .withTestSettings
 
-Revolver.settings.settings
+enablePlugins(RevolverPlugin)
+
+//Revolver.settings.settings
 
 Revolver.enableDebugging(port = 5051, suspend = false)
 
@@ -14,4 +16,4 @@ Revolver.enableDebugging(port = 5051, suspend = false)
 // itself rather than sbt, but they are not passed by default to the application, which is a forked
 // process. This passes them through to the "re-start" command, which is probably what a developer
 // would normally expect.
-javaOptions in Revolver.reStart ++= sys.env("JAVA_OPTS").split(" ").toSeq
+javaOptions in reStart ++= sys.env("JAVA_OPTS").split(" ").toSeq

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -1,6 +1,7 @@
 import sbt.Keys._
 import sbt._
 
+import scala.sys.process._
 
 object Version {
   val baseModelVersion = "0.1"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,1 @@
-# build was failing on sbt 1.0.2, so pin to sbt 0.13.
-sbt.version=0.13.17
+sbt.version=1.4.4

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,9 +1,5 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.3")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.15.0")
 
-addSbtPlugin("io.spray" % "sbt-revolver" % "0.7.2")
+addSbtPlugin("io.spray" % "sbt-revolver" % "0.9.1")
 
-addSbtPlugin("com.github.sbt" % "sbt-jacoco" % "3.2.0")
-
-addSbtPlugin("com.github.tkawachi" % "sbt-repeat" % "0.1.0")
-
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.2")
+addSbtPlugin("com.github.sbt" % "sbt-jacoco" % "3.3.0")


### PR DESCRIPTION
Upgrades the main orchestration build to use sbt latest version (1.4.4).

We should also upgrade the automation project to use sbt latest and Scala 2.12-latest; I'd like to do that as a separate PR to keep things clean.

See explanatory comments inline to the code. Anything not explained is purely for syntax compatibility.

--------

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
