### PR TITLE
AS-923: Remove original pricelist test

### DIFF
--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAOSpec.scala
@@ -41,22 +41,6 @@ class HttpGoogleServicesDAOSpec extends AnyFlatSpec with Matchers with PrivateMe
 
   behavior of "HttpGoogleServicesDAO"
 
-  // TODO: David An 2021-09-03: fix this test.
-  /* it is failing consistently for me with an error of:
-      Error:  [17:35:45.130] [HttpGoogleCloudStorageDAOSpec-akka.actor.default-dispatcher-17] o.b.d.f.d.HttpGoogleServicesDAO - Unable to fetch/parse latest Google price list. A cached (possibly outdated) value will be used instead. Error: Unexpected error: java.security.InvalidAlgorithmParameterException: the trustAnchors parameter must be non-empty
-      [info] - should fetch the current price list *** FAILED ***
-      [info]   -0.11 was not greater than 0 (HttpGoogleServicesDAOSpec.scala:50)
-   */
-  it should "fetch the current price list" ignore {
-
-    val priceList: GooglePriceList = Await.result(gcsDAO.fetchPriceList, Duration.Inf)
-
-    priceList.version should startWith ("v")
-    priceList.updated should not be empty
-    priceList.prices.cpBigstoreStorage("us") should be > BigDecimal(0)
-    priceList.prices.cpComputeengineInternetEgressNA.tiers.size should be > 0
-  }
-
   it should "default to the cached price list if it cannot fetch/parse one from Google" in {
     val errorGcsDAO = new HttpGoogleServicesDAO(priceListUrl + ".error", defaultPriceList)
 


### PR DESCRIPTION
I would like to "fix" this test by removing it entirely. I don't think it's particularly useful after #879 was merged. While that PR made the application code resilient to changes by Google, it didn't make this particular test resilient in the same manner. Instead, the improved resilience is tested with a new unit test (below this one). This test is vulnerable to Google changing key names which will cause the test to fail and the testing pipeline to break until the application code is updated. IMO, that defeats a part of the purpose of writing resilient code in the first place.

In summary, I feel comfortable removing this coverage because:

1) The code is resilient, and that resilience is tested
2) This unit test can't really tell us anything that we don't already know. Odds are very high that if this code breaks, it will be broken on production as well and we'll get plenty of Sentry alerts about it

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
