### PR TITLE
AS-560: don't use passthrough when extracting entity [risk: low]

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiService.scala
@@ -97,12 +97,14 @@ trait WorkspaceApiService extends FireCloudRequestBuilding with FireCloudDirecti
                     }
                   } ~
                     post {
-                      requireUserInfo() { _ =>
+                      requireUserInfo() { userInfo =>
                         entity(as[MethodConfiguration]) { methodConfig =>
-                          if (!methodConfig.outputs.exists { param => param._2.value.startsWith("this.library:") || param._2.value.startsWith("workspace.library:")})
-                            passthrough(workspacePath + "/methodconfigs", HttpMethods.GET, HttpMethods.POST)
-                          else
+                          if (!methodConfig.outputs.exists { param => param._2.value.startsWith("this.library:") || param._2.value.startsWith("workspace.library:")}) {
+                            val passthroughReq = Post(workspacePath + "/methodconfigs", methodConfig)
+                            complete { userAuthedRequest(passthroughReq)(userInfo) }
+                          } else {
                             complete(StatusCodes.Forbidden, ErrorReport("Methods and configurations can not create or modify library attributes"))
+                          }
                         }
                       }
                     }


### PR DESCRIPTION
Explanation of this PR is here: https://github.com/broadinstitute/firecloud-orchestration/wiki/Passthroughs#passthroughs-and-entities

Matt was spot on in his work on broadinstitute/firecloud-orchestration#823, and this PR builds on his.

This problem happens when:
* a route uses both  `entity(as[...])` and `passthrough`
* the inbound request entity is large enough that akka treats it as a stream, not an in-memory object (`HttpEntity.Default`  vs `HttpEntity.Strict`).  This condition is intermittent based on network conditions and the current state of akka's buffers -  in practical terms, it is unpredictably intermittent.

I searched the codebases for all uses of `entity(as[...])`. The route I changed in this PR is the only one that also uses `passthrough`.

Finally, I _*tried*_ to write a unit test for this, but could not get the test to fail. There may be something  different about running real server vs. running via testkit:
```
    "POST on /workspaces/.../.../methodconfigs with a non-strict entity succeeds" in {
      // create a large http entity, and explicitly make it HttpEntity.Default
      val manyinputs: Map[String, AttributeString] = (1 to 99999).map { idx =>
        s"input$idx" -> AttributeString(s"this.column$idx")
      }.toMap

      val config: MethodConfiguration = MethodConfiguration("namespace", "name", None, None, manyinputs, Map(),
        MethodRepoMethod("methodNamespace", "methodName", 1))
      val configJsonString: String = config.toJson.prettyPrint
      val testBytes: Array[Byte] = configJsonString.getBytes
      val byteString: ByteString = new ByteStringBuilder().putBytes(testBytes).result()
      val byteSource: Source[ByteString, Any] = Source.apply(List(byteString))
      val ent = HttpEntity.apply(ContentTypes.`application/json`, testBytes.length.toLong, byteSource)
      assert(ent.isDefault(), "test setup incorrect; fixture entity not of type HttpEntity.Default")

      stubRawlsService(HttpMethods.POST, methodconfigsPath, ImATeapot)

      Post(methodconfigsPath, ent) ~> dummyUserIdHeaders(dummyUserId) ~> sealRoute(workspaceRoutes) ~> check {
        status should be (ImATeapot)
      }
    }
```

---

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
