### PR TITLE
[AoU RW-5987] Add passthrough for Rawls addProjectToServicePerimeter

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -6729,7 +6729,7 @@ paths:
   /servicePerimeters/{servicePerimeterName}/projects/{projectName}:
     put:
       tags:
-        - servicePerimeters
+        - Service Perimeters
       summary: Add a project to a service perimeter
       description: |
         Add a project to a service perimeter, must have 'add_to_service_perimeter'

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -6726,6 +6726,61 @@ paths:
                   $ref: '#/components/schemas/ToolClass'
       x-passthrough: true
       x-passthrough-target: agora
+  /servicePerimeters/{servicePerimeterName}/projects/{projectName}:
+    put:
+      tags:
+        - servicePerimeters
+      summary: Add a project to a service perimeter
+      description: |
+        Add a project to a service perimeter, must have 'add_to_service_perimeter'
+        action on project and 'add_project' action on perimeter, included in owner
+        role for both
+      operationId: addProjectToServicePerimeter
+      parameters:
+        - name: servicePerimeterName
+          in: path
+          description: |
+            Fully qualified google service perimeter name in the form of
+            accessPolicies/[POLICY NUMBER]/servicePerimeters/[NAME], url encoded
+          required: true
+          schema:
+            type: string
+        - name: projectName
+          in: path
+          description: Project name
+          required: true
+          schema:
+            type: string
+      x-passthrough: true
+      x-passthrough-target: rawls
+      responses:
+        202:
+          description: Successful request, check the project's status for completion
+          content: {}
+        400:
+          description: Project is already in perimeter or is not in 'Ready' state
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        403:
+          description: Project does not exist or you do not have access
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        404:
+          description: Service Perimeter does not exist or you do not have access
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        500:
+          description: Rawls Internal Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
 components:
   schemas:
     AttributeEntityReference:

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudApiService.scala
@@ -69,6 +69,7 @@ trait FireCloudApiService extends CookieAuthedApiService
   with CromIamApiService
   with HealthService
   with StaticNotebooksApiService
+  with PerimeterApiService
 {
 
   override lazy val log = LoggerFactory.getLogger(getClass)
@@ -162,7 +163,8 @@ trait FireCloudApiService extends CookieAuthedApiService
           nihRoutes ~
           billingServiceRoutes ~
           shareLogServiceRoutes ~
-          staticNotebooksRoutes
+          staticNotebooksRoutes ~
+          perimeterServiceRoutes
       }
 
   val routeWrappers: Directive[Unit] =

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/PerimeterApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/PerimeterApiService.scala
@@ -1,0 +1,17 @@
+package org.broadinstitute.dsde.firecloud.webservice
+
+import akka.http.scaladsl.model.HttpMethods.PUT
+import akka.http.scaladsl.server.Route
+import org.broadinstitute.dsde.firecloud.FireCloudConfig
+import org.broadinstitute.dsde.firecloud.service.FireCloudDirectives
+
+trait PerimeterApiService extends FireCloudDirectives {
+  private val perimetersUrl = FireCloudConfig.Rawls.authUrl + "/servicePerimeters"
+
+  val perimeterServiceRoutes: Route =
+    path("servicePerimeters" / Segment / "projects" / Segment) { (servicePerimeterName, projectName) =>
+      put {
+        passthrough(s"$perimetersUrl/$servicePerimeterName/projects/$projectName", PUT)
+      }
+    }
+}

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/PerimeterApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/PerimeterApiServiceSpec.scala
@@ -1,0 +1,98 @@
+package org.broadinstitute.dsde.firecloud.webservice
+
+import akka.http.scaladsl.model.HttpMethods._
+import akka.http.scaladsl.model.StatusCodes._
+import akka.http.scaladsl.server.Route.{seal => sealRoute}
+import org.broadinstitute.dsde.firecloud.FireCloudConfig
+import org.broadinstitute.dsde.firecloud.mock.MockUtils
+import org.broadinstitute.dsde.firecloud.service.BaseServiceSpec
+import org.mockserver.integration.ClientAndServer
+import org.mockserver.integration.ClientAndServer._
+import org.mockserver.model.HttpRequest._
+import org.mockserver.model.HttpResponse
+
+import scala.concurrent.ExecutionContext
+
+final class PerimeterApiServiceSpec extends BaseServiceSpec with PerimeterApiService {
+
+  override val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
+
+  val validPerimeter = "foo"
+  val invalidPerimeter = "missing"
+
+  val validProject = "bar"
+  val invalidProject = "firehose"
+  val notReadyProject = "unready"
+
+  var mockWorkspaceServer: ClientAndServer = _
+
+  override def beforeAll(): Unit = {
+    val perimeterPath = FireCloudConfig.Rawls.authPrefix + "/servicePerimeters"
+
+    mockWorkspaceServer = startClientAndServer(MockUtils.workspaceServerPort)
+
+    mockWorkspaceServer.when(
+      request()
+        .withMethod(PUT.name)
+        .withPath(s"$perimeterPath/$validPerimeter/projects/$validProject"))
+      .respond(HttpResponse.response()
+          .withHeaders(MockUtils.header)
+          .withStatusCode(Accepted.intValue))
+
+    mockWorkspaceServer.when(
+      request()
+        .withMethod(PUT.name)
+        .withPath(s"$perimeterPath/$invalidPerimeter/projects/$validProject"))
+      .respond(HttpResponse.response()
+        .withHeaders(MockUtils.header)
+        .withStatusCode(NotFound.intValue))
+
+    mockWorkspaceServer.when(
+      request()
+        .withMethod(PUT.name)
+        .withPath(s"$perimeterPath/$validPerimeter/projects/$invalidProject"))
+      .respond(HttpResponse.response()
+        .withHeaders(MockUtils.header)
+        .withStatusCode(Forbidden.intValue))
+
+    mockWorkspaceServer.when(
+      request()
+        .withMethod(PUT.name)
+        .withPath(s"$perimeterPath/$validPerimeter/projects/$notReadyProject"))
+      .respond(HttpResponse.response()
+        .withHeaders(MockUtils.header)
+        .withStatusCode(BadRequest.intValue))
+
+  }
+
+  override def afterAll(): Unit = {
+    mockWorkspaceServer.stop()
+  }
+
+  "PerimeterApiService" - {
+    "add project to perimeter" in {
+      Put(s"/servicePerimeters/$validPerimeter/projects/$validProject") ~> dummyAuthHeaders ~> sealRoute(perimeterServiceRoutes) ~> check {
+        status should be(Accepted)
+      }
+    }
+
+    "add project to invalid perimeter" in {
+      Put(s"/servicePerimeters/$invalidPerimeter/projects/$validProject") ~> dummyAuthHeaders ~> sealRoute(perimeterServiceRoutes) ~> check {
+        status should be(NotFound)
+      }
+    }
+
+    "add invalid project to perimeter" in {
+      Put(s"/servicePerimeters/$validPerimeter/projects/$invalidProject") ~> dummyAuthHeaders ~> sealRoute(perimeterServiceRoutes) ~> check {
+        status should be(Forbidden)
+      }
+    }
+
+    "add unready project to perimeter" in {
+      Put(s"/servicePerimeters/$validPerimeter/projects/$notReadyProject") ~> dummyAuthHeaders ~> sealRoute(perimeterServiceRoutes) ~> check {
+        status should be(BadRequest)
+      }
+    }
+
+  }
+}


### PR DESCRIPTION
AoU is prototyping a change of our process from specifying a Service Perimeter at project creation time to adding it when we are ready to use it to create a workspace.  We will need this endpoint to do so. 

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
