### PR TITLE
AS-732 flakey test

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/LibraryService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/LibraryService.scala
@@ -140,10 +140,10 @@ class LibraryService (protected val argUserInfo: UserInfo,
    * Will republish if it is currently in the published state.
    */
   private def internalPatchWorkspaceAndRepublish(ns: String, name: String, allOperations: Seq[AttributeUpdateOperation], isPublished: Boolean): Future[WorkspaceDetails] = {
-    rawlsDAO.updateLibraryAttributes(ns, name, allOperations) map { newws =>
-      republishDocument(newws, ontologyDAO, searchDAO, consentDAO)
-      newws
-    }
+    for {
+      newws <- rawlsDAO.updateLibraryAttributes(ns, name, allOperations)
+      _ <- republishDocument(newws, ontologyDAO, searchDAO, consentDAO)
+    } yield newws
   }
 
   // should only be used to change published state

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockSearchDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockSearchDAO.scala
@@ -5,6 +5,7 @@ import org.broadinstitute.dsde.firecloud.model._
 import org.broadinstitute.dsde.workbench.util.health.SubsystemStatus
 import spray.json.JsValue
 
+import java.util.concurrent.atomic.AtomicBoolean
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
@@ -19,43 +20,43 @@ class MockSearchDAO extends SearchDAO {
   override def createIndex = Unit
   override def deleteIndex = Unit
 
-  var indexDocumentInvoked = false
-  var deleteDocumentInvoked = false
-  var findDocumentsInvoked = false
-  var autocompleteInvoked = false
-  var populateSuggestInvoked = false
+  var indexDocumentInvoked = new AtomicBoolean(false)
+  var deleteDocumentInvoked = new AtomicBoolean(false)
+  var findDocumentsInvoked = new AtomicBoolean(false)
+  var autocompleteInvoked = new AtomicBoolean(false)
+  var populateSuggestInvoked = new AtomicBoolean(false)
 
   override def bulkIndex(docs: Seq[Document], refresh:Boolean = false) = LibraryBulkIndexResponse(0, false, Map.empty)
 
   override def indexDocument(doc: Document) = {
-    indexDocumentInvoked = true
+    indexDocumentInvoked.set(true)
   }
 
   override def deleteDocument(id: String) = {
-    deleteDocumentInvoked = true
+    deleteDocumentInvoked.set(true)
   }
 
   override def findDocuments(librarySearchParams: LibrarySearchParams, groups: Seq[String], workspacePolicyMap: Map[String, UserPolicy]): Future[LibrarySearchResponse] = {
-    findDocumentsInvoked = true
+    findDocumentsInvoked.set(true)
     Future(LibrarySearchResponse(librarySearchParams, 0, Seq[JsValue](), Seq[LibraryAggregationResponse]()))
   }
 
   override def suggestionsFromAll(librarySearchParams: LibrarySearchParams, groups: Seq[String], workspacePolicyMap: Map[String, UserPolicy]): Future[LibrarySearchResponse] = {
-    autocompleteInvoked = true
+    autocompleteInvoked.set(true)
     Future(LibrarySearchResponse(librarySearchParams, 0, Seq[JsValue](), Seq[LibraryAggregationResponse]()))
   }
 
   override def suggestionsForFieldPopulate(field: String, text: String): Future[Seq[String]] = {
-    populateSuggestInvoked = true
+    populateSuggestInvoked.set(true)
     Future(Seq(field, text))
   }
 
   def reset = {
-    indexDocumentInvoked = false
-    deleteDocumentInvoked = false
-    findDocumentsInvoked = false
-    autocompleteInvoked = false
-    populateSuggestInvoked = false
+    indexDocumentInvoked.set(false)
+    deleteDocumentInvoked.set(false)
+    findDocumentsInvoked.set(false)
+    autocompleteInvoked.set(false)
+    populateSuggestInvoked.set(false)
   }
 
   def status: Future[SubsystemStatus] = Future(SubsystemStatus(ok = true, None))

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceServiceSpec.scala
@@ -133,9 +133,9 @@ class MockSearchDeleteWSDAO extends MockSearchDAO {
   override def deleteDocument(id: String): Unit = {
     id match {
       case "unpublishfailure" =>
-        deleteDocumentInvoked = false
+        deleteDocumentInvoked.set(false)
         throw new FireCloudException(s"Failed to remove document with id $id from elastic search")
-      case _ => deleteDocumentInvoked = true
+      case _ => deleteDocumentInvoked.set(true)
     }
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/LibraryApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/LibraryApiServiceSpec.scala
@@ -249,15 +249,15 @@ class LibraryApiServiceSpec extends BaseServiceSpec with LibraryApiService with 
         "should return OK and invoke indexDocument for unpublished workspace with valid dataset" in {
           new RequestBuilder(HttpMethods.POST)(publishedPath("libraryValid")) ~> dummyUserIdHeaders("1234") ~> sealRoute(libraryRoutes) ~> check {
             status should equal(OK)
-            assert(this.searchDao.indexDocumentInvoked, "indexDocument should have been invoked")
-            assert(!this.searchDao.deleteDocumentInvoked, "deleteDocument should not have been invoked")
+            assert(this.searchDao.indexDocumentInvoked.get(), "indexDocument should have been invoked")
+            assert(!this.searchDao.deleteDocumentInvoked.get(), "deleteDocument should not have been invoked")
           }
         }
         "should return BadRequest and not invoke indexDocument for unpublished workspace with invalid dataset" in {
           new RequestBuilder(HttpMethods.POST)(publishedPath()) ~> dummyUserIdHeaders("1234") ~> sealRoute(libraryRoutes) ~> check {
             status should equal(BadRequest)
-            assert(!this.searchDao.indexDocumentInvoked, "indexDocument should not have been invoked")
-            assert(!this.searchDao.deleteDocumentInvoked, "deleteDocument should not have been invoked")
+            assert(!this.searchDao.indexDocumentInvoked.get(), "indexDocument should not have been invoked")
+            assert(!this.searchDao.deleteDocumentInvoked.get(), "deleteDocument should not have been invoked")
           }
         }
       }
@@ -270,8 +270,8 @@ class LibraryApiServiceSpec extends BaseServiceSpec with LibraryApiService with 
         "as return OK and invoke deleteDocument for published workspace" in {
           new RequestBuilder(HttpMethods.DELETE)(publishedPath("publishedowner")) ~> dummyUserIdHeaders("1234") ~> sealRoute(libraryRoutes) ~> check {
             status should equal(OK)
-            assert(this.searchDao.deleteDocumentInvoked, "deleteDocument should have been invoked")
-            assert(!this.searchDao.indexDocumentInvoked, "indexDocument should not have been invoked")
+            assert(this.searchDao.deleteDocumentInvoked.get(), "deleteDocument should have been invoked")
+            assert(!this.searchDao.indexDocumentInvoked.get(), "indexDocument should not have been invoked")
           }
         }
       }
@@ -282,7 +282,7 @@ class LibraryApiServiceSpec extends BaseServiceSpec with LibraryApiService with 
           val content = HttpEntity(ContentTypes.`application/json`, "{}")
           new RequestBuilder(HttpMethods.POST)(librarySearchPath, content) ~> dummyUserIdHeaders("1234") ~> sealRoute(libraryRoutes) ~> check {
             status should equal(OK)
-            assert(this.searchDao.findDocumentsInvoked, "findDocuments should have been invoked")
+            assert(this.searchDao.findDocumentsInvoked.get(), "findDocuments should have been invoked")
           }
         }
       }
@@ -291,7 +291,7 @@ class LibraryApiServiceSpec extends BaseServiceSpec with LibraryApiService with 
           val content = HttpEntity(ContentTypes.`application/json`, "{\"searchTerm\":\"test\", \"from\":0, \"size\":10}")
           new RequestBuilder(HttpMethods.POST)(librarySearchPath, content) ~> dummyUserIdHeaders("1234") ~> sealRoute(libraryRoutes) ~> check {
             status should equal(OK)
-            assert(this.searchDao.findDocumentsInvoked, "findDocuments should have been invoked")
+            assert(this.searchDao.findDocumentsInvoked.get(), "findDocuments should have been invoked")
             val respdata = Await.result(Unmarshal(response).to[LibrarySearchResponse], Duration.Inf)
             assert(respdata.total == 0, "total results should be 0")
             assert(respdata.results.isEmpty, "results array should be empty")
@@ -303,7 +303,7 @@ class LibraryApiServiceSpec extends BaseServiceSpec with LibraryApiService with 
           val content = HttpEntity(ContentTypes.`application/json`, "{\"searchTerm\":\"test\", \"from\":0, \"size\":10}")
           new RequestBuilder(HttpMethods.POST)(librarySuggestPath, content) ~> dummyUserIdHeaders("1234") ~> sealRoute(libraryRoutes) ~> check {
             status should equal(OK)
-            assert(this.searchDao.autocompleteInvoked, "autocompleteInvoked should have been invoked")
+            assert(this.searchDao.autocompleteInvoked.get(), "autocompleteInvoked should have been invoked")
             val respdata = Await.result(Unmarshal(response).to[LibrarySearchResponse], Duration.Inf)
             assert(respdata.total == 0, "total results should be 0")
             assert(respdata.results.isEmpty, "results array should be empty")
@@ -314,7 +314,7 @@ class LibraryApiServiceSpec extends BaseServiceSpec with LibraryApiService with 
         "should return autcomplete suggestions" in {
           new RequestBuilder(HttpMethods.GET)(libraryPopulateSuggestPath + "library:datasetOwner?q=aha") ~> dummyUserIdHeaders("1234") ~> sealRoute(libraryRoutes) ~> check {
             status should equal(OK)
-            assert(this.searchDao.populateSuggestInvoked, "populateSuggestInvoked should have been invoked")
+            assert(this.searchDao.populateSuggestInvoked.get(), "populateSuggestInvoked should have been invoked")
             val respdata = Await.result(Unmarshal(response).to[String], Duration.Inf)
             assert(respdata.contains("library:datasetOwner"))
             assert(respdata.contains("aha"))

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiServiceSpec.scala
@@ -1230,7 +1230,7 @@ class WorkspaceApiServiceSpec extends BaseServiceSpec with WorkspaceApiService w
             ~> dummyUserIdHeaders(dummyUserId)
             ~> sealRoute(workspaceRoutes)) ~> check {
             status should equal(OK)
-            assert(!this.searchDao.indexDocumentInvoked, "Should not be indexing an unpublished WS")
+            assert(!this.searchDao.indexDocumentInvoked.get(), "Should not be indexing an unpublished WS")
           }
         }
 
@@ -1247,7 +1247,7 @@ class WorkspaceApiServiceSpec extends BaseServiceSpec with WorkspaceApiService w
             ~> dummyUserIdHeaders(dummyUserId)
             ~> sealRoute(workspaceRoutes)) ~> check {
             status should equal(OK)
-            assert(this.searchDao.indexDocumentInvoked, "Should have republished this published WS when changing attributes")
+            assert(this.searchDao.indexDocumentInvoked.get(), "Should have republished this published WS when changing attributes")
           }
         }
 
@@ -1283,7 +1283,7 @@ class WorkspaceApiServiceSpec extends BaseServiceSpec with WorkspaceApiService w
             ~> dummyUserIdHeaders(dummyUserId)
             ~> sealRoute(workspaceRoutes)) ~> check {
             status should equal(OK)
-            assert(!this.searchDao.indexDocumentInvoked, "Should not be indexing an unpublished WS")
+            assert(!this.searchDao.indexDocumentInvoked.get(), "Should not be indexing an unpublished WS")
           }
         }
 
@@ -1296,7 +1296,7 @@ class WorkspaceApiServiceSpec extends BaseServiceSpec with WorkspaceApiService w
             ~> dummyUserIdHeaders(dummyUserId)
             ~> sealRoute(workspaceRoutes)) ~> check {
             status should equal(OK)
-            assert(this.searchDao.indexDocumentInvoked, "Should have republished this published WS when changing attributes")
+            assert(this.searchDao.indexDocumentInvoked.get(), "Should have republished this published WS when changing attributes")
           }
         }
 


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AS-732

`WorkspacePublishingSupport.publishDocument` was doing a `Future` but returning `Unit`. The rest of the changes are handling the `Future` properly.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
