### PR TITLE
'userComment' passthrough in Orchestration - BW-761

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -5876,6 +5876,53 @@ paths:
           content: {}
       x-passthrough: true
       x-passthrough-target: rawls
+    patch:
+      tags:
+        - submissions
+      summary: Update user comment for a submission
+      description: Update user comment for a submission
+      operationId: updateSubmissionUserComment
+      parameters:
+        - name: workspaceNamespace
+          in: path
+          description: Workspace Namespace
+          required: true
+          schema:
+            type: string
+        - name: workspaceName
+          in: path
+          description: Workspace Name
+          required: true
+          schema:
+            type: string
+        - name: submissionId
+          in: path
+          description: Submission Id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: User comment to be updated
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/UserCommentUpdateOperation'
+        required: true
+      responses:
+        200:
+          description: Successful Request
+        404:
+          description: Workspace or submission not found
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        500:
+          description: Rawls Internal Error
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
   /api/workspaces/{workspaceNamespace}/{workspaceName}/submissions/validate:
     post:
       tags:
@@ -9012,6 +9059,9 @@ components:
           enum:
             - NoNewCalls
             - ContinueWhilePossible
+        userComment:
+          type: string
+          description: Comment for the submission
       description: ""
     SubmissionsCountResponse:
       type: object
@@ -9087,6 +9137,9 @@ components:
           enum:
             - NoNewCalls
             - ContinueWhilePossible
+        userComment:
+          type: string
+          description: Freeform user defined description, optional.
       description: If the referenced method configuration takes no root entity, do
         not define `entityType`, `entityName` and `expression`.
     SubmissionStatus:
@@ -9494,6 +9547,15 @@ components:
           description: The run cost of this workflow
           format: float
       description: ""
+    UserCommentUpdateOperation:
+      required:
+        - userComment
+      type: object
+      properties:
+        userComment:
+          type: string
+          description: The updated value for user comment (max length 1000 characters)
+      description: Update user comment for submission
     WorkflowCost:
       type: object
       properties:

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -9139,7 +9139,7 @@ components:
             - ContinueWhilePossible
         userComment:
           type: string
-          description: Freeform user defined description, optional.
+          description: Freeform user defined description, optional (max length 1000 characters)
       description: If the referenced method configuration takes no root entity, do
         not define `entityType`, `entityName` and `expression`.
     SubmissionStatus:

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
@@ -201,7 +201,7 @@ object ModelJsonProtocol extends WorkspaceJsonSupport with SprayJsonSupport {
 
   implicit val impEntityMetadata = jsonFormat3(EntityMetadata)
   implicit val impModelSchema = jsonFormat1(EntityModel)
-  implicit val impSubmissionRequest = jsonFormat10(SubmissionRequest)
+  implicit val impSubmissionRequest = jsonFormat11(SubmissionRequest)
 
   implicit val impEntityUpdateDefinition = jsonFormat3(EntityUpdateDefinition)
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
@@ -202,6 +202,7 @@ object ModelJsonProtocol extends WorkspaceJsonSupport with SprayJsonSupport {
   implicit val impEntityMetadata = jsonFormat3(EntityMetadata)
   implicit val impModelSchema = jsonFormat1(EntityModel)
   implicit val impSubmissionRequest = jsonFormat11(SubmissionRequest)
+  implicit val impUserCommentUpdateOperationFormat = jsonFormat1(UserCommentUpdateOperation)
 
   implicit val impEntityUpdateDefinition = jsonFormat3(EntityUpdateDefinition)
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
@@ -202,7 +202,7 @@ object ModelJsonProtocol extends WorkspaceJsonSupport with SprayJsonSupport {
   implicit val impEntityMetadata = jsonFormat3(EntityMetadata)
   implicit val impModelSchema = jsonFormat1(EntityModel)
   implicit val impSubmissionRequest = jsonFormat11(SubmissionRequest)
-  implicit val impUserCommentUpdateOperationFormat = jsonFormat1(UserCommentUpdateOperation)
+  // val impUserCommentUpdateOperationFormat = jsonFormat1(UserCommentUpdateOperation)
 
   implicit val impEntityUpdateDefinition = jsonFormat3(EntityUpdateDefinition)
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
@@ -202,7 +202,6 @@ object ModelJsonProtocol extends WorkspaceJsonSupport with SprayJsonSupport {
   implicit val impEntityMetadata = jsonFormat3(EntityMetadata)
   implicit val impModelSchema = jsonFormat1(EntityModel)
   implicit val impSubmissionRequest = jsonFormat11(SubmissionRequest)
-  // val impUserCommentUpdateOperationFormat = jsonFormat1(UserCommentUpdateOperation)
 
   implicit val impEntityUpdateDefinition = jsonFormat3(EntityUpdateDefinition)
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/Workspace.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/Workspace.scala
@@ -93,6 +93,7 @@ case class SubmissionRequest(
   deleteIntermediateOutputFiles: Option[Boolean],
   useReferenceDisks: Option[Boolean],
   memoryRetryMultiplier: Option[Double],
+  userComment: Option[String],
   workflowFailureMode: Option[String])
 
 case class RawlsGroupMemberList(

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/Workspace.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/Workspace.scala
@@ -103,3 +103,5 @@ case class RawlsGroupMemberList(
   subGroupNames: Option[Seq[String]] = None)
 
 case class WorkspaceStorageCostEstimate(estimate: String)
+
+case class UserCommentUpdateOperation(userComment: String)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/Workspace.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/Workspace.scala
@@ -103,5 +103,3 @@ case class RawlsGroupMemberList(
   subGroupNames: Option[Seq[String]] = None)
 
 case class WorkspaceStorageCostEstimate(estimate: String)
-
-case class UserCommentUpdateOperation(userComment: String)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/utils/RestJsonClient.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/utils/RestJsonClient.scala
@@ -16,7 +16,7 @@ import org.broadinstitute.dsde.firecloud.service.FireCloudRequestBuilding
 import org.broadinstitute.dsde.rawls.model.{ErrorReport, ErrorReportSource}
 import spray.json.DeserializationException
 
-import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.{ExecutionContext, Future}
 
 /**
   * Created by davidan on 10/7/16.

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/utils/RestJsonClient.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/utils/RestJsonClient.scala
@@ -110,13 +110,12 @@ trait RestJsonClient extends FireCloudRequestBuilding with PerformanceLogging {
         perfLogger.info(perfmsg(label.get, response.status.value, tick, tock))
       }
 
-      import scala.concurrent.duration._
       response.status match {
         case s if s.isSuccess =>
           Unmarshal(response.entity).to[T].recoverWith {
             case de: DeserializationException =>
               throw new FireCloudExceptionWithErrorReport(
-                ErrorReport(s"could not deserialize response: ${de.msg}. Entity: ${Await.result(response.entity.toStrict(1000.millis), 1000.millis)}"))
+                ErrorReport(s"could not deserialize response: ${de.msg}"))
             case e: Throwable => {
               FCErrorReport(response).map { errorReport =>
                 throw new FireCloudExceptionWithErrorReport(errorReport)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/utils/RestJsonClient.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/utils/RestJsonClient.scala
@@ -1,7 +1,6 @@
 package org.broadinstitute.dsde.firecloud.utils
 
 import java.time.Instant
-
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.coding.Coders._

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/SubmissionApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/SubmissionApiService.scala
@@ -37,7 +37,12 @@ trait SubmissionApiService extends FireCloudDirectives {
                 pathEnd {
                   (delete | get | patch) {
                     extract(_.request.method) { method =>
-                      passthrough(encodeUri(s"$workspacesUrl/$namespace/$name/submissions/$submissionId"), method)
+                      // Routes are evaluated in the order they're defined; don't let "validate" pass for submissionId.
+                      if (submissionId != "validate") {
+                        passthrough(encodeUri(s"$workspacesUrl/$namespace/$name/submissions/$submissionId"), method)
+                      } else {
+                        reject()
+                      }
                     }
                   }
                 } ~

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/SubmissionApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/SubmissionApiService.scala
@@ -35,7 +35,7 @@ trait SubmissionApiService extends FireCloudDirectives {
               } ~
               pathPrefix(Segment) { submissionId =>
                 pathEnd {
-                  (delete | get) {
+                  (delete | get | patch) {
                     extract(_.request.method) { method =>
                       passthrough(encodeUri(s"$workspacesUrl/$namespace/$name/submissions/$submissionId"), method)
                     }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockWorkspaceServer.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockWorkspaceServer.scala
@@ -83,14 +83,6 @@ object MockWorkspaceServer {
     workflowFailureMode = Option.empty
   )
 
-  val mockValidComment = UserCommentUpdateOperation(
-    userComment = "This submission came from a mock server."
-  )
-
-  val mockInvalidComment = UserCommentUpdateOperation(
-    userComment = "This invalid submission came from a mock server."
-  )
-
   val workspaceBasePath = FireCloudConfig.Rawls.authPrefix + FireCloudConfig.Rawls.workspacesPath
   val notificationsBasePath = FireCloudConfig.Rawls.authPrefix + FireCloudConfig.Rawls.notificationsPath
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockWorkspaceServer.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockWorkspaceServer.scala
@@ -224,7 +224,7 @@ object MockWorkspaceServer {
         response()
           .withHeaders(header)
           .withStatusCode(BadRequest.intValue)
-          .withBody(MockUtils.rawlsErrorReport(BadRequest).toJson.compactPrint)
+          .withBody(MockUtils.rawlsErrorReport(NotFound).toJson.compactPrint)
       )
 
     MockWorkspaceServer.workspaceServer

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockWorkspaceServer.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockWorkspaceServer.scala
@@ -53,6 +53,7 @@ object MockWorkspaceServer {
 
   val mockValidId = randomPositiveInt()
   val mockInvalidId = randomPositiveInt()
+  val mockValidId1 = randomPositiveInt()
 
   val mockValidSubmission = SubmissionRequest(
     methodConfigurationNamespace = Option(randomAlpha()),
@@ -80,6 +81,14 @@ object MockWorkspaceServer {
     userComment = Option("This invalid submission came from a mock server."),
     memoryRetryMultiplier = Option(1.1d),
     workflowFailureMode = Option.empty
+  )
+
+  val mockValidComment = UserCommentUpdateOperation(
+    userComment = "This submission came from a mock server."
+  )
+
+  val mockInvalidComment = UserCommentUpdateOperation(
+    userComment = "This invalid submission came from a mock server."
   )
 
   val workspaceBasePath = FireCloudConfig.Rawls.authPrefix + FireCloudConfig.Rawls.workspacesPath
@@ -195,6 +204,32 @@ object MockWorkspaceServer {
     MockWorkspaceServer.workspaceServer
       .when(
         request()
+          .withMethod("PATCH")
+          .withPath(s"${workspaceBasePath}/%s/%s/submissions/%s"
+          .format(mockValidWorkspace.namespace, mockValidWorkspace.name, mockValidId)))
+      .respond(
+        response()
+          .withHeaders(header)
+          .withStatusCode(OK.intValue)
+          .withBody(mockValidSubmission.toJson.prettyPrint)
+      )
+
+    MockWorkspaceServer.workspaceServer
+      .when(
+        request()
+          .withMethod("PATCH")
+          .withPath(s"${workspaceBasePath}/%s/%s/submissions/%s"
+            .format(mockValidWorkspace.namespace, mockValidWorkspace.name, mockValidId1)))
+      .respond(
+        response()
+          .withHeaders(header)
+          .withStatusCode(BadRequest.intValue)
+          .withBody(MockUtils.rawlsErrorReport(BadRequest).toJson.compactPrint)
+      )
+
+    MockWorkspaceServer.workspaceServer
+      .when(
+        request()
           .withMethod("GET")
           .withPath(s"${workspaceBasePath}/%s/%s/submissions/%s"
             .format(mockValidWorkspace.namespace, mockValidWorkspace.name, mockInvalidId)))
@@ -209,6 +244,19 @@ object MockWorkspaceServer {
       .when(
         request()
           .withMethod("DELETE")
+          .withPath(s"${workspaceBasePath}/%s/%s/submissions/%s"
+            .format(mockValidWorkspace.namespace, mockValidWorkspace.name, mockInvalidId)))
+      .respond(
+        response()
+          .withHeaders(header)
+          .withStatusCode(NotFound.intValue)
+          .withBody(MockUtils.rawlsErrorReport(NotFound).toJson.compactPrint)
+      )
+
+    MockWorkspaceServer.workspaceServer
+      .when(
+        request()
+          .withMethod("PATCH")
           .withPath(s"${workspaceBasePath}/%s/%s/submissions/%s"
             .format(mockValidWorkspace.namespace, mockValidWorkspace.name, mockInvalidId)))
       .respond(

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockWorkspaceServer.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockWorkspaceServer.scala
@@ -63,6 +63,7 @@ object MockWorkspaceServer {
     useCallCache = Option(randomBoolean()),
     deleteIntermediateOutputFiles = Option(randomBoolean()),
     useReferenceDisks = Option(randomBoolean()),
+    userComment = Option("This submission came from a mock server."),
     memoryRetryMultiplier = Option(1.1d),
     workflowFailureMode = Option(randomElement(List("ContinueWhilePossible", "NoNewCalls")))
   )
@@ -76,6 +77,7 @@ object MockWorkspaceServer {
     useCallCache = Option.empty,
     deleteIntermediateOutputFiles = Option.empty,
     useReferenceDisks = Option.empty,
+    userComment = Option("This invalid submission came from a mock server."),
     memoryRetryMultiplier = Option(1.1d),
     workflowFailureMode = Option.empty
   )

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockWorkspaceServer.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockWorkspaceServer.scala
@@ -87,6 +87,7 @@ object MockWorkspaceServer {
   val workspaceBasePath = FireCloudConfig.Rawls.authPrefix + FireCloudConfig.Rawls.workspacesPath
   val notificationsBasePath = FireCloudConfig.Rawls.authPrefix + FireCloudConfig.Rawls.notificationsPath
 
+  // Mapping from submission ID to the status code and response which the mock server should return when the PATCH endpoint is called
   val submissionIdPatchResponseMapping = List(
     (mockValidId, OK, mockValidSubmission.toJson.prettyPrint),
     (alternativeMockValidId, BadRequest, MockUtils.rawlsErrorReport(BadRequest).toJson.compactPrint),

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/SubmissionApiServiceNegativeSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/SubmissionApiServiceNegativeSpec.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.dsde.firecloud.webservice
 
-import akka.http.scaladsl.model.HttpMethods.{DELETE, GET, POST}
+import akka.http.scaladsl.model.HttpMethods.{DELETE, GET, PATCH, POST}
 import org.broadinstitute.dsde.firecloud.FireCloudConfig
 import org.broadinstitute.dsde.firecloud.mock.MockWorkspaceServer
 import org.broadinstitute.dsde.firecloud.service.ServiceSpec
@@ -48,15 +48,14 @@ final class SubmissionApiServiceNegativeSpec extends ServiceSpec with Submission
     }
 
     "non-POST requests hitting the /workspaces/*/*/submissions/validate path are not passed through" in {
-      // Also excluding DELETE and GET since the path matches
       // /workspaces/*/*/submissions/{submissionId} APIs as well
-      allHttpMethodsExcept(DELETE, GET, POST) foreach { method =>
+      allHttpMethodsExcept(POST) foreach { method =>
         checkIfPassedThrough(submissionServiceRoutes, method, s"$localSubmissionsPath/validate", toBeHandled = false)
       }
     }
 
-    "non-DELETE/GET requests hitting the /workspaces/*/*/submissions/* path are not passed through" in {
-      allHttpMethodsExcept(DELETE, GET) foreach { method =>
+    "non-DELETE/GET/PATCH requests hitting the /workspaces/*/*/submissions/* path are not passed through" in {
+      allHttpMethodsExcept(DELETE, GET, PATCH) foreach { method =>
         checkIfPassedThrough(submissionServiceRoutes, method, localSubmissionIdPath, toBeHandled = false)
       }
     }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/SubmissionApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/SubmissionApiServiceSpec.scala
@@ -6,10 +6,7 @@ import akka.http.scaladsl.server.Route.{seal => sealRoute}
 import org.broadinstitute.dsde.firecloud.FireCloudConfig
 import org.broadinstitute.dsde.firecloud.mock.MockWorkspaceServer
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
-import org.broadinstitute.dsde.firecloud.model.{SubmissionRequest, UserCommentUpdateOperation}
 import org.broadinstitute.dsde.firecloud.service.BaseServiceSpec
-import spray.json.DefaultJsonProtocol.{StringJsonFormat, jsonFormat1}
-import spray.json.JsonFormat
 
 import scala.concurrent.ExecutionContext
 
@@ -192,11 +189,9 @@ final class SubmissionApiServiceSpec extends BaseServiceSpec with SubmissionApiS
       }
     }
 
-    val impUserCommentUpdateOperationFormat = jsonFormat1(UserCommentUpdateOperation)
-
     "when calling PATCH on the /workspaces/*/*/submissions/* path with a valid submission" - {
       "OK response is returned" in {
-        (Patch(localSubmissionIdPath, MockWorkspaceServer.mockValidComment)(impUserCommentUpdateOperationFormat, implicitly[ExecutionContext])
+        (Patch(localSubmissionIdPath, "Never checked")
           ~> dummyAuthHeaders) ~> sealRoute(submissionServiceRoutes) ~> check {
           status should equal(OK)
         }
@@ -205,7 +200,7 @@ final class SubmissionApiServiceSpec extends BaseServiceSpec with SubmissionApiS
 
     "when calling PATCH on the /workspaces/*/*/submissions/* path with an invalid submission ID" - {
       "NotFound response is returned" in {
-        (Patch(localInvalidSubmissionIdPath, MockWorkspaceServer.mockValidComment)(impUserCommentUpdateOperationFormat, implicitly[ExecutionContext])
+        (Patch(localInvalidSubmissionIdPath, "Never checked")
           ~> dummyAuthHeaders) ~> sealRoute(submissionServiceRoutes) ~> check {
           status should equal(NotFound)
           errorReportCheck("Rawls", NotFound)
@@ -215,7 +210,7 @@ final class SubmissionApiServiceSpec extends BaseServiceSpec with SubmissionApiS
 
     "when calling PATCH on the /workspaces/*/*/submissions/* path with an invalid submission ID" - {
       "BadRequest response is returned" in {
-        (Patch(localSubmissionId1Path, MockWorkspaceServer.mockInvalidComment)(impUserCommentUpdateOperationFormat, implicitly[ExecutionContext])
+        (Patch(localSubmissionId1Path, "Never checked")
           ~> dummyAuthHeaders) ~> sealRoute(submissionServiceRoutes) ~> check {
           status should equal(BadRequest)
           errorReportCheck("Rawls", BadRequest)

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/SubmissionApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/SubmissionApiServiceSpec.scala
@@ -191,7 +191,7 @@ final class SubmissionApiServiceSpec extends BaseServiceSpec with SubmissionApiS
 
     "when calling PATCH on the /workspaces/*/*/submissions/* path with a valid submission" - {
       "OK response is returned" in {
-        (Patch(localSubmissionsPath, MockWorkspaceServer.mockValidComment)(impUserCommentUpdateOperationFormat, implicitly[ExecutionContext])
+        (Patch(localSubmissionIdPath, MockWorkspaceServer.mockValidComment)(impUserCommentUpdateOperationFormat, implicitly[ExecutionContext])
           ~> dummyAuthHeaders) ~> sealRoute(submissionServiceRoutes) ~> check {
           status should equal(OK)
         }
@@ -199,11 +199,11 @@ final class SubmissionApiServiceSpec extends BaseServiceSpec with SubmissionApiS
     }
 
     "when calling PATCH on the /workspaces/*/*/submissions/* path with an invalid submission" - {
-      "BadRequest response is returned" in {
-        (Patch(localSubmissionsPath, MockWorkspaceServer.mockInvalidComment)(impUserCommentUpdateOperationFormat, implicitly[ExecutionContext])
+      "Not Found response is returned" in {
+        (Patch(localInvalidSubmissionIdPath, MockWorkspaceServer.mockInvalidComment)(impUserCommentUpdateOperationFormat, implicitly[ExecutionContext])
           ~> dummyAuthHeaders) ~> sealRoute(submissionServiceRoutes) ~> check {
-          status should equal(BadRequest)
-          errorReportCheck("Rawls", BadRequest)
+          status should equal(NotFound)
+          errorReportCheck("Rawls", NotFound)
         }
       }
     }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/SubmissionApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/SubmissionApiServiceSpec.scala
@@ -186,7 +186,7 @@ final class SubmissionApiServiceSpec extends BaseServiceSpec with SubmissionApiS
         }
       }
     }
-   // import spray.json.{JsString, _}
+
     val impUserCommentUpdateOperationFormat = jsonFormat1(UserCommentUpdateOperation)
 
     "when calling PATCH on the /workspaces/*/*/submissions/* path with a valid submission" - {
@@ -199,11 +199,11 @@ final class SubmissionApiServiceSpec extends BaseServiceSpec with SubmissionApiS
     }
 
     "when calling PATCH on the /workspaces/*/*/submissions/* path with an invalid submission" - {
-      "Not Found response is returned" in {
+      "BadRequest response is returned" in {
         (Patch(localInvalidSubmissionIdPath, MockWorkspaceServer.mockInvalidComment)(impUserCommentUpdateOperationFormat, implicitly[ExecutionContext])
           ~> dummyAuthHeaders) ~> sealRoute(submissionServiceRoutes) ~> check {
-          status should equal(NotFound)
-          errorReportCheck("Rawls", NotFound)
+          status should equal(BadRequest)
+          errorReportCheck("Rawls", BadRequest)
         }
       }
     }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/SubmissionApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/SubmissionApiServiceSpec.scala
@@ -6,6 +6,7 @@ import akka.http.scaladsl.server.Route.{seal => sealRoute}
 import org.broadinstitute.dsde.firecloud.FireCloudConfig
 import org.broadinstitute.dsde.firecloud.mock.MockWorkspaceServer
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
+import org.broadinstitute.dsde.firecloud.model.SubmissionRequest
 import org.broadinstitute.dsde.firecloud.service.BaseServiceSpec
 
 import scala.concurrent.ExecutionContext

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/SubmissionApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/SubmissionApiServiceSpec.scala
@@ -185,6 +185,25 @@ final class SubmissionApiServiceSpec extends BaseServiceSpec with SubmissionApiS
       }
     }
 
+    "when calling PATCH on the /workspaces/*/*/submissions/* path with a valid submission" - {
+      "OK response is returned" in {
+        (Patch(localSubmissionsPath, MockWorkspaceServer.mockValidComment)
+          ~> dummyAuthHeaders) ~> sealRoute(submissionServiceRoutes) ~> check {
+          status should equal(OK)
+        }
+      }
+    }
+
+    "when calling PATCH on the /workspaces/*/*/submissions/* path with an invalid submission" - {
+      "BadRequest response is returned" in {
+        (Patch(localSubmissionsPath, MockWorkspaceServer.mockInvalidComment)
+          ~> dummyAuthHeaders) ~> sealRoute(submissionServiceRoutes) ~> check {
+          status should equal(BadRequest)
+          errorReportCheck("Rawls", BadRequest)
+        }
+      }
+    }
+
     "when calling GET on the /workspaces/*/*/submissions/*/workflows/* path" - {
       "with a valid id, OK response is returned" in {
         Get(localSubmissionWorkflowIdPath) ~> dummyAuthHeaders ~> sealRoute(submissionServiceRoutes) ~> check {

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/SubmissionApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/SubmissionApiServiceSpec.scala
@@ -6,8 +6,10 @@ import akka.http.scaladsl.server.Route.{seal => sealRoute}
 import org.broadinstitute.dsde.firecloud.FireCloudConfig
 import org.broadinstitute.dsde.firecloud.mock.MockWorkspaceServer
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
-import org.broadinstitute.dsde.firecloud.model.SubmissionRequest
+import org.broadinstitute.dsde.firecloud.model.{SubmissionRequest, UserCommentUpdateOperation}
 import org.broadinstitute.dsde.firecloud.service.BaseServiceSpec
+import spray.json.DefaultJsonProtocol.{StringJsonFormat, jsonFormat1}
+import spray.json.JsonFormat
 
 import scala.concurrent.ExecutionContext
 
@@ -184,10 +186,12 @@ final class SubmissionApiServiceSpec extends BaseServiceSpec with SubmissionApiS
         }
       }
     }
+   // import spray.json.{JsString, _}
+    val impUserCommentUpdateOperationFormat = jsonFormat1(UserCommentUpdateOperation)
 
     "when calling PATCH on the /workspaces/*/*/submissions/* path with a valid submission" - {
       "OK response is returned" in {
-        (Patch(localSubmissionsPath, MockWorkspaceServer.mockValidComment)
+        (Patch(localSubmissionsPath, MockWorkspaceServer.mockValidComment)(impUserCommentUpdateOperationFormat, implicitly[ExecutionContext])
           ~> dummyAuthHeaders) ~> sealRoute(submissionServiceRoutes) ~> check {
           status should equal(OK)
         }
@@ -196,7 +200,7 @@ final class SubmissionApiServiceSpec extends BaseServiceSpec with SubmissionApiS
 
     "when calling PATCH on the /workspaces/*/*/submissions/* path with an invalid submission" - {
       "BadRequest response is returned" in {
-        (Patch(localSubmissionsPath, MockWorkspaceServer.mockInvalidComment)
+        (Patch(localSubmissionsPath, MockWorkspaceServer.mockInvalidComment)(impUserCommentUpdateOperationFormat, implicitly[ExecutionContext])
           ~> dummyAuthHeaders) ~> sealRoute(submissionServiceRoutes) ~> check {
           status should equal(BadRequest)
           errorReportCheck("Rawls", BadRequest)

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/SubmissionApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/SubmissionApiServiceSpec.scala
@@ -38,6 +38,11 @@ final class SubmissionApiServiceSpec extends BaseServiceSpec with SubmissionApiS
     MockWorkspaceServer.mockValidWorkspace.name,
     MockWorkspaceServer.mockValidId)
 
+  val localSubmissionId1Path = FireCloudConfig.Rawls.submissionsIdPath.format(
+    MockWorkspaceServer.mockValidWorkspace.namespace,
+    MockWorkspaceServer.mockValidWorkspace.name,
+    MockWorkspaceServer.mockValidId1)
+
   val localInvalidSubmissionIdPath = FireCloudConfig.Rawls.submissionsIdPath.format(
     MockWorkspaceServer.mockValidWorkspace.namespace,
     MockWorkspaceServer.mockValidWorkspace.name,
@@ -198,9 +203,19 @@ final class SubmissionApiServiceSpec extends BaseServiceSpec with SubmissionApiS
       }
     }
 
-    "when calling PATCH on the /workspaces/*/*/submissions/* path with an invalid submission" - {
+    "when calling PATCH on the /workspaces/*/*/submissions/* path with an invalid submission ID" - {
+      "NotFound response is returned" in {
+        (Patch(localInvalidSubmissionIdPath, MockWorkspaceServer.mockValidComment)(impUserCommentUpdateOperationFormat, implicitly[ExecutionContext])
+          ~> dummyAuthHeaders) ~> sealRoute(submissionServiceRoutes) ~> check {
+          status should equal(NotFound)
+          errorReportCheck("Rawls", NotFound)
+        }
+      }
+    }
+
+    "when calling PATCH on the /workspaces/*/*/submissions/* path with an invalid submission ID" - {
       "BadRequest response is returned" in {
-        (Patch(localInvalidSubmissionIdPath, MockWorkspaceServer.mockInvalidComment)(impUserCommentUpdateOperationFormat, implicitly[ExecutionContext])
+        (Patch(localSubmissionId1Path, MockWorkspaceServer.mockInvalidComment)(impUserCommentUpdateOperationFormat, implicitly[ExecutionContext])
           ~> dummyAuthHeaders) ~> sealRoute(submissionServiceRoutes) ~> check {
           status should equal(BadRequest)
           errorReportCheck("Rawls", BadRequest)

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/SubmissionApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/SubmissionApiServiceSpec.scala
@@ -36,11 +36,6 @@ final class SubmissionApiServiceSpec extends BaseServiceSpec with SubmissionApiS
     MockWorkspaceServer.mockValidWorkspace.name,
     MockWorkspaceServer.mockValidId)
 
-  val localSubmissionId1Path = FireCloudConfig.Rawls.submissionsIdPath.format(
-    MockWorkspaceServer.mockValidWorkspace.namespace,
-    MockWorkspaceServer.mockValidWorkspace.name,
-    MockWorkspaceServer.alternativeMockValidId)
-
   val localInvalidSubmissionIdPath = FireCloudConfig.Rawls.submissionsIdPath.format(
     MockWorkspaceServer.mockValidWorkspace.namespace,
     MockWorkspaceServer.mockValidWorkspace.name,
@@ -198,7 +193,8 @@ final class SubmissionApiServiceSpec extends BaseServiceSpec with SubmissionApiS
             MockWorkspaceServer.mockValidWorkspace.name,
             id)
 
-          (Patch(submissionIdPath, "Never checked")
+          (Patch(submissionIdPath, "PATCH request body. The mock server will ignore this content and respond " +
+            "entirely based on submission ID instead")
             ~> dummyAuthHeaders) ~> sealRoute(submissionServiceRoutes) ~> check {
             status should equal(expectedResponseCode)
             if (status != OK) {


### PR DESCRIPTION
\<your comments for this PR go here\>

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [x] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
