### PR TITLE
[RW-6438]: Fix Firecloud-orch v2_billing swagger

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -257,7 +257,7 @@ paths:
         required: true
       responses:
         201:
-          description: Successfully Created Billing Project in Rawls
+          description: Successfully Created Billing Project in FireCloud
         400:
           description: both you and firecloud billing user must be a user of the billing account
           content:
@@ -268,7 +268,7 @@ paths:
           description: project already exists in rawls
           content: {}
         500:
-          description: Rawls Internal Error
+          description: FireCloud Internal Error
           content:
             'application/json':
               schema:
@@ -300,7 +300,7 @@ paths:
           content:
             'application/json':
               schema:
-                $ref: '#/components/schemas/RawlsBillingProjectResponse'
+                $ref: '#/components/schemas/BillingProjectResponse'
         404:
           description: Project Not Found
           content:
@@ -363,7 +363,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/RawlsBillingProjectMember'
+                  $ref: '#/components/schemas/BillingProjectMember'
         403:
           description: You must be a project owner to view the members of a project
           content:
@@ -371,7 +371,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
+          description: FireCloud Internal Error
           content:
             'application/json':
               schema:
@@ -421,7 +421,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
+          description: FireCloud Internal Error
           content:
             'application/json':
               schema:
@@ -470,7 +470,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         500:
-          description: Rawls Internal Error
+          description: FireCloud Internal Error
           content:
             'application/json':
               schema:
@@ -10201,6 +10201,30 @@ components:
         labels:
           type: string
           description: The custom labels as json
+    BillingProjectResponse:
+      required:
+        - projectName
+        - invalidBillingAccount
+        - roles
+      type: object
+      properties:
+        projectName:
+          type: string
+          description: the name of the project
+        billingAccount:
+          type: string
+          description: the billing account to use in google projects
+        servicePerimeter:
+          type: string
+          description: the name of the service permeters for google project
+        invalidBillingAccount:
+          type: boolean
+          description: whether or not the billing account is usable by Terra
+        roles:
+          type: array
+          items:
+            type: string
+          description: the roles the caller has on the project
   parameters:
     versionParam:
       name: version


### PR DESCRIPTION
This PR 

1. Change RawlsBillingProjectMember to BillingProjectMember because BillingProjectMember is something already exist, and I feel we should use the existing ones? 
2. Rename RawlsBillingProjectResponse to BillingProjectResponse because I feel that seems to be the pattern for other existing APIs, i.e. remove Rawls prefix?
3. Fix some doc comment Rawls -> Firecloud


Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
