### PR TITLE
handle non-strict responses from Import Service [QA-1230]

### DIFF
--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpImportServiceDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpImportServiceDAOSpec.scala
@@ -4,9 +4,10 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
 import akka.http.scaladsl.model.StatusCodes._
 import akka.http.scaladsl.model.{ContentTypes, HttpEntity, HttpResponse}
+import akka.stream.scaladsl.Source
 import akka.util.ByteString
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol.{impImportServiceResponse, impPfbImportResponse}
-import org.broadinstitute.dsde.firecloud.model.{ImportServiceResponse, PfbImportRequest, PfbImportResponse}
+import org.broadinstitute.dsde.firecloud.model.{ImportServiceResponse, PfbImportRequest, PfbImportResponse, RequestCompleteWithErrorReport}
 import org.broadinstitute.dsde.firecloud.service.PerRequest.RequestComplete
 import org.broadinstitute.dsde.rawls.model.WorkspaceName
 import org.scalatest.flatspec.AsyncFlatSpec
@@ -27,24 +28,57 @@ class HttpImportServiceDAOSpec extends AsyncFlatSpec with Matchers with SprayJso
   val pfbUrl = "unittest-fixture-url"
   val pfbRequest = PfbImportRequest(Some(pfbUrl))
 
-  it should "return Accepted if import service returns Created" in {
-    val jobId = UUID.randomUUID()
-    val importServicePayload = ImportServiceResponse(jobId.toString, "status", None).toJson.compactPrint
+  val jobId = UUID.randomUUID()
+  val importServicePayload = ImportServiceResponse(jobId.toString, "status", None).toJson.compactPrint
 
+  val expectedSuccessPayload = PfbImportResponse(
+    pfbUrl,
+    jobId.toString,
+    WorkspaceName(workspaceNamespace, workspaceName))
+
+  val expectedErrorPayload = s"this is a random error string: ${UUID.randomUUID()}"
+
+  it should "return Accepted if import service returns Created with a strict entity" in {
     val importServiceResponse = HttpResponse(status = Created,
-      entity = HttpEntity.Strict(ContentTypes.`application/json`, ByteString(importServicePayload.getBytes)))
+      entity = HttpEntity.Strict(ContentTypes.`application/json`, ByteString(importServicePayload)))
 
     val futureActual = new HttpImportServiceDAO().generateResponse(importServiceResponse, workspaceNamespace, workspaceName, pfbRequest)
 
-    val expectedPayload = PfbImportResponse(
-      pfbUrl,
-      jobId.toString,
-      WorkspaceName(workspaceNamespace, workspaceName))
-
     futureActual map { actual =>
-      actual shouldBe RequestComplete(Accepted, expectedPayload)
+      actual shouldBe RequestComplete(Accepted, expectedSuccessPayload)
     }
-
   }
 
+  it should "return Accepted if import service returns Created with a non-strict entity" in {
+    val importServiceResponse = HttpResponse(status = Created,
+      entity = HttpEntity.Default(ContentTypes.`application/json`, importServicePayload.getBytes.length, Source.single(ByteString(importServicePayload))))
+
+    val futureActual = new HttpImportServiceDAO().generateResponse(importServiceResponse, workspaceNamespace, workspaceName, pfbRequest)
+
+    futureActual map { actual =>
+      actual shouldBe RequestComplete(Accepted, expectedSuccessPayload)
+    }
+  }
+
+  it should "bubble up status code and payload if import service returns non-Created with a strict entity" in {
+    val importServiceResponse = HttpResponse(status = ImATeapot,
+      entity = HttpEntity.Strict(ContentTypes.`text/plain(UTF-8)`, ByteString(expectedErrorPayload)))
+
+    val futureActual = new HttpImportServiceDAO().generateResponse(importServiceResponse, workspaceNamespace, workspaceName, pfbRequest)
+
+    futureActual map { actual =>
+      actual shouldBe RequestCompleteWithErrorReport(ImATeapot, expectedErrorPayload)
+    }
+  }
+
+  it should "bubble up status code and payload if import service returns non-Created with a non-strict entity" in {
+    val importServiceResponse = HttpResponse(status = ImATeapot,
+      entity = HttpEntity.Default(ContentTypes.`text/plain(UTF-8)`, expectedErrorPayload.getBytes.length, Source.single(ByteString(expectedErrorPayload))))
+
+    val futureActual = new HttpImportServiceDAO().generateResponse(importServiceResponse, workspaceNamespace, workspaceName, pfbRequest)
+
+    futureActual map { actual =>
+      actual shouldBe RequestCompleteWithErrorReport(ImATeapot, expectedErrorPayload)
+    }
+  }
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpImportServiceDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpImportServiceDAOSpec.scala
@@ -1,0 +1,50 @@
+package org.broadinstitute.dsde.firecloud.dataaccess
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
+import akka.http.scaladsl.model.StatusCodes._
+import akka.http.scaladsl.model.{ContentTypes, HttpEntity, HttpResponse}
+import akka.util.ByteString
+import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol.{impImportServiceResponse, impPfbImportResponse}
+import org.broadinstitute.dsde.firecloud.model.{ImportServiceResponse, PfbImportRequest, PfbImportResponse}
+import org.broadinstitute.dsde.firecloud.service.PerRequest.RequestComplete
+import org.broadinstitute.dsde.rawls.model.WorkspaceName
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+import spray.json._
+
+import java.util.UUID
+
+class HttpImportServiceDAOSpec extends AsyncFlatSpec with Matchers with SprayJsonSupport {
+
+  implicit val system = ActorSystem("HttpGoogleCloudStorageDAOSpec")
+  import system.dispatcher
+
+  behavior of "HttpImportServiceDAO"
+
+  val workspaceNamespace = "workspaceNamespace"
+  val workspaceName = "workspaceName"
+  val pfbUrl = "unittest-fixture-url"
+  val pfbRequest = PfbImportRequest(Some(pfbUrl))
+
+  it should "return Accepted if import service returns Created" in {
+    val jobId = UUID.randomUUID()
+    val importServicePayload = ImportServiceResponse(jobId.toString, "status", None).toJson.compactPrint
+
+    val importServiceResponse = HttpResponse(status = Created,
+      entity = HttpEntity.Strict(ContentTypes.`application/json`, ByteString(importServicePayload.getBytes)))
+
+    val futureActual = new HttpImportServiceDAO().generateResponse(importServiceResponse, workspaceNamespace, workspaceName, pfbRequest)
+
+    val expectedPayload = PfbImportResponse(
+      pfbUrl,
+      jobId.toString,
+      WorkspaceName(workspaceNamespace, workspaceName))
+
+    futureActual map { actual =>
+      actual shouldBe RequestComplete(Accepted, expectedPayload)
+    }
+
+  }
+
+}


### PR DESCRIPTION
This solves _*one*_ of the test failures called out in QA-1230.

When `HttpImportServiceDAO.importPFB()` received an error response (non-`Created` status code) from Import Service, it only handled strict http entities properly. For those strict entities, it bubbled up the response body from Import Service.

However, for non-strict entities, e.g. `HttpEntity.Default`, it would call `toString()` on the entire `HttpResponse` and use *that* as its response body. This was a very different response.

In practice, this behavior meant that:
* strict entities from import service would result in a message like "Cannot perform the action write on $projectName/$workspaceName" to the end user
* non-strict entities from import service would result in a message like "HttpResponse(403 Forbidden,List(Date: Wed, 31 Mar 2021 17:37:40 GMT, Server: gunicorn/20.0.4),HttpEntity.Default(text/html; charset=UTF-8,153 bytes total),HttpProtocol(HTTP/1.1))" to the end user

And then in turn, this would cause a swatomation test to fail, because the test inspected the response body: https://github.com/broadinstitute/firecloud-orchestration/blob/dcaaa90f2c3ba70391033e0b8ecfacb9cd33df57/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/PFBImportSpec.scala#L153

Akka can and does decide on its own, based on available memory and network conditions, whether the entity it receives is strict or not (see https://doc.akka.io/docs/akka-http/current/common/http-model.html#httpentity). Thus we must be able to handle both cases.

**_Reviewer:_** codecov seems to hate this PR. You might want to "hide annotations".