### PR TITLE
PROD-528: Use user pet service account to fetch bucket information

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/GoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/GoogleServicesDAO.scala
@@ -43,5 +43,5 @@ trait GoogleServicesDAO extends ReportsSubsystemStatus {
 
   def publishMessages(fullyQualifiedTopic: String, messages: Seq[String]): Future[Unit]
 
-  def getBucket(bucketName: String, userAuthToken: WithAccessToken): Option[Bucket]
+  def getBucket(bucketName: String, petKey: String): Option[Bucket]
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/GoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/GoogleServicesDAO.scala
@@ -43,5 +43,5 @@ trait GoogleServicesDAO extends ReportsSubsystemStatus {
 
   def publishMessages(fullyQualifiedTopic: String, messages: Seq[String]): Future[Unit]
 
-  def getBucket(bucketName: String): Option[Bucket]
+  def getBucket(bucketName: String, userAuthToken: WithAccessToken): Option[Bucket]
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
@@ -1,7 +1,6 @@
 package org.broadinstitute.dsde.firecloud.dataaccess
 
-import java.io.FileInputStream
-
+import java.io.{ByteArrayInputStream, FileInputStream}
 import akka.actor.ActorSystem
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
 import akka.http.scaladsl.model.StatusCodes._
@@ -187,8 +186,11 @@ class HttpGoogleServicesDAO(implicit val system: ActorSystem, implicit val mater
     storage.objects().get(bucketName, objectKey).executeMediaAsInputStream
   }
 
-  def getBucket(bucketName: String, userAuthToken: WithAccessToken): Option[Bucket] = {
-    val storage = new Storage.Builder(httpTransport, jsonFactory, new HttpCredentialsAdapter(userAuthToken).setApplicationName(appName).build()
+  def getBucket(bucketName: String, petKey: String): Option[Bucket] = {
+    val keyStream = new ByteArrayInputStream(petKey.getBytes)
+    val credential = ServiceAccountCredentials.fromStream(keyStream).createScoped(storageReadOnly.asJava)
+
+    val storage = new Storage.Builder(httpTransport, jsonFactory, new HttpCredentialsAdapter(credential)).setApplicationName(appName).build()
 
     Try(executeGoogleRequest[Bucket](storage.buckets().get(bucketName))) match {
       case Failure(ex) =>

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
@@ -187,8 +187,8 @@ class HttpGoogleServicesDAO(implicit val system: ActorSystem, implicit val mater
     storage.objects().get(bucketName, objectKey).executeMediaAsInputStream
   }
 
-  def getBucket(bucketName: String): Option[Bucket] = {
-    val storage = new Storage.Builder(httpTransport, jsonFactory, new HttpCredentialsAdapter(getBucketServiceAccountCredential)).setApplicationName(appName).build()
+  def getBucket(bucketName: String, userAuthToken: WithAccessToken): Option[Bucket] = {
+    val storage = new Storage.Builder(httpTransport, jsonFactory, new HttpCredentialsAdapter(userAuthToken).setApplicationName(appName).build()
 
     Try(executeGoogleRequest[Bucket](storage.buckets().get(bucketName))) match {
       case Failure(ex) =>

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
@@ -188,7 +188,7 @@ class HttpGoogleServicesDAO(implicit val system: ActorSystem, implicit val mater
 
   def getBucket(bucketName: String, petKey: String): Option[Bucket] = {
     val keyStream = new ByteArrayInputStream(petKey.getBytes)
-    val credential = ServiceAccountCredentials.fromStream(keyStream).createScoped(storageReadOnly.asJava)
+    val credential = getScopedServiceAccountCredentials(ServiceAccountCredentials.fromStream(keyStream), storageReadOnly)
 
     val storage = new Storage.Builder(httpTransport, jsonFactory, new HttpCredentialsAdapter(credential)).setApplicationName(appName).build()
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpSamDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpSamDAO.scala
@@ -2,7 +2,6 @@ package org.broadinstitute.dsde.firecloud.dataaccess
 
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets.UTF_8
-
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
@@ -19,6 +18,7 @@ import org.broadinstitute.dsde.firecloud.model.{AccessToken, FireCloudManagedGro
 import org.broadinstitute.dsde.firecloud.utils.RestJsonClient
 import org.broadinstitute.dsde.rawls.model.RawlsUserEmail
 import org.broadinstitute.dsde.workbench.model.WorkbenchIdentityJsonSupport._
+import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.model.{WorkbenchEmail, WorkbenchGroupName}
 import org.broadinstitute.dsde.workbench.util.health.SubsystemStatus
 import spray.json.DefaultJsonProtocol._
@@ -126,6 +126,13 @@ class HttpSamDAO( implicit val system: ActorSystem, val materializer: Materializ
         quotedToken
       AccessToken.apply(token)
     }
+  }
+
+
+  def getPetServiceAccountKeyForUser(user: WithAccessToken, project: GoogleProject): Future[String] = {
+    implicit val accessToken = user
+
+    authedRequestToObject[String](Get(samPetKeyForProject.format(project.value)), label=Some("HttpSamDAO.getPetServiceAccountKeyForUser"))
   }
 
   override def status: Future[SubsystemStatus] = {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/SamDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/SamDAO.scala
@@ -2,13 +2,13 @@ package org.broadinstitute.dsde.firecloud.dataaccess
 
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets.UTF_8
-
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.FireCloudConfig
 import org.broadinstitute.dsde.firecloud.model.ManagedGroupRoles.ManagedGroupRole
 import org.broadinstitute.dsde.firecloud.model.SamResource.UserPolicy
 import org.broadinstitute.dsde.firecloud.model.{AccessToken, FireCloudManagedGroupMembership, RegistrationInfo, RegistrationInfoV2, UserIdInfo, UserInfo, WithAccessToken}
 import org.broadinstitute.dsde.rawls.model.{ErrorReportSource, RawlsUserEmail}
+import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.model.{WorkbenchEmail, WorkbenchGroupName}
 
 import scala.concurrent.Future
@@ -32,6 +32,7 @@ trait SamDAO extends LazyLogging with ReportsSubsystemStatus {
   val samStatusUrl = FireCloudConfig.Sam.baseUrl + "/status"
   val samGetUserIdsUrl = FireCloudConfig.Sam.baseUrl + "/api/users/v1/%s"
   val samArbitraryPetTokenUrl = FireCloudConfig.Sam.baseUrl + "/api/google/v1/user/petServiceAccount/token"
+  val samPetKeyForProject = FireCloudConfig.Sam.baseUrl + "/api/google/v1/user/petServiceAccount/%s/key"
 
   val samManagedGroupsBase: String = FireCloudConfig.Sam.baseUrl + "/api/groups"
   val samManagedGroupBase: String = FireCloudConfig.Sam.baseUrl + "/api/group"
@@ -73,6 +74,7 @@ trait SamDAO extends LazyLogging with ReportsSubsystemStatus {
   def setPolicyPublic(resourceTypeName: String, resourceId: String, policyName: String, public: Boolean)(implicit userInfo: WithAccessToken): Future[Unit]
 
   def getPetServiceAccountTokenForUser(user: WithAccessToken, scopes: Seq[String]): Future[AccessToken]
+  def getPetServiceAccountKeyForUser(user: WithAccessToken, project: GoogleProject): Future[String]
 
   val serviceName = SamDAO.serviceName
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceService.scala
@@ -50,7 +50,7 @@ class WorkspaceService(protected val argUserToken: WithAccessToken, val rawlsDAO
 
   def getStorageCostEstimate(workspaceNamespace: String, workspaceName: String): Future[RequestComplete[WorkspaceStorageCostEstimate]] = {
     rawlsDAO.getWorkspace(workspaceNamespace, workspaceName) flatMap { workspaceResponse =>
-      googleServicesDAO.getBucket(workspaceResponse.workspace.bucketName) match {
+      googleServicesDAO.getBucket(workspaceResponse.workspace.bucketName, argUserToken) match {
         case Some(bucket) =>
           rawlsDAO.getBucketUsage(workspaceNamespace, workspaceName).zip(googleServicesDAO.fetchPriceList) map {
             case (usage, priceList) =>

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceService.scala
@@ -52,18 +52,18 @@ class WorkspaceService(protected val argUserToken: WithAccessToken, val rawlsDAO
   def getStorageCostEstimate(workspaceNamespace: String, workspaceName: String): Future[RequestComplete[WorkspaceStorageCostEstimate]] = {
     rawlsDAO.getWorkspace(workspaceNamespace, workspaceName) flatMap { workspaceResponse =>
       samDao.getPetServiceAccountKeyForUser(userToken, GoogleProject(workspaceNamespace)) flatMap { petKey =>
-      googleServicesDAO.getBucket(workspaceResponse.workspace.bucketName, petKey) match {
-        case Some(bucket) =>
-          rawlsDAO.getBucketUsage(workspaceNamespace, workspaceName).zip(googleServicesDAO.fetchPriceList) map {
-            case (usage, priceList) =>
-              val rate = priceList.prices.cpBigstoreStorage.getOrElse(bucket.getLocation.toLowerCase(), priceList.prices.cpBigstoreStorage("us"))
-              // Convert bytes to GB since rate is based on GB.
-              val estimate: BigDecimal = BigDecimal(usage.usageInBytes) / (1024 * 1024 * 1024) * rate
-              RequestComplete(WorkspaceStorageCostEstimate(f"$$$estimate%.2f"))
-          }
-        case None => throw new FireCloudExceptionWithErrorReport(ErrorReport(StatusCodes.InternalServerError, "Unable to fetch bucket to calculate storage cost"))
+        googleServicesDAO.getBucket(workspaceResponse.workspace.bucketName, petKey) match {
+          case Some(bucket) =>
+            rawlsDAO.getBucketUsage(workspaceNamespace, workspaceName).zip(googleServicesDAO.fetchPriceList) map {
+             case (usage, priceList) =>
+                val rate = priceList.prices.cpBigstoreStorage.getOrElse(bucket.getLocation.toLowerCase(), priceList.prices.cpBigstoreStorage("us"))
+                // Convert bytes to GB since rate is based on GB.
+                val estimate: BigDecimal = BigDecimal(usage.usageInBytes) / (1024 * 1024 * 1024) * rate
+                RequestComplete(WorkspaceStorageCostEstimate(f"$$$estimate%.2f"))
+            }
+          case None => throw new FireCloudExceptionWithErrorReport(ErrorReport(StatusCodes.InternalServerError, "Unable to fetch bucket to calculate storage cost"))
+        }
       }
-    }
     }
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockSamDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockSamDAO.scala
@@ -6,6 +6,7 @@ import org.broadinstitute.dsde.firecloud.model.ManagedGroupRoles.ManagedGroupRol
 import org.broadinstitute.dsde.firecloud.model.{AccessToken, FireCloudManagedGroupMembership, RegistrationInfo, RegistrationInfoV2, SamResource, UserIdInfo, UserInfo, WithAccessToken, WorkbenchEnabled, WorkbenchUserInfo}
 import org.broadinstitute.dsde.workbench.util.health.SubsystemStatus
 import org.broadinstitute.dsde.rawls.model.RawlsUserEmail
+import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.model.{WorkbenchEmail, WorkbenchGroupName}
 
 import scala.concurrent.Future
@@ -105,6 +106,8 @@ class MockSamDAO extends SamDAO {
 
   override def getPetServiceAccountTokenForUser(user: WithAccessToken, scopes: Seq[String]): Future[AccessToken] =
     Future.failed(new FireCloudException("mock not implemented"))
+
+  override def getPetServiceAccountKeyForUser(user: WithAccessToken, project: GoogleProject): Future[String] = Future.successful("""{"fake":"key""}""")
 
   override def setPolicyPublic(resourceTypeName: String, resourceId: String, policyName: String, public: Boolean)(implicit userInfo: WithAccessToken): Future[Unit] = Future.successful(())
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockGoogleServicesDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockGoogleServicesDAO.scala
@@ -101,7 +101,7 @@ class MockGoogleServicesDAO extends GoogleServicesDAO {
   override def deleteGoogleGroup(groupEmail: String): Unit = Unit
   override def createGoogleGroup(groupName: String): Option[String] = Option("new-google-group@support.something.firecloud.org")
   override def addMemberToAnonymizedGoogleGroup(groupName: String, targetUserEmail: String): Option[String] = Option("user-email@something.com")
-  override def getBucket(bucketName: String): Option[Bucket] = {
+  override def getBucket(bucketName: String, petKey: String): Option[Bucket] = {
     bucketName match {
       case "usBucket" => Option(new Bucket().setName("usBucket").setLocation("US"))
       case "europeWest1Bucket"=> Option(new Bucket().setName("europeWest1").setLocation("EUROPE-WEST1"))


### PR DESCRIPTION
We are getting this error when fetching bucket information to calculate bucket cost:
`firecloud-prod@broad-dsde-prod.iam.gserviceaccount.com does not have storage.buckets.get access to the Google Cloud Storage bucket.`
This is not captured in lower env because in lower env, `firecloud-env@ SA` has permission to those bucket. 

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
