### PR TITLE
[AS-719]: Use base 2 when calculating cost/gb 

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceService.scala
@@ -52,7 +52,7 @@ class WorkspaceService(protected val argUserToken: WithAccessToken, val rawlsDAO
     rawlsDAO.getBucketUsage(workspaceNamespace, workspaceName).zip(googleServicesDAO.fetchPriceList) map {
       case (usage, priceList) =>
         val rate = priceList.prices.cpBigstoreStorage.us
-        val estimate: BigDecimal = BigDecimal(usage.usageInBytes) / 1000000000 * rate
+        val estimate: BigDecimal = BigDecimal(usage.usageInBytes) / (1024 * 1024 * 1024) * rate
         RequestComplete(WorkspaceStorageCostEstimate(f"$$$estimate%.2f"))
     }
   }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceService.scala
@@ -52,6 +52,7 @@ class WorkspaceService(protected val argUserToken: WithAccessToken, val rawlsDAO
     rawlsDAO.getBucketUsage(workspaceNamespace, workspaceName).zip(googleServicesDAO.fetchPriceList) map {
       case (usage, priceList) =>
         val rate = priceList.prices.cpBigstoreStorage.us
+        // Convert bytes to GB since rate is based on GB.
         val estimate: BigDecimal = BigDecimal(usage.usageInBytes) / (1024 * 1024 * 1024) * rate
         RequestComplete(WorkspaceStorageCostEstimate(f"$$$estimate%.2f"))
     }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiServiceSpec.scala
@@ -1369,7 +1369,8 @@ class WorkspaceApiServiceSpec extends BaseServiceSpec with WorkspaceApiService w
         "should return 200 with result for good request" in {
           Get(storageCostEstimatePath) ~> dummyUserIdHeaders(dummyUserId) ~> sealRoute(workspaceRoutes) ~> check {
             status should be (OK)
-            responseAs[WorkspaceStorageCostEstimate].estimate should be ("$2.56")
+            // 256000000000 / (1024 * 1024 * 1024) *0.01
+            responseAs[WorkspaceStorageCostEstimate].estimate should be ("$2.38")
           }
         }
       }


### PR DESCRIPTION
\<your comments for this PR go here\>
byte -> KM -> MB -> GB so it is (1024 * 1024 * 1024)

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
