### PR TITLE
[DO NOT MERGE] Convert entity to strict entity in export methodconfig endpoint

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiService.scala
@@ -99,6 +99,7 @@ trait WorkspaceApiService extends FireCloudRequestBuilding with FireCloudDirecti
                   } ~
                     post {
                       requireUserInfo() { _ =>
+                        //TODO: pull timeout from config
                         toStrictEntity(10.seconds) {
                           entity(as[MethodConfiguration]) { methodConfig =>
                             if (!methodConfig.outputs.exists { param => param._2.value.startsWith("this.library:") || param._2.value.startsWith("workspace.library:") })


### PR DESCRIPTION
Disclaimer: I'm only opening this PR to help illustrate the bug and to discuss it. I think this needs a bit more discussion before proposing a real fix.

This is a potential fix for a bug that occurs if a user tries to export a workflow (née method config) to their workspace. In rare cases, they will get a "Substream cannot be materialized twice" error. This does not seem to happen with smaller workflows, only with large ones that have many inputs. In production and dev, 300 was a sufficient number of inputs to trigger the error. While testing with a local orch, I had to push the number to 1000 inputs to get a fairly repeatable error. 

Digging in, it seems that it is actually possible to unmarshal a request entity twice without converting it into a strict entity, but only if it is small enough to fit inside of akka-http's internal buffer. That would explain why this only occurs with a large payload and why it sometimes works and sometimes doesn't (the buffer might not always be near the limit).

The fix proposed here wraps the route in a directive that converts the request entity to strict- guaranteeing that it will be stored in memory rather than streamed. It's not ideal, but it's still bound to the akka-http `max-to-strict-bytes` config setting so we would have some protection against OOMs.

I am concerned that this is not localized to just this endpoint, but I haven't tested that other endpoints are vulnerable. I suspect that somewhere under the hood, either `entity(as[Foo])` and/or somewhere in our `generateExternalHttpRequestForMethod` method, we are somehow reading the request entity more than once. If that's the case, then it's possible that other endpoints could experience this bug, specifically if they meet the following criteria:

* Passthrough
* POST
* We look at the payload before passing it into the `passthrough` directive 

This needs a bit more investigation, though.

Possible solutions:

A) There may be a bug in `generateExternalHttpRequestForMethod`, fix that instead (best case)
B) Adopt this change (and apply it to other endpoints that meet the above criteria. only acceptable if it's deemed that there is no bug in option A)
C) Convert this passthrough to use a DAO which doesn't seem to be susceptible (not ideal, ignores the problem)


Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
