### PR TITLE
deprecate importPFB/jobId; add importJob/jobId [AS-916]

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -4904,11 +4904,12 @@ paths:
       x-codegen-request-body-name: pfbImportRequest
   /api/workspaces/{workspaceNamespace}/{workspaceName}/importPFB/{jobId}:
     get:
+      deprecated: true
       tags:
         - Entities
-      summary: Report status on a PFB import job
+      summary: Use the importJob API instead.
       description: |
-        This API will return status of an import jobID. The jobID was returned from a previous import request.
+        Use /api/workspaces/{workspaceNamespace}/{workspaceName}/importJob/{jobId} instead.
       operationId: importPFBStatus
       parameters:
         - name: workspaceNamespace
@@ -4935,7 +4936,48 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PFBStatusResponse'
+                $ref: '#/components/schemas/ImportJobStatusResponse'
+        404:
+          description: workspace or job ID not found
+          content: {}
+        500:
+          description: Internal Error
+          content: {}
+      x-passthrough: false
+  /api/workspaces/{workspaceNamespace}/{workspaceName}/importJob/{jobId}:
+    get:
+      tags:
+        - Entities
+      summary: Report status on an asynchronous import job
+      description: |
+        This API will return status of an import jobID. The jobID was returned from a previous import request.
+      operationId: importJobStatus
+      parameters:
+        - name: workspaceNamespace
+          in: path
+          description: Workspace Namespace
+          required: true
+          schema:
+            type: string
+        - name: workspaceName
+          in: path
+          description: Workspace Name
+          required: true
+          schema:
+            type: string
+        - name: jobId
+          in: path
+          description: job ID of the import to check
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: Successful Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ImportJobStatusResponse'
         404:
           description: workspace or job ID not found
           content: {}
@@ -8745,7 +8787,7 @@ components:
             name:
               type: string
               description: the workspace name specified in the request
-    PFBStatusResponse:
+    ImportJobStatusResponse:
       required:
         - jobId
         - status

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiService.scala
@@ -158,7 +158,8 @@ trait WorkspaceApiService extends FireCloudRequestBuilding with FireCloudDirecti
                       }
                     }
                 } ~
-                path("importPFB" / Segment) { jobId =>
+                // importPFB/jobId is deprecated; use importJob/jobId instead
+                path(("importPFB" | "importJob") / Segment) { jobId =>
                   get {
                     requireUserInfo() { userInfo =>
                       passthrough(Uri(encodeUri(s"${FireCloudConfig.ImportService.server}/$workspaceNamespace/$workspaceName/imports/$jobId")), HttpMethods.GET)


### PR DESCRIPTION
**REVIEWER**: I suggest you ignore whitespace, the diff is much easier to read!

-----

This PR:
* Deprecates the `/api/workspaces/{workspaceNamespace}/{workspaceName}/importPFB/{jobId}` API
* Adds a copy of that now-deprecated API at `/api/workspaces/{workspaceNamespace}/{workspaceName}/importJob/{jobId}`