### PR TITLE
AS-924: Support attribute arrays in TSVs

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelSchema.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelSchema.scala
@@ -24,6 +24,10 @@ trait ModelSchema {
   def getTypeSchema(entityType: String): Try[EntityMetadata]
   def supportsBackwardsCompatibleIds: Boolean
 
+  def isAttributeArray(value: String): Boolean = {
+    value.startsWith("[") && value.endsWith("]") //TODO: this would be much better with a regex
+  }
+
   def isEntityTypeInSchema(entityType: String): Boolean = {
     Try(this.getCollectionMemberType(entityType)) match {
       case Failure(_) => false

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelSchema.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelSchema.scala
@@ -5,6 +5,7 @@ import akka.http.scaladsl.model.StatusCodes
 import scala.io.Source
 import scala.util.{Failure, Success, Try}
 import spray.json._
+import DefaultJsonProtocol._
 import org.broadinstitute.dsde.firecloud.{FireCloudConfig, FireCloudException, FireCloudExceptionWithErrorReport}
 import org.broadinstitute.dsde.rawls.model.ErrorReport
 
@@ -25,7 +26,7 @@ trait ModelSchema {
   def supportsBackwardsCompatibleIds: Boolean
 
   def isAttributeArray(value: String): Boolean = {
-    value.startsWith("[") && value.endsWith("]") //TODO: this would be much better with a regex
+    Try(value.parseJson.convertTo[JsArray]).isSuccess
   }
 
   def isEntityTypeInSchema(entityType: String): Boolean = {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/TSVFileSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/TSVFileSupport.scala
@@ -154,7 +154,7 @@ trait TSVFileSupport {
             val listNameEntry = "attributeListName" -> AttributeString(attributeName)
             def listValEntry( attr: Attribute ) = "newMember" -> attr
 
-            listElements match {
+            val addElements = listElements match {
               case elements if elements.forall(_.isInstanceOf[JsString]) =>
                 val elementsTyped: List[JsString] = elements.asInstanceOf[List[JsString]]
                 elementsTyped.map(jsstr => Map(addListMemberOperation, listNameEntry, listValEntry(AttributeString(jsstr.value))))
@@ -169,6 +169,8 @@ trait TSVFileSupport {
 
               case _ => throw new FireCloudException("Mixed-type entity attribute lists are not supported.")
             }
+            val removeOldListOp = Seq(Map(removeAttrOperation,nameEntry))
+            removeOldListOp ++ addElements
           }
           case _ => Seq(Map(upsertAttrOperation,nameEntry,valEntry(AttributeString(value))))
         }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/TSVFileSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/TSVFileSupport.scala
@@ -176,6 +176,9 @@ trait TSVFileSupport {
   def generateAttributeArrayOperations(attributeValue: String, attributeName: String): Seq[Map[String, Attribute]] = {
     val listElements = attributeValue.parseJson.convertTo[JsArray].elements.toList
 
+    def addListEntry(attrVal: AttributeValue) =
+      Map(addListMemberOperation, listNameEntry(attributeName), listValEntry(attrVal))
+
     //if the list is empty, short-circuit and just replace any existing list with an empty list
     if(listElements.isEmpty) {
       Seq(Map(removeAttrOperation, nameEntry(attributeName)), Map(createAttrValueListOperation, nameEntry(attributeName)))
@@ -183,15 +186,15 @@ trait TSVFileSupport {
       val addElements = listElements match {
         case elements if elements.forall(_.isInstanceOf[JsString]) =>
           val elementsTyped: List[JsString] = elements.asInstanceOf[List[JsString]]
-          elementsTyped.map(jsstr => Map(addListMemberOperation, listNameEntry(attributeName), listValEntry(AttributeString(jsstr.value))))
+          elementsTyped.map(jsstr => addListEntry(AttributeString(jsstr.value)))
 
         case elements if elements.forall(_.isInstanceOf[JsNumber]) =>
           val elementsTyped: List[JsNumber] = elements.asInstanceOf[List[JsNumber]]
-          elementsTyped.map(jsnum => Map(addListMemberOperation, listNameEntry(attributeName), listValEntry(AttributeNumber(jsnum.value))))
+          elementsTyped.map(jsnum => addListEntry(AttributeNumber(jsnum.value)))
 
         case elements if elements.forall(_.isInstanceOf[JsBoolean]) =>
           val elementsTyped: List[JsBoolean] = elements.asInstanceOf[List[JsBoolean]]
-          elementsTyped.map(jsbool => Map(addListMemberOperation, listNameEntry(attributeName), listValEntry(AttributeBoolean(jsbool.value))))
+          elementsTyped.map(jsbool => addListEntry(AttributeBoolean(jsbool.value)))
 
         case _ => throw new FireCloudException("Mixed-type entity attribute lists are not supported.")
       }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/TSVFileSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/TSVFileSupport.scala
@@ -142,7 +142,6 @@ trait TSVFileSupport {
     //Iterate over the attribute names and their values
     //I (hussein) think the refTypeOpt.isDefined is to ensure that if required attributes are left empty, the empty
     //string gets passed to Rawls, which should error as they're required?
-    println("hello!!")
     val ops = for { (value,(attributeName,refTypeOpt)) <- row.tail zip colInfo if refTypeOpt.isDefined || !value.isEmpty } yield {
       val nameEntry = "attributeName" -> AttributeString(attributeName)
       val listNameEntry = "attributeListName" -> AttributeString(attributeName)
@@ -187,9 +186,7 @@ trait TSVFileSupport {
     } else {
       None
     }
-    val x = EntityUpdateDefinition(row.headOption.get,entityType,ops.flatten ++ collectionMemberAttrOp )
-    println(x)
-    x
+    EntityUpdateDefinition(row.headOption.get,entityType,ops.flatten ++ collectionMemberAttrOp )
   }
 
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockTSV.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockTSV.scala
@@ -133,6 +133,10 @@ object MockTSVStrings {
     List("part_01", "de").tabbed,
     List("part_01", "hip").tabbed).newlineSeparated
 
+  val entityHasArray = List(
+    List("entity:participant_id", "values").tabbed,
+    List("part_01", """["foo","bar","baz"]""").tabbed).newlineSeparated
+
   val entityHasCollectionMembers = List(
     List("entity:sample_set_id", "sample").tabbed,
     List("sset_01", "sample_01").tabbed,
@@ -315,6 +319,11 @@ object MockTSVLoadFiles {
   val validNamespacedAttributes = TSVLoadFile("foo", Seq("foo", "tag:foo", "bar", "tag:bar"), Seq(Seq("1","2","3","4"), Seq("5","6","7","8")))
   val missingFields1 = TSVLoadFile("foo", Seq("foo", "bar", "baz"), Seq(Seq("biz", "", "buz")))
   val missingFields2 = TSVLoadFile("foo", Seq("foo", "bar", "baz"), Seq(Seq("", "", "buz"), Seq("abc", "123", "")))
+
+  val entityWithAttributeBooleanArray = TSVLoadFile("array", Seq("array"), Seq(Seq("bla", """[false,true,true]""")))
+  val entityWithAttributeNumberArray = TSVLoadFile("array", Seq("array"), Seq(Seq("bla", """[1,2,3]""")))
+  val entityWithAttributeStringArray = TSVLoadFile("array", Seq("array"), Seq(Seq("bla", """["foo","bar","baz"]""")))
+  val entityWithAttributeMixedArray = TSVLoadFile("array", Seq("array"), Seq(Seq("bla", """[false,"foo",1]""")))
 
   val validHugeFile = TSVLoadFile("header1",
     (1 to 1000).map(num => s"header$num"),

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockTSV.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockTSV.scala
@@ -133,10 +133,6 @@ object MockTSVStrings {
     List("part_01", "de").tabbed,
     List("part_01", "hip").tabbed).newlineSeparated
 
-  val entityHasArray = List(
-    List("entity:participant_id", "values").tabbed,
-    List("part_01", """["foo","bar","baz"]""").tabbed).newlineSeparated
-
   val entityHasCollectionMembers = List(
     List("entity:sample_set_id", "sample").tabbed,
     List("sset_01", "sample_01").tabbed,

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockTSV.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockTSV.scala
@@ -319,6 +319,7 @@ object MockTSVLoadFiles {
   val entityWithAttributeBooleanArray = TSVLoadFile("array", Seq("array"), Seq(Seq("bla", """[false,true,true]""")))
   val entityWithAttributeNumberArray = TSVLoadFile("array", Seq("array"), Seq(Seq("bla", """[1,2,3]""")))
   val entityWithAttributeStringArray = TSVLoadFile("array", Seq("array"), Seq(Seq("bla", """["foo","bar","baz"]""")))
+  val entityWithAttributeEntityReferenceArray = TSVLoadFile("array", Seq("array"), Seq(Seq("bla", """[{"entityType":"sample","entityName":"HCC1143"},{"entityType":"sample","entityName":"HCC1143_10"},{"entityType":"sample","entityName":"HCC1143_100"}]""")))
   val entityWithAttributeMixedArray = TSVLoadFile("array", Seq("array"), Seq(Seq("bla", """[false,"foo",1]""")))
   val entityWithAttributeArrayOfObjects = TSVLoadFile("array", Seq("array"), Seq(Seq("bla", """[{"one":"two"},{"three":"four"},{"five":"six"}]""")))
   val entityWithEmptyAttributeArray = TSVLoadFile("array", Seq("array"), Seq(Seq("bla", """[]""")))

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockTSV.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockTSV.scala
@@ -320,6 +320,7 @@ object MockTSVLoadFiles {
   val entityWithAttributeNumberArray = TSVLoadFile("array", Seq("array"), Seq(Seq("bla", """[1,2,3]""")))
   val entityWithAttributeStringArray = TSVLoadFile("array", Seq("array"), Seq(Seq("bla", """["foo","bar","baz"]""")))
   val entityWithAttributeMixedArray = TSVLoadFile("array", Seq("array"), Seq(Seq("bla", """[false,"foo",1]""")))
+  val entityWithEmptyAttributeArray = TSVLoadFile("array", Seq("array"), Seq(Seq("bla", """[]""")))
 
   val validHugeFile = TSVLoadFile("header1",
     (1 to 1000).map(num => s"header$num"),

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockTSV.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockTSV.scala
@@ -320,6 +320,7 @@ object MockTSVLoadFiles {
   val entityWithAttributeNumberArray = TSVLoadFile("array", Seq("array"), Seq(Seq("bla", """[1,2,3]""")))
   val entityWithAttributeStringArray = TSVLoadFile("array", Seq("array"), Seq(Seq("bla", """["foo","bar","baz"]""")))
   val entityWithAttributeMixedArray = TSVLoadFile("array", Seq("array"), Seq(Seq("bla", """[false,"foo",1]""")))
+  val entityWithAttributeArrayOfObjects = TSVLoadFile("array", Seq("array"), Seq(Seq("bla", """[{"one":"two"},{"three":"four"},{"five":"six"}]""")))
   val entityWithEmptyAttributeArray = TSVLoadFile("array", Seq("array"), Seq(Seq("bla", """[]""")))
 
   val validHugeFile = TSVLoadFile("header1",

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/model/FlexibleModelSchemaSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/model/FlexibleModelSchemaSpec.scala
@@ -1,0 +1,33 @@
+package org.broadinstitute.dsde.firecloud.model
+
+import org.scalatest.freespec.AnyFreeSpec
+
+class FlexibleModelSchemaSpec extends AnyFreeSpec {
+
+  val schema = FlexibleModelSchema
+
+  "ModelSchema.isAttributeArray" - {
+
+    "should be false for various scalars" in {
+      List("", "-1", "0", "1", "hello", "{}", "true", "false",
+        "null", "123.45", "[", "]", "][", "[-]") foreach { input =>
+        withClue(s"for input '$input', should return false") {
+          assert(!schema.isAttributeArray(input))
+        }
+      }
+    }
+
+    "should be true for various arrays" in {
+      List("[]", "[1]", "[1,2,3]", "[true]", "[true,false]", "[true,1,null]",
+        """["foo"]""", """["foo","bar"]""", """["white",     "space"]""",
+        """["foo",1,true,null]""",
+        """[{}, [{},{},{"a":"b"},true], "foo"]"""
+      ) foreach { input =>
+        withClue(s"for input '$input', should return true") {
+          assert(schema.isAttributeArray(input))
+        }
+      }
+    }
+
+  }
+}

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/TSVFileSupportSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/TSVFileSupportSpec.scala
@@ -5,7 +5,7 @@ import org.broadinstitute.dsde.firecloud.FireCloudExceptionWithErrorReport
 import org.broadinstitute.dsde.firecloud.mock.MockTSVLoadFiles
 import org.broadinstitute.dsde.firecloud.model.FlexibleModelSchema
 import org.broadinstitute.dsde.firecloud.utils.TSVLoadFile
-import org.broadinstitute.dsde.rawls.model.{AttributeBoolean, AttributeName, AttributeNumber, AttributeString, AttributeValue}
+import org.broadinstitute.dsde.rawls.model.{AttributeBoolean, AttributeEntityReference, AttributeListElementable, AttributeName, AttributeNumber, AttributeString}
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.{AddUpdateAttribute, RemoveAttribute}
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers.contain
@@ -61,7 +61,7 @@ class TSVFileSupportSpec extends AnyFreeSpec with TSVFileSupport {
 
     case class TsvArrayTestCase(loadFile: TSVLoadFile,
                                 testHint: String,
-                                exemplarValue: AttributeValue,
+                                exemplarValue: AttributeListElementable,
                                 expectedSize: Int = 4,
                                 colname: String = "arrays",
                                 entityType: String = "some_type")
@@ -69,7 +69,9 @@ class TSVFileSupportSpec extends AnyFreeSpec with TSVFileSupport {
     val testCases = List(
       TsvArrayTestCase(MockTSVLoadFiles.entityWithAttributeStringArray, "all strings", AttributeString("")),
       TsvArrayTestCase(MockTSVLoadFiles.entityWithAttributeNumberArray, "all numbers", AttributeNumber(0)),
-      TsvArrayTestCase(MockTSVLoadFiles.entityWithAttributeBooleanArray, "all booleans", AttributeBoolean(true))
+      TsvArrayTestCase(MockTSVLoadFiles.entityWithAttributeBooleanArray, "all booleans", AttributeBoolean(true)),
+      TsvArrayTestCase(MockTSVLoadFiles.entityWithAttributeEntityReferenceArray,
+        "all entity references", AttributeEntityReference("entityType", "entityName"))
     )
 
     testCases foreach { testCase =>
@@ -111,7 +113,7 @@ class TSVFileSupportSpec extends AnyFreeSpec with TSVFileSupport {
         setAttributesOnEntity("some_type", None, MockTSVLoadFiles.entityWithAttributeArrayOfObjects.tsvData.head, Seq(("arrays", None)), FlexibleModelSchema)
       }
       caught.errorReport.statusCode should contain (BadRequest)
-      caught.errorReport.message shouldBe "Only arrays of strings, numbers, or booleans are supported."
+      caught.errorReport.message shouldBe UNSUPPORTED_ARRAY_TYPE_ERROR_MSG
     }
 
     "parse an attribute empty array" in {

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/TSVFileSupportSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/TSVFileSupportSpec.scala
@@ -57,28 +57,27 @@ class TSVFileSupportSpec extends AnyFreeSpec with TSVFileSupport {
 
   "setAttributesOnEntity" - {
     "parse an attribute array consisting of all strings" in {
-      val resultingOps = setAttributesOnEntity("some_type", Some("idc"), MockTSVLoadFiles.entityWithAttributeStringArray.tsvData.head, Seq(("arrays", Some("foo"))), FlexibleModelSchema)
-      println(resultingOps)
+      val resultingOps = setAttributesOnEntity("some_type", None, MockTSVLoadFiles.entityWithAttributeStringArray.tsvData.head, Seq(("arrays", None)), FlexibleModelSchema)
       resultingOps.operations.size shouldBe 3
       resultingOps.entityType shouldBe "some_type"
-      resultingOps.operations.map(_.values) should contain theSameElementsAs List(AttributeBoolean(true), AttributeBoolean(false), AttributeBoolean(true))
     }
 
     "parse an attribute array consisting of all numbers" in {
-      val resultingOps = setAttributesOnEntity("some_type", Some("idc"), MockTSVLoadFiles.entityWithAttributeNumberArray.tsvData.head, Seq(("arrays", Some("foo"))), FlexibleModelSchema)
+      val resultingOps = setAttributesOnEntity("some_type", None, MockTSVLoadFiles.entityWithAttributeNumberArray.tsvData.head, Seq(("arrays", None)), FlexibleModelSchema)
       resultingOps.operations.size shouldBe 3
+      resultingOps.entityType shouldBe "some_type"
     }
 
     "parse an attribute array consisting of all booleans" in {
-      val resultingOps = setAttributesOnEntity("some_type", Some("idc"), MockTSVLoadFiles.entityWithAttributeBooleanArray.tsvData.head, Seq(("arrays", Some("foo"))), FlexibleModelSchema)
+      val resultingOps = setAttributesOnEntity("some_type", None, MockTSVLoadFiles.entityWithAttributeBooleanArray.tsvData.head, Seq(("arrays", None)), FlexibleModelSchema)
       resultingOps.operations.size shouldBe 3
+      resultingOps.entityType shouldBe "some_type"
     }
 
     "throw an exception when parsing an attribute array consisting of mixed attribute types" in {
       intercept[FireCloudException] {
-        setAttributesOnEntity("some_type", Some("idc"), MockTSVLoadFiles.entityWithAttributeMixedArray.tsvData.head, Seq(("arrays", Some("foo"))), FlexibleModelSchema)
+        setAttributesOnEntity("some_type", None, MockTSVLoadFiles.entityWithAttributeMixedArray.tsvData.head, Seq(("arrays", None)), FlexibleModelSchema)
       }
-
     }
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/TSVFileSupportSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/TSVFileSupportSpec.scala
@@ -70,9 +70,6 @@ class TSVFileSupportSpec extends AnyFreeSpec with TSVFileSupport {
       resultingOpNames.tail.map { op =>
         op shouldBe AttributeString("AddListMember")
       }
-
-      println(resultingOps)
-
     }
 
     "parse an attribute array consisting of all numbers" in {

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/TSVFileSupportSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/TSVFileSupportSpec.scala
@@ -1,9 +1,13 @@
 package org.broadinstitute.dsde.firecloud.service
 
+import org.broadinstitute.dsde.firecloud.FireCloudException
 import org.broadinstitute.dsde.firecloud.mock.MockTSVLoadFiles
-import org.broadinstitute.dsde.rawls.model.{AttributeName, AttributeString}
+import org.broadinstitute.dsde.firecloud.model.FlexibleModelSchema
+import org.broadinstitute.dsde.rawls.model.{AttributeBoolean, AttributeName, AttributeString}
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.{AddUpdateAttribute, RemoveAttribute}
 import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.must.Matchers.contain
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 
 /**
   * Created by ansingh on 11/16/16.
@@ -48,6 +52,33 @@ class TSVFileSupportSpec extends AnyFreeSpec with TSVFileSupport {
         List(RemoveAttribute(AttributeName("default", "a1")),
           AddUpdateAttribute(AttributeName("default", "a2"), AttributeString("v2")))
       }
+    }
+  }
+
+  "setAttributesOnEntity" - {
+    "parse an attribute array consisting of all strings" in {
+      val resultingOps = setAttributesOnEntity("some_type", Some("idc"), MockTSVLoadFiles.entityWithAttributeStringArray.tsvData.head, Seq(("arrays", Some("foo"))), FlexibleModelSchema)
+      println(resultingOps)
+      resultingOps.operations.size shouldBe 3
+      resultingOps.entityType shouldBe "some_type"
+      resultingOps.operations.map(_.values) should contain theSameElementsAs List(AttributeBoolean(true), AttributeBoolean(false), AttributeBoolean(true))
+    }
+
+    "parse an attribute array consisting of all numbers" in {
+      val resultingOps = setAttributesOnEntity("some_type", Some("idc"), MockTSVLoadFiles.entityWithAttributeNumberArray.tsvData.head, Seq(("arrays", Some("foo"))), FlexibleModelSchema)
+      resultingOps.operations.size shouldBe 3
+    }
+
+    "parse an attribute array consisting of all booleans" in {
+      val resultingOps = setAttributesOnEntity("some_type", Some("idc"), MockTSVLoadFiles.entityWithAttributeBooleanArray.tsvData.head, Seq(("arrays", Some("foo"))), FlexibleModelSchema)
+      resultingOps.operations.size shouldBe 3
+    }
+
+    "throw an exception when parsing an attribute array consisting of mixed attribute types" in {
+      intercept[FireCloudException] {
+        setAttributesOnEntity("some_type", Some("idc"), MockTSVLoadFiles.entityWithAttributeMixedArray.tsvData.head, Seq(("arrays", Some("foo"))), FlexibleModelSchema)
+      }
+
     }
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/TSVFileSupportSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/TSVFileSupportSpec.scala
@@ -70,6 +70,9 @@ class TSVFileSupportSpec extends AnyFreeSpec with TSVFileSupport {
       resultingOpNames.tail.map { op =>
         op shouldBe AttributeString("AddListMember")
       }
+
+      println(resultingOps)
+
     }
 
     "parse an attribute array consisting of all numbers" in {
@@ -108,6 +111,20 @@ class TSVFileSupportSpec extends AnyFreeSpec with TSVFileSupport {
       intercept[FireCloudException] {
         setAttributesOnEntity("some_type", None, MockTSVLoadFiles.entityWithAttributeMixedArray.tsvData.head, Seq(("arrays", None)), FlexibleModelSchema)
       }
+    }
+
+    "parse an attribute empty array" in {
+      val resultingOps = setAttributesOnEntity("some_type", None, MockTSVLoadFiles.entityWithEmptyAttributeArray.tsvData.head, Seq(("arrays", None)), FlexibleModelSchema)
+
+      resultingOps.operations.size shouldBe 2 //1 to remove any existing attribute with this name, 1 to create the empty attr value list
+
+      val resultingOpNames = resultingOps.operations.map(ops => ops("op"))
+
+      //assert that these operations always remove the existing attribute by this name
+      resultingOpNames.head shouldBe AttributeString("RemoveAttribute")
+
+      //assert that the second operation is creating the empty list
+      resultingOpNames.last shouldBe AttributeString("CreateAttributeValueList")
     }
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/TSVFileSupportSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/TSVFileSupportSpec.scala
@@ -58,20 +58,50 @@ class TSVFileSupportSpec extends AnyFreeSpec with TSVFileSupport {
   "setAttributesOnEntity" - {
     "parse an attribute array consisting of all strings" in {
       val resultingOps = setAttributesOnEntity("some_type", None, MockTSVLoadFiles.entityWithAttributeStringArray.tsvData.head, Seq(("arrays", None)), FlexibleModelSchema)
-      resultingOps.operations.size shouldBe 3
+      resultingOps.operations.size shouldBe 4 //1 to remove any existing list, 3 to add the list elements
       resultingOps.entityType shouldBe "some_type"
+
+      val resultingOpNames = resultingOps.operations.map(ops => ops("op"))
+
+      //assert that these operations always remove the existing attribute by this name
+      resultingOpNames.head shouldBe AttributeString("RemoveAttribute")
+
+      //assert that all of the remaining operations are adding a list member
+      resultingOpNames.tail.map { op =>
+        op shouldBe AttributeString("AddListMember")
+      }
     }
 
     "parse an attribute array consisting of all numbers" in {
       val resultingOps = setAttributesOnEntity("some_type", None, MockTSVLoadFiles.entityWithAttributeNumberArray.tsvData.head, Seq(("arrays", None)), FlexibleModelSchema)
-      resultingOps.operations.size shouldBe 3
+      resultingOps.operations.size shouldBe 4 //1 to remove any existing list, 3 to add the list elements
       resultingOps.entityType shouldBe "some_type"
+
+      val resultingOpNames = resultingOps.operations.map(ops => ops("op"))
+
+      //assert that these operations always remove the existing attribute by this name
+      resultingOpNames.head shouldBe AttributeString("RemoveAttribute")
+
+      //assert that all of the remaining operations are adding a list member
+      resultingOpNames.tail.map { op =>
+        op shouldBe AttributeString("AddListMember")
+      }
     }
 
     "parse an attribute array consisting of all booleans" in {
       val resultingOps = setAttributesOnEntity("some_type", None, MockTSVLoadFiles.entityWithAttributeBooleanArray.tsvData.head, Seq(("arrays", None)), FlexibleModelSchema)
-      resultingOps.operations.size shouldBe 3
+      resultingOps.operations.size shouldBe 4 //1 to remove any existing list, 3 to add the list elements
       resultingOps.entityType shouldBe "some_type"
+
+      val resultingOpNames = resultingOps.operations.map(ops => ops("op"))
+
+      //assert that these operations always remove the existing attribute by this name
+      resultingOpNames.head shouldBe AttributeString("RemoveAttribute")
+
+      //assert that all of the remaining operations are adding a list member
+      resultingOpNames.tail.map { op =>
+        op shouldBe AttributeString("AddListMember")
+      }
     }
 
     "throw an exception when parsing an attribute array consisting of mixed attribute types" in {


### PR DESCRIPTION
Support attribute arrays in TSV uploads, AS-924.

We only support:
* arrays whose elements are all the same datatype
* arrays of strings, numbers, booleans, entity references
* empty arrays

We will throw BadRequest if the TSV contains anything else.

If the value in the TSV is malformed json, e.g. `["foo">`, we will treat it as a String. In other words, we have no way to detect that you *meant* for it to be an array.

if your existing data does not contain the attribute in question, we will create the attribute.

If your existing data contains the attribute in question, we will replace it with the array in the TSV regardless of the pre-existing datatype. If your existing data already contains an array, we will replace it with the new array (we do not merge arrays)

