### PR TITLE
more helpful test output [QA-1584]

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/WorkspaceApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/WorkspaceApiSpec.scala
@@ -64,7 +64,7 @@ class WorkspaceApiSpec extends FreeSpec with Matchers with Eventually
             }
             val exceptionMessage = exception.message.parseJson.asJsObject.fields("message").convertTo[String]
 
-            exceptionMessage.contains(s"insufficient permissions to perform operation on $projectName/$workspaceName") should be (true)
+            exceptionMessage should include(s"insufficient permissions to perform operation on $projectName/$workspaceName")
           } (ownerAuthToken)
         }
       }


### PR DESCRIPTION
helps with but does not solve QA-1584.

This PR simply changes the output if/when the 'should not return a storage cost estimate for readers of a workspace' test fails, by using Scalatest's higher-level matchers.

Previous output:
```
false was not true
```

after this PR:
```
"The actual error message" did not include substring "insufficient permissions to perform operation …."
```