### PR TITLE
AS-562: Upgrade to Scala 2.13

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -35,4 +35,4 @@ jobs:
 
     - uses: codecov/codecov-action@v1
       with:
-        file: ./target/scala-2.12/jacoco/report/jacoco.xml
+        file: ./target/scala-2.13/jacoco/report/jacoco.xml

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ sbt
 
 ```
 java -Dconfig.file=src/main/resources/application.conf \
-  -jar $(ls target/scala-2.12/FireCloud-Orchestration-assembly-* | tail -n 1)
+  -jar $(ls target/scala-2.13/FireCloud-Orchestration-assembly-* | tail -n 1)
 ```
 
 For development, you can have sbt recompile and restart the server whenever a file changes on disk:

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,10 +7,10 @@ object Dependencies {
   val jacksonHotfixV = "2.10.0" // for when only some of the Jackson libs have hotfix releases
 
   def excludeGuava(m: ModuleID): ModuleID = m.exclude("com.google.guava", "guava")
-  val excludeAkkaActor =        ExclusionRule(organization = "com.typesafe.akka", name = "akka-actor_2.12")
-  val excludeAkkaStream =       ExclusionRule(organization = "com.typesafe.akka", name = "akka-stream_2.12")
-  val excludeAkkaHttp = ExclusionRule(organization = "com.typesafe.akka", name = "akka-http_2.12");
-  val excludeSprayJson = ExclusionRule(organization = "com.typesafe.akka", name = "akka-http-spray-json_2.12");
+  val excludeAkkaActor =        ExclusionRule(organization = "com.typesafe.akka", name = "akka-actor_2.13")
+  val excludeAkkaStream =       ExclusionRule(organization = "com.typesafe.akka", name = "akka-stream_2.13")
+  val excludeAkkaHttp = ExclusionRule(organization = "com.typesafe.akka", name = "akka-http_2.13");
+  val excludeSprayJson = ExclusionRule(organization = "com.typesafe.akka", name = "akka-http-spray-json_2.13");
 
   val rootDependencies = Seq(
     // proactively pull in latest versions of these libraries, instead of relying on the versions
@@ -27,15 +27,15 @@ object Dependencies {
     "org.apache.logging.log4j"       % "log4j-to-slf4j"      % "2.8.2", // ... but we redirect log4j to logback.
     "ch.qos.logback"                 % "logback-classic"     % "1.2.2",
     "com.getsentry.raven"            % "raven-logback"       % "7.8.6",
-    "com.typesafe.scala-logging"    %% "scala-logging"       % "3.7.2",
+    "com.typesafe.scala-logging"    %% "scala-logging"       % "3.9.2",
 
     "org.parboiled" % "parboiled-core" % "1.2.0",
-    excludeGuava("org.broadinstitute.dsde"       %% "rawls-model"         % "0.1-18b1c01e0")
-      exclude("com.typesafe.scala-logging", "scala-logging_2.12")
-      exclude("com.typesafe.akka", "akka-stream_2.12")
+    excludeGuava("org.broadinstitute.dsde"       %% "rawls-model"         % "0.1-2356e282")
+      exclude("com.typesafe.scala-logging", "scala-logging_2.13")
+      exclude("com.typesafe.akka", "akka-stream_2.13")
       exclude("com.google.code.findbugs", "jsr305")
       excludeAll(excludeAkkaHttp, excludeSprayJson),
-    excludeGuava("org.broadinstitute.dsde.workbench" %% "workbench-util"  % "0.3-12b7791-SNAP"),
+    excludeGuava("org.broadinstitute.dsde.workbench" %% "workbench-util"  % "0.6-bc324ba"),
 
     "com.typesafe.akka"   %%  "akka-actor"           % akkaV,
     "com.typesafe.akka"   %%  "akka-contrib"         % akkaV               excludeAll(excludeAkkaActor, excludeAkkaStream),
@@ -72,11 +72,11 @@ object Dependencies {
     "com.univocity"                  % "univocity-parsers"   % "2.4.1",
     "org.ocpsoft.prettytime"         % "prettytime"          % "4.0.1.Final",
     "com.github.everit-org.json-schema" % "org.everit.json.schema" % "1.12.0",
-    "com.github.pathikrit"          %% "better-files"        % "2.17.1",
+    "com.github.pathikrit"          %% "better-files"        % "3.9.1",
     "org.apache.httpcomponents"      % "httpclient"          % "4.5.3",
 
-    "org.specs2"                    %% "specs2-core"         % "3.10.0"     % "test",
-    "org.scalatest"                 %% "scalatest"           % "3.0.5"   % "test",
+    "org.specs2"                    %% "specs2-core"         % "4.10.0"     % "test",
+    "org.scalatest"                 %% "scalatest"           % "3.2.3"   % "test",
     "org.mock-server"                % "mockserver-netty"    % "3.10.2"  % "test"
   )
 }

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -40,7 +40,7 @@ object Settings {
   val commonSettings =
     commonBuildSettings ++ commonAssemblySettings ++ commonTestSettings ++ List(
     organization  := "org.broadinstitute.dsde.firecloud",
-    scalaVersion  := "2.12.12",
+    scalaVersion  := "2.13.4",
     resolvers ++= commonResolvers,
     scalacOptions ++= commonCompilerSettings
   )

--- a/src/docker/run.sh
+++ b/src/docker/run.sh
@@ -3,8 +3,8 @@ set -euox pipefail
 IFS=$'\n\t'
 
 
-if [ -e /app/target/scala-2.12/FireCloud-Orchestration-assembly-*.jar ]; then
-  exec java $JAVA_OPTS -jar /app/target/scala-2.12/FireCloud-Orchestration-assembly-*.jar
+if [ -e /app/target/scala-2.13/FireCloud-Orchestration-assembly-*.jar ]; then
+  exec java $JAVA_OPTS -jar /app/target/scala-2.13/FireCloud-Orchestration-assembly-*.jar
 else
   cd /app
   exec sbt '~ reStart'

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/EntityService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/EntityService.scala
@@ -20,7 +20,7 @@ import org.broadinstitute.dsde.firecloud.utils.TSVLoadFile
 import org.broadinstitute.dsde.rawls.model._
 import spray.json.DefaultJsonProtocol._
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.io.Source
 import scala.language.postfixOps
@@ -93,7 +93,7 @@ object EntityService {
   private def unzipSingleFile(zis: InputStream, fileTarget: File): Unit = {
     val fout = new FileOutputStream(fileTarget)
     val buffer = new Array[Byte](1024)
-    Stream.continually(zis.read(buffer)).takeWhile(_ != -1).foreach(fout.write(buffer, 0, _))
+    LazyList.continually(zis.read(buffer)).takeWhile(_ != -1).foreach(fout.write(buffer, 0, _))
   }
 
 }
@@ -255,7 +255,7 @@ class EntityService(rawlsDAO: RawlsDAO, importServiceDAO: ImportServiceDAO, mode
         case _ => throw new FireCloudExceptionWithErrorReport(errorReport = ErrorReport(StatusCodes.BadRequest, "Invalid first column header, should look like tsvType:entity_type_id"))
       }
 
-      val strippedTsv = if (modelSchema.supportsBackwardsCompatibleIds) {
+      val strippedTsv = if (modelSchema.supportsBackwardsCompatibleIds()) {
           backwardsCompatStripIdSuffixes(tsv, entityType, modelSchema)
         } else {
           tsv

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.dsde.firecloud
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import com.typesafe.config.{ConfigFactory, ConfigObject}
 import org.broadinstitute.dsde.firecloud.service.{FireCloudDirectiveUtils, NihWhitelist}
 import org.broadinstitute.dsde.rawls.model.{EntityQuery, SortDirections}
@@ -162,7 +162,7 @@ object FireCloudConfig {
   }
 
   def parseESServers(confString: String): Seq[Authority] = {
-    confString.split(',') map { hostport =>
+    confString.split(',').toIndexedSeq map { hostport =>
       val hp = hostport.split(':')
       Authority(Host(hp(0)), hp(1).toInt)
     }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/AgoraDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/AgoraDAO.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.dsde.firecloud.dataaccess
 
-import org.broadinstitute.dsde.firecloud.model.MethodRepository.{AgoraEntityType, AgoraPermission, EntityAccessControlAgora, Method}
+import org.broadinstitute.dsde.firecloud.model.OrchMethodRepository.{AgoraEntityType, AgoraPermission, EntityAccessControlAgora, Method}
 import org.broadinstitute.dsde.firecloud.model.UserInfo
 import org.broadinstitute.dsde.rawls.model.ErrorReportSource
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchDAOQuerySupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchDAOQuerySupport.scala
@@ -19,7 +19,7 @@ import org.elasticsearch.search.sort.SortOrder
 import spray.json._
 import spray.json.DefaultJsonProtocol._
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.{Failure, Success, Try}

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchDAOQuerySupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ElasticSearchDAOQuerySupport.scala
@@ -197,7 +197,7 @@ trait ElasticSearchDAOQuerySupport extends ElasticSearchDAOSupport {
         val terms: Terms = aggResults.get(field)
         LibraryAggregationResponse(terms.getName,
           AggregationFieldResults(terms.getSumOfOtherDocCounts.toInt,
-            terms.getBuckets.asScala map { bucket: Terms.Bucket =>
+            terms.getBuckets.asScala.toList map { bucket: Terms.Bucket =>
               AggregationTermResult(bucket.getKey.toString, bucket.getDocCount.toInt)
             }))
       }
@@ -284,7 +284,7 @@ trait ElasticSearchDAOQuerySupport extends ElasticSearchDAOSupport {
             logger.warn(s"failed to get populate suggestions for field [$field] and term [$text]")
             Seq.empty[String]
         }
-        Future(buckets)
+        Future(buckets.toList)
 
       case Failure(ex) =>
         logger.warn(s"failed to get populate suggestions for field [$field] and term [$text]: ${ex.getMessage}")

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpAgoraDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpAgoraDAO.scala
@@ -4,7 +4,7 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
 import akka.http.scaladsl.model.Uri
 import akka.stream.Materializer
-import org.broadinstitute.dsde.firecloud.model.MethodRepository.{AgoraEntityType, AgoraPermission, EntityAccessControlAgora, Method}
+import org.broadinstitute.dsde.firecloud.model.OrchMethodRepository.{AgoraEntityType, AgoraPermission, EntityAccessControlAgora, Method}
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
 import org.broadinstitute.dsde.firecloud.model.UserInfo
 import org.broadinstitute.dsde.firecloud.utils.RestJsonClient

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
@@ -35,7 +35,7 @@ import org.broadinstitute.dsde.rawls.model.ErrorReport
 import org.broadinstitute.dsde.workbench.util.health.SubsystemStatus
 import spray.json.{DefaultJsonProtocol, _}
 
-import collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpRawlsDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpRawlsDAO.scala
@@ -9,7 +9,7 @@ import akka.http.scaladsl.unmarshalling.Unmarshal
 import akka.stream.Materializer
 import org.broadinstitute.dsde.firecloud.FireCloudConfig.Rawls
 import org.broadinstitute.dsde.firecloud.model.ErrorReportExtensions._
-import org.broadinstitute.dsde.firecloud.model.MethodRepository.AgoraConfigurationShort
+import org.broadinstitute.dsde.firecloud.model.OrchMethodRepository.AgoraConfigurationShort
 import org.broadinstitute.dsde.firecloud.model.Metrics.AdminStats
 import org.broadinstitute.dsde.firecloud.model.MetricsFormat.AdminStatsFormat
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol.{impRawlsBillingProjectMember, _}

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/RawlsDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/RawlsDAO.scala
@@ -4,7 +4,7 @@ import akka.http.scaladsl.model.HttpResponse
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.FireCloudConfig
 import org.broadinstitute.dsde.firecloud.model.ManagedGroupRoles.ManagedGroupRole
-import org.broadinstitute.dsde.firecloud.model.MethodRepository.AgoraConfigurationShort
+import org.broadinstitute.dsde.firecloud.model.OrchMethodRepository.AgoraConfigurationShort
 import org.broadinstitute.dsde.firecloud.model.Metrics.AdminStats
 import org.broadinstitute.dsde.firecloud.model.Project.ProjectRoles.ProjectRole
 import org.broadinstitute.dsde.firecloud.model.Project.{RawlsBillingProjectMember, RawlsBillingProjectMembership}

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/metrics/MetricsActor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/metrics/MetricsActor.scala
@@ -23,7 +23,7 @@ class MetricsActor(logitDAO: LogitDAO, rawlsDAO: RawlsDAO, searchDAO: SearchDAO)
   import context.dispatcher
 
   override def receive: Receive = {
-    case RecordMetrics => recordMetrics pipeTo sender
+    case RecordMetrics => recordMetrics pipeTo sender()
   }
 
   private def recordMetrics: Future[LogitMetric] = {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
@@ -8,7 +8,7 @@ import akka.http.scaladsl.server.{MalformedRequestContentRejection, RejectionHan
 import org.broadinstitute.dsde.firecloud.model.DUOS._
 import org.broadinstitute.dsde.firecloud.model.DataUse._
 import org.broadinstitute.dsde.firecloud.model.ManagedGroupRoles.ManagedGroupRole
-import org.broadinstitute.dsde.firecloud.model.MethodRepository._
+import org.broadinstitute.dsde.firecloud.model.OrchMethodRepository._
 import org.broadinstitute.dsde.firecloud.model.Ontology.{ESTermParent, TermParent, TermResource}
 import org.broadinstitute.dsde.firecloud.model.Project.ProjectRoles.ProjectRole
 import org.broadinstitute.dsde.firecloud.model.Project._
@@ -169,9 +169,9 @@ object ModelJsonProtocol extends WorkspaceJsonSupport with SprayJsonSupport {
   }
 
   // Build error about missing implicit for Spray parameter unmarshaller? Add an entry here.
-  implicit val impMethod = jsonFormat11(MethodRepository.Method.apply)
-  implicit val impConfiguration = jsonFormat10(MethodRepository.Configuration)
-  implicit val impAgoraConfigurationShort = jsonFormat4(MethodRepository.AgoraConfigurationShort)
+  implicit val impMethod = jsonFormat11(OrchMethodRepository.Method.apply)
+  implicit val impConfiguration = jsonFormat10(OrchMethodRepository.Configuration)
+  implicit val impAgoraConfigurationShort = jsonFormat4(OrchMethodRepository.AgoraConfigurationShort)
 
   implicit val impWorkspaceDeleteResponse = jsonFormat1(WorkspaceDeleteResponse)
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
@@ -187,7 +187,7 @@ object ModelJsonProtocol extends WorkspaceJsonSupport with SprayJsonSupport {
   implicit val impConfigurationCopyIngest = jsonFormat5(CopyConfigurationIngest)
   implicit val impMethodConfigurationPublish = jsonFormat3(MethodConfigurationPublish)
   implicit val impPublishConfigurationIngest = jsonFormat4(PublishConfigurationIngest)
-  implicit val impMethodConfigurationName = jsonFormat2(MethodConfigurationName.apply)
+  implicit val impMethodConfigurationName = jsonFormat2(OrchMethodConfigurationName.apply)
 
   implicit val impFireCloudPermission = jsonFormat2(FireCloudPermission)
   implicit val impAgoraPermission = jsonFormat2(AgoraPermission)
@@ -284,7 +284,7 @@ object ModelJsonProtocol extends WorkspaceJsonSupport with SprayJsonSupport {
           case _ => f.getName -> JsNull
         }
       }) match {
-        case Success(props) => props.filterNot(_._2 == JsNull)
+        case Success(props) => props.toIndexedSeq.filterNot(_._2 == JsNull)
         case Failure(ex) => serializationError(ex.getMessage)
       }
       JsObject(existingProps.toMap)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelSchema.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelSchema.scala
@@ -22,7 +22,7 @@ trait ModelSchema {
   def getPlural (entityType: String): Try[String]
   def getRequiredAttributes(entityType: String): Try[Map[String, String]]
   def getTypeSchema(entityType: String): Try[EntityMetadata]
-  def supportsBackwardsCompatibleIds: Boolean
+  def supportsBackwardsCompatibleIds(): Boolean
 
   def isEntityTypeInSchema(entityType: String): Boolean = {
     Try(this.getCollectionMemberType(entityType)) match {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/OrchMethodRepository.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/OrchMethodRepository.scala
@@ -87,7 +87,7 @@ object OrchMethodRepository {
 
   case class MethodAclPair(method: AgoraMethod, acls: Seq[FireCloudPermission], message: Option[String] = None)
 
-  case class EntityAccessControl(method:Option[Method], referencedBy: MethodConfigurationName, acls: Seq[FireCloudPermission], message: Option[String] = None)
+  case class EntityAccessControl(method:Option[Method], referencedBy: OrchMethodConfigurationName, acls: Seq[FireCloudPermission], message: Option[String] = None)
 
   object ACLNames {
     val NoAccess = "NO ACCESS"

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/OrchMethodRepository.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/OrchMethodRepository.scala
@@ -6,7 +6,7 @@ import org.broadinstitute.dsde.rawls.model.{AgoraMethod, DockstoreMethod, Method
 
 import scala.util.Try
 
-object MethodRepository {
+object OrchMethodRepository {
 
   object AgoraEntityType extends Enumeration {
     type EntityType = Value

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/PermissionReport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/PermissionReport.scala
@@ -13,5 +13,5 @@ case class PermissionReport (
 
 case class PermissionReportRequest (
   users: Option[Seq[String]],
-  configs: Option[Seq[MethodConfigurationName]]
+  configs: Option[Seq[OrchMethodConfigurationName]]
 )

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/PermissionReport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/PermissionReport.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.dsde.firecloud.model
 
-import org.broadinstitute.dsde.firecloud.model.MethodRepository.EntityAccessControl
+import org.broadinstitute.dsde.firecloud.model.OrchMethodRepository.EntityAccessControl
 import org.broadinstitute.dsde.rawls.model.AccessEntry
 
 /**

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/Workspace.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/Workspace.scala
@@ -1,7 +1,7 @@
 package org.broadinstitute.dsde.firecloud.model
 
 import org.broadinstitute.dsde.firecloud.FireCloudConfig
-import org.broadinstitute.dsde.firecloud.model.MethodRepository.AgoraConfigurationShort
+import org.broadinstitute.dsde.firecloud.model.OrchMethodRepository.AgoraConfigurationShort
 import org.broadinstitute.dsde.rawls.model.Attributable.AttributeMap
 import org.broadinstitute.dsde.rawls.model.WorkspaceAccessLevels.WorkspaceAccessLevel
 import org.broadinstitute.dsde.rawls.model._
@@ -53,9 +53,9 @@ case class MethodConfigurationName(
   name: String)
 
 object MethodConfigurationName {
-  def apply(mcs:MethodConfigurationShort) =
+  def apply(mcs:MethodConfigurationShort): MethodConfigurationName =
     new MethodConfigurationName(mcs.namespace, mcs.name)
-  def apply(mcs: AgoraConfigurationShort) =
+  def apply(mcs: AgoraConfigurationShort): MethodConfigurationName =
     new MethodConfigurationName(mcs.namespace, mcs.name)
 }
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/Workspace.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/Workspace.scala
@@ -48,15 +48,15 @@ case class MethodConfigurationId(
   namespace: Option[String] = None,
   workspaceName: Option[WorkspaceName] = None)
 
-case class MethodConfigurationName(
+case class OrchMethodConfigurationName(
   namespace: String,
   name: String)
 
-object MethodConfigurationName {
-  def apply(mcs:MethodConfigurationShort): MethodConfigurationName =
-    new MethodConfigurationName(mcs.namespace, mcs.name)
-  def apply(mcs: AgoraConfigurationShort): MethodConfigurationName =
-    new MethodConfigurationName(mcs.namespace, mcs.name)
+object OrchMethodConfigurationName {
+  def apply(mcs:MethodConfigurationShort): OrchMethodConfigurationName =
+    new OrchMethodConfigurationName(mcs.namespace, mcs.name)
+  def apply(mcs: AgoraConfigurationShort): OrchMethodConfigurationName =
+    new OrchMethodConfigurationName(mcs.namespace, mcs.name)
 }
 
 case class MethodConfigurationCopy(

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/AgoraPermissionService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/AgoraPermissionService.scala
@@ -5,8 +5,8 @@ import akka.http.scaladsl.model.StatusCodes._
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.Application
 import org.broadinstitute.dsde.firecloud.dataaccess.AgoraDAO
-import org.broadinstitute.dsde.firecloud.model.MethodRepository.ACLNames._
-import org.broadinstitute.dsde.firecloud.model.MethodRepository.{AgoraPermission, EntityAccessControlAgora, FireCloudPermission, MethodAclPair}
+import org.broadinstitute.dsde.firecloud.model.OrchMethodRepository.ACLNames._
+import org.broadinstitute.dsde.firecloud.model.OrchMethodRepository.{AgoraPermission, EntityAccessControlAgora, FireCloudPermission, MethodAclPair}
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
 import org.broadinstitute.dsde.firecloud.model.{RequestCompleteWithErrorReport, UserInfo}
 import org.broadinstitute.dsde.firecloud.service.PerRequest.{PerRequestMessage, RequestComplete}

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupport.scala
@@ -107,11 +107,11 @@ trait DataUseRestrictionSupport extends LazyLogging {
   }
 
   def generateUseRestrictionDSStructuredMap(request: StructuredDataRequest): Map[AttributeName, Attribute] = {
-    Map(AttributeName.withDefaultNS(ConsentCodes.DS) -> AttributeValueList(request.diseaseUseRequired.map(DiseaseOntologyNodeId(_).numericId).map(AttributeNumber(_))))
+    Map(AttributeName.withDefaultNS(ConsentCodes.DS) -> AttributeValueList(request.diseaseUseRequired.map(DiseaseOntologyNodeId(_).numericId).toIndexedSeq.map(AttributeNumber(_))))
   }
 
   def generateUseRestrictionDSDisplayMap(request: StructuredDataRequest): Map[AttributeName, Attribute] = {
-    Map(AttributeName.withDefaultNS(ConsentCodes.DSURL) -> AttributeValueList(request.diseaseUseRequired.map(AttributeString(_))))
+    Map(AttributeName.withDefaultNS(ConsentCodes.DSURL) -> AttributeValueList(request.diseaseUseRequired.toIndexedSeq.map(AttributeString(_))))
   }
 
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupport.scala
@@ -79,7 +79,7 @@ trait DataUseRestrictionSupport extends LazyLogging {
 
 
   def generateStructuredUseRestrictionAttribute(request: StructuredDataRequest, ontologyDAO: OntologyDAO): Map[String, JsValue] = {
-    generateStructuredDataResponse(request, ontologyDAO).formatWithPrefix
+    generateStructuredDataResponse(request, ontologyDAO).formatWithPrefix()
   }
 
   def generateStructuredDataResponse(request: StructuredDataRequest, ontologyDAO: OntologyDAO): StructuredDataResponse = {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/ExportEntitiesByTypeActor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/ExportEntitiesByTypeActor.scala
@@ -152,7 +152,7 @@ class ExportEntitiesByTypeActor(rawlsDAO: RawlsDAO,
           import GraphDSL.Implicits._
 
           // Sources
-          val querySource: Outlet[EntityQuery] = builder.add(AkkaSource(entityQueries.toStream)).out
+          val querySource: Outlet[EntityQuery] = builder.add(AkkaSource(entityQueries.to(LazyList))).out
           val entityHeaderSource: Outlet[ByteString] = builder.add(AkkaSource.single(ByteString(entityHeaders.mkString("\t") + "\n"))).out
 
           // Flows
@@ -208,7 +208,7 @@ class ExportEntitiesByTypeActor(rawlsDAO: RawlsDAO,
           import GraphDSL.Implicits._
 
           // Sources
-          val querySource: Outlet[EntityQuery] = builder.add(AkkaSource(entityQueries.toStream)).out
+          val querySource: Outlet[EntityQuery] = builder.add(AkkaSource(entityQueries.to(LazyList))).out
           val entityHeaderSource: Outlet[ByteString] = builder.add(AkkaSource.single(ByteString(entityHeaders.mkString("\t") + "\n"))).out
           val membershipHeaderSource: Outlet[ByteString] = builder.add(AkkaSource.single(ByteString(membershipHeaders.mkString("\t") + "\n"))).out
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/ExportEntitiesByTypeActor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/ExportEntitiesByTypeActor.scala
@@ -79,7 +79,7 @@ class ExportEntitiesByTypeActor(rawlsDAO: RawlsDAO,
     case None => ModelSchemaRegistry.getModelForSchemaType(SchemaTypes.FIRECLOUD)
   }
 
-  def ExportEntities = streamEntities
+  def ExportEntities(): Future[HttpResponse] = streamEntities()
 
   /**
     * Two basic code paths

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/LibraryServiceSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/LibraryServiceSupport.scala
@@ -19,7 +19,7 @@ import org.parboiled.common.FileUtils
 import spray.json.DefaultJsonProtocol._
 import spray.json._
 
-import collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.language.postfixOps
 import scala.util.{Failure, Success, Try}

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/NamespaceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/NamespaceService.scala
@@ -3,7 +3,7 @@ package org.broadinstitute.dsde.firecloud.service
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
 import akka.http.scaladsl.model.StatusCodes._
 import org.broadinstitute.dsde.firecloud.dataaccess.AgoraDAO
-import org.broadinstitute.dsde.firecloud.model.MethodRepository.{AgoraPermission, FireCloudPermission}
+import org.broadinstitute.dsde.firecloud.model.OrchMethodRepository.{AgoraPermission, FireCloudPermission}
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol.impFireCloudPermission
 import org.broadinstitute.dsde.firecloud.model.{RequestCompleteWithErrorReport, UserInfo}
 import org.broadinstitute.dsde.firecloud.service.PerRequest.{PerRequestMessage, RequestComplete}

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/NihService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/NihService.scala
@@ -106,7 +106,7 @@ class NihService(val samDao: SamDAO, val thurloeDao: ThurloeDAO, val googleDao: 
 
       //Sam APIs don't consume subject IDs. Now we must look up the emails in Thurloe...
       members <- thurloeDao.getAllUserValuesForKey("email").map { keyValues =>
-        keyValues.filterKeys(subjectId => subjectIds.contains(subjectId)).values.map(WorkbenchEmail).toList
+        keyValues.view.filterKeys(subjectId => subjectIds.contains(subjectId)).toMap.values.map(WorkbenchEmail).toList
       }
 
       _ <- ensureWhitelistGroupExists(nihWhitelist.groupToSync)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/PermissionReportService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/PermissionReportService.scala
@@ -7,7 +7,7 @@ import org.broadinstitute.dsde.firecloud.{Application, FireCloudExceptionWithErr
 import org.broadinstitute.dsde.firecloud.dataaccess.{AgoraDAO, RawlsDAO}
 import org.broadinstitute.dsde.firecloud.model.OrchMethodRepository._
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
-import org.broadinstitute.dsde.firecloud.model.{MethodConfigurationName, PermissionReport, PermissionReportRequest, UserInfo}
+import org.broadinstitute.dsde.firecloud.model.{OrchMethodConfigurationName, PermissionReport, PermissionReportRequest, UserInfo}
 import org.broadinstitute.dsde.firecloud.service.PerRequest.RequestComplete
 import org.broadinstitute.dsde.rawls.model.{AccessEntry, WorkspaceACL}
 import akka.http.scaladsl.model.StatusCodes._
@@ -42,7 +42,7 @@ class PermissionReportService (protected val argUserInfo: UserInfo, val rawlsDAO
     val futureWorkspaceConfigs = rawlsDAO.getAgoraMethodConfigs(workspaceNamespace, workspaceName) map { configs =>
       // filter to just those the user requested
       if (reportInput.configs.isEmpty || reportInput.configs.get.isEmpty) configs
-      else configs.filter( x => reportInput.configs.get.contains(MethodConfigurationName(x)))
+      else configs.filter( x => reportInput.configs.get.contains(OrchMethodConfigurationName(x)))
     }
 
     for {
@@ -60,8 +60,8 @@ class PermissionReportService (protected val argUserInfo: UserInfo, val rawlsDAO
         agoraMethodReference match {
           case Some(agora) =>
             EntityAccessControl(Some(Method(config.methodRepoMethod, agora.entity.managers, agora.entity.public)),
-              MethodConfigurationName(config), agora.acls map AgoraPermissionService.toFireCloudPermission, agora.message)
-          case None => EntityAccessControl(None, MethodConfigurationName(config), Seq.empty[FireCloudPermission], Some("referenced method not found."))
+              OrchMethodConfigurationName(config), agora.acls map AgoraPermissionService.toFireCloudPermission, agora.message)
+          case None => EntityAccessControl(None, OrchMethodConfigurationName(config), Seq.empty[FireCloudPermission], Some("referenced method not found."))
         }
       }
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/PermissionReportService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/PermissionReportService.scala
@@ -5,7 +5,7 @@ import akka.pattern._
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.{Application, FireCloudExceptionWithErrorReport}
 import org.broadinstitute.dsde.firecloud.dataaccess.{AgoraDAO, RawlsDAO}
-import org.broadinstitute.dsde.firecloud.model.MethodRepository._
+import org.broadinstitute.dsde.firecloud.model.OrchMethodRepository._
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
 import org.broadinstitute.dsde.firecloud.model.{MethodConfigurationName, PermissionReport, PermissionReportRequest, UserInfo}
 import org.broadinstitute.dsde.firecloud.service.PerRequest.RequestComplete

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/TSVFileSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/TSVFileSupport.scala
@@ -121,7 +121,7 @@ trait TSVFileSupport {
       if (value.equals("__DELETE__"))
         RemoveAttribute(AttributeName.fromDelimitedName(name))
       else {
-        AddUpdateAttribute(AttributeName.fromDelimitedName(name), AttributeString(StringContext.treatEscapes(value)))
+        AddUpdateAttribute(AttributeName.fromDelimitedName(name), AttributeString(StringContext.processEscapes(value)))
       }
     }
   }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceService.scala
@@ -154,7 +154,7 @@ class WorkspaceService(protected val argUserToken: WithAccessToken, val rawlsDAO
 
   def putTags(workspaceNamespace: String, workspaceName: String, tags: List[String]): Future[PerRequestMessage] = {
     val attrList = AttributeValueList(tags map (tag => AttributeString(tag.trim)))
-    val op = AddUpdateAttribute(AttributeName.withTagsNS, attrList)
+    val op = AddUpdateAttribute(AttributeName.withTagsNS(), attrList)
     rawlsDAO.patchWorkspaceAttributes(workspaceNamespace, workspaceName, Seq(op)) flatMap { ws =>
       republishDocument(ws, ontologyDAO, searchDAO, consentDAO)
 
@@ -166,7 +166,7 @@ class WorkspaceService(protected val argUserToken: WithAccessToken, val rawlsDAO
   def patchTags(workspaceNamespace: String, workspaceName: String, tags: List[String]): Future[PerRequestMessage] = {
     rawlsDAO.getWorkspace(workspaceNamespace, workspaceName) flatMap { origWs =>
       val origTags = getTagsFromWorkspace(origWs.workspace)
-      val attrOps = (tags diff origTags) map (tag => AddListMember(AttributeName.withTagsNS, AttributeString(tag.trim)))
+      val attrOps = (tags diff origTags) map (tag => AddListMember(AttributeName.withTagsNS(), AttributeString(tag.trim)))
       rawlsDAO.patchWorkspaceAttributes(workspaceNamespace, workspaceName, attrOps) flatMap { patchedWs =>
         republishDocument(patchedWs, ontologyDAO, searchDAO, consentDAO)
 
@@ -177,7 +177,7 @@ class WorkspaceService(protected val argUserToken: WithAccessToken, val rawlsDAO
   }
 
   def deleteTags(workspaceNamespace: String, workspaceName: String, tags: List[String]): Future[PerRequestMessage] = {
-    val attrOps = tags map (tag => RemoveListMember(AttributeName.withTagsNS, AttributeString(tag.trim)))
+    val attrOps = tags map (tag => RemoveListMember(AttributeName.withTagsNS(), AttributeString(tag.trim)))
     rawlsDAO.patchWorkspaceAttributes(workspaceNamespace, workspaceName, attrOps) flatMap { ws =>
       republishDocument(ws, ontologyDAO, searchDAO, consentDAO)
 
@@ -213,7 +213,7 @@ class WorkspaceService(protected val argUserToken: WithAccessToken, val rawlsDAO
   }
 
   private def getTagsFromWorkspace(ws:WorkspaceDetails): Seq[String] = {
-    ws.attributes.getOrElse(Map.empty).get(AttributeName.withTagsNS) match {
+    ws.attributes.getOrElse(Map.empty).get(AttributeName.withTagsNS()) match {
       case Some(vals:AttributeValueList) => vals.list collect {
         case s:AttributeString => s.value
       }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceService.scala
@@ -110,7 +110,7 @@ class WorkspaceService(protected val argUserToken: WithAccessToken, val rawlsDAO
   def exportWorkspaceAttributesTSV(workspaceNamespace: String, workspaceName: String, filename: String): Future[PerRequestMessage] = {
     rawlsDAO.getWorkspace(workspaceNamespace, workspaceName) map { workspaceResponse =>
       val attributeFormat = new AttributeFormat with PlainArrayAttributeListSerializer
-      val attributes = workspaceResponse.workspace.attributes.getOrElse(Map.empty).filterKeys(_ != AttributeName.withDefaultNS("description"))
+      val attributes = workspaceResponse.workspace.attributes.getOrElse(Map.empty).view.filterKeys(_ != AttributeName.withDefaultNS("description")).toMap
       val headerString = "workspace:" + (attributes map { case (attName, attValue) => attName.name }).mkString("\t")
       val valueString = (attributes map { case (attName, attValue) => TSVFormatter.cleanValue(attributeFormat.write(attValue)) }).mkString("\t")
       // TODO: entity TSVs are downloaded as text/tab-separated-value, but workspace attributes are text/plain. Align these?

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/utils/StandardUserInfoDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/utils/StandardUserInfoDirectives.scala
@@ -11,7 +11,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 trait StandardUserInfoDirectives extends UserInfoDirectives {
 
-  def requireUserInfo: Directive1[UserInfo] = (
+  def requireUserInfo(): Directive1[UserInfo] = (
     headerValueByName("OIDC_access_token") &
       headerValueByName("OIDC_CLAIM_user_id") &
       headerValueByName("OIDC_CLAIM_expires_in") &

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/utils/TSVParser.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/utils/TSVParser.scala
@@ -1,7 +1,7 @@
 package org.broadinstitute.dsde.firecloud.utils
 
 import java.io.StringReader
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import com.univocity.parsers.csv.{CsvParser, CsvParserSettings}
 
 case class TSVLoadFile(

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/CookieAuthedApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/CookieAuthedApiService.scala
@@ -31,24 +31,24 @@ trait CookieAuthedApiService extends Directives with RequestBuilding with LazyLo
       // this endpoint allows an arbitrary number of attribute names in the POST body (GAWB-1435)
       // but the URL cannot be saved for later use (firecloud-app#80)
       post {
-        formFields('FCtoken, 'attributeNames.?, 'model.?) { (tokenValue, attributeNamesString, modelString) =>
+        formFields(Symbol("FCtoken"), Symbol("attributeNames").?, Symbol("model").?) { (tokenValue, attributeNamesString, modelString) =>
           val attributeNames = attributeNamesString.map(_.split(",").toIndexedSeq)
           val userInfo = dummyUserInfo(tokenValue)
           val exportArgs = ExportEntitiesByTypeArguments(userInfo, workspaceNamespace, workspaceName, entityType, attributeNames, modelString)
 
-          complete { exportEntitiesByTypeConstructor(exportArgs).ExportEntities }
+          complete { exportEntitiesByTypeConstructor(exportArgs).ExportEntities() }
         }
       } ~
         // this endpoint allows saving the URL for later use (firecloud-app#80)
         // but it's possible to exceed the maximum URI length by specifying too many attributes (GAWB-1435)
         get {
           cookie("FCtoken") { tokenCookie =>
-            parameters('attributeNames.?, 'model.?) { (attributeNamesString, modelString) =>
+            parameters(Symbol("attributeNames").?, Symbol("model").?) { (attributeNamesString, modelString) =>
               val attributeNames = attributeNamesString.map(_.split(",").toIndexedSeq)
               val userInfo = dummyUserInfo(tokenCookie.value)
               val exportArgs = ExportEntitiesByTypeArguments(userInfo, workspaceNamespace, workspaceName, entityType, attributeNames, modelString)
 
-              complete { exportEntitiesByTypeConstructor(exportArgs).ExportEntities }
+              complete { exportEntitiesByTypeConstructor(exportArgs).ExportEntities() }
             }
           }
         }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/EntityApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/EntityApiService.scala
@@ -42,7 +42,7 @@ trait EntityApiService extends FireCloudDirectives
               path("copy") {
                 post {
                   requireUserInfo() { userInfo =>
-                    parameter('linkExistingEntities.?) { linkExistingEntities =>
+                    parameter(Symbol("linkExistingEntities").?) { linkExistingEntities =>
                       entity(as[EntityCopyWithoutDestinationDefinition]) { copyRequest =>
                         val linkExistingEntitiesBool = Try(linkExistingEntities.getOrElse("false").toBoolean).getOrElse(false)
                           val copyMethodConfig = new EntityCopyDefinition(

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/ExportEntitiesApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/ExportEntitiesApiService.scala
@@ -19,13 +19,13 @@ trait ExportEntitiesApiService extends Directives with RequestBuilding with Stan
 
     // Note that this endpoint works in the same way as CookieAuthedApiService tsv download.
     path( "api" / "workspaces" / Segment / Segment / "entities" / Segment / "tsv" ) { (workspaceNamespace, workspaceName, entityType) =>
-      parameters('attributeNames.?, 'model.?) { (attributeNamesString, modelString) =>
+      parameters(Symbol("attributeNames").?, Symbol("model").?) { (attributeNamesString, modelString) =>
         requireUserInfo() { userInfo =>
           get {
             val attributeNames = attributeNamesString.map(_.split(",").toIndexedSeq)
             val exportArgs = ExportEntitiesByTypeArguments(userInfo, workspaceNamespace, workspaceName, entityType, attributeNames, modelString)
 
-            complete { exportEntitiesByTypeConstructor(exportArgs).ExportEntities }
+            complete { exportEntitiesByTypeConstructor(exportArgs).ExportEntities() }
           }
         }
       }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/LibraryApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/LibraryApiService.scala
@@ -140,7 +140,7 @@ trait LibraryApiService extends FireCloudDirectives with StandardUserInfoDirecti
                 } ~
                 pathPrefix("populate" / "suggest" / Segment ) { (field) =>
                   get {
-                    parameter('q) { text =>
+                    parameter(Symbol("q")) { text =>
                       complete { libraryServiceConstructor(userInfo).PopulateSuggest(field, text) }
                     }
                   }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/LibraryApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/LibraryApiService.scala
@@ -11,7 +11,7 @@ import org.broadinstitute.dsde.firecloud.service.{FireCloudDirectives, LibrarySe
 import org.broadinstitute.dsde.firecloud.utils.{RestJsonClient, StandardUserInfoDirectives}
 import spray.json.DefaultJsonProtocol._
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.concurrent.ExecutionContext
 
 trait LibraryApiService extends FireCloudDirectives with StandardUserInfoDirectives with RestJsonClient {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/MethodsApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/MethodsApiService.scala
@@ -3,7 +3,7 @@ package org.broadinstitute.dsde.firecloud.webservice
 import akka.http.scaladsl.model.{HttpMethods, Uri}
 import akka.http.scaladsl.server.Route
 import org.broadinstitute.dsde.firecloud.FireCloudConfig
-import org.broadinstitute.dsde.firecloud.model.MethodRepository._
+import org.broadinstitute.dsde.firecloud.model.OrchMethodRepository._
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
 import org.broadinstitute.dsde.firecloud.model.UserInfo
 import org.broadinstitute.dsde.firecloud.service.{AgoraPermissionService, FireCloudDirectives}

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/NamespaceApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/NamespaceApiService.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.firecloud.webservice
 
 import akka.http.scaladsl.client.RequestBuilding
 import akka.http.scaladsl.server.{Directives, Route}
-import org.broadinstitute.dsde.firecloud.model.MethodRepository.FireCloudPermission
+import org.broadinstitute.dsde.firecloud.model.OrchMethodRepository.FireCloudPermission
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
 import org.broadinstitute.dsde.firecloud.model.UserInfo
 import org.broadinstitute.dsde.firecloud.service.NamespaceService

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiService.scala
@@ -61,7 +61,7 @@ trait WorkspaceApiService extends FireCloudRequestBuilding with FireCloudDirecti
             pathPrefix("tags") {
               pathEnd {
                 requireUserInfo() { _ =>
-                  parameter('q.?) { queryString =>
+                  parameter(Symbol("q").?) { queryString =>
                     val baseUri = Uri(rawlsWorkspacesRoot + "/tags")
                     val uri = queryString match {
                       case Some(query) => baseUri.withQuery(Query(("q", query)))
@@ -110,7 +110,7 @@ trait WorkspaceApiService extends FireCloudRequestBuilding with FireCloudDirecti
                 path("flexibleImportEntities") {
                   post {
                     requireUserInfo() { userInfo =>
-                      formFields('entities) { entitiesTSV =>
+                      formFields(Symbol("entities")) { entitiesTSV =>
                         complete { entityServiceConstructor(FlexibleModelSchema).ImportEntitiesFromTSV(workspaceNamespace, workspaceName, entitiesTSV, userInfo) }
                       }
                     }
@@ -119,7 +119,7 @@ trait WorkspaceApiService extends FireCloudRequestBuilding with FireCloudDirecti
                 path("importEntities") {
                   post {
                     requireUserInfo() { userInfo =>
-                      formFields('entities) { entitiesTSV =>
+                      formFields(Symbol("entities")) { entitiesTSV =>
                         complete { entityServiceConstructor(FirecloudModelSchema).ImportEntitiesFromTSV(workspaceNamespace, workspaceName, entitiesTSV, userInfo) }
                       }
                     }
@@ -186,7 +186,7 @@ trait WorkspaceApiService extends FireCloudRequestBuilding with FireCloudDirecti
                 path("importAttributesTSV") {
                   post {
                     requireUserInfo() { userInfo =>
-                      formFields('attributes) { attributesTSV =>
+                      formFields(Symbol("attributes")) { attributesTSV =>
                         complete { workspaceServiceConstructor(userInfo).ImportAttributesFromTSV(workspaceNamespace, workspaceName, attributesTSV) }
                       }
                     }
@@ -195,7 +195,7 @@ trait WorkspaceApiService extends FireCloudRequestBuilding with FireCloudDirecti
                 path("acl") {
                   patch {
                     requireUserInfo() { userInfo =>
-                      parameter('inviteUsersNotFound.?) { inviteUsersNotFound =>
+                      parameter(Symbol("inviteUsersNotFound").?) { inviteUsersNotFound =>
                         entity(as[List[WorkspaceACLUpdate]]) { aclUpdates =>
                           complete { workspaceServiceConstructor(userInfo).UpdateWorkspaceACL(workspaceNamespace, workspaceName, aclUpdates, userInfo.userEmail, userInfo.id, inviteUsersNotFound.getOrElse("false").toBoolean) }
                         }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/HealthChecksSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/HealthChecksSpec.scala
@@ -132,7 +132,7 @@ class StartupChecksMockSamDAO(unregisteredTokens:Seq[String] = Seq.empty[String]
                               cantRegister:Seq[String] = Seq.empty[String]) extends MockSamDAO {
 
   val system = ActorSystem("StartupChecksSpec")
-  val registerUserStateActor: ActorRef = system.actorOf(Props[RegisterTokenActor], name = "RegisterTokenActor")
+  val registerUserStateActor: ActorRef = system.actorOf(Props[RegisterTokenActor](), name = "RegisterTokenActor")
 
   override def getRegistrationStatus(implicit userInfo: WithAccessToken): Future[RegistrationInfo] = {
     if (notFounds.contains(userInfo.accessToken.token)) {
@@ -174,7 +174,7 @@ class RegisterTokenActor extends Actor {
 
   override def receive: Receive = {
     case RegisterUserToken(entity) => entitySet += entity
-    case ListUserTokens => sender ! entitySet.toSeq
+    case ListUserTokens => sender() ! entitySet.toSeq
   }
 
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAOSpec.scala
@@ -10,14 +10,16 @@ import akka.stream.Materializer
 import com.google.api.services.sheets.v4.model.ValueRange
 import org.broadinstitute.dsde.firecloud.model.ObjectMetadata
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
-import org.scalatest.{FlatSpec, Matchers, PrivateMethodTester}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.PrivateMethodTester
 import spray.json._
+import org.scalatest.matchers.should.Matchers
 
 import scala.jdk.CollectionConverters._
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
-class HttpGoogleServicesDAOSpec(implicit val materializer: Materializer) extends FlatSpec with Matchers with PrivateMethodTester {
+class HttpGoogleServicesDAOSpec(implicit val materializer: Materializer) extends AnyFlatSpec with Matchers with PrivateMethodTester {
 
   val testProject = "broad-dsde-dev"
   implicit val system = ActorSystem("HttpGoogleCloudStorageDAOSpec")

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAOSpec.scala
@@ -13,7 +13,7 @@ import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
 import org.scalatest.{FlatSpec, Matchers, PrivateMethodTester}
 import spray.json._
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockAgoraDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockAgoraDAO.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.firecloud.dataaccess
 
 import akka.http.scaladsl.model.Uri
 import org.broadinstitute.dsde.firecloud.mock.MockAgoraACLData
-import org.broadinstitute.dsde.firecloud.model.MethodRepository.{ACLNames, AgoraPermission, EntityAccessControlAgora, Method}
+import org.broadinstitute.dsde.firecloud.model.OrchMethodRepository.{ACLNames, AgoraPermission, EntityAccessControlAgora, Method}
 import org.broadinstitute.dsde.firecloud.model.UserInfo
 import org.broadinstitute.dsde.workbench.util.health.SubsystemStatus
 
@@ -27,7 +27,7 @@ class MockAgoraDAO extends AgoraDAO {
     Future(List(MockAgoraDAO.agoraPermission))
   }
 
-  override def getMultiEntityPermissions(entityType: _root_.org.broadinstitute.dsde.firecloud.model.MethodRepository.AgoraEntityType.Value, entities: List[Method])(implicit userInfo: UserInfo) = {
+  override def getMultiEntityPermissions(entityType: _root_.org.broadinstitute.dsde.firecloud.model.OrchMethodRepository.AgoraEntityType.Value, entities: List[Method])(implicit userInfo: UserInfo) = {
     Future(List.empty[EntityAccessControlAgora])
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockRawlsDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockRawlsDAO.scala
@@ -180,7 +180,7 @@ class MockRawlsDAO extends RawlsDAO {
     false,
     Some(Set.empty), //authdomain
     WorkspaceVersions.V2,
-    "googleProject"
+    GoogleProjectId("googleProject")
   )
 
   val publishedRawlsWorkspaceWithAttributes = WorkspaceDetails(
@@ -207,7 +207,7 @@ class MockRawlsDAO extends RawlsDAO {
     false,
     Some(Set.empty), //authdomain
     WorkspaceVersions.V2,
-    "googleProject"
+    GoogleProjectId("googleProject")
   )
 
   val unpublishedRawlsWorkspaceLibraryValid = WorkspaceDetails(
@@ -245,7 +245,7 @@ class MockRawlsDAO extends RawlsDAO {
     false,
     Some(Set.empty), //authdomain
     WorkspaceVersions.V2,
-    "googleProject"
+    GoogleProjectId("googleProject")
   )
 
   val rawlsWorkspaceResponseWithAttributes = WorkspaceResponse(Some(WorkspaceAccessLevels.Owner), canShare = Some(false), canCompute = Some(true), catalog = Some(false), rawlsWorkspaceWithAttributes, Some(WorkspaceSubmissionStats(None, None, runningSubmissionsCount = 0)), Some(WorkspaceBucketOptions(false)), Some(Set.empty))
@@ -265,7 +265,7 @@ class MockRawlsDAO extends RawlsDAO {
       isLocked = true,
       authorizationDomain = Some(Set.empty),
       workspaceVersion = WorkspaceVersions.V2,
-      googleProject = "googleProject"
+      googleProject = GoogleProjectId("googleProject")
     )
   }
   
@@ -466,5 +466,5 @@ class MockRawlsDAO extends RawlsDAO {
 
   override def batchUpdateEntities(workspaceNamespace: String, workspaceName: String, entityType: String, updates: Seq[EntityUpdateDefinition])(implicit userToken: UserInfo): Future[HttpResponse] = Future.successful(HttpResponse(StatusCodes.NoContent))
 
-  override def cloneWorkspace(workspaceNamespace: String, workspaceName: String, cloneRequest: WorkspaceRequest)(implicit userToken: WithAccessToken): Future[WorkspaceDetails] = Future.successful(WorkspaceDetails(cloneRequest.namespace, cloneRequest.name, "id", "bucket", Some("workflow-collection-id"), DateTime.now(), DateTime.now(), "test-user", Some(cloneRequest.attributes), false, cloneRequest.authorizationDomain, WorkspaceVersions.V2, "googleProject"))
+  override def cloneWorkspace(workspaceNamespace: String, workspaceName: String, cloneRequest: WorkspaceRequest)(implicit userToken: WithAccessToken): Future[WorkspaceDetails] = Future.successful(WorkspaceDetails(cloneRequest.namespace, cloneRequest.name, "id", "bucket", Some("workflow-collection-id"), DateTime.now(), DateTime.now(), "test-user", Some(cloneRequest.attributes), false, cloneRequest.authorizationDomain, WorkspaceVersions.V2, GoogleProjectId("googleProject")))
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockRawlsDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockRawlsDAO.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.firecloud.dataaccess
 
 import org.broadinstitute.dsde.firecloud.dataaccess.MockRawlsDAO._
 import org.broadinstitute.dsde.firecloud.mock.MockUtils
-import org.broadinstitute.dsde.firecloud.model.MethodRepository.AgoraConfigurationShort
+import org.broadinstitute.dsde.firecloud.model.OrchMethodRepository.AgoraConfigurationShort
 import org.broadinstitute.dsde.firecloud.model.Project.ProjectRoles.ProjectRole
 import org.broadinstitute.dsde.firecloud.model.Project.{ProjectRoles, RawlsBillingProjectMember}
 import org.broadinstitute.dsde.firecloud.model._
@@ -15,7 +15,7 @@ import org.joda.time.DateTime
 import akka.http.scaladsl.model.{HttpResponse, StatusCodes}
 import MockRawlsDAO._
 import org.broadinstitute.dsde.firecloud.model.ManagedGroupRoles.ManagedGroupRole
-import org.broadinstitute.dsde.firecloud.model.MethodRepository.AgoraConfigurationShort
+import org.broadinstitute.dsde.firecloud.model.OrchMethodRepository.AgoraConfigurationShort
 import org.broadinstitute.dsde.firecloud.model.Project.ProjectRoles.ProjectRole
 import org.broadinstitute.dsde.firecloud.model.Project.{ProjectRoles, RawlsBillingProjectMember}
 import org.broadinstitute.dsde.firecloud.webservice.WorkspaceApiServiceSpec

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockSearchDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockSearchDAO.scala
@@ -14,11 +14,11 @@ import scala.concurrent.Future
   */
 class MockSearchDAO extends SearchDAO {
 
-  override def initIndex = Unit
-  override def recreateIndex = Unit
-  override def indexExists = false
-  override def createIndex = Unit
-  override def deleteIndex = Unit
+  override def initIndex() = ()
+  override def recreateIndex() = ()
+  override def indexExists() = false
+  override def createIndex() = ()
+  override def deleteIndex() = ()
 
   var indexDocumentInvoked = false
   var deleteDocumentInvoked = false

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/AutoSuggestSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/AutoSuggestSpec.scala
@@ -3,15 +3,17 @@ package org.broadinstitute.dsde.firecloud.integrationtest
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.dataaccess.ElasticSearchDAOQuerySupport
 import org.broadinstitute.dsde.firecloud.integrationtest.ESIntegrationSupport._
-import org.scalatest.{BeforeAndAfterAll, FreeSpec, Ignore, Matchers}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.{BeforeAndAfterAll, Ignore}
 import spray.json.{JsObject, JsString}
 
 import scala.concurrent.Await
 import scala.concurrent.duration.{Duration, MINUTES}
 
-class AutoSuggestSpec extends FreeSpec with Matchers with BeforeAndAfterAll with LazyLogging with ElasticSearchDAOQuerySupport {
+class AutoSuggestSpec extends AnyFreeSpec with Matchers with BeforeAndAfterAll with LazyLogging with ElasticSearchDAOQuerySupport {
 
-  override def beforeAll = {
+  override def beforeAll() = {
     // use re-create here, since instantiating the DAO will create it in the first place
     searchDAO.recreateIndex()
     // make sure we specify refresh=true here; otherwise, the documents may not be available in the index by the
@@ -21,7 +23,7 @@ class AutoSuggestSpec extends FreeSpec with Matchers with BeforeAndAfterAll with
     logger.info("... fixtures indexed.")
   }
 
-  override def afterAll = {
+  override def afterAll() = {
     searchDAO.deleteIndex()
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/DataUseRestrictionSearchSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/DataUseRestrictionSearchSpec.scala
@@ -7,20 +7,22 @@ import org.broadinstitute.dsde.firecloud.model.{AccessToken, LibrarySearchRespon
 import org.broadinstitute.dsde.firecloud.service.DataUseRestrictionTestFixtures.DataUseRestriction
 import org.broadinstitute.dsde.firecloud.service.{DataUseRestrictionTestFixtures, LibraryServiceSupport}
 import org.broadinstitute.dsde.rawls.model.{AttributeName, WorkspaceDetails}
-import org.scalatest.{BeforeAndAfterAll, FreeSpec, Matchers}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.BeforeAndAfterAll
 
 import scala.concurrent.Await
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.language.postfixOps
 import spray.json.DefaultJsonProtocol._
 
-class DataUseRestrictionSearchSpec extends FreeSpec with SearchResultValidation with BeforeAndAfterAll with Matchers with LibraryServiceSupport {
+class DataUseRestrictionSearchSpec extends AnyFreeSpec with SearchResultValidation with BeforeAndAfterAll with Matchers with LibraryServiceSupport {
 
   val datasets: Seq[WorkspaceDetails] = DataUseRestrictionTestFixtures.allDatasets
 
   implicit val userToken: WithAccessToken = AccessToken("DataUseRestrictionSearchSpec")
 
-  override def beforeAll: Unit = {
+  override def beforeAll(): Unit = {
     // use re-create here, since instantiating the DAO will create it in the first place
     searchDAO.recreateIndex()
     // make sure we specify refresh=true here; otherwise, the documents may not be available in the index by the
@@ -31,7 +33,7 @@ class DataUseRestrictionSearchSpec extends FreeSpec with SearchResultValidation 
     logger.info("... fixtures indexed.")
   }
 
-  override def afterAll: Unit = {
+  override def afterAll(): Unit = {
     searchDAO.deleteIndex()
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/ElasticSearchShareLogDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/ElasticSearchShareLogDAOSpec.scala
@@ -4,12 +4,14 @@ import akka.stream.Materializer
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.integrationtest.ESIntegrationSupport.{searchDAO, shareLogDAO}
 import org.broadinstitute.dsde.firecloud.model.ShareLog.{Share, ShareType}
-import org.scalatest.{BeforeAndAfterAll, FreeSpec, Matchers}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.util.Try
 
-class ElasticSearchShareLogDAOSpec extends FreeSpec with Matchers with BeforeAndAfterAll with LazyLogging {
-  override def beforeAll = {
+class ElasticSearchShareLogDAOSpec extends AnyFreeSpec with Matchers with BeforeAndAfterAll with LazyLogging {
+  override def beforeAll() = {
     // using the recreate from search dao because we don't have recreate in sharelog dao
     searchDAO.recreateIndex()
     ElasticSearchShareLogDAOSpecFixtures.fixtureShares map { share =>
@@ -17,7 +19,7 @@ class ElasticSearchShareLogDAOSpec extends FreeSpec with Matchers with BeforeAnd
     }
   }
 
-  override def afterAll = {
+  override def afterAll() = {
     // using the delete from search dao because we don't have recreate in sharelog dao
     searchDAO.deleteIndex()
   }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/FilterLimitsSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/FilterLimitsSpec.scala
@@ -5,13 +5,15 @@ import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.integrationtest.ESIntegrationSupport.searchDAO
 import org.broadinstitute.dsde.firecloud.model.SamResource.{AccessPolicyName, ResourceId, UserPolicy}
 import org.broadinstitute.dsde.rawls.model.WorkspaceAccessLevels
-import org.scalatest.{BeforeAndAfterAll, FreeSpec, Matchers}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.BeforeAndAfterAll
 
 import scala.concurrent.duration.{Duration, MINUTES}
 
-class FilterLimitsSpec extends FreeSpec with Matchers with SearchResultValidation with BeforeAndAfterAll with LazyLogging {
+class FilterLimitsSpec extends AnyFreeSpec with Matchers with SearchResultValidation with BeforeAndAfterAll with LazyLogging {
 
-  override def beforeAll = {
+  override def beforeAll() = {
     // use re-create here, since instantiating the DAO will create it in the first place
     searchDAO.recreateIndex()
     // make sure we specify refresh=true here; otherwise, the documents may not be available in the index by the
@@ -21,7 +23,7 @@ class FilterLimitsSpec extends FreeSpec with Matchers with SearchResultValidatio
     logger.info("... fixtures indexed.")
   }
 
-  override def afterAll = {
+  override def afterAll() = {
     searchDAO.deleteIndex()
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/OntologyAutocompleteSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/OntologyAutocompleteSpec.scala
@@ -1,11 +1,10 @@
 package org.broadinstitute.dsde.firecloud.integrationtest
 
-import akka.stream.Materializer
 import org.broadinstitute.dsde.firecloud.integrationtest.ESIntegrationSupport._
 import org.broadinstitute.dsde.firecloud.model.Ontology.TermResource
-import org.scalatest.FreeSpec
+import org.scalatest.freespec.AnyFreeSpec
 
-class OntologyAutocompleteSpec extends FreeSpec {
+class OntologyAutocompleteSpec extends AnyFreeSpec {
 
 
   "Ontology Autocompete" - {

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/OntologySearchSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/OntologySearchSpec.scala
@@ -3,11 +3,13 @@ package org.broadinstitute.dsde.firecloud.integrationtest
 import akka.stream.Materializer
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.integrationtest.ESIntegrationSupport._
-import org.scalatest.{BeforeAndAfterAll, FreeSpec, Ignore, Matchers}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.{BeforeAndAfterAll, Ignore}
 
-class OntologySearchSpec extends FreeSpec with Matchers with BeforeAndAfterAll with LazyLogging with SearchResultValidation {
+class OntologySearchSpec extends AnyFreeSpec with Matchers with BeforeAndAfterAll with LazyLogging with SearchResultValidation {
 
-  override def beforeAll = {
+  override def beforeAll() = {
     // use re-create here, since instantiating the DAO will create it in the first place
     searchDAO.recreateIndex()
     // make sure we specify refresh=true here; otherwise, the documents may not be available in the index by the
@@ -17,7 +19,7 @@ class OntologySearchSpec extends FreeSpec with Matchers with BeforeAndAfterAll w
     logger.info("... fixtures indexed.")
   }
 
-  override def afterAll = {
+  override def afterAll() = {
     searchDAO.deleteIndex()
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/OntologyTermResourceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/OntologyTermResourceSpec.scala
@@ -4,9 +4,9 @@ import akka.stream.Materializer
 import org.broadinstitute.dsde.firecloud.dataaccess.MockOntologyDAO
 import org.broadinstitute.dsde.firecloud.integrationtest.ESIntegrationSupport._
 import org.broadinstitute.dsde.firecloud.model.Ontology.TermParent
-import org.scalatest.FreeSpec
+import org.scalatest.freespec.AnyFreeSpec
 
-class OntologyTermResourceSpec extends FreeSpec {
+class OntologyTermResourceSpec extends AnyFreeSpec {
 
   val mockdata = new MockOntologyDAO().data
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/ResearchPurposeSearchSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/ResearchPurposeSearchSpec.scala
@@ -4,11 +4,13 @@ import akka.stream.Materializer
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.integrationtest.ESIntegrationSupport.searchDAO
 import org.broadinstitute.dsde.firecloud.model.DataUse.{DiseaseOntologyNodeId, ResearchPurpose}
-import org.scalatest.{BeforeAndAfterAll, FreeSpec, Matchers}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.BeforeAndAfterAll
 
-class ResearchPurposeSearchSpec extends FreeSpec with SearchResultValidation with Matchers with BeforeAndAfterAll with LazyLogging {
+class ResearchPurposeSearchSpec extends AnyFreeSpec with SearchResultValidation with Matchers with BeforeAndAfterAll with LazyLogging {
 
-  override def beforeAll = {
+  override def beforeAll() = {
     // use re-create here, since instantiating the DAO will create it in the first place
     searchDAO.recreateIndex()
     // make sure we specify refresh=true here; otherwise, the documents may not be available in the index by the
@@ -18,7 +20,7 @@ class ResearchPurposeSearchSpec extends FreeSpec with SearchResultValidation wit
     logger.info("... fixtures indexed.")
   }
 
-  override def afterAll = {
+  override def afterAll() = {
     searchDAO.deleteIndex()
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/ResearchPurposeSearchUseCasesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/ResearchPurposeSearchUseCasesSpec.scala
@@ -5,14 +5,16 @@ import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.integrationtest.ESIntegrationSupport.searchDAO
 import org.broadinstitute.dsde.firecloud.model.DataUse.{DiseaseOntologyNodeId, ResearchPurpose}
 import org.broadinstitute.dsde.firecloud.model.LibrarySearchResponse
-import org.scalatest.{BeforeAndAfterAll, FreeSpec, Matchers}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class ResearchPurposeSearchUseCasesSpec extends FreeSpec with SearchResultValidation with Matchers with BeforeAndAfterAll with LazyLogging {
+class ResearchPurposeSearchUseCasesSpec extends AnyFreeSpec with SearchResultValidation with Matchers with BeforeAndAfterAll with LazyLogging {
 
   // cases as defined in the doc at
   // https://docs.google.com/a/broadinstitute.org/spreadsheets/d/16XzKpOFCyqRTNy9XHFFPx-Vf4PWFydsWAS7exzx26WM/edit?usp=sharing
 
-  override def beforeAll = {
+  override def beforeAll() = {
     // use re-create here, since instantiating the DAO will create it in the first place
     searchDAO.recreateIndex()
     // make sure we specify refresh=true here; otherwise, the documents may not be available in the index by the
@@ -22,7 +24,7 @@ class ResearchPurposeSearchUseCasesSpec extends FreeSpec with SearchResultValida
     logger.info("... fixtures indexed.")
   }
 
-  override def afterAll = {
+  override def afterAll() = {
     searchDAO.deleteIndex()
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/SortSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/SortSpec.scala
@@ -4,19 +4,21 @@ import akka.stream.Materializer
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.integrationtest.ESIntegrationSupport._
 import org.broadinstitute.dsde.firecloud.model.{LibrarySearchParams, LibrarySearchResponse}
-import org.scalatest.{BeforeAndAfterAll, FreeSpec, Ignore, Matchers}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.{BeforeAndAfterAll, Ignore}
 import spray.json.DefaultJsonProtocol._
 import spray.json.{JsNumber, JsObject, JsString, JsValue}
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-class SortSpec extends FreeSpec with Matchers with BeforeAndAfterAll with LazyLogging {
+class SortSpec extends AnyFreeSpec with Matchers with BeforeAndAfterAll with LazyLogging {
 
   val dur = Duration(2, MINUTES)
 
 
-  override def beforeAll = {
+  override def beforeAll() = {
     // use re-create here, since instantiating the DAO will create it in the first place
     searchDAO.recreateIndex()
     // make sure we specify refresh=true here; otherwise, the documents may not be available in the index by the
@@ -26,7 +28,7 @@ class SortSpec extends FreeSpec with Matchers with BeforeAndAfterAll with LazyLo
     logger.info("... fixtures indexed.")
   }
 
-  override def afterAll = {
+  override def afterAll() = {
     searchDAO.deleteIndex()
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/StatisticsSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/StatisticsSpec.scala
@@ -7,9 +7,11 @@ import org.broadinstitute.dsde.firecloud.integrationtest.ESIntegrationSupport._
 import org.broadinstitute.dsde.firecloud.model.Document
 import org.broadinstitute.dsde.firecloud.model.Metrics.NumSubjects
 import org.broadinstitute.dsde.rawls.model.{AttributeName, AttributeNumber, AttributeString}
-import org.scalatest.{BeforeAndAfterEach, FreeSpec, Matchers}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.BeforeAndAfterEach
 
-class StatisticsSpec extends FreeSpec with Matchers with BeforeAndAfterEach with LazyLogging {
+class StatisticsSpec extends AnyFreeSpec with Matchers with BeforeAndAfterEach with LazyLogging {
 
   /* Conf file contains one or more workspace namespaces, referenced via FireCloudConfig.Metrics.libraryNamespaces.
      We filter Library datasets to just those namespaces when calculating metrics.
@@ -50,12 +52,12 @@ class StatisticsSpec extends FreeSpec with Matchers with BeforeAndAfterEach with
     }
   }
 
-  override def beforeEach = {
+  override def beforeEach() = {
     // use re-create here, since instantiating the DAO will create it in the first place
     searchDAO.recreateIndex()
   }
 
-  override def afterEach = {
+  override def afterEach() = {
     searchDAO.deleteIndex()
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/TextSearchSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/TextSearchSpec.scala
@@ -3,11 +3,13 @@ package org.broadinstitute.dsde.firecloud.integrationtest
 import akka.stream.Materializer
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.integrationtest.ESIntegrationSupport._
-import org.scalatest.{BeforeAndAfterAll, FreeSpec, Ignore, Matchers}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.{BeforeAndAfterAll, Ignore}
 
-class TextSearchSpec extends FreeSpec with Matchers with BeforeAndAfterAll with LazyLogging with SearchResultValidation {
+class TextSearchSpec extends AnyFreeSpec with Matchers with BeforeAndAfterAll with LazyLogging with SearchResultValidation {
 
-  override def beforeAll = {
+  override def beforeAll() = {
     // use re-create here, since instantiating the DAO will create it in the first place
     searchDAO.recreateIndex()
     // make sure we specify refresh=true here; otherwise, the documents may not be available in the index by the
@@ -17,7 +19,7 @@ class TextSearchSpec extends FreeSpec with Matchers with BeforeAndAfterAll with 
     logger.info("... fixtures indexed.")
   }
 
-  override def afterAll = {
+  override def afterAll() = {
     searchDAO.deleteIndex()
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockAgoraACLData.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockAgoraACLData.scala
@@ -1,7 +1,7 @@
 package org.broadinstitute.dsde.firecloud.mock
 
-import org.broadinstitute.dsde.firecloud.model.MethodRepository.ACLNames._
-import org.broadinstitute.dsde.firecloud.model.MethodRepository.{AgoraPermission, EntityAccessControlAgora, FireCloudPermission, Method}
+import org.broadinstitute.dsde.firecloud.model.OrchMethodRepository.ACLNames._
+import org.broadinstitute.dsde.firecloud.model.OrchMethodRepository.{AgoraPermission, EntityAccessControlAgora, FireCloudPermission, Method}
 
 /**
  * Created by davidan on 10/29/15.

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockGoogleServicesDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockGoogleServicesDAO.scala
@@ -97,14 +97,14 @@ class MockGoogleServicesDAO extends GoogleServicesDAO {
     Future.successful(GooglePriceList(GooglePrices(UsPriceItem(BigDecimal(0.01)), UsTieredPriceItem(Map(1024L -> BigDecimal(0.12)))), "v0", "18-November-2016"))
   }
 
-  override def deleteGoogleGroup(groupEmail: String): Unit = Unit
+  override def deleteGoogleGroup(groupEmail: String): Unit = ()
   override def createGoogleGroup(groupName: String): Option[String] = Option("new-google-group@support.something.firecloud.org")
   override def addMemberToAnonymizedGoogleGroup(groupName: String, targetUserEmail: String): Option[String] = Option("user-email@something.com")
 
   def status: Future[SubsystemStatus] = Future(SubsystemStatus(ok = true, messages = None))
 
   override def publishMessages(fullyQualifiedTopic: String, messages: Seq[String]): Future[Unit] = {
-    import collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     pubsubMessages.addAll(messages.asJava)
     Future.successful(())
   }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockWorkspaceServer.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockWorkspaceServer.scala
@@ -4,7 +4,7 @@ import org.broadinstitute.dsde.firecloud.FireCloudConfig
 import org.broadinstitute.dsde.firecloud.mock.MockUtils._
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
 import org.broadinstitute.dsde.firecloud.model._
-import org.broadinstitute.dsde.rawls.model.{WorkspaceDetails, WorkspaceVersions}
+import org.broadinstitute.dsde.rawls.model.{GoogleProjectId, WorkspaceDetails, WorkspaceVersions}
 import org.joda.time.DateTime
 import org.mockserver.integration.ClientAndServer
 import org.mockserver.integration.ClientAndServer._
@@ -32,7 +32,7 @@ object MockWorkspaceServer {
     false, //locked
     Some(Set.empty), //authdomain
     WorkspaceVersions.V2,
-    "googleProject"
+    GoogleProjectId("googleProject")
   )
 
   val mockSpacedWorkspace = WorkspaceDetails(
@@ -48,7 +48,7 @@ object MockWorkspaceServer {
     false, //locked
     Some(Set.empty), //authdomain
     WorkspaceVersions.V2,
-    "googleProject"
+    GoogleProjectId("googleProject")
   )
 
   val mockValidId = randomPositiveInt()

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/model/DuosModelSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/model/DuosModelSpec.scala
@@ -1,10 +1,11 @@
 package org.broadinstitute.dsde.firecloud.model
 
 import org.broadinstitute.dsde.firecloud.model.DUOS.DuosDataUse
-import org.scalatest.{FreeSpec, Matchers}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 import spray.json._
 
-class DuosModelSpec extends FreeSpec with Matchers {
+class DuosModelSpec extends AnyFreeSpec with Matchers {
 
   private implicit val impDuosDataUse: ModelJsonProtocol.impDuosDataUse.type = ModelJsonProtocol.impDuosDataUse
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/model/ElasticSearchSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/model/ElasticSearchSpec.scala
@@ -1,16 +1,17 @@
 package org.broadinstitute.dsde.firecloud.model
 
 import org.broadinstitute.dsde.firecloud.model.DataUse.{DiseaseOntologyNodeId, ResearchPurpose}
-import org.scalatest.{Assertions, FreeSpec}
+import org.scalatest.Assertions
 import spray.json.JsString
 import spray.json._
 import spray.json.DefaultJsonProtocol._
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
+import org.scalatest.freespec.AnyFreeSpec
 
 /**
   * Created by ahaessly on 1/19/17.
   */
-class ElasticSearchSpec  extends FreeSpec with Assertions {
+class ElasticSearchSpec  extends AnyFreeSpec with Assertions {
 
   "LibrarySearchParams model" - {
     "when unmarshalling from json" - {

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/model/OrchMethodRepositorySpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/model/OrchMethodRepositorySpec.scala
@@ -1,9 +1,9 @@
 package org.broadinstitute.dsde.firecloud.model
 
-import org.broadinstitute.dsde.firecloud.model.MethodRepository.{ACLNames, FireCloudPermission}
+import org.broadinstitute.dsde.firecloud.model.OrchMethodRepository.{ACLNames, FireCloudPermission}
 import org.scalatest.{FreeSpec, Matchers}
 
-class MethodRepositorySpec extends FreeSpec with Matchers {
+class OrchMethodRepositorySpec extends FreeSpec with Matchers {
 
   "FireCloudPermission" - {
     "Correctly formed permissions should validate" - {

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/model/OrchMethodRepositorySpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/model/OrchMethodRepositorySpec.scala
@@ -1,9 +1,10 @@
 package org.broadinstitute.dsde.firecloud.model
 
 import org.broadinstitute.dsde.firecloud.model.OrchMethodRepository.{ACLNames, FireCloudPermission}
-import org.scalatest.{FreeSpec, Matchers}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class OrchMethodRepositorySpec extends FreeSpec with Matchers {
+class OrchMethodRepositorySpec extends AnyFreeSpec with Matchers {
 
   "FireCloudPermission" - {
     "Correctly formed permissions should validate" - {

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/model/ProfileSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/model/ProfileSpec.scala
@@ -1,9 +1,10 @@
 package org.broadinstitute.dsde.firecloud.model
 
 import org.broadinstitute.dsde.firecloud.mock.MockUtils
-import org.scalatest.{FreeSpec, Matchers}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class ProfileSpec extends FreeSpec with Matchers {
+class ProfileSpec extends AnyFreeSpec with Matchers {
 
   val randomString = MockUtils.randomAlpha()
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/model/SamResourceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/model/SamResourceSpec.scala
@@ -1,14 +1,15 @@
 package org.broadinstitute.dsde.firecloud.model
 
 import org.broadinstitute.dsde.firecloud.model.SamResource.{AccessPolicyName, ResourceId, UserPolicy}
-import org.scalatest.{FreeSpec, Matchers}
 import spray.json._
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 import spray.json.DefaultJsonProtocol._
 
 import scala.util.parsing.json.JSONFormat
 
-class SamResourceSpec extends FreeSpec with Matchers {
+class SamResourceSpec extends AnyFreeSpec with Matchers {
 
   val userPolicyJSON =     """
     |  {

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/AgoraACLTranslationSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/AgoraACLTranslationSpec.scala
@@ -1,7 +1,7 @@
 package org.broadinstitute.dsde.firecloud.service
 
-import org.broadinstitute.dsde.firecloud.model.MethodRepository.ACLNames._
-import org.broadinstitute.dsde.firecloud.model.MethodRepository.{AgoraPermission, FireCloudPermission}
+import org.broadinstitute.dsde.firecloud.model.OrchMethodRepository.ACLNames._
+import org.broadinstitute.dsde.firecloud.model.OrchMethodRepository.{AgoraPermission, FireCloudPermission}
 import org.scalatest.FreeSpec
 
 class AgoraACLTranslationSpec extends FreeSpec {

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/AgoraACLTranslationSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/AgoraACLTranslationSpec.scala
@@ -2,9 +2,9 @@ package org.broadinstitute.dsde.firecloud.service
 
 import org.broadinstitute.dsde.firecloud.model.OrchMethodRepository.ACLNames._
 import org.broadinstitute.dsde.firecloud.model.OrchMethodRepository.{AgoraPermission, FireCloudPermission}
-import org.scalatest.FreeSpec
+import org.scalatest.freespec.AnyFreeSpec
 
-class AgoraACLTranslationSpec extends FreeSpec {
+class AgoraACLTranslationSpec extends AnyFreeSpec {
 
   val email = Some("davidan@broadinstitute.org")
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupportSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionSupportSpec.scala
@@ -8,13 +8,14 @@ import org.broadinstitute.dsde.firecloud.model.DUOS.DuosDataUse
 import org.broadinstitute.dsde.firecloud.model.DataUse.StructuredDataRequest
 import org.broadinstitute.dsde.firecloud.service.DataUseRestrictionTestFixtures._
 import org.broadinstitute.dsde.rawls.model._
-import org.scalatest.{FreeSpec, Matchers}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 import spray.json._
 import spray.json.DefaultJsonProtocol._
 
 import scala.language.postfixOps
 
-class DataUseRestrictionSupportSpec extends FreeSpec with Matchers with DataUseRestrictionSupport {
+class DataUseRestrictionSupportSpec extends AnyFreeSpec with Matchers with DataUseRestrictionSupport {
 
   "DataUseRestrictionSupport" - {
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionTestFixtures.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionTestFixtures.scala
@@ -126,7 +126,7 @@ object DataUseRestrictionTestFixtures {
       workflowCollectionName=Some("wf-collection"),
       authorizationDomain=Some(Set.empty[ManagedGroupRef]),
       workspaceVersion=WorkspaceVersions.V2,
-      googleProject="googleProject")
+      googleProject=GoogleProjectId("googleProject"))
   }
 
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/ElasticSearchDAOQuerySupportSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/ElasticSearchDAOQuerySupportSpec.scala
@@ -9,13 +9,13 @@ import org.broadinstitute.dsde.firecloud.model._
 import org.broadinstitute.dsde.rawls.model.WorkspaceAccessLevels
 import org.elasticsearch.action.search.SearchRequestBuilder
 import org.elasticsearch.client.transport.TransportClient
-import org.scalatest.FreeSpec
 import org.scalatest.Assertions._
+import org.scalatest.freespec.AnyFreeSpec
 import spray.json._
 
 import scala.collection.Set
 
-class ElasticSearchDAOQuerySupportSpec extends FreeSpec with ElasticSearchDAOQuerySupport {
+class ElasticSearchDAOQuerySupportSpec extends AnyFreeSpec with ElasticSearchDAOQuerySupport {
 
   val indexname = "ElasticSearchSpec"
 
@@ -297,7 +297,7 @@ class ElasticSearchDAOQuerySupportSpec extends FreeSpec with ElasticSearchDAOQue
                   val actualWorkspaces = t.fields("workspaceId.keyword")
                   assertResult(Set(JsString(wksp))) {actualWorkspaces.asInstanceOf[JsArray].elements.toSet}
                 }
-              case _ => Unit
+              case _ => ()
             }
             // assertResult(expectedNoDiscoverableGroups, "group criteria should be just the must-not-exists") {groupbool}
           case x => throw new Exception(s"unmatched case for  ${x.getClass.getName}: ${x.toString()}")

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/FireCloudDirectivesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/FireCloudDirectivesSpec.scala
@@ -1,11 +1,11 @@
 package org.broadinstitute.dsde.firecloud.service
 
 import akka.http.scaladsl.testkit.ScalatestRouteTest
-import org.scalatest.FreeSpec
+import org.scalatest.freespec.AnyFreeSpec
 
 import scala.concurrent.ExecutionContext
 
-class FireCloudDirectivesSpec extends FreeSpec with ScalatestRouteTest with FireCloudDirectives {
+class FireCloudDirectivesSpec extends AnyFreeSpec with ScalatestRouteTest with FireCloudDirectives {
 
   override val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/LibraryServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/LibraryServiceSpec.scala
@@ -11,15 +11,15 @@ import org.broadinstitute.dsde.firecloud.model._
 import org.broadinstitute.dsde.firecloud.service.LibraryService._
 import org.everit.json.schema.ValidationException
 import org.parboiled.common.FileUtils
-import org.scalatest.FreeSpecLike
 import spray.json.{JsObject, _}
 import spray.json.DefaultJsonProtocol._
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
 import org.broadinstitute.dsde.firecloud.model.Ontology.{TermParent, TermResource}
 import org.broadinstitute.dsde.workbench.model.WorkbenchGroupName
 import org.joda.time.DateTime
+import org.scalatest.freespec.AnyFreeSpecLike
 
-import collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.util.Try
@@ -57,7 +57,7 @@ object LibraryServiceSpec {
   val testLibraryMetadataJsObject = testLibraryMetadata.parseJson.asJsObject
 
 }
-class LibraryServiceSpec extends BaseServiceSpec with FreeSpecLike with LibraryServiceSupport with AttributeSupport with ElasticSearchDAOSupport {
+class LibraryServiceSpec extends BaseServiceSpec with AnyFreeSpecLike with LibraryServiceSupport with AttributeSupport with ElasticSearchDAOSupport {
   def toName(s:String) = AttributeName.fromDelimitedName(s)
 
   implicit val userToken: WithAccessToken = AccessToken("LibraryServiceSpec")
@@ -85,7 +85,7 @@ class LibraryServiceSpec extends BaseServiceSpec with FreeSpecLike with LibraryS
     bucketName = "bucketName",
     workflowCollectionName = Some("wf-collection"),
     workspaceVersion=WorkspaceVersions.V2,
-    googleProject="googleProject")
+    googleProject=GoogleProjectId("googleProject"))
 
 
   val DULAdditionalJsObject =
@@ -823,7 +823,7 @@ class LibraryServiceSpec extends BaseServiceSpec with FreeSpecLike with LibraryS
           false, //locked
           Some(Set.empty), //authdomain
           WorkspaceVersions.V2,
-          "googleProject"
+          GoogleProjectId("googleProject")
         )
 
         attrMaps map { attrMap =>

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/NihServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/NihServiceSpec.scala
@@ -3,14 +3,15 @@ package org.broadinstitute.dsde.firecloud.service
 import org.broadinstitute.dsde.firecloud.dataaccess._
 import org.broadinstitute.dsde.firecloud.mock.MockGoogleServicesDAO
 import org.broadinstitute.dsde.firecloud.utils.DateUtils
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.ExecutionContext
 
 /**
   * Created by mbemis on 3/7/17.
   */
-class NihServiceSpec extends FlatSpec with Matchers {
+class NihServiceSpec extends AnyFlatSpec with Matchers {
 
   implicit val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
   val samDao = new MockSamDAO

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/PassthroughDirectivesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/PassthroughDirectivesSpec.scala
@@ -25,7 +25,7 @@ final class PassthroughDirectivesSpec extends BaseServiceSpec with FireCloudDire
 
   var echoServer: ClientAndServer = _
 
-  override def beforeAll = {
+  override def beforeAll() = {
     echoServer = startClientAndServer(echoPort)
       echoServer.when(request())
         .callback(
@@ -33,7 +33,7 @@ final class PassthroughDirectivesSpec extends BaseServiceSpec with FireCloudDire
             withCallbackClass("org.broadinstitute.dsde.firecloud.service.EchoCallback"))
   }
 
-  override def afterAll = {
+  override def afterAll() = {
     echoServer.stop
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/PassthroughDirectivesSpecSupport.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/PassthroughDirectivesSpecSupport.scala
@@ -10,7 +10,7 @@ import akka.http.scaladsl.model.Uri
 import akka.http.scaladsl.model.Uri.{Path, Query}
 import spray.json.DefaultJsonProtocol._
 
-import collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 class EchoCallback extends ExpectationCallback {
   override def handle(httpRequest: HttpRequest): HttpResponse = {

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/ServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/ServiceSpec.scala
@@ -1,26 +1,21 @@
 package org.broadinstitute.dsde.firecloud.service
 
-import org.broadinstitute.dsde.rawls.model.ErrorReport
-import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
-import org.broadinstitute.dsde.firecloud.utils.TestRequestBuilding
-import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
-import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{FreeSpec, Matchers}
 import akka.http.scaladsl.model.HttpMethods._
-import akka.http.scaladsl.model.HttpMethod
-import akka.http.scaladsl.model.StatusCode
-import akka.http.scaladsl.server._
-import akka.http.scaladsl.server.Directives._
-import akka.stream.ActorMaterializer
-
+import akka.http.scaladsl.model.{HttpMethod, StatusCode}
 import akka.http.scaladsl.server.Route
 import akka.http.scaladsl.testkit.{RouteTestTimeout, ScalatestRouteTest}
 import akka.testkit.TestKitBase
+import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
+import org.broadinstitute.dsde.firecloud.utils.TestRequestBuilding
+import org.broadinstitute.dsde.rawls.model.ErrorReport
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.duration._
 
 // common Service Spec to be inherited by service tests
-trait ServiceSpec extends FreeSpec with ScalaFutures with ScalatestRouteTest with Matchers with TestRequestBuilding with TestKitBase {
+trait ServiceSpec extends AnyFreeSpec with ScalaFutures with ScalatestRouteTest with Matchers with TestRequestBuilding with TestKitBase {
 
   implicit val routeTestTimeout = RouteTestTimeout(5.seconds)
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/TSVFileSupportSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/TSVFileSupportSpec.scala
@@ -3,12 +3,12 @@ package org.broadinstitute.dsde.firecloud.service
 import org.broadinstitute.dsde.firecloud.mock.MockTSVLoadFiles
 import org.broadinstitute.dsde.rawls.model.{AttributeName, AttributeString}
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.{AddUpdateAttribute, RemoveAttribute}
-import org.scalatest.FreeSpec
+import org.scalatest.freespec.AnyFreeSpec
 
 /**
   * Created by ansingh on 11/16/16.
   */
-class TSVFileSupportSpec extends FreeSpec with TSVFileSupport {
+class TSVFileSupportSpec extends AnyFreeSpec with TSVFileSupport {
 
 
   "getWorkspaceAttributeCalls" - {

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceTagsServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceTagsServiceSpec.scala
@@ -299,7 +299,7 @@ class WorkspaceTagsServiceSpec extends BaseServiceSpec with WorkspaceApiService 
   */
 class MockTagsRawlsDao extends MockRawlsDAO with Assertions {
 
-  import collection.JavaConverters._
+  import scala.jdk.CollectionConverters._
 
   private var statefulTagMap = new ConcurrentHashMap[String, ListBuffer[String]]().asScala
 
@@ -316,7 +316,7 @@ class MockTagsRawlsDao extends MockRawlsDAO with Assertions {
     false, //locked
     Some(Set.empty), //authdomain
     WorkspaceVersions.V2,
-    "googleProject"
+    GoogleProjectId("googleProject")
   )
 
   private def workspaceResponse(ws:WorkspaceDetails=workspace) = WorkspaceResponse(
@@ -335,7 +335,7 @@ class MockTagsRawlsDao extends MockRawlsDAO with Assertions {
     val tags = statefulTagMap.getOrElse(name, ListBuffer.empty[String])
     val tagAttrs = (tags map AttributeString)
     workspace.copy(attributes = Option(Map(
-      AttributeName.withTagsNS() -> AttributeValueList(tagAttrs)
+      AttributeName.withTagsNS() -> AttributeValueList(tagAttrs.toList)
     )))
   }
 
@@ -385,7 +385,7 @@ class MockTagsRawlsDao extends MockRawlsDAO with Assertions {
           "Delete operation should consist of only AddListMember operations" )
         val removeTags = attributes.map(_.asInstanceOf[RemoveListMember].removeMember.asInstanceOf[AttributeString].value)
         val currentTags = statefulTagMap.getOrElse(name, ListBuffer.empty[String])
-        val finalTags = currentTags -- removeTags
+        val finalTags = currentTags --= removeTags
         statefulTagMap.put(name, finalTags)
       case _ => fail("is the unit test correct?")
     }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/utils/PermissionsSupportSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/utils/PermissionsSupportSpec.scala
@@ -5,14 +5,14 @@ import org.broadinstitute.dsde.firecloud.model.UserInfo
 import org.broadinstitute.dsde.firecloud.service.PerRequest.RequestComplete
 import org.broadinstitute.dsde.firecloud.{FireCloudException, FireCloudExceptionWithErrorReport}
 import org.broadinstitute.dsde.workbench.model.WorkbenchGroupName
-import org.scalatest.FreeSpecLike
 import akka.http.scaladsl.model.StatusCodes
+import org.scalatest.freespec.AnyFreeSpecLike
 
 import scala.concurrent.duration.{Duration, SECONDS}
 import scala.concurrent.{Await, ExecutionContext, Future}
 
 
-class PermissionsSupportSpec extends PermissionsSupport with FreeSpecLike {
+class PermissionsSupportSpec extends PermissionsSupport with AnyFreeSpecLike {
   protected val rawlsDAO: RawlsDAO = new MockRawlsDAO
   protected val samDao: SamDAO = new PermissionsSupportMockSamDAO
   implicit protected val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/utils/TSVFormatterSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/utils/TSVFormatterSpec.scala
@@ -6,12 +6,14 @@ import org.broadinstitute.dsde.firecloud.service.TsvTypes
 import org.broadinstitute.dsde.firecloud.service.TsvTypes.TsvType
 import org.broadinstitute.dsde.rawls.model._
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{FreeSpec, Inspectors, Matchers}
+import org.scalatest.Inspectors
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.io.Source
 import scala.language.postfixOps
 
-class TSVFormatterSpec extends FreeSpec with ScalaFutures with Matchers with Inspectors {
+class TSVFormatterSpec extends AnyFreeSpec with ScalaFutures with Matchers with Inspectors {
 
   implicit val modelSchema: ModelSchema = FirecloudModelSchema
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/utils/TSVParserSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/utils/TSVParserSpec.scala
@@ -1,11 +1,11 @@
 package org.broadinstitute.dsde.firecloud.utils
 
-import org.scalatest.FlatSpec
 import org.broadinstitute.dsde.firecloud.EntityService
 import org.broadinstitute.dsde.firecloud.mock.{MockTSVLoadFiles, MockTSVStrings}
 import org.broadinstitute.dsde.firecloud.model.FirecloudModelSchema
+import org.scalatest.flatspec.AnyFlatSpec
 
-class TSVParserSpec extends FlatSpec {
+class TSVParserSpec extends AnyFlatSpec {
   "TSV parser" should "throw an exception when given an empty file to parse" in {
     intercept[RuntimeException] {
       TSVParser.parse(MockTSVStrings.empty)

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/ApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/ApiServiceSpec.scala
@@ -7,7 +7,8 @@ import org.broadinstitute.dsde.firecloud.dataaccess._
 import org.broadinstitute.dsde.firecloud.mock.MockGoogleServicesDAO
 import org.broadinstitute.dsde.firecloud.service.NihService
 import org.broadinstitute.dsde.firecloud.utils.TestRequestBuilding
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.duration._
 
@@ -16,7 +17,7 @@ import scala.concurrent.duration._
   */
 
 // common trait to be inherited by API service tests
-trait ApiServiceSpec extends FlatSpec with Matchers with ScalatestRouteTest with SprayJsonSupport with TestRequestBuilding {
+trait ApiServiceSpec extends AnyFlatSpec with Matchers with ScalatestRouteTest with SprayJsonSupport with TestRequestBuilding {
   // increase the timeout for ScalatestRouteTest from the default of 1 second, otherwise
   // intermittent failures occur on requests not completing in time
   implicit val routeTestTimeout = RouteTestTimeout(5.seconds)
@@ -46,8 +47,8 @@ trait ApiServiceSpec extends FlatSpec with Matchers with ScalatestRouteTest with
   }
 
   // lifted from rawls. prefer this to using theSameElementsAs directly, because its functionality depends on whitespace
-  def assertSameElements[T](expected: TraversableOnce[T], actual: TraversableOnce[T]): Unit = {
-    expected.toTraversable should contain theSameElementsAs actual.toTraversable
+  def assertSameElements[T](expected: IterableOnce[T], actual: IterableOnce[T]): Unit = {
+    expected.iterator.to(Iterable) should contain theSameElementsAs actual.iterator.to(Iterable)
   }
 
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/LibraryApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/LibraryApiServiceSpec.scala
@@ -390,7 +390,7 @@ class LibraryApiServiceSpec extends BaseServiceSpec with LibraryApiService with 
         val request = ResearchPurposeRequest.empty.copy(DS = Some(Seq(s"${doidPrefix}1234", s"${doidPrefix}5678")))
         new RequestBuilder(HttpMethods.POST)(duosResearchPurposeQuery, request) ~> sealRoute(libraryRoutes) ~> check {
           status should equal(OK)
-          val diseaseIds = responseAs[JsObject].extract[Int]('bool / 'should / * / 'term / "structuredUseRestriction.DS" / 'value)
+          val diseaseIds = responseAs[JsObject].extract[Int](Symbol("bool") / Symbol("should") / * / Symbol("term") / "structuredUseRestriction.DS" / Symbol("value"))
           diseaseIds should equal(Seq(1234, 5678))
         }
       }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/LibraryApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/LibraryApiServiceSpec.scala
@@ -24,7 +24,7 @@ import spray.json.DefaultJsonProtocol._
 import spray.json._
 import spray.json.lenses.JsonLenses._
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, ExecutionContext}
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/MethodConfigurationApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/MethodConfigurationApiServiceSpec.scala
@@ -8,7 +8,7 @@ import org.broadinstitute.dsde.firecloud.mock.MockUtils
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
 import org.broadinstitute.dsde.firecloud.model.{CopyConfigurationIngest, PublishConfigurationIngest}
 import org.broadinstitute.dsde.firecloud.service.ServiceSpec
-import org.broadinstitute.dsde.rawls.model.{WorkspaceDetails, WorkspaceVersions}
+import org.broadinstitute.dsde.rawls.model.{GoogleProjectId, WorkspaceDetails, WorkspaceVersions}
 import org.joda.time.DateTime
 import org.mockserver.integration.ClientAndServer
 import org.mockserver.integration.ClientAndServer._
@@ -34,7 +34,7 @@ class MethodConfigurationApiServiceSpec extends ServiceSpec with MethodConfigura
     false, //locked
     Some(Set.empty), //authdomain
     WorkspaceVersions.V2,
-    "googleProject"
+    GoogleProjectId("googleProject")
   )
 
   override def beforeAll(): Unit = {

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/MethodsApiServiceACLSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/MethodsApiServiceACLSpec.scala
@@ -6,7 +6,7 @@ import akka.http.scaladsl.model.StatusCodes._
 import akka.http.scaladsl.server.Route.{seal => sealRoute}
 import org.broadinstitute.dsde.firecloud.mock.MockAgoraACLData
 import org.broadinstitute.dsde.firecloud.mock.MockAgoraACLData._
-import org.broadinstitute.dsde.firecloud.model.MethodRepository.FireCloudPermission
+import org.broadinstitute.dsde.firecloud.model.OrchMethodRepository.FireCloudPermission
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol.impFireCloudPermission
 import org.broadinstitute.dsde.firecloud.model.UserInfo
 import org.broadinstitute.dsde.firecloud.service.{AgoraPermissionService, BaseServiceSpec}

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/MethodsApiServiceMultiACLSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/MethodsApiServiceMultiACLSpec.scala
@@ -4,7 +4,7 @@ import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
 import akka.http.scaladsl.model.HttpMethods
 import akka.http.scaladsl.model.StatusCodes._
 import akka.http.scaladsl.server.Route.{seal => sealRoute}
-import org.broadinstitute.dsde.firecloud.model.MethodRepository._
+import org.broadinstitute.dsde.firecloud.model.OrchMethodRepository._
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol.impMethodAclPair
 import org.broadinstitute.dsde.firecloud.model.UserInfo
 import org.broadinstitute.dsde.firecloud.service.{AgoraPermissionService, BaseServiceSpec, ServiceSpec}

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/MethodsApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/MethodsApiServiceSpec.scala
@@ -13,7 +13,6 @@ import org.mockserver.model.HttpCallback.callback
 import org.mockserver.model.HttpRequest._
 import org.mockserver.model.HttpResponse.response
 import org.mockserver.model.{HttpRequest, HttpResponse}
-import org.scalatest.Matchers
 import akka.http.scaladsl.model.HttpMethods._
 import akka.http.scaladsl.model.StatusCodes._
 import org.broadinstitute.dsde.firecloud.model.UserInfo

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/NamespaceApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/NamespaceApiServiceSpec.scala
@@ -4,7 +4,7 @@ import akka.http.scaladsl.model.HttpMethods
 import akka.http.scaladsl.model.StatusCodes._
 import akka.http.scaladsl.server.Route.{seal => sealRoute}
 import org.broadinstitute.dsde.firecloud.dataaccess.MockAgoraDAO
-import org.broadinstitute.dsde.firecloud.model.MethodRepository.FireCloudPermission
+import org.broadinstitute.dsde.firecloud.model.OrchMethodRepository.FireCloudPermission
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
 import org.broadinstitute.dsde.firecloud.model.UserInfo
 import org.broadinstitute.dsde.firecloud.service.{AgoraPermissionService, BaseServiceSpec, NamespaceService}

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/PermissionReportApiSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/PermissionReportApiSpec.scala
@@ -6,7 +6,7 @@ import org.broadinstitute.dsde.firecloud.{EntityService, FireCloudExceptionWithE
 import org.broadinstitute.dsde.firecloud.dataaccess.{MockAgoraDAO, MockRawlsDAO}
 import org.broadinstitute.dsde.firecloud.model.ErrorReportExtensions.FCErrorReport
 import org.broadinstitute.dsde.firecloud.model.OrchMethodRepository._
-import org.broadinstitute.dsde.firecloud.model.{MethodConfigurationName, ModelSchema, PermissionReport, PermissionReportRequest, UserInfo, WithAccessToken}
+import org.broadinstitute.dsde.firecloud.model.{OrchMethodConfigurationName, ModelSchema, PermissionReport, PermissionReportRequest, UserInfo, WithAccessToken}
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
 import org.broadinstitute.dsde.firecloud.service.{BaseServiceSpec, PermissionReportService, WorkspaceService}
 import org.broadinstitute.dsde.rawls.model.{MethodConfigurationShort, MethodRepoMethod, _}
@@ -60,7 +60,7 @@ class PermissionReportApiSpec extends BaseServiceSpec with WorkspaceApiService w
     }
 
     "should accept correctly-formed input" in {
-      val payload = PermissionReportRequest(Some(Seq("foo")),Some(Seq(MethodConfigurationName("ns","name"))))
+      val payload = PermissionReportRequest(Some(Seq("foo")),Some(Seq(OrchMethodConfigurationName("ns","name"))))
       Post(permissionReportPath("foo","bar"), payload) ~> dummyUserIdHeaders("1234") ~> sealRoute(workspaceRoutes) ~> check {
         status should equal(OK)
       }
@@ -81,9 +81,9 @@ class PermissionReportApiSpec extends BaseServiceSpec with WorkspaceApiService w
         assertResult(Set("alice@example.com","bob@example.com","carol@example.com")) {report.workspaceACL.keySet}
 
         val expectedConfigsNoAcls = Map(
-          MethodConfigurationName("configns1", "configname1") -> Some(mockMethod1),
-          MethodConfigurationName("configns2", "configname2") -> Some(mockMethod2),
-          MethodConfigurationName("configns3", "configname3") -> Some(mockMethod3)
+          OrchMethodConfigurationName("configns1", "configname1") -> Some(mockMethod1),
+          OrchMethodConfigurationName("configns2", "configname2") -> Some(mockMethod2),
+          OrchMethodConfigurationName("configns3", "configname3") -> Some(mockMethod3)
         )
 
         assertResult(expectedConfigsNoAcls) {(report.referencedMethods map {
@@ -100,9 +100,9 @@ class PermissionReportApiSpec extends BaseServiceSpec with WorkspaceApiService w
         assertResult(Set("carol@example.com")) {report.workspaceACL.keySet}
 
         val expectedConfigsNoAcls = Map(
-          MethodConfigurationName("configns1", "configname1") -> Some(mockMethod1),
-          MethodConfigurationName("configns2", "configname2") -> Some(mockMethod2),
-          MethodConfigurationName("configns3", "configname3") -> Some(mockMethod3)
+          OrchMethodConfigurationName("configns1", "configname1") -> Some(mockMethod1),
+          OrchMethodConfigurationName("configns2", "configname2") -> Some(mockMethod2),
+          OrchMethodConfigurationName("configns3", "configname3") -> Some(mockMethod3)
         )
 
         assertResult(expectedConfigsNoAcls) {(report.referencedMethods map {
@@ -112,14 +112,14 @@ class PermissionReportApiSpec extends BaseServiceSpec with WorkspaceApiService w
     }
 
     "should filter configs if caller specifies" in {
-      val payload = PermissionReportRequest(None,Some(Seq(MethodConfigurationName("configns2","configname2"))))
+      val payload = PermissionReportRequest(None,Some(Seq(OrchMethodConfigurationName("configns2","configname2"))))
       Post(permissionReportPath("foo","bar"), payload) ~> dummyUserIdHeaders("1234") ~> sealRoute(workspaceRoutes) ~> check {
         status should equal(OK)
         val report = responseAs[PermissionReport]
         assertResult(Set("alice@example.com","bob@example.com","carol@example.com")) {report.workspaceACL.keySet}
 
         val expectedConfigsNoAcls = Map(
-          MethodConfigurationName("configns2", "configname2") -> Some(mockMethod2)
+          OrchMethodConfigurationName("configns2", "configname2") -> Some(mockMethod2)
         )
 
         assertResult(expectedConfigsNoAcls) {(report.referencedMethods map {
@@ -129,14 +129,14 @@ class PermissionReportApiSpec extends BaseServiceSpec with WorkspaceApiService w
     }
 
     "should filter both users and configs if caller specifies" in {
-      val payload = PermissionReportRequest(Some(Seq("carol@example.com")),Some(Seq(MethodConfigurationName("configns2","configname2"))))
+      val payload = PermissionReportRequest(Some(Seq("carol@example.com")),Some(Seq(OrchMethodConfigurationName("configns2","configname2"))))
       Post(permissionReportPath("foo","bar"), payload) ~> dummyUserIdHeaders("1234") ~> sealRoute(workspaceRoutes) ~> check {
         status should equal(OK)
         val report = responseAs[PermissionReport]
         assertResult(Set("carol@example.com")) {report.workspaceACL.keySet}
 
         val expectedConfigsNoAcls = Map(
-          MethodConfigurationName("configns2", "configname2") -> Some(mockMethod2)
+          OrchMethodConfigurationName("configns2", "configname2") -> Some(mockMethod2)
         )
 
         assertResult(expectedConfigsNoAcls) {(report.referencedMethods map {
@@ -166,9 +166,9 @@ class PermissionReportApiSpec extends BaseServiceSpec with WorkspaceApiService w
         assertResult(Set("carol@example.com")) {report.workspaceACL.keySet}
 
         val expectedConfigsNoAcls = Map(
-          MethodConfigurationName("configns1", "configname1") -> Some(mockMethod1),
-          MethodConfigurationName("configns2", "configname2") -> Some(mockMethod2),
-          MethodConfigurationName("configns3", "configname3") -> Some(mockMethod3)
+          OrchMethodConfigurationName("configns1", "configname1") -> Some(mockMethod1),
+          OrchMethodConfigurationName("configns2", "configname2") -> Some(mockMethod2),
+          OrchMethodConfigurationName("configns3", "configname3") -> Some(mockMethod3)
         )
 
         assertResult(expectedConfigsNoAcls) {(report.referencedMethods map {
@@ -180,8 +180,8 @@ class PermissionReportApiSpec extends BaseServiceSpec with WorkspaceApiService w
     "should omit a caller-specified config if config doesn't exist in the workspace" in {
       val payload = PermissionReportRequest(None,
         Some(Seq(
-          MethodConfigurationName("configns2","configname2"),
-          MethodConfigurationName("confignsZZZ","confignameZZZ")
+          OrchMethodConfigurationName("configns2","configname2"),
+          OrchMethodConfigurationName("confignsZZZ","confignameZZZ")
         ))
       )
       Post(permissionReportPath("foo","bar"), payload) ~> dummyUserIdHeaders("1234") ~> sealRoute(workspaceRoutes) ~> check {
@@ -190,7 +190,7 @@ class PermissionReportApiSpec extends BaseServiceSpec with WorkspaceApiService w
         assertResult(Set("alice@example.com","bob@example.com","carol@example.com")) {report.workspaceACL.keySet}
 
         val expectedConfigsNoAcls = Map(
-          MethodConfigurationName("configns2", "configname2") -> Some(mockMethod2)
+          OrchMethodConfigurationName("configns2", "configname2") -> Some(mockMethod2)
         )
 
         assertResult(expectedConfigsNoAcls) {(report.referencedMethods map {
@@ -208,9 +208,9 @@ class PermissionReportApiSpec extends BaseServiceSpec with WorkspaceApiService w
         assert(report.workspaceACL.isEmpty)
 
         val expectedConfigsNoAcls = Map(
-          MethodConfigurationName("configns1", "configname1") -> Some(mockMethod1),
-          MethodConfigurationName("configns2", "configname2") -> Some(mockMethod2),
-          MethodConfigurationName("configns3", "configname3") -> Some(mockMethod3)
+          OrchMethodConfigurationName("configns1", "configname1") -> Some(mockMethod1),
+          OrchMethodConfigurationName("configns2", "configname2") -> Some(mockMethod2),
+          OrchMethodConfigurationName("configns3", "configname3") -> Some(mockMethod3)
         )
 
         assertResult(expectedConfigsNoAcls) {(report.referencedMethods map {

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/PermissionReportApiSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/PermissionReportApiSpec.scala
@@ -5,7 +5,7 @@ import akka.http.scaladsl.model.{HttpMethods, HttpResponse}
 import org.broadinstitute.dsde.firecloud.{EntityService, FireCloudExceptionWithErrorReport}
 import org.broadinstitute.dsde.firecloud.dataaccess.{MockAgoraDAO, MockRawlsDAO}
 import org.broadinstitute.dsde.firecloud.model.ErrorReportExtensions.FCErrorReport
-import org.broadinstitute.dsde.firecloud.model.MethodRepository._
+import org.broadinstitute.dsde.firecloud.model.OrchMethodRepository._
 import org.broadinstitute.dsde.firecloud.model.{MethodConfigurationName, ModelSchema, PermissionReport, PermissionReportRequest, UserInfo, WithAccessToken}
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
 import org.broadinstitute.dsde.firecloud.service.{BaseServiceSpec, PermissionReportService, WorkspaceService}

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/StatusApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/StatusApiServiceSpec.scala
@@ -27,13 +27,13 @@ class StatusApiServiceSpec extends BaseServiceSpec with StatusApiService with Sp
   val healthMonitor = system.actorOf(HealthMonitor.props(healthMonitorChecks().keySet)( healthMonitorChecks ), "health-monitor")
   val monitorSchedule = system.scheduler.schedule(Duration.Zero, 1.second, healthMonitor, HealthMonitor.CheckAll)
 
-  override def beforeAll = {
+  override def beforeAll() = {
     // wait for the healthMonitor to start up ...
     Thread.sleep(3000)
   }
 
-  override def afterAll = {
-    monitorSchedule.cancel
+  override def afterAll() = {
+    monitorSchedule.cancel()
   }
 
   override val statusServiceConstructor: () => StatusService = StatusService.constructor(healthMonitor)

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/UserApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/UserApiServiceSpec.scala
@@ -312,7 +312,7 @@ class UserApiServiceSpec extends BaseServiceSpec with RegisterApiService with Us
             org.mockserver.model.HttpResponse.response()
               .withHeaders(MockUtils.header)
               .withStatusCode(InternalServerError.intValue)
-              .withBody(Conflict.intValue + " " + Conflict.reason)
+              .withBody(s"${Conflict.intValue} ${Conflict.reason}")
           )
         Post(s"/$ApiPrefix", fullProfile) ~> dummyUserIdHeaders(uniqueId) ~>
             sealRoute(registerRoutes) ~> check {

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiServiceSpec.scala
@@ -45,7 +45,7 @@ object WorkspaceApiServiceSpec {
     false, //locked
     Some(Set.empty), //authorizationDomain
     WorkspaceVersions.V2,
-    "googleProject"
+    GoogleProjectId("googleProject")
   )
 
 }
@@ -67,7 +67,7 @@ class WorkspaceApiServiceSpec extends BaseServiceSpec with WorkspaceApiService w
     false, //locked
     Some(Set.empty), //authorizationDomain
     WorkspaceVersions.V2,
-    "googleProject"
+    GoogleProjectId("googleProject")
   )
 
   val jobId = "testOp"
@@ -123,7 +123,7 @@ class WorkspaceApiServiceSpec extends BaseServiceSpec with WorkspaceApiService w
     false,
     Some(Set(nihProtectedAuthDomain)), //authorizationDomain
     WorkspaceVersions.V2,
-    "googleProject"
+    GoogleProjectId("googleProject")
   )
 
   val authDomainRawlsWorkspace = WorkspaceDetails(
@@ -139,7 +139,7 @@ class WorkspaceApiServiceSpec extends BaseServiceSpec with WorkspaceApiService w
     false,
     Some(Set(ManagedGroupRef(RawlsGroupName("secret_realm")))), //authorizationDomain
     WorkspaceVersions.V2,
-    "googleProject"
+    GoogleProjectId("googleProject")
   )
 
   val nonAuthDomainRawlsWorkspace = WorkspaceDetails(
@@ -155,7 +155,7 @@ class WorkspaceApiServiceSpec extends BaseServiceSpec with WorkspaceApiService w
     false,
     Some(Set.empty), //authorizationDomain
     WorkspaceVersions.V2,
-    "googleProject"
+    GoogleProjectId("googleProject")
   )
 
   val protectedRawlsWorkspaceResponse = WorkspaceResponse(Some(WorkspaceAccessLevels.Owner), canShare=Some(false), canCompute=Some(true), catalog=Some(false), protectedRawlsWorkspace, Some(WorkspaceSubmissionStats(None, None, runningSubmissionsCount = 0)), Some(WorkspaceBucketOptions(false)), Some(Set.empty))
@@ -201,7 +201,7 @@ class WorkspaceApiServiceSpec extends BaseServiceSpec with WorkspaceApiService w
   def stubRawlsCreateWorkspace(namespace: String, name: String, authDomain: Set[ManagedGroupRef] = Set.empty): (WorkspaceRequest, WorkspaceDetails) = {
     rawlsServer.reset()
     val rawlsRequest = WorkspaceRequest(namespace, name, Map(), Option(authDomain))
-    val rawlsResponse = WorkspaceDetails(namespace, name, "foo", "bar", Some("wf-collection"), DateTime.now(), DateTime.now(), "bob", Some(Map()), false, Some(authDomain), WorkspaceVersions.V2, "googleProject")
+    val rawlsResponse = WorkspaceDetails(namespace, name, "foo", "bar", Some("wf-collection"), DateTime.now(), DateTime.now(), "bob", Some(Map()), false, Some(authDomain), WorkspaceVersions.V2, GoogleProjectId("googleProject"))
     stubRawlsService(HttpMethods.POST, workspacesRoot, Created, Option(rawlsResponse.toJson.compactPrint))
     (rawlsRequest, rawlsResponse)
   }
@@ -223,7 +223,7 @@ class WorkspaceApiServiceSpec extends BaseServiceSpec with WorkspaceApiService w
     val published: (AttributeName, AttributeBoolean) = AttributeName("library", "published") -> AttributeBoolean(false)
     val discoverable = AttributeName("library", "discoverableByGroups") -> AttributeValueEmptyList
     val rawlsRequest: WorkspaceRequest = WorkspaceRequest(namespace, name, attributes + published + discoverable, Option(authDomain))
-    val rawlsResponse = WorkspaceDetails(namespace, name, "foo", "bar", Some("wf-collection"), DateTime.now(), DateTime.now(), "bob", Some(attributes + published + discoverable), false, Some(authDomain), WorkspaceVersions.V2, "googleProject")
+    val rawlsResponse = WorkspaceDetails(namespace, name, "foo", "bar", Some("wf-collection"), DateTime.now(), DateTime.now(), "bob", Some(attributes + published + discoverable), false, Some(authDomain), WorkspaceVersions.V2, GoogleProjectId("googleProject"))
     stubRawlsService(HttpMethods.POST, clonePath, Created, Option(rawlsResponse.toJson.compactPrint))
     (rawlsRequest, rawlsResponse)
   }


### PR DESCRIPTION
This is untested- gonna let the automation do the heavy lifting and then diagnose any failures if needed.

Edit: Looks like there are a few failures related to collection orderings.

Incomplete summary of changes:

* FreeSpec -> AnyFreeSpec (and FlatSpec -> AnyFlatSpec, etc)
* Fixed a lot of deprecations, significant ones are:
  * JavaConverters -> scala.jdk.CollectionConverters
  * Auto-application to () deprecated, must explicitly supply empty arg list
  * Various list/seq/etc deprecations
* Upgrade a bunch of dependencies (rawls model required some changes in our test code)

This does not update `automation`, I will look at that tmrw

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
