### PR TITLE
specs should be no-arg [AS-713]

### DIFF
--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAOSpec.scala
@@ -19,7 +19,7 @@ import scala.collection.JavaConverters._
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
-class HttpGoogleServicesDAOSpec(implicit val materializer: Materializer) extends AnyFlatSpec with Matchers with PrivateMethodTester {
+class HttpGoogleServicesDAOSpec extends AnyFlatSpec with Matchers with PrivateMethodTester {
 
   val testProject = "broad-dsde-dev"
   implicit val system = ActorSystem("HttpGoogleCloudStorageDAOSpec")


### PR DESCRIPTION
`HttpGoogleServicesDAOSpec` has not been running its tests, because it needs to be no-arg to be picked up by the test runner.