### PR TITLE
AS-245: Improve resilience of storage cost estimate endpoint

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -48,4 +48,47 @@ googlecloud {
   # egress key previouly was "CP-COMPUTEENGINE-INTERNET-EGRESS-NA-NA"
   priceListEgressKey = "CP-INTERNET-EGRESS-STANDARD-TIER-FROM-NA"
   priceListStorageKey = "CP-BIGSTORE-STANDARD"
+
+  defaultStoragePriceList = {
+                               "us-central1": 0.02,
+                               "us-east1": 0.02,
+                               "us-east4": 0.023,
+                               "us-west4": 0.023,
+                               "us-west1": 0.02,
+                               "us-west2": 0.023,
+                               "us-west3": 0.023,
+                               "europe-west1": 0.02,
+                               "europe-west2": 0.023,
+                               "europe-west3": 0.023,
+                               "europe-central2": 0.023,
+                               "europe-west4": 0.020,
+                               "europe-west6": 0.025,
+                               "europe-north1": 0.020,
+                               "northamerica-northeast1": 0.023,
+                               "northamerica-northeast2": 0.023,
+                               "asia-east1": 0.02,
+                               "asia-east2": 0.023,
+                               "asia-northeast1": 0.023,
+                               "asia-southeast2": 0.023,
+                               "asia-northeast2": 0.023,
+                               "asia-northeast3": 0.023,
+                               "asia-southeast1": 0.02,
+                               "australia-southeast1": 0.023,
+                               "australia-southeast2": 0.023,
+                               "southamerica-east1": 0.035,
+                               "asia-south1": 0.023,
+                               "asia-south2": 0.023,
+                               "us": 0.026,
+                               "europe": 0.026,
+                               "asia": 0.026,
+                               "asia1": 0.046,
+                               "eur4": 0.036,
+                               "nam4": 0.036
+                             }
+
+  defaultEgressPriceList = {
+                            "10240": 0.085,
+                            "153600": 0.065,
+                            "153601": 0.045
+                           }
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/Boot.scala
@@ -27,7 +27,7 @@ object Boot extends App with LazyLogging {
     val rawlsDAO:RawlsDAO = new HttpRawlsDAO
     val samDAO:SamDAO = new HttpSamDAO
     val thurloeDAO:ThurloeDAO = new HttpThurloeDAO
-    val googleServicesDAO:GoogleServicesDAO = new HttpGoogleServicesDAO
+    val googleServicesDAO:GoogleServicesDAO = new HttpGoogleServicesDAO(GooglePriceList(GooglePrices(FireCloudConfig.GoogleCloud.defaultStoragePriceList, UsTieredPriceItem(FireCloudConfig.GoogleCloud.defaultEgressPriceList)), "1", "1"))
     val ontologyDAO:OntologyDAO = new ElasticSearchOntologyDAO(elasticSearchClient, FireCloudConfig.ElasticSearch.ontologyIndexName)
     val consentDAO:ConsentDAO = new HttpConsentDAO
     val researchPurposeSupport:ResearchPurposeSupport = new ESResearchPurposeSupport(ontologyDAO)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/Boot.scala
@@ -27,7 +27,7 @@ object Boot extends App with LazyLogging {
     val rawlsDAO:RawlsDAO = new HttpRawlsDAO
     val samDAO:SamDAO = new HttpSamDAO
     val thurloeDAO:ThurloeDAO = new HttpThurloeDAO
-    val googleServicesDAO:GoogleServicesDAO = new HttpGoogleServicesDAO(GooglePriceList(GooglePrices(FireCloudConfig.GoogleCloud.defaultStoragePriceList, UsTieredPriceItem(FireCloudConfig.GoogleCloud.defaultEgressPriceList)), "1", "1"))
+    val googleServicesDAO:GoogleServicesDAO = new HttpGoogleServicesDAO(FireCloudConfig.GoogleCloud.priceListUrl, GooglePriceList(GooglePrices(FireCloudConfig.GoogleCloud.defaultStoragePriceList, UsTieredPriceItem(FireCloudConfig.GoogleCloud.defaultEgressPriceList)), "v1", "1"))
     val ontologyDAO:OntologyDAO = new ElasticSearchOntologyDAO(elasticSearchClient, FireCloudConfig.ElasticSearch.ontologyIndexName)
     val consentDAO:ConsentDAO = new HttpConsentDAO
     val researchPurposeSupport:ResearchPurposeSupport = new ESResearchPurposeSupport(ontologyDAO)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
@@ -173,6 +173,10 @@ object FireCloudConfig {
     val priceListUrl = googlecloud.getString("priceListUrl")
     val priceListEgressKey = googlecloud.getString("priceListEgressKey")
     val priceListStorageKey = googlecloud.getString("priceListStorageKey")
+    val defaultStoragePriceListConf = googlecloud.getConfig("defaultStoragePriceList")
+    val defaultStoragePriceList = defaultStoragePriceListConf.root().keySet().asScala.map(key => key -> BigDecimal(defaultStoragePriceListConf.getDouble(key))).toMap
+    val defaultEgressPriceListConf = googlecloud.getConfig("defaultEgressPriceList")
+    val defaultEgressPriceList = defaultEgressPriceListConf.root().keySet().asScala.map(key => key.toLong -> BigDecimal(defaultEgressPriceListConf.getDouble(key))).toMap
   }
 
   object Duos {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/GoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/GoogleServicesDAO.scala
@@ -32,7 +32,7 @@ trait GoogleServicesDAO extends ReportsSubsystemStatus {
   def listObjectsAsRawlsSA(bucketName: String, prefix: String): List[String]
   def getObjectContentsAsRawlsSA(bucketName: String, objectKey: String): String
 
-  def fetchPriceList(implicit executionContext: ExecutionContext): Future[GooglePriceList]
+  val fetchPriceList: Future[GooglePriceList]
 
   def deleteGoogleGroup(groupEmail: String) : Unit
   def createGoogleGroup(groupName: String): Option[String]

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
@@ -466,7 +466,7 @@ class HttpGoogleServicesDAO(priceListUrl: String, defaultPriceList: GooglePriceL
   //Because the price list is brittle and Google sometimes changes the names of keys in the JSON, there is a
   //default cached value in configuration to use as a backup. If we fallback to it, the error will be logged
   //but users will probably not notice a difference. They're cost *estimates*, after all.
-  val fetchPriceList: Future[GooglePriceList] = {
+  lazy val fetchPriceList: Future[GooglePriceList] = {
     val httpReq = Get(priceListUrl)
 
     unAuthedRequestToObject[GooglePriceList](httpReq).recover {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
@@ -104,7 +104,7 @@ object HttpGoogleServicesDAO {
   }
 }
 
-class HttpGoogleServicesDAO(defaultPriceList: GooglePriceList)(implicit val system: ActorSystem, implicit val materializer: Materializer, implicit val executionContext: ExecutionContext) extends GoogleServicesDAO with FireCloudRequestBuilding with LazyLogging with RestJsonClient with SprayJsonSupport {
+class HttpGoogleServicesDAO(priceListUrl: String, defaultPriceList: GooglePriceList)(implicit val system: ActorSystem, implicit val materializer: Materializer, implicit val executionContext: ExecutionContext) extends GoogleServicesDAO with FireCloudRequestBuilding with LazyLogging with RestJsonClient with SprayJsonSupport {
 
   // application name to use within Google api libraries
   private final val appName = "firecloud:orchestration"
@@ -467,9 +467,7 @@ class HttpGoogleServicesDAO(defaultPriceList: GooglePriceList)(implicit val syst
   //default cached value in configuration to use as a backup. If we fallback to it, the error will be logged
   //but users will probably not notice a difference. They're cost *estimates*, after all.
   val fetchPriceList: Future[GooglePriceList] = {
-    val httpReq = Get(FireCloudConfig.GoogleCloud.priceListUrl)
-
-    println("fetching pricelist...")
+    val httpReq = Get(priceListUrl)
 
     unAuthedRequestToObject[GooglePriceList](httpReq).recover {
       case t: Throwable =>

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
@@ -471,7 +471,7 @@ class HttpGoogleServicesDAO(priceListUrl: String, defaultPriceList: GooglePriceL
 
     unAuthedRequestToObject[GooglePriceList](httpReq).recover {
       case t: Throwable =>
-        logger.warn(s"Unable to fetch/parse latest Google price list. A cached (possibly outdated) value will be used instead. Error: ${t.getMessage}")
+        logger.error(s"Unable to fetch/parse latest Google price list. A cached (possibly outdated) value will be used instead. Error: ${t.getMessage}")
         defaultPriceList
     }
   }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAOSpec.scala
@@ -59,7 +59,7 @@ class HttpGoogleServicesDAOSpec extends AnyFlatSpec with Matchers with PrivateMe
     priceList.version should startWith ("v")
     priceList.updated should not be empty
     priceList.prices.cpBigstoreStorage("us") shouldBe BigDecimal(-0.11)
-    priceList.prices.cpComputeengineInternetEgressNA.tiers.size shouldBe BigDecimal(-0.22)
+    priceList.prices.cpComputeengineInternetEgressNA.tiers.size shouldBe 1
   }
 
   /** This test will fail if md5Hash is not optional. However, its relationship to the code that depends on this

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockGoogleServicesDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockGoogleServicesDAO.scala
@@ -96,7 +96,7 @@ class MockGoogleServicesDAO extends GoogleServicesDAO {
                              (implicit executionContext: ExecutionContext): Future[HttpResponse] = Future.failed(new UnsupportedOperationException)
   override def getDownload(bucketName: String, objectKey: String, userAuthToken: WithAccessToken)
                           (implicit executionContext: ExecutionContext): Future[PerRequestMessage] = {Future.successful(RequestComplete(StatusCodes.NotImplemented))}
-  override def fetchPriceList(implicit executionContext: ExecutionContext): Future[GooglePriceList] = {
+  override val fetchPriceList: Future[GooglePriceList] = {
     Future.successful(GooglePriceList(GooglePrices(Map("us" -> 0.01, "europe-west1" -> 0.02), UsTieredPriceItem(Map(1024L -> BigDecimal(0.12)))), "v0", "18-November-2016"))
   }
 


### PR DESCRIPTION
Improvements:

- only call the pricelist once when booting, then cache it as a `val`
- if the pricelist isn't available or can't be parsed, default to a hardcoded json and log an error so we can fix it at our leisure

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
