### PR TITLE
exclude javax.activation from javax.mail [risk: no]

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -68,7 +68,10 @@ object Dependencies {
     "org.webjars.npm"                % "swagger-ui-dist"     % "3.35.0",
     "org.webjars"                    % "webjars-locator"     % "0.40",
     "com.pauldijou"                 %% "jwt-core"            % "3.1.0",
-    "com.sun.mail"                   % "javax.mail"          % "1.5.6",
+    // javax.mail is used only by MethodRepository.validatePublicOrEmail(). Consider
+    // refactoring that method to remove this entire dependency.
+    "com.sun.mail"                   % "javax.mail"          % "1.6.2"
+      exclude("javax.activation", "activation"),
     "com.univocity"                  % "univocity-parsers"   % "2.4.1",
     "org.ocpsoft.prettytime"         % "prettytime"          % "4.0.1.Final",
     "com.github.everit-org.json-schema" % "org.everit.json.schema" % "1.12.0",


### PR DESCRIPTION
This PR resolves problems with `sbt assembly`, e.g. https://fc-jenkins.dsp-techops.broadinstitute.org/job/firecloud-orchestration-build/1825/. due to conflicts between com.sun.activation and javax.activation.


---

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
