### PR TITLE
[CA-1362, CA-1517] bump rawls-model and add swagger for async bucket copying

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -30,7 +30,7 @@ object Dependencies {
     "com.typesafe.scala-logging"    %% "scala-logging"       % "3.9.2",
 
     "org.parboiled" % "parboiled-core" % "1.3.2",
-    excludeGuava("org.broadinstitute.dsde"       %% "rawls-model"         % "0.1-d3c0583e7-SNAP") // todo: update this with an official version
+    excludeGuava("org.broadinstitute.dsde"       %% "rawls-model"         % "0.1-384ab501b")
       exclude("com.typesafe.scala-logging", "scala-logging_2.12")
       exclude("com.typesafe.akka", "akka-stream_2.12")
       exclude("com.google.code.findbugs", "jsr305")

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -9960,6 +9960,11 @@ components:
         billingAccountErrorMessage:
           type: string
           description: Error message received during most recent attempt to update the current billing account on workspace's Google project. Empty if update was successful.
+        completedCloneWorkspaceFileTransfer:
+          type: string
+          description: The date all files were successfully transferred to the workspace bucket if applicable
+            in yyyy-MM-ddTHH:mm:ss.SSSZZ format
+          format: date-time
       description: ""
     WorkspaceListResponse:
       type: object

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockRawlsDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockRawlsDAO.scala
@@ -182,7 +182,9 @@ class MockRawlsDAO extends RawlsDAO {
     WorkspaceVersions.V2,
     GoogleProjectId("googleProject"),
     Some(GoogleProjectNumber("googleProjectNumber")),
-    Some(RawlsBillingAccountName("billingAccount"))
+    Some(RawlsBillingAccountName("billingAccount")),
+    None,
+    Option(DateTime.now())
   )
 
   val publishedRawlsWorkspaceWithAttributes = WorkspaceDetails(
@@ -211,7 +213,9 @@ class MockRawlsDAO extends RawlsDAO {
     WorkspaceVersions.V2,
     GoogleProjectId("googleProject"),
     Some(GoogleProjectNumber("googleProjectNumber")),
-    Some(RawlsBillingAccountName("billingAccount"))
+    Some(RawlsBillingAccountName("billingAccount")),
+    None,
+    Option(DateTime.now())
   )
 
   val unpublishedRawlsWorkspaceLibraryValid = WorkspaceDetails(
@@ -251,7 +255,9 @@ class MockRawlsDAO extends RawlsDAO {
     WorkspaceVersions.V2,
     GoogleProjectId("googleProject"),
     Some(GoogleProjectNumber("googleProjectNumber")),
-    Some(RawlsBillingAccountName("billingAccount"))
+    Some(RawlsBillingAccountName("billingAccount")),
+    None,
+    Option(DateTime.now())
   )
 
   val rawlsWorkspaceResponseWithAttributes = WorkspaceResponse(Some(WorkspaceAccessLevels.Owner), canShare = Some(false), canCompute = Some(true), catalog = Some(false), rawlsWorkspaceWithAttributes, Some(WorkspaceSubmissionStats(None, None, runningSubmissionsCount = 0)), Some(WorkspaceBucketOptions(false)), Some(Set.empty))
@@ -273,7 +279,8 @@ class MockRawlsDAO extends RawlsDAO {
       workspaceVersion = WorkspaceVersions.V2,
       googleProject = GoogleProjectId("googleProject"),
       googleProjectNumber = Some(GoogleProjectNumber("googleProjectNumber")),
-      billingAccount = Some(RawlsBillingAccountName("billingAccount"))
+      billingAccount = Some(RawlsBillingAccountName("billingAccount")),
+      completedCloneWorkspaceFileTransfer = Option(DateTime.now())
     )
   }
 
@@ -474,5 +481,5 @@ class MockRawlsDAO extends RawlsDAO {
 
   override def batchUpdateEntities(workspaceNamespace: String, workspaceName: String, entityType: String, updates: Seq[EntityUpdateDefinition])(implicit userToken: UserInfo): Future[HttpResponse] = Future.successful(HttpResponse(StatusCodes.NoContent))
 
-  override def cloneWorkspace(workspaceNamespace: String, workspaceName: String, cloneRequest: WorkspaceRequest)(implicit userToken: WithAccessToken): Future[WorkspaceDetails] = Future.successful(WorkspaceDetails(cloneRequest.namespace, cloneRequest.name, "id", "bucket", Some("workflow-collection-id"), DateTime.now(), DateTime.now(), "test-user", Some(cloneRequest.attributes), false, cloneRequest.authorizationDomain, WorkspaceVersions.V2, GoogleProjectId("googleProject"), Some(GoogleProjectNumber("googleProjectNumber")), Some(RawlsBillingAccountName("billingAccount"))))
+  override def cloneWorkspace(workspaceNamespace: String, workspaceName: String, cloneRequest: WorkspaceRequest)(implicit userToken: WithAccessToken): Future[WorkspaceDetails] = Future.successful(WorkspaceDetails(cloneRequest.namespace, cloneRequest.name, "id", "bucket", Some("workflow-collection-id"), DateTime.now(), DateTime.now(), "test-user", Some(cloneRequest.attributes), false, cloneRequest.authorizationDomain, WorkspaceVersions.V2, GoogleProjectId("googleProject"), Some(GoogleProjectNumber("googleProjectNumber")), Some(RawlsBillingAccountName("billingAccount")), None, Option(DateTime.now())))
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockWorkspaceServer.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockWorkspaceServer.scala
@@ -35,7 +35,9 @@ object MockWorkspaceServer {
     WorkspaceVersions.V2,
     GoogleProjectId("googleProject"),
     Some(GoogleProjectNumber("googleProjectNumber")),
-    Some(RawlsBillingAccountName("billingAccount"))
+    Some(RawlsBillingAccountName("billingAccount")),
+    None,
+    Option(DateTime.now())
   )
 
   val mockSpacedWorkspace = WorkspaceDetails(
@@ -53,7 +55,9 @@ object MockWorkspaceServer {
     WorkspaceVersions.V2,
     GoogleProjectId("googleProject"),
     Some(GoogleProjectNumber("googleProjectNumber")),
-    Some(RawlsBillingAccountName("billingAccount"))
+    Some(RawlsBillingAccountName("billingAccount")),
+    None,
+    Option(DateTime.now())
   )
 
   val mockValidId = randomPositiveInt()

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionTestFixtures.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/DataUseRestrictionTestFixtures.scala
@@ -128,7 +128,9 @@ object DataUseRestrictionTestFixtures {
       workspaceVersion=WorkspaceVersions.V2,
       googleProject = GoogleProjectId("googleProject"),
       googleProjectNumber = Some(GoogleProjectNumber("googleProjectNumber")),
-      billingAccount = Some(RawlsBillingAccountName("billingAccount")))
+      billingAccount = Some(RawlsBillingAccountName("billingAccount")),
+      completedCloneWorkspaceFileTransfer = Option(DateTime.now())
+    )
   }
 
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/LibraryServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/LibraryServiceSpec.scala
@@ -85,9 +85,10 @@ class LibraryServiceSpec extends BaseServiceSpec with AnyFreeSpecLike with Libra
     bucketName = "bucketName",
     workflowCollectionName = Some("wf-collection"),
     workspaceVersion=WorkspaceVersions.V2,
-      googleProject = GoogleProjectId("googleProject"),
-      googleProjectNumber = Some(GoogleProjectNumber("googleProjectNumber")),
-      billingAccount = Some(RawlsBillingAccountName("billingAccount")))
+    googleProject = GoogleProjectId("googleProject"),
+    googleProjectNumber = Some(GoogleProjectNumber("googleProjectNumber")),
+    billingAccount = Some(RawlsBillingAccountName("billingAccount")),
+    completedCloneWorkspaceFileTransfer = Some(DateTime.now()))
 
 
   val DULAdditionalJsObject =
@@ -825,9 +826,11 @@ class LibraryServiceSpec extends BaseServiceSpec with AnyFreeSpecLike with Libra
           false, //locked
           Some(Set.empty), //authdomain
           WorkspaceVersions.V2,
-    GoogleProjectId("googleProject"),
-    Some(GoogleProjectNumber("googleProjectNumber")),
-    Some(RawlsBillingAccountName("billingAccount"))
+          GoogleProjectId("googleProject"),
+          Some(GoogleProjectNumber("googleProjectNumber")),
+          Some(RawlsBillingAccountName("billingAccount")),
+          None,
+          Option(DateTime.now())
         )
 
         attrMaps map { attrMap =>

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceTagsServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceTagsServiceSpec.scala
@@ -318,7 +318,9 @@ class MockTagsRawlsDao extends MockRawlsDAO with Assertions {
     WorkspaceVersions.V2,
     GoogleProjectId("googleProject"),
     Some(GoogleProjectNumber("googleProjectNumber")),
-    Some(RawlsBillingAccountName("billingAccount"))
+    Some(RawlsBillingAccountName("billingAccount")),
+    None,
+    Option(DateTime.now())
   )
 
   private def workspaceResponse(ws:WorkspaceDetails=workspace) = WorkspaceResponse(

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/MethodConfigurationApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/MethodConfigurationApiServiceSpec.scala
@@ -36,7 +36,9 @@ class MethodConfigurationApiServiceSpec extends ServiceSpec with MethodConfigura
     WorkspaceVersions.V2,
     GoogleProjectId("googleProject"),
     Some(GoogleProjectNumber("googleProjectNumber")),
-    Some(RawlsBillingAccountName("billingAccount"))
+    Some(RawlsBillingAccountName("billingAccount")),
+    None,
+    Option(DateTime.now())
   )
 
   override def beforeAll(): Unit = {

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiServiceSpec.scala
@@ -47,7 +47,9 @@ object WorkspaceApiServiceSpec {
     WorkspaceVersions.V2,
     GoogleProjectId("googleProject"),
     Some(GoogleProjectNumber("googleProjectNumber")),
-    Some(RawlsBillingAccountName("billingAccount"))
+    Some(RawlsBillingAccountName("billingAccount")),
+    None,
+    Option(DateTime.now())
   )
 
 }
@@ -71,7 +73,9 @@ class WorkspaceApiServiceSpec extends BaseServiceSpec with WorkspaceApiService w
     WorkspaceVersions.V2,
     GoogleProjectId("googleProject"),
     Some(GoogleProjectNumber("googleProjectNumber")),
-    Some(RawlsBillingAccountName("billingAccount"))
+    Some(RawlsBillingAccountName("billingAccount")),
+    None,
+    Option(DateTime.now())
   )
 
   val jobId = "testOp"
@@ -131,7 +135,9 @@ class WorkspaceApiServiceSpec extends BaseServiceSpec with WorkspaceApiService w
     WorkspaceVersions.V2,
     GoogleProjectId("googleProject"),
     Some(GoogleProjectNumber("googleProjectNumber")),
-    Some(RawlsBillingAccountName("billingAccount"))
+    Some(RawlsBillingAccountName("billingAccount")),
+    None,
+    Option(DateTime.now())
   )
 
   val authDomainRawlsWorkspace = WorkspaceDetails(
@@ -149,7 +155,9 @@ class WorkspaceApiServiceSpec extends BaseServiceSpec with WorkspaceApiService w
     WorkspaceVersions.V2,
     GoogleProjectId("googleProject"),
     Some(GoogleProjectNumber("googleProjectNumber")),
-    Some(RawlsBillingAccountName("billingAccount"))
+    Some(RawlsBillingAccountName("billingAccount")),
+    None,
+    Option(DateTime.now())
   )
 
   val nonAuthDomainRawlsWorkspace = WorkspaceDetails(
@@ -167,7 +175,9 @@ class WorkspaceApiServiceSpec extends BaseServiceSpec with WorkspaceApiService w
     WorkspaceVersions.V2,
     GoogleProjectId("googleProject"),
     Some(GoogleProjectNumber("googleProjectNumber")),
-    Some(RawlsBillingAccountName("billingAccount"))
+    Some(RawlsBillingAccountName("billingAccount")),
+    None,
+    Option(DateTime.now())
   )
 
   val protectedRawlsWorkspaceResponse = WorkspaceResponse(Some(WorkspaceAccessLevels.Owner), canShare=Some(false), canCompute=Some(true), catalog=Some(false), protectedRawlsWorkspace, Some(WorkspaceSubmissionStats(None, None, runningSubmissionsCount = 0)), Some(WorkspaceBucketOptions(false)), Some(Set.empty))
@@ -213,7 +223,7 @@ class WorkspaceApiServiceSpec extends BaseServiceSpec with WorkspaceApiService w
   def stubRawlsCreateWorkspace(namespace: String, name: String, authDomain: Set[ManagedGroupRef] = Set.empty): (WorkspaceRequest, WorkspaceDetails) = {
     rawlsServer.reset()
     val rawlsRequest = WorkspaceRequest(namespace, name, Map(), Option(authDomain))
-    val rawlsResponse = WorkspaceDetails(namespace, name, "foo", "bar", Some("wf-collection"), DateTime.now(), DateTime.now(), "bob", Some(Map()), false, Some(authDomain), WorkspaceVersions.V2, GoogleProjectId("googleProject"), Some(GoogleProjectNumber("googleProjectNumber")), Some(RawlsBillingAccountName("billingAccount")))
+    val rawlsResponse = WorkspaceDetails(namespace, name, "foo", "bar", Some("wf-collection"), DateTime.now(), DateTime.now(), "bob", Some(Map()), false, Some(authDomain), WorkspaceVersions.V2, GoogleProjectId("googleProject"), Some(GoogleProjectNumber("googleProjectNumber")), Some(RawlsBillingAccountName("billingAccount")), None, Option(DateTime.now()))
     stubRawlsService(HttpMethods.POST, workspacesRoot, Created, Option(rawlsResponse.toJson.compactPrint))
     (rawlsRequest, rawlsResponse)
   }
@@ -235,7 +245,7 @@ class WorkspaceApiServiceSpec extends BaseServiceSpec with WorkspaceApiService w
     val published: (AttributeName, AttributeBoolean) = AttributeName("library", "published") -> AttributeBoolean(false)
     val discoverable = AttributeName("library", "discoverableByGroups") -> AttributeValueEmptyList
     val rawlsRequest: WorkspaceRequest = WorkspaceRequest(namespace, name, attributes + published + discoverable, Option(authDomain))
-    val rawlsResponse = WorkspaceDetails(namespace, name, "foo", "bar", Some("wf-collection"), DateTime.now(), DateTime.now(), "bob", Some(attributes + published + discoverable), false, Some(authDomain), WorkspaceVersions.V2, GoogleProjectId("googleProject"), Some(GoogleProjectNumber("googleProjectNumber")), Some(RawlsBillingAccountName("billingAccount")))
+    val rawlsResponse = WorkspaceDetails(namespace, name, "foo", "bar", Some("wf-collection"), DateTime.now(), DateTime.now(), "bob", Some(attributes + published + discoverable), false, Some(authDomain), WorkspaceVersions.V2, GoogleProjectId("googleProject"), Some(GoogleProjectNumber("googleProjectNumber")), Some(RawlsBillingAccountName("billingAccount")), None, Option(DateTime.now()))
     stubRawlsService(HttpMethods.POST, clonePath, Created, Option(rawlsResponse.toJson.compactPrint))
     (rawlsRequest, rawlsResponse)
   }


### PR DESCRIPTION
Ticket: [CA-1362](https://broadworkbench.atlassian.net/browse/CA-1362), [CA-1517](https://broadworkbench.atlassian.net/browse/CA-1517)
Bump rawls-model and make swagger changes for async bucket copying

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
