### PR TITLE
Attempt 2 at memoryRetryMultipler addition [BW-281]

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -8766,6 +8766,14 @@ components:
           type: boolean
           description: Whether or not to delete intermediate output files when the
             workflow completes. See Cromwell docs for more information.
+        useReferenceDisks:
+          type: boolean
+          description: Whether or not to use pre-built disks for common genome references
+        memoryRetryMultiplier:
+          type: number
+          description: If a task fails due to running out of memory and the task has `maxRetries` in its runtime attributes,
+            then it will be retried with its memory multiplied by this amount.  See [Cromwell docs](https://cromwell.readthedocs.io/en/develop/cromwell_features/RetryWithMoreMemory/#retry-with-more-memory)
+            for more information.
         workflowFailureMode:
           type: string
           description: What happens after a task fails. Choose from ContinueWhilePossible
@@ -8836,6 +8844,11 @@ components:
         useReferenceDisks:
           type: boolean
           description: Whether or not to use pre-built disks for common genome references
+        memoryRetryMultiplier:
+          type: number
+          description: If a task fails due to running out of memory and the task has `maxRetries` in its runtime attributes,
+            then it will be retried with its memory multiplied by this amount.  See [Cromwell docs](https://cromwell.readthedocs.io/en/develop/cromwell_features/RetryWithMoreMemory/#retry-with-more-memory)
+            for more information.
         workflowFailureMode:
           type: string
           description: What happens after a task fails. Choose from ContinueWhilePossible

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
@@ -201,7 +201,7 @@ object ModelJsonProtocol extends WorkspaceJsonSupport with SprayJsonSupport {
 
   implicit val impEntityMetadata = jsonFormat3(EntityMetadata)
   implicit val impModelSchema = jsonFormat1(EntityModel)
-  implicit val impSubmissionRequest = jsonFormat9(SubmissionRequest)
+  implicit val impSubmissionRequest = jsonFormat10(SubmissionRequest)
 
   implicit val impEntityUpdateDefinition = jsonFormat3(EntityUpdateDefinition)
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/Workspace.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/Workspace.scala
@@ -92,6 +92,7 @@ case class SubmissionRequest(
   useCallCache: Option[Boolean],
   deleteIntermediateOutputFiles: Option[Boolean],
   useReferenceDisks: Option[Boolean],
+  memoryRetryMultiplier: Option[Double],
   workflowFailureMode: Option[String])
 
 case class RawlsGroupMemberList(

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockWorkspaceServer.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockWorkspaceServer.scala
@@ -63,6 +63,7 @@ object MockWorkspaceServer {
     useCallCache = Option(randomBoolean()),
     deleteIntermediateOutputFiles = Option(randomBoolean()),
     useReferenceDisks = Option(randomBoolean()),
+    memoryRetryMultiplier = Option(1.1d),
     workflowFailureMode = Option(randomElement(List("ContinueWhilePossible", "NoNewCalls")))
   )
 
@@ -75,6 +76,7 @@ object MockWorkspaceServer {
     useCallCache = Option.empty,
     deleteIntermediateOutputFiles = Option.empty,
     useReferenceDisks = Option.empty,
+    memoryRetryMultiplier = Option(1.1d),
     workflowFailureMode = Option.empty
   )
 


### PR DESCRIPTION
Equivalent to #854 but only adding the passthrough, not attempting to update workbench-libs imports (which seem to be unhappy being updated in this repo right now)

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
