### PR TITLE
log FireCloudExceptionWithErrorReports that happen during route handling [AS-893]

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudApiService.scala
@@ -32,7 +32,16 @@ object FireCloudApiService extends LazyLogging {
 
     ExceptionHandler {
       case withErrorReport: FireCloudExceptionWithErrorReport =>
-        complete(withErrorReport.errorReport.statusCode.getOrElse(StatusCodes.InternalServerError) -> withErrorReport.errorReport)
+        extractUri { uri =>
+          extractMethod { method =>
+            val statusCode = withErrorReport.errorReport.statusCode.getOrElse(StatusCodes.InternalServerError)
+            if (statusCode.intValue / 100 == 5) {
+              // mimic the log pattern from logRequests, below
+              logger.error(s"${method} ${uri}: ${statusCode} error: ${withErrorReport.getMessage}")
+            }
+            complete(statusCode -> withErrorReport.errorReport)
+          }
+        }
       case e: Throwable =>
         // so we don't log the error twice when debug is enabled
         if (logger.underlying.isDebugEnabled) {


### PR DESCRIPTION
if a `FireCloudExceptionWithErrorReport` occurred while processing an akka-http route, our `exceptionHandler` dutifully caught that exception and completed the route … but it didn't log the error.

I have added logic to `exceptionHandler` that now logs the error, if its status code is a 5xx or if its status code is None, in which case we default to 500.

I think the rejectionHandler also doesn't log: https://github.com/broadinstitute/firecloud-orchestration/blob/eb6c0fc09dc85b927e7e4d4b7df14f660a49a265/src/main/scala/org/broadinstitute/dsde/firecloud/model/package.scala#L19-L33 but I don't know if that's relevant to the current use case