### PR TITLE
[CA-1048] Fix NIH relinking by adding compatibility with new Shibboleth

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/Application.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/Application.scala
@@ -16,4 +16,5 @@ case class Application(agoraDAO: AgoraDAO,
                        researchPurposeSupport: ResearchPurposeSupport,
                        thurloeDAO: ThurloeDAO,
                        shareLogDAO: ShareLogDAO,
-                       importServiceDAO: ImportServiceDAO)
+                       importServiceDAO: ImportServiceDAO,
+                       shibbolethDAO: ShibbolethDAO)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/Boot.scala
@@ -34,8 +34,9 @@ object Boot extends App with LazyLogging {
     val searchDAO:SearchDAO = new ElasticSearchDAO(elasticSearchClient, FireCloudConfig.ElasticSearch.indexName, researchPurposeSupport)
     val shareLogDAO:ShareLogDAO = new ElasticSearchShareLogDAO(elasticSearchClient, FireCloudConfig.ElasticSearch.shareLogIndexName)
     val importServiceDAO:ImportServiceDAO = new HttpImportServiceDAO
+    val shibbolethDAO:ShibbolethDAO = new HttpShibbolethDAO
 
-    val app:Application = Application(agoraDAO, googleServicesDAO, ontologyDAO, consentDAO, rawlsDAO, samDAO, searchDAO, researchPurposeSupport, thurloeDAO, shareLogDAO, importServiceDAO);
+    val app:Application = Application(agoraDAO, googleServicesDAO, ontologyDAO, consentDAO, rawlsDAO, samDAO, searchDAO, researchPurposeSupport, thurloeDAO, shareLogDAO, importServiceDAO, shibbolethDAO);
 
     val agoraPermissionServiceConstructor: (UserInfo) => AgoraPermissionService = AgoraPermissionService.constructor(app)
     val exportEntitiesByTypeActorConstructor: (ExportEntitiesByTypeArguments) => ExportEntitiesByTypeActor = ExportEntitiesByTypeActor.constructor(app, materializer)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
@@ -131,7 +131,7 @@ object FireCloudConfig {
 
   object Shibboleth {
     private val shibboleth = config.getConfig("shibboleth")
-    val signingKey = shibboleth.getString("jwtSigningKey")
+    val publicKeyUrl = shibboleth.getString("publicKeyUrl")
   }
 
   object Nih {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpShibbolethDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpShibbolethDAO.scala
@@ -1,0 +1,19 @@
+package org.broadinstitute.dsde.firecloud.dataaccess
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
+import akka.stream.Materializer
+import org.broadinstitute.dsde.firecloud.FireCloudConfig
+import org.broadinstitute.dsde.firecloud.utils.RestJsonClient
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class HttpShibbolethDAO(implicit val system: ActorSystem, implicit val materializer: Materializer, implicit val executionContext: ExecutionContext)
+  extends ShibbolethDAO with RestJsonClient with SprayJsonSupport {
+
+  override def getPublicKey(): Future[String] = {
+    val publicKeyUrl = FireCloudConfig.Shibboleth.publicKeyUrl
+
+    unAuthedRequestToObject[String](Get(publicKeyUrl))
+  }
+}

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ShibbolethDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ShibbolethDAO.scala
@@ -1,0 +1,13 @@
+package org.broadinstitute.dsde.firecloud.dataaccess
+
+import org.broadinstitute.dsde.rawls.model.ErrorReportSource
+
+import scala.concurrent.Future
+
+trait ShibbolethDAO {
+
+  implicit val errorReportSource: ErrorReportSource = ErrorReportSource("shibboleth")
+
+  def getPublicKey(): Future[String]
+
+}

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
@@ -213,6 +213,7 @@ object ModelJsonProtocol extends WorkspaceJsonSupport with SprayJsonSupport {
   implicit val impProfileWrapper = jsonFormat2(ProfileWrapper)
   implicit val impProfileKVP = jsonFormat2(ProfileKVP)
   implicit val impTerraPreference = jsonFormat2(TerraPreference)
+  implicit val impShibbolethToken = jsonFormat2(ShibbolethToken)
 
   implicit val impJWTWrapper = jsonFormat1(JWTWrapper)
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/Profile.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/Profile.scala
@@ -120,6 +120,12 @@ case class NihLink(linkedNihUsername: String, linkExpireTime: Long) extends mapp
   require(ProfileValidator.nonEmpty(linkedNihUsername), "linkedNihUsername must be non-empty")
 }
 
+// For parsing the decoded JWT received from Shibboleth
+case class ShibbolethToken(eraCommonsUsername: String, iat: Long) {
+  // Link should expire in 30 days
+  def toNihLink: NihLink = NihLink(eraCommonsUsername, iat + 60 * 60 * 24 * 30)
+}
+
 object ProfileValidator {
   private val emailRegex = """^([\w-\+]+(?:\.[\w-\+]+)*)@((?:[\w-]+\.)*\w[\w-]{0,66})\.([a-z]{2,6}(?:\.[a-z]{2})?)$""".r
   def nonEmpty(field: String): Boolean = !field.trim.isEmpty

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/NihApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/NihApiService.scala
@@ -1,18 +1,14 @@
 package org.broadinstitute.dsde.firecloud.webservice
 
 import akka.http.scaladsl.client.RequestBuilding
-import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.{Directives, Route}
-import org.broadinstitute.dsde.firecloud.FireCloudConfig
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
 import org.broadinstitute.dsde.firecloud.model._
 import org.broadinstitute.dsde.firecloud.service.NihService
-import org.broadinstitute.dsde.firecloud.utils.{DateUtils, StandardUserInfoDirectives}
+import org.broadinstitute.dsde.firecloud.utils.StandardUserInfoDirectives
 import org.slf4j.LoggerFactory
-import pdi.jwt.{Jwt, JwtAlgorithm}
 
 import scala.concurrent.ExecutionContext
-import scala.util.{Failure, Success}
 
 trait NihApiService extends Directives with RequestBuilding with StandardUserInfoDirectives {
 
@@ -39,38 +35,7 @@ trait NihApiService extends Directives with RequestBuilding with StandardUserInf
         path("callback") {
           post {
             entity(as[JWTWrapper]) { jwtWrapper =>
-
-              // get the token from the json wrapper
-              val jwt = jwtWrapper.jwt
-
-              // validate the token.
-              // the NIH JWT is nonstandard. The claims portion of the token *should* be json, but is in fact
-              // a simple string. So, use decodeRaw here:
-              val decodeAttempt = Jwt.decodeRawAll(jwt, FireCloudConfig.Shibboleth.signingKey, Seq(JwtAlgorithm.RS256))
-
-              decodeAttempt match {
-                case Success((_, linkedNihUsername, _)) =>
-                  // The entirety of the claims portion of the jwt is the NIH username.
-
-                  // JWT standard uses epoch time for dates, so we'll follow that convention here.
-                  val linkExpireTime = DateUtils.nowPlus30Days
-
-                  val nihLink = NihLink(linkedNihUsername, linkExpireTime)
-
-                  // update this user's dbGaP access in rawls, assuming the user exists in the whitelist
-                  // and save the NIH link keys into Thurloe
-                  complete { nihServiceConstructor().UpdateNihLinkAndSyncSelf(userInfo, nihLink) }
-                case Failure(_) =>
-                  // The exception's error message contains the raw JWT. For an abundance of security, don't
-                  // log the error message - even though if we reached this point, the JWT is invalid. It could
-                  // still contain sensitive info.
-                  log.error(s"Failed to decode JWT")
-                  complete { StatusCodes.BadRequest }
-                case _ =>
-                  // this should never happen: decodeAttempt returned a type it shouldn't.
-                  log.error("Unexpected error decoding JWT")
-                  complete { StatusCodes.BadRequest }
-              }
+              complete { nihServiceConstructor().UpdateNihLinkAndSyncSelf(userInfo, jwtWrapper) }
             }
           }
         } ~

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/NihApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/NihApiService.scala
@@ -46,7 +46,7 @@ trait NihApiService extends Directives with RequestBuilding with StandardUserInf
               // validate the token.
               // the NIH JWT is nonstandard. The claims portion of the token *should* be json, but is in fact
               // a simple string. So, use decodeRaw here:
-              val decodeAttempt = Jwt.decodeRawAll(jwt, FireCloudConfig.Shibboleth.signingKey, Seq(JwtAlgorithm.HS256))
+              val decodeAttempt = Jwt.decodeRawAll(jwt, FireCloudConfig.Shibboleth.signingKey, Seq(JwtAlgorithm.RS256))
 
               decodeAttempt match {
                 case Success((_, linkedNihUsername, _)) =>

--- a/src/test/resources/reference.conf
+++ b/src/test/resources/reference.conf
@@ -46,10 +46,6 @@ firecloud {
   userAdminAccount = "fake-admin@fake.firecloud.org"
 }
 
-shibboleth {
-  jwtSigningKey = "notasecret"
-}
-
 nih {
   whitelistBucket = "firecloud-whitelist-dev"
   whitelists = {

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockShibbolethDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockShibbolethDAO.scala
@@ -1,0 +1,10 @@
+package org.broadinstitute.dsde.firecloud.dataaccess
+
+import scala.concurrent.Future
+
+class MockShibbolethDAO extends ShibbolethDAO {
+  val publicKey = "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsDPAkAwpWiO2659gPsIj\nzx9IypuiInn2F4IaCCJSxtjqRNw5g6QPJeMVjmnn3jT8CCMzvoOIOq8n7rmyog/p\npjJpq4AcVA0GjV8Nz7cWF/VwR+e/mN5CGvY4OfnCTBi5PUmywGLZMcJNhcbnka69\nexL18WwnM0d6/A/LYcmCQcI+YuakDksGAdrOn74WOrKQFa78SVOnB6Mfpf65rmu7\nTMQ66JBUuM2vIW+P1p4//+9MBSKUoGyXkbOsykBc1XYn/lLRoDCf2onYDTGjdILh\n7eSXdi6+VzgQ7j3hdkSRSj+mN2Vmq/AEWHd1lc/OQDMcRcEnRPyhwny9VW0gehyt\nWwIDAQAB\n-----END PUBLIC KEY-----"
+  override def getPublicKey(): Future[String] = {
+    Future.successful(publicKey)
+  }
+}

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/BaseServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/BaseServiceSpec.scala
@@ -21,8 +21,9 @@ class BaseServiceSpec extends ServiceSpec with BeforeAndAfter {
   val thurloeDao:MockThurloeDAO = new MockThurloeDAO
   val shareLogDao:MockShareLogDAO = new MockShareLogDAO
   val importServiceDao:MockImportServiceDAO = new MockImportServiceDAO
+  val shibbolethDao:MockShibbolethDAO = new MockShibbolethDAO
 
   val app:Application =
-    new Application(agoraDao, googleServicesDao, ontologyDao, consentDao, rawlsDao, samDao, searchDao, researchPurposeSupport, thurloeDao, shareLogDao, importServiceDao)
+    new Application(agoraDao, googleServicesDao, ontologyDao, consentDao, rawlsDao, samDao, searchDao, researchPurposeSupport, thurloeDao, shareLogDao, importServiceDao, shibbolethDao)
 
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/NihServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/NihServiceSpec.scala
@@ -16,9 +16,10 @@ class NihServiceSpec extends FlatSpec with Matchers {
   val samDao = new MockSamDAO
   val thurloeDao = new MockThurloeDAO
   val googleDao = new MockGoogleServicesDAO
+  val shibbolethDao = new MockShibbolethDAO
 
   // build the service instance we'll use for tests
-  val nihService = new NihService(samDao, thurloeDao, googleDao)
+  val nihService = new NihService(samDao, thurloeDao, googleDao, shibbolethDao)
 
   val usernames = Map("fcSubjectId1" -> "nihUsername1", "fcSubjectId2" -> "nihUsername2")
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/UserServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/UserServiceSpec.scala
@@ -15,7 +15,7 @@ import scala.concurrent.duration._
 
 class UserServiceSpec  extends BaseServiceSpec with BeforeAndAfterEach {
 
-  val customApp = Application(agoraDao, new MockGoogleServicesFailedGroupsDAO(), ontologyDao, consentDao, new MockRawlsDeleteWSDAO(), samDao, new MockSearchDeleteWSDAO(), new MockResearchPurposeSupport, thurloeDao, new MockShareLogDAO, new MockImportServiceDAO)
+  val customApp = Application(agoraDao, new MockGoogleServicesFailedGroupsDAO(), ontologyDao, consentDao, new MockRawlsDeleteWSDAO(), samDao, new MockSearchDeleteWSDAO(), new MockResearchPurposeSupport, thurloeDao, new MockShareLogDAO, new MockImportServiceDAO, shibbolethDao)
 
   val userServiceConstructor: (UserInfo) => UserService = UserService.constructor(customApp)
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceServiceSpec.scala
@@ -16,7 +16,7 @@ import scala.concurrent.{Await, ExecutionContext, Future}
 
 class WorkspaceServiceSpec extends BaseServiceSpec with BeforeAndAfterEach {
 
-  val customApp = Application(agoraDao, googleServicesDao, ontologyDao, consentDao, new MockRawlsDeleteWSDAO(), samDao, new MockSearchDeleteWSDAO(), new MockResearchPurposeSupport, thurloeDao, new MockShareLogDAO, new MockImportServiceDAO)
+  val customApp = Application(agoraDao, googleServicesDao, ontologyDao, consentDao, new MockRawlsDeleteWSDAO(), samDao, new MockSearchDeleteWSDAO(), new MockResearchPurposeSupport, thurloeDao, new MockShareLogDAO, new MockImportServiceDAO, shibbolethDao)
 
   val workspaceServiceConstructor: (WithAccessToken) => WorkspaceService = WorkspaceService.constructor(customApp)
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/ApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/ApiServiceSpec.scala
@@ -35,11 +35,12 @@ trait ApiServiceSpec extends FlatSpec with Matchers with ScalatestRouteTest with
     val thurloeDao: MockThurloeDAO
     val shareLogDao: MockShareLogDAO
     val importServiceDao: ImportServiceDAO
+    val shibbolethDao: ShibbolethDAO
 
     def actorRefFactory = system
 
     val nihServiceConstructor = NihService.constructor(
-      new Application(agoraDao, googleDao, ontologyDao, consentDao, rawlsDao, samDao, searchDao, researchPurposeSupport, thurloeDao, shareLogDao, importServiceDao)
+      new Application(agoraDao, googleDao, ontologyDao, consentDao, rawlsDao, samDao, searchDao, researchPurposeSupport, thurloeDao, shareLogDao, importServiceDao, shibbolethDao)
     ) _
 
   }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/NihApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/NihApiServiceSpec.scala
@@ -36,129 +36,129 @@ class NihApiServiceSpec extends ApiServiceSpec {
     testCode(apiService)
   }
 
-  "NihApiService" should "return NotFound when GET-ting a profile with no NIH username" in withDefaultApiServices { services =>
-    val toLink = WorkbenchEmail(services.thurloeDao.TCGA_AND_TARGET_UNLINKED)
-
-    Get("/nih/status") ~> dummyUserIdHeaders(toLink.value, "access_token", toLink.value) ~> sealRoute(services.nihRoutes) ~> check {
-      status should equal(NotFound)
-    }
-  }
-
-  it should "return NotFound when GET-ting a non-existent profile" in withDefaultApiServices { services =>
-    Get("/nih/status") ~> dummyUserIdHeaders("userThatDoesntExist") ~> sealRoute(services.nihRoutes) ~> check {
-      status should equal(NotFound)
-    }
-  }
-
-  it should "return BadRequest when NIH linking with an invalid JWT" in withDefaultApiServices { services =>
-    val toLink = WorkbenchEmail(services.thurloeDao.TCGA_AND_TARGET_UNLINKED)
-
-    Post("/nih/callback", JWTWrapper("bad-token")) ~> dummyUserIdHeaders(toLink.value, "access_token", toLink.value) ~> sealRoute(services.nihRoutes) ~> check {
-      status should equal(BadRequest)
-      assert(!services.samDao.groups(tcgaDbGaPAuthorized).contains(toLink))
-      assert(!services.samDao.groups(targetDbGaPAuthorized).contains(toLink))
-    }
-  }
-
-  it should "link and sync when user is on TCGA whitelist but not TARGET" in withDefaultApiServices { services =>
-    val toLink = WorkbenchEmail(services.thurloeDao.TCGA_UNLINKED)
-
-    assert(!services.samDao.groups(targetDbGaPAuthorized).contains(toLink))
-    assert(!services.samDao.groups(tcgaDbGaPAuthorized).contains(toLink))
-    Post("/nih/callback", tcgaUserJwt) ~> dummyUserIdHeaders(toLink.value, "access_token", toLink.value) ~> sealRoute(services.nihRoutes) ~> check {
-      status should equal(OK)
-      assert(!services.samDao.groups(targetDbGaPAuthorized).contains(toLink))
-      assert(services.samDao.groups(tcgaDbGaPAuthorized).contains(toLink))
-    }
-  }
-
-  it should "link and sync when user is on TARGET whitelist but not TCGA" in withDefaultApiServices { services =>
-    val toLink = WorkbenchEmail(services.thurloeDao.TARGET_UNLINKED)
-
-    assert(!services.samDao.groups(targetDbGaPAuthorized).contains(toLink))
-    assert(!services.samDao.groups(tcgaDbGaPAuthorized).contains(toLink))
-    Post("/nih/callback", targetUserJwt) ~> dummyUserIdHeaders(toLink.value, "access_token", toLink.value) ~> sealRoute(services.nihRoutes) ~> check {
-      status should equal(OK)
-      assert(services.samDao.groups(targetDbGaPAuthorized).contains(toLink))
-      assert(!services.samDao.groups(tcgaDbGaPAuthorized).contains(toLink))
-    }
-  }
-
-  it should "link and sync when user is on both the TARGET and TCGA whitelists" in withDefaultApiServices { services =>
-    val toLink = WorkbenchEmail(services.thurloeDao.TCGA_AND_TARGET_UNLINKED)
-
-    assert(!services.samDao.groups(targetDbGaPAuthorized).contains(toLink))
-    assert(!services.samDao.groups(tcgaDbGaPAuthorized).contains(toLink))
-    Post("/nih/callback", firecloudDevJwt) ~> dummyUserIdHeaders(toLink.value, "access_token", toLink.value) ~> sealRoute(services.nihRoutes) ~> check {
-      status should equal(OK)
-      assert(services.samDao.groups(targetDbGaPAuthorized).contains(toLink))
-      assert(services.samDao.groups(tcgaDbGaPAuthorized).contains(toLink))
-    }
-  }
-
-  it should "link but not sync when user is on neither the TARGET nor the TCGA whitelist" in withDefaultApiServices { services =>
-    val toLink = WorkbenchEmail(services.thurloeDao.TCGA_AND_TARGET_UNLINKED)
-
-    Post("/nih/callback", validJwtNotOnWhitelist) ~> dummyUserIdHeaders(toLink.value, "access_token", toLink.value) ~> sealRoute(services.nihRoutes) ~> check {
-      status should equal(OK)
-      assert(!services.samDao.groups(tcgaDbGaPAuthorized).contains(toLink))
-      assert(!services.samDao.groups(targetDbGaPAuthorized).contains(toLink))
-    }
-  }
-
-  it should "return OK when an expired user re-links. their new link time should be 30 days in the future" in withDefaultApiServices { services =>
-    //verify that their link is indeed already expired
-    val toLink = WorkbenchEmail(services.thurloeDao.TCGA_AND_TARGET_LINKED_EXPIRED)
-
-    Get("/nih/status") ~> dummyUserIdHeaders(toLink.value, "access_token", toLink.value) ~> sealRoute(services.nihRoutes) ~> check {
-      status should equal(OK)
-      assert(responseAs[NihStatus].linkExpireTime.get < DateUtils.now)
-    }
-
-    //link them using a valid JWT for a user on the whitelist
-    Post("/nih/callback", firecloudDevJwt) ~> dummyUserIdHeaders(toLink.value, "access_token", toLink.value) ~> sealRoute(services.nihRoutes) ~> check {
-      status should equal(OK)
-    }
-
-    //verify that their link expiration has been updated
-    Get("/nih/status") ~> dummyUserIdHeaders(toLink.value, "access_token", toLink.value) ~> sealRoute(services.nihRoutes) ~> check {
-      status should equal(OK)
-      val linkExpireTime = responseAs[NihStatus].linkExpireTime.get
-
-      assert(linkExpireTime >= DateUtils.nowMinus1Hour) //link expire time is fresh
-      assert(linkExpireTime <= DateUtils.nowPlus30Days) //link expire time is approx 30 days in the future
-      assert(services.samDao.groups(tcgaDbGaPAuthorized).contains(toLink))
-      assert(services.samDao.groups(targetDbGaPAuthorized).contains(toLink))
-    }
-  }
-
-  /* Test scenario:
-     1 user that is linked but their TCGA access has expired. they should be removed from the TCGA group
-     1 user that is linked but their TARGET access has expired. they should be removed from the TARGET group
-     1 user that is linked but they have no expiration date stored in their profile. they should be removed from the TCGA group
-     1 user that is linked but their TCGA and TARGET access has expired. they should be removed from the TARGET and TCGA groups
-     1 user that is linked and has active TCGA access. they should remain in the TCGA group
-     1 user that is linked and has active TARGET access. they should remain in the TARGET group
-     1 user that is linked and has active TARGET & TCGA access. they should remain in the TARGET and TCGA groups
-   */
-  it should "return NoContent and properly sync the whitelist for users of different link statuses across whitelists" in withDefaultApiServices { services =>
-    Post("/sync_whitelist") ~> sealRoute(services.syncRoute) ~> check {
-      status should equal(NoContent)
-      assertSameElements(Set(services.thurloeDao.TCGA_AND_TARGET_LINKED, services.thurloeDao.TCGA_LINKED), services.samDao.groups(tcgaDbGaPAuthorized).map(_.value))
-      assertSameElements(Set(services.thurloeDao.TCGA_AND_TARGET_LINKED, services.thurloeDao.TARGET_LINKED), services.samDao.groups(targetDbGaPAuthorized).map(_.value))
-    }
-  }
-
-  it should "return NoContent and properly sync a single whitelist" in withDefaultApiServices { services =>
-    Post("/sync_whitelist/TCGA") ~> sealRoute(services.syncRoute) ~> check {
-      status should equal(NoContent)
-      assertSameElements(Set(services.thurloeDao.TCGA_AND_TARGET_LINKED, services.thurloeDao.TCGA_LINKED), services.samDao.groups(tcgaDbGaPAuthorized).map(_.value))
-    }
-  }
-
-  it should "return NotFound for unknown whitelist" in withDefaultApiServices { services =>
-    Post("/sync_whitelist/foobar") ~> sealRoute(services.syncRoute) ~> check {
-      status should equal(NotFound)
-    }
-  }
+//  "NihApiService" should "return NotFound when GET-ting a profile with no NIH username" in withDefaultApiServices { services =>
+//    val toLink = WorkbenchEmail(services.thurloeDao.TCGA_AND_TARGET_UNLINKED)
+//
+//    Get("/nih/status") ~> dummyUserIdHeaders(toLink.value, "access_token", toLink.value) ~> sealRoute(services.nihRoutes) ~> check {
+//      status should equal(NotFound)
+//    }
+//  }
+//
+//  it should "return NotFound when GET-ting a non-existent profile" in withDefaultApiServices { services =>
+//    Get("/nih/status") ~> dummyUserIdHeaders("userThatDoesntExist") ~> sealRoute(services.nihRoutes) ~> check {
+//      status should equal(NotFound)
+//    }
+//  }
+//
+//  it should "return BadRequest when NIH linking with an invalid JWT" in withDefaultApiServices { services =>
+//    val toLink = WorkbenchEmail(services.thurloeDao.TCGA_AND_TARGET_UNLINKED)
+//
+//    Post("/nih/callback", JWTWrapper("bad-token")) ~> dummyUserIdHeaders(toLink.value, "access_token", toLink.value) ~> sealRoute(services.nihRoutes) ~> check {
+//      status should equal(BadRequest)
+//      assert(!services.samDao.groups(tcgaDbGaPAuthorized).contains(toLink))
+//      assert(!services.samDao.groups(targetDbGaPAuthorized).contains(toLink))
+//    }
+//  }
+//
+//  it should "link and sync when user is on TCGA whitelist but not TARGET" in withDefaultApiServices { services =>
+//    val toLink = WorkbenchEmail(services.thurloeDao.TCGA_UNLINKED)
+//
+//    assert(!services.samDao.groups(targetDbGaPAuthorized).contains(toLink))
+//    assert(!services.samDao.groups(tcgaDbGaPAuthorized).contains(toLink))
+//    Post("/nih/callback", tcgaUserJwt) ~> dummyUserIdHeaders(toLink.value, "access_token", toLink.value) ~> sealRoute(services.nihRoutes) ~> check {
+//      status should equal(OK)
+//      assert(!services.samDao.groups(targetDbGaPAuthorized).contains(toLink))
+//      assert(services.samDao.groups(tcgaDbGaPAuthorized).contains(toLink))
+//    }
+//  }
+//
+//  it should "link and sync when user is on TARGET whitelist but not TCGA" in withDefaultApiServices { services =>
+//    val toLink = WorkbenchEmail(services.thurloeDao.TARGET_UNLINKED)
+//
+//    assert(!services.samDao.groups(targetDbGaPAuthorized).contains(toLink))
+//    assert(!services.samDao.groups(tcgaDbGaPAuthorized).contains(toLink))
+//    Post("/nih/callback", targetUserJwt) ~> dummyUserIdHeaders(toLink.value, "access_token", toLink.value) ~> sealRoute(services.nihRoutes) ~> check {
+//      status should equal(OK)
+//      assert(services.samDao.groups(targetDbGaPAuthorized).contains(toLink))
+//      assert(!services.samDao.groups(tcgaDbGaPAuthorized).contains(toLink))
+//    }
+//  }
+//
+//  it should "link and sync when user is on both the TARGET and TCGA whitelists" in withDefaultApiServices { services =>
+//    val toLink = WorkbenchEmail(services.thurloeDao.TCGA_AND_TARGET_UNLINKED)
+//
+//    assert(!services.samDao.groups(targetDbGaPAuthorized).contains(toLink))
+//    assert(!services.samDao.groups(tcgaDbGaPAuthorized).contains(toLink))
+//    Post("/nih/callback", firecloudDevJwt) ~> dummyUserIdHeaders(toLink.value, "access_token", toLink.value) ~> sealRoute(services.nihRoutes) ~> check {
+//      status should equal(OK)
+//      assert(services.samDao.groups(targetDbGaPAuthorized).contains(toLink))
+//      assert(services.samDao.groups(tcgaDbGaPAuthorized).contains(toLink))
+//    }
+//  }
+//
+//  it should "link but not sync when user is on neither the TARGET nor the TCGA whitelist" in withDefaultApiServices { services =>
+//    val toLink = WorkbenchEmail(services.thurloeDao.TCGA_AND_TARGET_UNLINKED)
+//
+//    Post("/nih/callback", validJwtNotOnWhitelist) ~> dummyUserIdHeaders(toLink.value, "access_token", toLink.value) ~> sealRoute(services.nihRoutes) ~> check {
+//      status should equal(OK)
+//      assert(!services.samDao.groups(tcgaDbGaPAuthorized).contains(toLink))
+//      assert(!services.samDao.groups(targetDbGaPAuthorized).contains(toLink))
+//    }
+//  }
+//
+//  it should "return OK when an expired user re-links. their new link time should be 30 days in the future" in withDefaultApiServices { services =>
+//    //verify that their link is indeed already expired
+//    val toLink = WorkbenchEmail(services.thurloeDao.TCGA_AND_TARGET_LINKED_EXPIRED)
+//
+//    Get("/nih/status") ~> dummyUserIdHeaders(toLink.value, "access_token", toLink.value) ~> sealRoute(services.nihRoutes) ~> check {
+//      status should equal(OK)
+//      assert(responseAs[NihStatus].linkExpireTime.get < DateUtils.now)
+//    }
+//
+//    //link them using a valid JWT for a user on the whitelist
+//    Post("/nih/callback", firecloudDevJwt) ~> dummyUserIdHeaders(toLink.value, "access_token", toLink.value) ~> sealRoute(services.nihRoutes) ~> check {
+//      status should equal(OK)
+//    }
+//
+//    //verify that their link expiration has been updated
+//    Get("/nih/status") ~> dummyUserIdHeaders(toLink.value, "access_token", toLink.value) ~> sealRoute(services.nihRoutes) ~> check {
+//      status should equal(OK)
+//      val linkExpireTime = responseAs[NihStatus].linkExpireTime.get
+//
+//      assert(linkExpireTime >= DateUtils.nowMinus1Hour) //link expire time is fresh
+//      assert(linkExpireTime <= DateUtils.nowPlus30Days) //link expire time is approx 30 days in the future
+//      assert(services.samDao.groups(tcgaDbGaPAuthorized).contains(toLink))
+//      assert(services.samDao.groups(targetDbGaPAuthorized).contains(toLink))
+//    }
+//  }
+//
+//  /* Test scenario:
+//     1 user that is linked but their TCGA access has expired. they should be removed from the TCGA group
+//     1 user that is linked but their TARGET access has expired. they should be removed from the TARGET group
+//     1 user that is linked but they have no expiration date stored in their profile. they should be removed from the TCGA group
+//     1 user that is linked but their TCGA and TARGET access has expired. they should be removed from the TARGET and TCGA groups
+//     1 user that is linked and has active TCGA access. they should remain in the TCGA group
+//     1 user that is linked and has active TARGET access. they should remain in the TARGET group
+//     1 user that is linked and has active TARGET & TCGA access. they should remain in the TARGET and TCGA groups
+//   */
+//  it should "return NoContent and properly sync the whitelist for users of different link statuses across whitelists" in withDefaultApiServices { services =>
+//    Post("/sync_whitelist") ~> sealRoute(services.syncRoute) ~> check {
+//      status should equal(NoContent)
+//      assertSameElements(Set(services.thurloeDao.TCGA_AND_TARGET_LINKED, services.thurloeDao.TCGA_LINKED), services.samDao.groups(tcgaDbGaPAuthorized).map(_.value))
+//      assertSameElements(Set(services.thurloeDao.TCGA_AND_TARGET_LINKED, services.thurloeDao.TARGET_LINKED), services.samDao.groups(targetDbGaPAuthorized).map(_.value))
+//    }
+//  }
+//
+//  it should "return NoContent and properly sync a single whitelist" in withDefaultApiServices { services =>
+//    Post("/sync_whitelist/TCGA") ~> sealRoute(services.syncRoute) ~> check {
+//      status should equal(NoContent)
+//      assertSameElements(Set(services.thurloeDao.TCGA_AND_TARGET_LINKED, services.thurloeDao.TCGA_LINKED), services.samDao.groups(tcgaDbGaPAuthorized).map(_.value))
+//    }
+//  }
+//
+//  it should "return NotFound for unknown whitelist" in withDefaultApiServices { services =>
+//    Post("/sync_whitelist/foobar") ~> sealRoute(services.syncRoute) ~> check {
+//      status should equal(NotFound)
+//    }
+//  }
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/NihApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/NihApiServiceSpec.scala
@@ -17,148 +17,149 @@ class NihApiServiceSpec extends ApiServiceSpec {
   val tcgaDbGaPAuthorized = FireCloudConfig.Nih.whitelists.filter(_.name.equals("TCGA")).head.groupToSync
   val targetDbGaPAuthorized = FireCloudConfig.Nih.whitelists.filter(_.name.equals("TARGET")).head.groupToSync
 
+  // These tokens were encoded using the private key that pairs with the public key in MockShibbolethDAO
   //JWT for NIH username "firecloud-dev"
-  val firecloudDevJwt = JWTWrapper("eyJhbGciOiJIUzI1NiJ9.ZmlyZWNsb3VkLWRldg.NPXbSpTmAOUvJ1HX85TauAARnlMKfqBsPjumCC7zE7s")
+  val firecloudDevJwt = JWTWrapper("eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJlcmFDb21tb25zVXNlcm5hbWUiOiJmaXJlY2xvdWQtZGV2IiwiaWF0IjoxNjEyMjE4NzE2fQ.rObTxJcplho3AxI6oENAr4Km8O8XThUNu_fWnHspsLtuOlbMIBr3Cxp7gTKzI0raLY5oKNuHal9f6q4QS4aYzUq4E8IbuWHAA51wSevFvv7kzGy9fmdl757pYDwHXEeTKoTQa4enlcGAL3VSIHYLSrEy-PhYo3om_sXcsX86oVW4ogn79CoF4dTrLTSu9f9MWrwIxkbtXb-OUQaUGY6Tzhw_qdthcUbvC1cww00D-Tfx13oKVTGCv4wMiPXIbSjObQMTFJRuBzRpFUy4OWyq0AihSvSrbT47kTU4bw21QKavJMVlylwpmV60na310okEoHsOeGgnA0HlsJI55M8WrQ")
 
   //JWT for NIH username "tcga-user"
-  val tcgaUserJwt = JWTWrapper("eyJhbGciOiJIUzI1NiJ9.dGNnYS11c2Vy.js6xodKBskGhcvetna7N1t6ltZ71WJkgs1ucIwm0Mss")
+  val tcgaUserJwt = JWTWrapper("eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJlcmFDb21tb25zVXNlcm5hbWUiOiJ0Y2dhLXVzZXIiLCJpYXQiOjE2MTIyMTg3MzZ9.JbKZ7vRnD9iACOM9SCCnccoLy5RV78PvOHqcctshBzVjNKXX2xOyFcAo9iEwLoEq478a-WprrxTmHz8JcKSacMIFHSAy1EAcfEl9bUnbnt9qNTUFPrVFCsBMABw2CutMFdNDp3YdkBWa5wkRieb6uOf5ml6tnwFL6T-3ZIysl04XG_bUwsRFqLiMYX9ilVlDTvu67p2HKkhwbIpxFMTlZYPkWTeGqEkiS1_e-NKbk0Oh9ipCqglVxCzyBlh8XnkpggjUJ6V6Jc5wHctdu3RyOw9M0VY56nVGgAM86u-Uy6L32iavu50xHW3htOHRhtUOfqA0jKvq77rnZ1eyykvAjA")
 
   //JWT for NIH username "target-user"
-  val targetUserJwt = JWTWrapper("eyJhbGciOiJIUzI1NiJ9.dGFyZ2V0LXVzZXI.afm1xC0XfV0c_V34cy727P2-rlQQNbFhCFkEsDKwqH8")
+  val targetUserJwt = JWTWrapper("eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJlcmFDb21tb25zVXNlcm5hbWUiOiJ0YXJnZXQtdXNlciIsImlhdCI6MTYxMjIxODc1NH0.Tl5mNwExOcJMcWe3eEdihnUPOk5411Hi4DyVbjqqi3_RLy4TDtPr7h9RtUwHU7bvx7p1l0M78L9G1SqJiD_NB_GK8TttPLNncy9JLEeKYOglHA4ZI9BbBTEggym-axUherSZ8W2UuXzRruZ8K4NkVPyvJmmWc86iCdCTQd8ETxahwgGL5_PTvPtbg-XsASmjbrmAMN8r9_fhB_lU9ltRvbVCMmk34SNBQk8f5FISmW4zVfMVRy00Sx-UYASJzT5CJneiGAHNVGJCilFCs_626KP5YiVqg3tdEcz7O5Om0UDHQY07HZCaESO31FiVv1R3k1xy6rFzn_brwXWhMQGrYA")
 
   //JWT for NIH username "not-on-whitelist" (don't ever add this to the mock whitelists in MockGoogleServicesDAO.scala)
-  val validJwtNotOnWhitelist = JWTWrapper("eyJhbGciOiJIUzI1NiJ9.bm90LW9uLXdoaXRlbGlzdA.DayvfECuGAQsXx-MEwXiuQyq86Eqc3Lmn46_9BGs6t0")
+  val validJwtNotOnWhitelist = JWTWrapper("eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJlcmFDb21tb25zVXNlcm5hbWUiOiJub3Qtb24td2hpdGVsaXN0IiwiaWF0IjoxNjEyMjE4ODExfQ.OnVGz_9QJ5MhQbnDgz85sUDpFuSpLP0iMZymUNyIQX6I9wB_Q64yNMS34uq3tX33vioJ4HELWHtUssARXRn8YUntPm5tQO_pTLKuklx8V3HQXlvB_lN7lPAHR8EHY3NhYQsdxHnWfra7ZetmiakKmTu8AH3Lc6WOFUh18j4L-6nUKUW8mLY4hDMtAiAYMi6SIy4eISuuOVH3305gbqDKZOqNGfvzM19Vq7Gk5_zqEdRrQ9wYr_kDRIm7Sgok6Cd6GEF5FzILGWdXh2YKhzd_nVZR4aMb82NWUYSLgULpjX55kGxYWYI9pLbNPp97hB9qIE3-vufYoBc7PRnsAkpNCw")
 
-  case class TestApiService(agoraDao: MockAgoraDAO, googleDao: MockGoogleServicesDAO, ontologyDao: MockOntologyDAO, consentDao: MockConsentDAO, rawlsDao: MockRawlsDAO, samDao: MockSamDAO, searchDao: MockSearchDAO, researchPurposeSupport: MockResearchPurposeSupport, thurloeDao: MockThurloeDAO, shareLogDao: MockShareLogDAO, importServiceDao: MockImportServiceDAO)(implicit val executionContext: ExecutionContext) extends ApiServices
+  case class TestApiService(agoraDao: MockAgoraDAO, googleDao: MockGoogleServicesDAO, ontologyDao: MockOntologyDAO, consentDao: MockConsentDAO, rawlsDao: MockRawlsDAO, samDao: MockSamDAO, searchDao: MockSearchDAO, researchPurposeSupport: MockResearchPurposeSupport, thurloeDao: MockThurloeDAO, shareLogDao: MockShareLogDAO, importServiceDao: MockImportServiceDAO, shibbolethDao: MockShibbolethDAO)(implicit val executionContext: ExecutionContext) extends ApiServices
 
   def withDefaultApiServices[T](testCode: TestApiService => T): T = {
-    val apiService = TestApiService(new MockAgoraDAO, new MockGoogleServicesDAO, new MockOntologyDAO, new MockConsentDAO, new MockRawlsDAO, new MockSamDAO, new MockSearchDAO, new MockResearchPurposeSupport, new MockThurloeDAO, new MockShareLogDAO, new MockImportServiceDAO)
+    val apiService = TestApiService(new MockAgoraDAO, new MockGoogleServicesDAO, new MockOntologyDAO, new MockConsentDAO, new MockRawlsDAO, new MockSamDAO, new MockSearchDAO, new MockResearchPurposeSupport, new MockThurloeDAO, new MockShareLogDAO, new MockImportServiceDAO, new MockShibbolethDAO)
     testCode(apiService)
   }
 
-//  "NihApiService" should "return NotFound when GET-ting a profile with no NIH username" in withDefaultApiServices { services =>
-//    val toLink = WorkbenchEmail(services.thurloeDao.TCGA_AND_TARGET_UNLINKED)
-//
-//    Get("/nih/status") ~> dummyUserIdHeaders(toLink.value, "access_token", toLink.value) ~> sealRoute(services.nihRoutes) ~> check {
-//      status should equal(NotFound)
-//    }
-//  }
-//
-//  it should "return NotFound when GET-ting a non-existent profile" in withDefaultApiServices { services =>
-//    Get("/nih/status") ~> dummyUserIdHeaders("userThatDoesntExist") ~> sealRoute(services.nihRoutes) ~> check {
-//      status should equal(NotFound)
-//    }
-//  }
-//
-//  it should "return BadRequest when NIH linking with an invalid JWT" in withDefaultApiServices { services =>
-//    val toLink = WorkbenchEmail(services.thurloeDao.TCGA_AND_TARGET_UNLINKED)
-//
-//    Post("/nih/callback", JWTWrapper("bad-token")) ~> dummyUserIdHeaders(toLink.value, "access_token", toLink.value) ~> sealRoute(services.nihRoutes) ~> check {
-//      status should equal(BadRequest)
-//      assert(!services.samDao.groups(tcgaDbGaPAuthorized).contains(toLink))
-//      assert(!services.samDao.groups(targetDbGaPAuthorized).contains(toLink))
-//    }
-//  }
-//
-//  it should "link and sync when user is on TCGA whitelist but not TARGET" in withDefaultApiServices { services =>
-//    val toLink = WorkbenchEmail(services.thurloeDao.TCGA_UNLINKED)
-//
-//    assert(!services.samDao.groups(targetDbGaPAuthorized).contains(toLink))
-//    assert(!services.samDao.groups(tcgaDbGaPAuthorized).contains(toLink))
-//    Post("/nih/callback", tcgaUserJwt) ~> dummyUserIdHeaders(toLink.value, "access_token", toLink.value) ~> sealRoute(services.nihRoutes) ~> check {
-//      status should equal(OK)
-//      assert(!services.samDao.groups(targetDbGaPAuthorized).contains(toLink))
-//      assert(services.samDao.groups(tcgaDbGaPAuthorized).contains(toLink))
-//    }
-//  }
-//
-//  it should "link and sync when user is on TARGET whitelist but not TCGA" in withDefaultApiServices { services =>
-//    val toLink = WorkbenchEmail(services.thurloeDao.TARGET_UNLINKED)
-//
-//    assert(!services.samDao.groups(targetDbGaPAuthorized).contains(toLink))
-//    assert(!services.samDao.groups(tcgaDbGaPAuthorized).contains(toLink))
-//    Post("/nih/callback", targetUserJwt) ~> dummyUserIdHeaders(toLink.value, "access_token", toLink.value) ~> sealRoute(services.nihRoutes) ~> check {
-//      status should equal(OK)
-//      assert(services.samDao.groups(targetDbGaPAuthorized).contains(toLink))
-//      assert(!services.samDao.groups(tcgaDbGaPAuthorized).contains(toLink))
-//    }
-//  }
-//
-//  it should "link and sync when user is on both the TARGET and TCGA whitelists" in withDefaultApiServices { services =>
-//    val toLink = WorkbenchEmail(services.thurloeDao.TCGA_AND_TARGET_UNLINKED)
-//
-//    assert(!services.samDao.groups(targetDbGaPAuthorized).contains(toLink))
-//    assert(!services.samDao.groups(tcgaDbGaPAuthorized).contains(toLink))
-//    Post("/nih/callback", firecloudDevJwt) ~> dummyUserIdHeaders(toLink.value, "access_token", toLink.value) ~> sealRoute(services.nihRoutes) ~> check {
-//      status should equal(OK)
-//      assert(services.samDao.groups(targetDbGaPAuthorized).contains(toLink))
-//      assert(services.samDao.groups(tcgaDbGaPAuthorized).contains(toLink))
-//    }
-//  }
-//
-//  it should "link but not sync when user is on neither the TARGET nor the TCGA whitelist" in withDefaultApiServices { services =>
-//    val toLink = WorkbenchEmail(services.thurloeDao.TCGA_AND_TARGET_UNLINKED)
-//
-//    Post("/nih/callback", validJwtNotOnWhitelist) ~> dummyUserIdHeaders(toLink.value, "access_token", toLink.value) ~> sealRoute(services.nihRoutes) ~> check {
-//      status should equal(OK)
-//      assert(!services.samDao.groups(tcgaDbGaPAuthorized).contains(toLink))
-//      assert(!services.samDao.groups(targetDbGaPAuthorized).contains(toLink))
-//    }
-//  }
-//
-//  it should "return OK when an expired user re-links. their new link time should be 30 days in the future" in withDefaultApiServices { services =>
-//    //verify that their link is indeed already expired
-//    val toLink = WorkbenchEmail(services.thurloeDao.TCGA_AND_TARGET_LINKED_EXPIRED)
-//
-//    Get("/nih/status") ~> dummyUserIdHeaders(toLink.value, "access_token", toLink.value) ~> sealRoute(services.nihRoutes) ~> check {
-//      status should equal(OK)
-//      assert(responseAs[NihStatus].linkExpireTime.get < DateUtils.now)
-//    }
-//
-//    //link them using a valid JWT for a user on the whitelist
-//    Post("/nih/callback", firecloudDevJwt) ~> dummyUserIdHeaders(toLink.value, "access_token", toLink.value) ~> sealRoute(services.nihRoutes) ~> check {
-//      status should equal(OK)
-//    }
-//
-//    //verify that their link expiration has been updated
-//    Get("/nih/status") ~> dummyUserIdHeaders(toLink.value, "access_token", toLink.value) ~> sealRoute(services.nihRoutes) ~> check {
-//      status should equal(OK)
-//      val linkExpireTime = responseAs[NihStatus].linkExpireTime.get
-//
-//      assert(linkExpireTime >= DateUtils.nowMinus1Hour) //link expire time is fresh
-//      assert(linkExpireTime <= DateUtils.nowPlus30Days) //link expire time is approx 30 days in the future
-//      assert(services.samDao.groups(tcgaDbGaPAuthorized).contains(toLink))
-//      assert(services.samDao.groups(targetDbGaPAuthorized).contains(toLink))
-//    }
-//  }
-//
-//  /* Test scenario:
-//     1 user that is linked but their TCGA access has expired. they should be removed from the TCGA group
-//     1 user that is linked but their TARGET access has expired. they should be removed from the TARGET group
-//     1 user that is linked but they have no expiration date stored in their profile. they should be removed from the TCGA group
-//     1 user that is linked but their TCGA and TARGET access has expired. they should be removed from the TARGET and TCGA groups
-//     1 user that is linked and has active TCGA access. they should remain in the TCGA group
-//     1 user that is linked and has active TARGET access. they should remain in the TARGET group
-//     1 user that is linked and has active TARGET & TCGA access. they should remain in the TARGET and TCGA groups
-//   */
-//  it should "return NoContent and properly sync the whitelist for users of different link statuses across whitelists" in withDefaultApiServices { services =>
-//    Post("/sync_whitelist") ~> sealRoute(services.syncRoute) ~> check {
-//      status should equal(NoContent)
-//      assertSameElements(Set(services.thurloeDao.TCGA_AND_TARGET_LINKED, services.thurloeDao.TCGA_LINKED), services.samDao.groups(tcgaDbGaPAuthorized).map(_.value))
-//      assertSameElements(Set(services.thurloeDao.TCGA_AND_TARGET_LINKED, services.thurloeDao.TARGET_LINKED), services.samDao.groups(targetDbGaPAuthorized).map(_.value))
-//    }
-//  }
-//
-//  it should "return NoContent and properly sync a single whitelist" in withDefaultApiServices { services =>
-//    Post("/sync_whitelist/TCGA") ~> sealRoute(services.syncRoute) ~> check {
-//      status should equal(NoContent)
-//      assertSameElements(Set(services.thurloeDao.TCGA_AND_TARGET_LINKED, services.thurloeDao.TCGA_LINKED), services.samDao.groups(tcgaDbGaPAuthorized).map(_.value))
-//    }
-//  }
-//
-//  it should "return NotFound for unknown whitelist" in withDefaultApiServices { services =>
-//    Post("/sync_whitelist/foobar") ~> sealRoute(services.syncRoute) ~> check {
-//      status should equal(NotFound)
-//    }
-//  }
+  "NihApiService" should "return NotFound when GET-ting a profile with no NIH username" in withDefaultApiServices { services =>
+    val toLink = WorkbenchEmail(services.thurloeDao.TCGA_AND_TARGET_UNLINKED)
+
+    Get("/nih/status") ~> dummyUserIdHeaders(toLink.value, "access_token", toLink.value) ~> sealRoute(services.nihRoutes) ~> check {
+      status should equal(NotFound)
+    }
+  }
+
+  it should "return NotFound when GET-ting a non-existent profile" in withDefaultApiServices { services =>
+    Get("/nih/status") ~> dummyUserIdHeaders("userThatDoesntExist") ~> sealRoute(services.nihRoutes) ~> check {
+      status should equal(NotFound)
+    }
+  }
+
+  it should "return BadRequest when NIH linking with an invalid JWT" in withDefaultApiServices { services =>
+    val toLink = WorkbenchEmail(services.thurloeDao.TCGA_AND_TARGET_UNLINKED)
+
+    Post("/nih/callback", JWTWrapper("bad-token")) ~> dummyUserIdHeaders(toLink.value, "access_token", toLink.value) ~> sealRoute(services.nihRoutes) ~> check {
+      status should equal(BadRequest)
+      assert(!services.samDao.groups(tcgaDbGaPAuthorized).contains(toLink))
+      assert(!services.samDao.groups(targetDbGaPAuthorized).contains(toLink))
+    }
+  }
+
+  it should "link and sync when user is on TCGA whitelist but not TARGET" in withDefaultApiServices { services =>
+    val toLink = WorkbenchEmail(services.thurloeDao.TCGA_UNLINKED)
+
+    assert(!services.samDao.groups(targetDbGaPAuthorized).contains(toLink))
+    assert(!services.samDao.groups(tcgaDbGaPAuthorized).contains(toLink))
+    Post("/nih/callback", tcgaUserJwt) ~> dummyUserIdHeaders(toLink.value, "access_token", toLink.value) ~> sealRoute(services.nihRoutes) ~> check {
+      status should equal(OK)
+      assert(!services.samDao.groups(targetDbGaPAuthorized).contains(toLink))
+      assert(services.samDao.groups(tcgaDbGaPAuthorized).contains(toLink))
+    }
+  }
+
+  it should "link and sync when user is on TARGET whitelist but not TCGA" in withDefaultApiServices { services =>
+    val toLink = WorkbenchEmail(services.thurloeDao.TARGET_UNLINKED)
+
+    assert(!services.samDao.groups(targetDbGaPAuthorized).contains(toLink))
+    assert(!services.samDao.groups(tcgaDbGaPAuthorized).contains(toLink))
+    Post("/nih/callback", targetUserJwt) ~> dummyUserIdHeaders(toLink.value, "access_token", toLink.value) ~> sealRoute(services.nihRoutes) ~> check {
+      status should equal(OK)
+      assert(services.samDao.groups(targetDbGaPAuthorized).contains(toLink))
+      assert(!services.samDao.groups(tcgaDbGaPAuthorized).contains(toLink))
+    }
+  }
+
+  it should "link and sync when user is on both the TARGET and TCGA whitelists" in withDefaultApiServices { services =>
+    val toLink = WorkbenchEmail(services.thurloeDao.TCGA_AND_TARGET_UNLINKED)
+
+    assert(!services.samDao.groups(targetDbGaPAuthorized).contains(toLink))
+    assert(!services.samDao.groups(tcgaDbGaPAuthorized).contains(toLink))
+    Post("/nih/callback", firecloudDevJwt) ~> dummyUserIdHeaders(toLink.value, "access_token", toLink.value) ~> sealRoute(services.nihRoutes) ~> check {
+      status should equal(OK)
+      assert(services.samDao.groups(targetDbGaPAuthorized).contains(toLink))
+      assert(services.samDao.groups(tcgaDbGaPAuthorized).contains(toLink))
+    }
+  }
+
+  it should "link but not sync when user is on neither the TARGET nor the TCGA whitelist" in withDefaultApiServices { services =>
+    val toLink = WorkbenchEmail(services.thurloeDao.TCGA_AND_TARGET_UNLINKED)
+
+    Post("/nih/callback", validJwtNotOnWhitelist) ~> dummyUserIdHeaders(toLink.value, "access_token", toLink.value) ~> sealRoute(services.nihRoutes) ~> check {
+      status should equal(OK)
+      assert(!services.samDao.groups(tcgaDbGaPAuthorized).contains(toLink))
+      assert(!services.samDao.groups(targetDbGaPAuthorized).contains(toLink))
+    }
+  }
+
+  it should "return OK when an expired user re-links. their new link time should be 30 days in the future" in withDefaultApiServices { services =>
+    //verify that their link is indeed already expired
+    val toLink = WorkbenchEmail(services.thurloeDao.TCGA_AND_TARGET_LINKED_EXPIRED)
+
+    Get("/nih/status") ~> dummyUserIdHeaders(toLink.value, "access_token", toLink.value) ~> sealRoute(services.nihRoutes) ~> check {
+      status should equal(OK)
+      assert(responseAs[NihStatus].linkExpireTime.get < DateUtils.now)
+    }
+
+    //link them using a valid JWT for a user on the whitelist
+    Post("/nih/callback", firecloudDevJwt) ~> dummyUserIdHeaders(toLink.value, "access_token", toLink.value) ~> sealRoute(services.nihRoutes) ~> check {
+      status should equal(OK)
+    }
+
+    //verify that their link expiration has been updated
+    Get("/nih/status") ~> dummyUserIdHeaders(toLink.value, "access_token", toLink.value) ~> sealRoute(services.nihRoutes) ~> check {
+      status should equal(OK)
+      val linkExpireTime = responseAs[NihStatus].linkExpireTime.get
+
+      assert(linkExpireTime >= DateUtils.nowMinus1Hour) //link expire time is fresh
+      assert(linkExpireTime <= DateUtils.nowPlus30Days) //link expire time is approx 30 days in the future
+      assert(services.samDao.groups(tcgaDbGaPAuthorized).contains(toLink))
+      assert(services.samDao.groups(targetDbGaPAuthorized).contains(toLink))
+    }
+  }
+
+  /* Test scenario:
+     1 user that is linked but their TCGA access has expired. they should be removed from the TCGA group
+     1 user that is linked but their TARGET access has expired. they should be removed from the TARGET group
+     1 user that is linked but they have no expiration date stored in their profile. they should be removed from the TCGA group
+     1 user that is linked but their TCGA and TARGET access has expired. they should be removed from the TARGET and TCGA groups
+     1 user that is linked and has active TCGA access. they should remain in the TCGA group
+     1 user that is linked and has active TARGET access. they should remain in the TARGET group
+     1 user that is linked and has active TARGET & TCGA access. they should remain in the TARGET and TCGA groups
+   */
+  it should "return NoContent and properly sync the whitelist for users of different link statuses across whitelists" in withDefaultApiServices { services =>
+    Post("/sync_whitelist") ~> sealRoute(services.syncRoute) ~> check {
+      status should equal(NoContent)
+      assertSameElements(Set(services.thurloeDao.TCGA_AND_TARGET_LINKED, services.thurloeDao.TCGA_LINKED), services.samDao.groups(tcgaDbGaPAuthorized).map(_.value))
+      assertSameElements(Set(services.thurloeDao.TCGA_AND_TARGET_LINKED, services.thurloeDao.TARGET_LINKED), services.samDao.groups(targetDbGaPAuthorized).map(_.value))
+    }
+  }
+
+  it should "return NoContent and properly sync a single whitelist" in withDefaultApiServices { services =>
+    Post("/sync_whitelist/TCGA") ~> sealRoute(services.syncRoute) ~> check {
+      status should equal(NoContent)
+      assertSameElements(Set(services.thurloeDao.TCGA_AND_TARGET_LINKED, services.thurloeDao.TCGA_LINKED), services.samDao.groups(tcgaDbGaPAuthorized).map(_.value))
+    }
+  }
+
+  it should "return NotFound for unknown whitelist" in withDefaultApiServices { services =>
+    Post("/sync_whitelist/foobar") ~> sealRoute(services.syncRoute) ~> check {
+      status should equal(NotFound)
+    }
+  }
 }


### PR DESCRIPTION
Ticket: [CA-1048](https://broadworkbench.atlassian.net/browse/CA-1048)

See corresponding firecloud-develop PR: https://github.com/broadinstitute/firecloud-develop/pull/2416
and firecloud-automated-testing PR: https://github.com/broadinstitute/firecloud-automated-testing/pull/135

New Shibboleth uses a different process to sign the JWT it returns that contains the user's NIH username. We used to use a shared private key to decrypt and verify the JWT we got from Shibboleth. Now, we can use Shibboleth's public key to verify the JWT. To do so, I added a ShibbolethDAO which just grabs the public key from Shibboleth. I also decided to move all of the JWT decryption into the service level since all of the Futures played nicely together in the for comprehension and I like having less logic in the API level.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
