### PR TITLE
SA health check resiliency/logging [AS-667]

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/HealthChecks.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/HealthChecks.scala
@@ -60,8 +60,8 @@ class HealthChecks(app: Application, registerSAs: Boolean = true)
         } else {
           Future.successful(Option(s"$name already exists!"))
         }
-      case errorReport: FireCloudExceptionWithErrorReport =>
-        Future.successful(Option(s"Error on registration status for $name: ${errorReport.getMessage}"))
+      case e: FireCloudExceptionWithErrorReport =>
+        Future.successful(Option(s"Error on registration status for $name: ${e.errorReport.message} (${e.errorReport.source})"))
       case e: Exception =>
         Future.successful(Option(s"Error on registration status for $name: ${e.getMessage}"))
     }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/HealthChecks.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/HealthChecks.scala
@@ -31,8 +31,7 @@ class HealthChecks(app: Application, registerSAs: Boolean = true)
     val lookup = manageRegistration(name, app.samDAO.getRegistrationStatus(token))
     lookup flatMap {
       case Some(err) if registerSAs =>
-        logger.warn(s"SA registration lookup found: $err")
-        logger.info(s"attempting to register $name ...")
+        logger.warn(s"SA registration lookup failed; attempting to register $name. Lookup failure was: $err")
         manageRegistration(name, app.samDAO.registerUser(token))
 
       case registerMessage =>

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/HealthChecks.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/HealthChecks.scala
@@ -43,8 +43,7 @@ class HealthChecks(app: Application, registerSAs: Boolean = true)
   private def manageRegistration(name: String, req: Future[RegistrationInfo], retry: Boolean = true): Future[Option[String]] = {
     req map {
       case RegistrationInfo(_, WorkbenchEnabled(true, true, true), _) => None
-      case regInfo =>
-        Option(s"$name is registered but not fully enabled: $regInfo!")
+      case regInfo => Option(s"$name is registered but not fully enabled: $regInfo!")
     } recoverWith {
       case e: FireCloudExceptionWithErrorReport if e.errorReport.statusCode == Option(StatusCodes.NotFound) =>
         Future.successful(Option(s"$name is not registered!"))
@@ -53,8 +52,8 @@ class HealthChecks(app: Application, registerSAs: Boolean = true)
             We can reach here in the case of transient errors during the registration lookup, or in case of an
             infrequent race condition: multiple orch instances see that the SA is not registered, so they all
             attempt to register it in parallel. One registration attempt succeeds but the others find a conflict.
-            Add a retry here to get the SA's registration status once more; iif the retry lookup fails should we
-            bubble up the Conflict error.
+            Add a retry here to get the SA's registration status once more; iif the retry lookup fails, we bubble
+            up its error.
          */
         if (retry) {
           val token = AccessToken(app.googleServicesDAO.getAdminUserAccessToken)

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/NihApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/NihApiServiceSpec.scala
@@ -37,7 +37,7 @@ class NihApiServiceSpec extends ApiServiceSpec {
     testCode(apiService)
   }
 
-  "NihApiService" should "return NotFound when GET-ting a profile with no NIH username" in withDefaultApiServices { services =>
+  "NihApiService" should "return NotFound when GET-ting a profile with no NIH username" ignore withDefaultApiServices { services =>
     val toLink = WorkbenchEmail(services.thurloeDao.TCGA_AND_TARGET_UNLINKED)
 
     Get("/nih/status") ~> dummyUserIdHeaders(toLink.value, "access_token", toLink.value) ~> sealRoute(services.nihRoutes) ~> check {
@@ -45,13 +45,13 @@ class NihApiServiceSpec extends ApiServiceSpec {
     }
   }
 
-  it should "return NotFound when GET-ting a non-existent profile" in withDefaultApiServices { services =>
+  it should "return NotFound when GET-ting a non-existent profile" ignore withDefaultApiServices { services =>
     Get("/nih/status") ~> dummyUserIdHeaders("userThatDoesntExist") ~> sealRoute(services.nihRoutes) ~> check {
       status should equal(NotFound)
     }
   }
 
-  it should "return BadRequest when NIH linking with an invalid JWT" in withDefaultApiServices { services =>
+  it should "return BadRequest when NIH linking with an invalid JWT" ignore withDefaultApiServices { services =>
     val toLink = WorkbenchEmail(services.thurloeDao.TCGA_AND_TARGET_UNLINKED)
 
     Post("/nih/callback", JWTWrapper("bad-token")) ~> dummyUserIdHeaders(toLink.value, "access_token", toLink.value) ~> sealRoute(services.nihRoutes) ~> check {
@@ -61,7 +61,7 @@ class NihApiServiceSpec extends ApiServiceSpec {
     }
   }
 
-  it should "link and sync when user is on TCGA whitelist but not TARGET" in withDefaultApiServices { services =>
+  it should "link and sync when user is on TCGA whitelist but not TARGET" ignore withDefaultApiServices { services =>
     val toLink = WorkbenchEmail(services.thurloeDao.TCGA_UNLINKED)
 
     assert(!services.samDao.groups(targetDbGaPAuthorized).contains(toLink))
@@ -73,7 +73,7 @@ class NihApiServiceSpec extends ApiServiceSpec {
     }
   }
 
-  it should "link and sync when user is on TARGET whitelist but not TCGA" in withDefaultApiServices { services =>
+  it should "link and sync when user is on TARGET whitelist but not TCGA" ignore withDefaultApiServices { services =>
     val toLink = WorkbenchEmail(services.thurloeDao.TARGET_UNLINKED)
 
     assert(!services.samDao.groups(targetDbGaPAuthorized).contains(toLink))
@@ -85,7 +85,7 @@ class NihApiServiceSpec extends ApiServiceSpec {
     }
   }
 
-  it should "link and sync when user is on both the TARGET and TCGA whitelists" in withDefaultApiServices { services =>
+  it should "link and sync when user is on both the TARGET and TCGA whitelists" ignore withDefaultApiServices { services =>
     val toLink = WorkbenchEmail(services.thurloeDao.TCGA_AND_TARGET_UNLINKED)
 
     assert(!services.samDao.groups(targetDbGaPAuthorized).contains(toLink))
@@ -97,7 +97,7 @@ class NihApiServiceSpec extends ApiServiceSpec {
     }
   }
 
-  it should "link but not sync when user is on neither the TARGET nor the TCGA whitelist" in withDefaultApiServices { services =>
+  it should "link but not sync when user is on neither the TARGET nor the TCGA whitelist" ignore withDefaultApiServices { services =>
     val toLink = WorkbenchEmail(services.thurloeDao.TCGA_AND_TARGET_UNLINKED)
 
     Post("/nih/callback", validJwtNotOnWhitelist) ~> dummyUserIdHeaders(toLink.value, "access_token", toLink.value) ~> sealRoute(services.nihRoutes) ~> check {
@@ -107,7 +107,7 @@ class NihApiServiceSpec extends ApiServiceSpec {
     }
   }
 
-  it should "return OK when an expired user re-links. their new link time should be 30 days in the future" in withDefaultApiServices { services =>
+  it should "return OK when an expired user re-links. their new link time should be 30 days in the future" ignore withDefaultApiServices { services =>
     //verify that their link is indeed already expired
     val toLink = WorkbenchEmail(services.thurloeDao.TCGA_AND_TARGET_LINKED_EXPIRED)
 
@@ -142,7 +142,7 @@ class NihApiServiceSpec extends ApiServiceSpec {
      1 user that is linked and has active TARGET access. they should remain in the TARGET group
      1 user that is linked and has active TARGET & TCGA access. they should remain in the TARGET and TCGA groups
    */
-  it should "return NoContent and properly sync the whitelist for users of different link statuses across whitelists" in withDefaultApiServices { services =>
+  it should "return NoContent and properly sync the whitelist for users of different link statuses across whitelists" ignore withDefaultApiServices { services =>
     Post("/sync_whitelist") ~> sealRoute(services.syncRoute) ~> check {
       status should equal(NoContent)
       assertSameElements(Set(services.thurloeDao.TCGA_AND_TARGET_LINKED, services.thurloeDao.TCGA_LINKED), services.samDao.groups(tcgaDbGaPAuthorized).map(_.value))
@@ -150,14 +150,14 @@ class NihApiServiceSpec extends ApiServiceSpec {
     }
   }
 
-  it should "return NoContent and properly sync a single whitelist" in withDefaultApiServices { services =>
+  it should "return NoContent and properly sync a single whitelist" ignore withDefaultApiServices { services =>
     Post("/sync_whitelist/TCGA") ~> sealRoute(services.syncRoute) ~> check {
       status should equal(NoContent)
       assertSameElements(Set(services.thurloeDao.TCGA_AND_TARGET_LINKED, services.thurloeDao.TCGA_LINKED), services.samDao.groups(tcgaDbGaPAuthorized).map(_.value))
     }
   }
 
-  it should "return NotFound for unknown whitelist" in withDefaultApiServices { services =>
+  it should "return NotFound for unknown whitelist" ignore withDefaultApiServices { services =>
     Post("/sync_whitelist/foobar") ~> sealRoute(services.syncRoute) ~> check {
       status should equal(NotFound)
     }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/NihApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/NihApiServiceSpec.scala
@@ -37,7 +37,7 @@ class NihApiServiceSpec extends ApiServiceSpec {
     testCode(apiService)
   }
 
-  "NihApiService" should "return NotFound when GET-ting a profile with no NIH username" ignore withDefaultApiServices { services =>
+  "NihApiService" should "return NotFound when GET-ting a profile with no NIH username" in withDefaultApiServices { services =>
     val toLink = WorkbenchEmail(services.thurloeDao.TCGA_AND_TARGET_UNLINKED)
 
     Get("/nih/status") ~> dummyUserIdHeaders(toLink.value, "access_token", toLink.value) ~> sealRoute(services.nihRoutes) ~> check {
@@ -45,13 +45,13 @@ class NihApiServiceSpec extends ApiServiceSpec {
     }
   }
 
-  it should "return NotFound when GET-ting a non-existent profile" ignore withDefaultApiServices { services =>
+  it should "return NotFound when GET-ting a non-existent profile" in withDefaultApiServices { services =>
     Get("/nih/status") ~> dummyUserIdHeaders("userThatDoesntExist") ~> sealRoute(services.nihRoutes) ~> check {
       status should equal(NotFound)
     }
   }
 
-  it should "return BadRequest when NIH linking with an invalid JWT" ignore withDefaultApiServices { services =>
+  it should "return BadRequest when NIH linking with an invalid JWT" in withDefaultApiServices { services =>
     val toLink = WorkbenchEmail(services.thurloeDao.TCGA_AND_TARGET_UNLINKED)
 
     Post("/nih/callback", JWTWrapper("bad-token")) ~> dummyUserIdHeaders(toLink.value, "access_token", toLink.value) ~> sealRoute(services.nihRoutes) ~> check {
@@ -61,7 +61,7 @@ class NihApiServiceSpec extends ApiServiceSpec {
     }
   }
 
-  it should "link and sync when user is on TCGA whitelist but not TARGET" ignore withDefaultApiServices { services =>
+  it should "link and sync when user is on TCGA whitelist but not TARGET" in withDefaultApiServices { services =>
     val toLink = WorkbenchEmail(services.thurloeDao.TCGA_UNLINKED)
 
     assert(!services.samDao.groups(targetDbGaPAuthorized).contains(toLink))
@@ -73,7 +73,7 @@ class NihApiServiceSpec extends ApiServiceSpec {
     }
   }
 
-  it should "link and sync when user is on TARGET whitelist but not TCGA" ignore withDefaultApiServices { services =>
+  it should "link and sync when user is on TARGET whitelist but not TCGA" in withDefaultApiServices { services =>
     val toLink = WorkbenchEmail(services.thurloeDao.TARGET_UNLINKED)
 
     assert(!services.samDao.groups(targetDbGaPAuthorized).contains(toLink))
@@ -85,7 +85,7 @@ class NihApiServiceSpec extends ApiServiceSpec {
     }
   }
 
-  it should "link and sync when user is on both the TARGET and TCGA whitelists" ignore withDefaultApiServices { services =>
+  it should "link and sync when user is on both the TARGET and TCGA whitelists" in withDefaultApiServices { services =>
     val toLink = WorkbenchEmail(services.thurloeDao.TCGA_AND_TARGET_UNLINKED)
 
     assert(!services.samDao.groups(targetDbGaPAuthorized).contains(toLink))
@@ -97,7 +97,7 @@ class NihApiServiceSpec extends ApiServiceSpec {
     }
   }
 
-  it should "link but not sync when user is on neither the TARGET nor the TCGA whitelist" ignore withDefaultApiServices { services =>
+  it should "link but not sync when user is on neither the TARGET nor the TCGA whitelist" in withDefaultApiServices { services =>
     val toLink = WorkbenchEmail(services.thurloeDao.TCGA_AND_TARGET_UNLINKED)
 
     Post("/nih/callback", validJwtNotOnWhitelist) ~> dummyUserIdHeaders(toLink.value, "access_token", toLink.value) ~> sealRoute(services.nihRoutes) ~> check {
@@ -107,7 +107,7 @@ class NihApiServiceSpec extends ApiServiceSpec {
     }
   }
 
-  it should "return OK when an expired user re-links. their new link time should be 30 days in the future" ignore withDefaultApiServices { services =>
+  it should "return OK when an expired user re-links. their new link time should be 30 days in the future" in withDefaultApiServices { services =>
     //verify that their link is indeed already expired
     val toLink = WorkbenchEmail(services.thurloeDao.TCGA_AND_TARGET_LINKED_EXPIRED)
 
@@ -142,7 +142,7 @@ class NihApiServiceSpec extends ApiServiceSpec {
      1 user that is linked and has active TARGET access. they should remain in the TARGET group
      1 user that is linked and has active TARGET & TCGA access. they should remain in the TARGET and TCGA groups
    */
-  it should "return NoContent and properly sync the whitelist for users of different link statuses across whitelists" ignore withDefaultApiServices { services =>
+  it should "return NoContent and properly sync the whitelist for users of different link statuses across whitelists" in withDefaultApiServices { services =>
     Post("/sync_whitelist") ~> sealRoute(services.syncRoute) ~> check {
       status should equal(NoContent)
       assertSameElements(Set(services.thurloeDao.TCGA_AND_TARGET_LINKED, services.thurloeDao.TCGA_LINKED), services.samDao.groups(tcgaDbGaPAuthorized).map(_.value))
@@ -150,14 +150,14 @@ class NihApiServiceSpec extends ApiServiceSpec {
     }
   }
 
-  it should "return NoContent and properly sync a single whitelist" ignore withDefaultApiServices { services =>
+  it should "return NoContent and properly sync a single whitelist" in withDefaultApiServices { services =>
     Post("/sync_whitelist/TCGA") ~> sealRoute(services.syncRoute) ~> check {
       status should equal(NoContent)
       assertSameElements(Set(services.thurloeDao.TCGA_AND_TARGET_LINKED, services.thurloeDao.TCGA_LINKED), services.samDao.groups(tcgaDbGaPAuthorized).map(_.value))
     }
   }
 
-  it should "return NotFound for unknown whitelist" ignore withDefaultApiServices { services =>
+  it should "return NotFound for unknown whitelist" in withDefaultApiServices { services =>
     Post("/sync_whitelist/foobar") ~> sealRoute(services.syncRoute) ~> check {
       status should equal(NotFound)
     }


### PR DESCRIPTION
AS-667.

* modifies the low-level `RestJsonClient.resultsToObject` to bubble up detail about deserialization/unmarshalling errors. This is called from many daos/services, so it's worth attention from reviewers.
* modifies the `is_admin_sa_registered` health check to log more info, including the aforementioned newly-exposed deserialization error messages
* modifies the `is_admin_sa_registered` health check to retry one time the SA's registration lookup, if the first lookup failed but the self-healing registration attempt resulted in a 409 conflict

This PR modifies the message displayed in orch's /status API in the case where orch cannot successfully read the admin SA's registration status.  Previously, this would typically result in orch showing an "Admin SA already exists!" message, because orch tried to self-heal and register the SA after it couldn't verify it was registered. Now, orch will display the error it  encountered when trying to read the registration. For instance, if orch can't deserialize Sam's registration response, orch will display a DeserializationException message.

before:
```
'is_admin_sa_registered': {
	'messages': [
		'Admin SA already exists!'
	],
	'ok': false
}
```

after:
```
'is_admin_sa_registered': {
	'messages': [
		'Error on registration status for Admin SA: could not deserialize response: Object is missing required member 'userDetails' (Sam)'
	],
	'ok': false
}
```
