### PR TITLE
CA-1230: Add passthroughs for updating spend report configurations

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -8875,6 +8875,15 @@ components:
           description: line number
           format: int32
       description: ""
+    SpendReportConfiguration:
+      required:
+        - datasetName
+      type: object
+      properties:
+        datasetName:
+          type: string
+          description: the name of the BigQuery dataset containing project spend data
+      description: ""
     StringArray:
       type: array
       example:

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -132,7 +132,7 @@ paths:
   /api/billing/v2/{projectId}/spendReportConfiguration:
     put:
       tags:
-        - billing_v2
+        - BillingV2
       summary: set the spend configuration for the billing project
       description: set the spend configuration for the billing project
       operationId: setSpendReportConfiguration
@@ -180,7 +180,7 @@ paths:
       x-passthrough-target: rawls
     delete:
       tags:
-        - billing_v2
+        - BillingV2
       summary: clear the spend configuration for the billing project
       description: clear the spend configuration for the billing project
       operationId: clearSpendReportConfiguration

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -129,6 +129,85 @@ paths:
             - profile
       x-passthrough: true
       x-passthrough-target: rawls
+  /api/billing/v2/{projectId}/spendReportConfiguration:
+    put:
+      tags:
+        - billing_v2
+      summary: set the spend configuration for the billing project
+      description: set the spend configuration for the billing project
+      operationId: setSpendReportConfiguration
+      parameters:
+        - name: projectId
+          in: path
+          description: Billing Project ID
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: billing project spend configuration information
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/SpendReportConfiguration'
+      responses:
+        204:
+          description: Successfully updated spend configuration
+        400:
+          description: Either the billing project does not have an active billing account, the specified dataset does not exist, or the specified table does not exist
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        403:
+          description: You must be a billing project owner to alter the spend configuration of the billing project
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        404:
+          description: The specified billing project could not be found
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        500:
+          description: Rawls Internal Error
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+      x-passthrough: true
+      x-passthrough-target: rawls
+    delete:
+      tags:
+        - billing_v2
+      summary: clear the spend configuration for the billing project
+      description: clear the spend configuration for the billing project
+      operationId: clearSpendReportConfiguration
+      parameters:
+        - name: projectId
+          in: path
+          description: Billing Project ID
+          required: true
+          schema:
+            type: string
+      responses:
+        204:
+          description: Successfully cleared spend configuration
+        403:
+          description: You must be a billing project owner to alter the spend configuration of the billing project
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        500:
+          description: Rawls Internal Error
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+      x-passthrough: true
+      x-passthrough-target: rawls
   /api/billing/{projectId}/{workbenchRole}/{email}:
     put:
       tags:

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/BillingApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/BillingApiService.scala
@@ -58,6 +58,13 @@ trait BillingApiService extends FireCloudDirectives {
                   }
                 }
               } ~
+              path("spendReportConfiguration") {
+                (put | delete) {
+                  extract(_.request.method) { method =>
+                    passthrough(s"$v2BillingUrl/$projectId/spendReportConfiguration", method)
+                  }
+                }
+              } ~
               // workbench project role: owner or user
               path(Segment / Segment) { (workbenchRole, email) =>
                 (delete | put) {


### PR DESCRIPTION
Note that this merges into the feature branch.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
