### PR TITLE
rename pfb classes/methods [AS-916]

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/EntityService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/EntityService.scala
@@ -229,9 +229,8 @@ class EntityService(rawlsDAO: RawlsDAO, importServiceDAO: ImportServiceDAO, goog
     val insertedObject = googleServicesDAO.writeObjectAsRawlsSA(bucketToWrite, fileToWrite, dataBytes)
     val gcsPath = s"gs://${insertedObject.bucketName.value}/${insertedObject.objectName.value}"
 
-    // TODO: this is functional, but the class name "PfbImportRequest" is misleading; rename it?
-    val importRequest = PfbImportRequest(Option(gcsPath))
-    importServiceDAO.importBatchUpsertJson(workspaceNamespace, workspaceName, importRequest)(userInfo)
+    val importRequest = AsyncImportRequest(Option(gcsPath))
+    importServiceDAO.importRawlsJson(workspaceNamespace, workspaceName, importRequest)(userInfo)
   }
 
   private def handleBatchRawlsResponse(entityType: String, response: Future[HttpResponse]): Future[PerRequestMessage] = {
@@ -348,7 +347,7 @@ class EntityService(rawlsDAO: RawlsDAO, importServiceDAO: ImportServiceDAO, goog
     }
   }
 
-  def importPFB(workspaceNamespace: String, workspaceName: String, pfbRequest: PfbImportRequest, userInfo: UserInfo): Future[PerRequestMessage] = {
+  def importPFB(workspaceNamespace: String, workspaceName: String, pfbRequest: AsyncImportRequest, userInfo: UserInfo): Future[PerRequestMessage] = {
     importServiceDAO.importPFB(workspaceNamespace, workspaceName, pfbRequest)(userInfo)
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ImportServiceDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ImportServiceDAO.scala
@@ -1,14 +1,14 @@
 package org.broadinstitute.dsde.firecloud.dataaccess
 
-import org.broadinstitute.dsde.firecloud.model.{ImportServiceRequest, PfbImportRequest, UserInfo}
+import org.broadinstitute.dsde.firecloud.model.{ImportServiceRequest, AsyncImportRequest, UserInfo}
 import org.broadinstitute.dsde.firecloud.service.PerRequest.PerRequestMessage
 
 import scala.concurrent.Future
 
 trait ImportServiceDAO {
 
-  def importPFB(workspaceNamespace: String, workspaceName: String, pfbRequest: PfbImportRequest)(implicit userInfo: UserInfo): Future[PerRequestMessage]
+  def importPFB(workspaceNamespace: String, workspaceName: String, pfbRequest: AsyncImportRequest)(implicit userInfo: UserInfo): Future[PerRequestMessage]
 
-  def importBatchUpsertJson(workspaceNamespace: String, workspaceName: String, pfbRequest: PfbImportRequest)(implicit userInfo: UserInfo): Future[PerRequestMessage]
+  def importRawlsJson(workspaceNamespace: String, workspaceName: String, rawlsJsonRequest: AsyncImportRequest)(implicit userInfo: UserInfo): Future[PerRequestMessage]
 
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
@@ -229,8 +229,8 @@ object ModelJsonProtocol extends WorkspaceJsonSupport with SprayJsonSupport {
   implicit val impUserImportPermission = jsonFormat2(UserImportPermission)
 
   implicit val impBagitImportRequest = jsonFormat2(BagitImportRequest)
-  implicit val impPfbImportRequest = jsonFormat1(PfbImportRequest)
-  implicit val impPfbImportResponse = jsonFormat3(PfbImportResponse)
+  implicit val impAsyncImportRequest = jsonFormat1(AsyncImportRequest)
+  implicit val impAsyncImportResponse = jsonFormat3(AsyncImportResponse)
   implicit val impImportServiceRequest = jsonFormat2(ImportServiceRequest)
   implicit val impImportServiceResponse = jsonFormat3(ImportServiceResponse)
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/Workspace.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/Workspace.scala
@@ -28,7 +28,7 @@ case class EntityId(entityType: String, entityName: String)
 
 case class BagitImportRequest(bagitURL: String, format: String)
 
-// the request payload sent by users to Orchestration for async PFB/TSV imports
+// the request payload sent by users to Orchestration for async PFB imports
 case class AsyncImportRequest(url: Option[String])
 
 // the response payload received by users from Orchestration for async PFB/TSV imports

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/Workspace.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/Workspace.scala
@@ -28,16 +28,19 @@ case class EntityId(entityType: String, entityName: String)
 
 case class BagitImportRequest(bagitURL: String, format: String)
 
-case class PfbImportRequest(url: Option[String])
+// the request payload sent by users to Orchestration for async PFB/TSV imports
+case class AsyncImportRequest(url: Option[String])
 
-case class PfbImportResponse(url: String,
-                             jobId: String,
-                             workspace: WorkspaceName)
+// the response payload received by users from Orchestration for async PFB/TSV imports
+case class AsyncImportResponse(url: String,
+                               jobId: String,
+                               workspace: WorkspaceName)
 
+// the request payload sent by Orchestration to Import Service
 case class ImportServiceRequest(
   path: String,
   filetype: String)
-
+// the response payload received by Orchestration from Import Service
 case class ImportServiceResponse(
   jobId: String,
   status: String,

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiService.scala
@@ -145,7 +145,7 @@ trait WorkspaceApiService extends FireCloudRequestBuilding with FireCloudDirecti
                 path("importPFB") {
                   post {
                     requireUserInfo() { userInfo =>
-                      entity(as[PfbImportRequest]) { pfbRequest =>
+                      entity(as[AsyncImportRequest]) { pfbRequest =>
                         complete { entityServiceConstructor(FlexibleModelSchema).importPFB(workspaceNamespace, workspaceName, pfbRequest, userInfo) }
                       }
                     }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/EntityServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/EntityServiceSpec.scala
@@ -6,7 +6,7 @@ import com.google.cloud.storage.StorageException
 import org.broadinstitute.dsde.firecloud.dataaccess.MockImportServiceDAO
 import org.broadinstitute.dsde.firecloud.mock.MockGoogleServicesDAO
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
-import org.broadinstitute.dsde.firecloud.model.{FirecloudModelSchema, ImportServiceResponse, ModelSchema, PfbImportRequest, RequestCompleteWithErrorReport, UserInfo}
+import org.broadinstitute.dsde.firecloud.model.{FirecloudModelSchema, ImportServiceResponse, ModelSchema, AsyncImportRequest, RequestCompleteWithErrorReport, UserInfo}
 import org.broadinstitute.dsde.firecloud.service.PerRequest.RequestComplete
 import org.broadinstitute.dsde.firecloud.service.{BaseServiceSpec, PerRequest}
 import org.broadinstitute.dsde.rawls.model.{ErrorReport, ErrorReportSource}
@@ -208,7 +208,7 @@ class EntityServiceSpec extends BaseServiceSpec with BeforeAndAfterEach {
   class SuccessfulImportServiceDAO extends MockImportServiceDAO {
     def successDefinition: RequestComplete[(StatusCodes.Success, ImportServiceResponse)] = RequestComplete(StatusCodes.Created, ImportServiceResponse("unit-test-job-id", "unit-test-created-status", None))
 
-    override def importBatchUpsertJson(workspaceNamespace: String, workspaceName: String, pfbRequest: PfbImportRequest)(implicit userInfo: UserInfo): Future[PerRequest.PerRequestMessage] = {
+    override def importRawlsJson(workspaceNamespace: String, workspaceName: String, rawlsJsonRequest: AsyncImportRequest)(implicit userInfo: UserInfo): Future[PerRequest.PerRequestMessage] = {
       Future.successful(successDefinition)
     }
   }
@@ -218,7 +218,7 @@ class EntityServiceSpec extends BaseServiceSpec with BeforeAndAfterEach {
     // return a 429 so unit tests have an easy way to distinguish this error vs an error somewhere else in the stack
     def errorDefinition: RequestComplete[(StatusCode, ErrorReport)] = RequestCompleteWithErrorReport(StatusCodes.TooManyRequests, "intentional ErroringImportServiceDAO error")
 
-    override def importBatchUpsertJson(workspaceNamespace: String, workspaceName: String, pfbRequest: PfbImportRequest)(implicit userInfo: UserInfo): Future[PerRequest.PerRequestMessage] = {
+    override def importRawlsJson(workspaceNamespace: String, workspaceName: String, rawlsJsonRequest: AsyncImportRequest)(implicit userInfo: UserInfo): Future[PerRequest.PerRequestMessage] = {
       Future.successful(errorDefinition)
     }
   }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpImportServiceDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpImportServiceDAOSpec.scala
@@ -6,8 +6,8 @@ import akka.http.scaladsl.model.StatusCodes._
 import akka.http.scaladsl.model.{ContentTypes, HttpEntity, HttpResponse}
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
-import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol.{impImportServiceResponse, impPfbImportResponse}
-import org.broadinstitute.dsde.firecloud.model.{ImportServiceResponse, PfbImportRequest, PfbImportResponse, RequestCompleteWithErrorReport}
+import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol.{impImportServiceResponse, impAsyncImportResponse}
+import org.broadinstitute.dsde.firecloud.model.{ImportServiceResponse, AsyncImportRequest, AsyncImportResponse, RequestCompleteWithErrorReport}
 import org.broadinstitute.dsde.firecloud.service.PerRequest.RequestComplete
 import org.broadinstitute.dsde.rawls.model.WorkspaceName
 import org.scalatest.flatspec.AsyncFlatSpec
@@ -26,12 +26,12 @@ class HttpImportServiceDAOSpec extends AsyncFlatSpec with Matchers with SprayJso
   val workspaceNamespace = "workspaceNamespace"
   val workspaceName = "workspaceName"
   val pfbUrl = "unittest-fixture-url"
-  val pfbRequest = PfbImportRequest(Some(pfbUrl))
+  val pfbRequest = AsyncImportRequest(Some(pfbUrl))
 
   val jobId = UUID.randomUUID()
   val importServicePayload = ImportServiceResponse(jobId.toString, "status", None).toJson.compactPrint
 
-  val expectedSuccessPayload = PfbImportResponse(
+  val expectedSuccessPayload = AsyncImportResponse(
     pfbUrl,
     jobId.toString,
     WorkspaceName(workspaceNamespace, workspaceName))

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockImportServiceDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockImportServiceDAO.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.firecloud.dataaccess
 import java.util.UUID
 
 import akka.http.scaladsl.model.StatusCodes._
-import org.broadinstitute.dsde.firecloud.model.{PfbImportRequest, PfbImportResponse, UserInfo}
+import org.broadinstitute.dsde.firecloud.model.{AsyncImportRequest, AsyncImportResponse, UserInfo}
 import org.broadinstitute.dsde.firecloud.service.PerRequest
 import org.broadinstitute.dsde.firecloud.service.PerRequest.RequestComplete
 import org.broadinstitute.dsde.rawls.model.WorkspaceName
@@ -11,14 +11,14 @@ import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
 import scala.concurrent.Future
 
 class MockImportServiceDAO extends ImportServiceDAO {
-  override def importPFB(workspaceNamespace: String, workspaceName: String, pfbRequest: PfbImportRequest)(implicit userInfo: UserInfo): Future[PerRequest.PerRequestMessage] = {
+  override def importPFB(workspaceNamespace: String, workspaceName: String, pfbRequest: AsyncImportRequest)(implicit userInfo: UserInfo): Future[PerRequest.PerRequestMessage] = {
     pfbRequest.url match {
       case Some(url) => {
         if(url.contains("forbidden")) Future.successful(RequestComplete(Forbidden, "Missing Authorization: Bearer token in header"))
         else if(url.contains("bad.request")) Future.successful(RequestComplete(BadRequest, "Bad request as reported by import service"))
         else if(url.contains("its.lawsuit.time")) Future.successful(RequestComplete(UnavailableForLegalReasons, "import service message"))
         else if(url.contains("good")) Future.successful(RequestComplete(Accepted,
-          PfbImportResponse(url = pfbRequest.url.getOrElse(""),
+          AsyncImportResponse(url = pfbRequest.url.getOrElse(""),
             jobId = UUID.randomUUID().toString,
             workspace = WorkspaceName(workspaceNamespace, workspaceName))
           )
@@ -30,5 +30,5 @@ class MockImportServiceDAO extends ImportServiceDAO {
     }
   }
 
-  override def importBatchUpsertJson(workspaceNamespace: String, workspaceName: String, pfbRequest: PfbImportRequest)(implicit userInfo: UserInfo): Future[PerRequest.PerRequestMessage] = ???
+  override def importRawlsJson(workspaceNamespace: String, workspaceName: String, rawlsJsonRequest: AsyncImportRequest)(implicit userInfo: UserInfo): Future[PerRequest.PerRequestMessage] = ???
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiServiceSpec.scala
@@ -1065,7 +1065,7 @@ class WorkspaceApiServiceSpec extends BaseServiceSpec with WorkspaceApiService w
 
         val pfbPath = "https://good.avro"
 
-        val orchExpectedPayload = PfbImportResponse(url = pfbPath,
+        val orchExpectedPayload = AsyncImportResponse(url = pfbPath,
                                                    jobId = "MockImportServiceDAO will generate a random UUID",
                                                    workspace = WorkspaceName(workspace.namespace, workspace.name))
 
@@ -1073,7 +1073,7 @@ class WorkspaceApiServiceSpec extends BaseServiceSpec with WorkspaceApiService w
           ~> dummyUserIdHeaders(dummyUserId)
           ~> sealRoute(workspaceRoutes)) ~> check {
             status should equal(Accepted)
-            val jobResponse = responseAs[PfbImportResponse]
+            val jobResponse = responseAs[AsyncImportResponse]
             jobResponse.url should be (orchExpectedPayload.url)
             jobResponse.workspace should be (orchExpectedPayload.workspace)
             jobResponse.jobId  should not be empty


### PR DESCRIPTION
This is a followup to #861. This PR includes renaming that could have been part of that other PR, but I wanted to put in its own PR to ease reviews. In this PR:
* rename `ImportServiceDAO. importBatchUpsertJson` to `ImportServiceDAO.importRawlsJson` to be generic - it will support both upserts and updates soon.
* rename `PfbImportRequest` to `AsyncImportRequest`, since it now handles both PFBs and TSVs
* rename `PfbImportResponse` to `AsyncImportResponse`, since it now handles both PFBs and TSVs

There should be no functional changes beyond these renamings!
