### PR TITLE
AS-906 Orch added optional field in request body for TOS

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -7050,6 +7050,9 @@ paths:
         400:
           description: Bad request
           content: {}
+        403:
+          description: Forbidden
+          content: {}
         500:
           description: Internal server error
           content: {}

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -8850,6 +8850,11 @@ components:
         nonProfitStatus:
           type: string
           description: User's program non-profit status
+        termsOfService:
+          type: string
+          description:
+            The Terms of Service url, "app.terra.bio/#terms-of-service", which a user
+            must include to show they accept the Terms of Service
     PublishConfigurationIngest:
       required:
         - configurationName

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/HealthChecks.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/HealthChecks.scala
@@ -32,7 +32,7 @@ class HealthChecks(app: Application, registerSAs: Boolean = true)
     lookup flatMap {
       case Some(err) if registerSAs =>
         logger.warn(s"SA registration lookup failed; attempting to register $name. Lookup failure was: $err")
-        manageRegistration(name, app.samDAO.registerUser(token))
+        manageRegistration(name, app.samDAO.registerUser(token, None))
 
       case registerMessage =>
         Future.successful(registerMessage)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/HealthChecks.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/HealthChecks.scala
@@ -11,6 +11,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 object HealthChecks {
   val adminSaRegistered = Subsystems.Custom("is_admin_sa_registered")
+  val termsOfServiceUrl = "app.terra.bio/#terms-of-service"
 }
 
 class HealthChecks(app: Application, registerSAs: Boolean = true)
@@ -32,7 +33,7 @@ class HealthChecks(app: Application, registerSAs: Boolean = true)
     lookup flatMap {
       case Some(err) if registerSAs =>
         logger.warn(s"SA registration lookup failed; attempting to register $name. Lookup failure was: $err")
-        manageRegistration(name, app.samDAO.registerUser(token, None))
+        manageRegistration(name, app.samDAO.registerUser(Some(termsOfServiceUrl))(token))
 
       case registerMessage =>
         Future.successful(registerMessage)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpSamDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpSamDAO.scala
@@ -34,7 +34,7 @@ class HttpSamDAO( implicit val system: ActorSystem, val materializer: Materializ
     authedRequestToObject[Seq[UserPolicy]](Get(samListResources("workspace")), label=Some("HttpSamDAO.listWorkspaceResources"))
   }
 
-  override def registerUser(implicit userInfo: WithAccessToken, termsOfService: Option[String]): Future[RegistrationInfo] = {
+  override def registerUser(termsOfService: Option[String])(implicit userInfo: WithAccessToken): Future[RegistrationInfo] = {
     authedRequestToObject[RegistrationInfo](Post(samUserRegistrationUrl, termsOfService), label=Some("HttpSamDAO.registerUser"))
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpSamDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpSamDAO.scala
@@ -3,9 +3,7 @@ package org.broadinstitute.dsde.firecloud.dataaccess
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets.UTF_8
 import akka.actor.ActorSystem
-import akka.http.scaladsl.Http
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
-import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.model.HttpRequest
 import akka.http.scaladsl.unmarshalling.Unmarshal
 import akka.stream.Materializer
@@ -36,8 +34,8 @@ class HttpSamDAO( implicit val system: ActorSystem, val materializer: Materializ
     authedRequestToObject[Seq[UserPolicy]](Get(samListResources("workspace")), label=Some("HttpSamDAO.listWorkspaceResources"))
   }
 
-  override def registerUser(implicit userInfo: WithAccessToken): Future[RegistrationInfo] = {
-    authedRequestToObject[RegistrationInfo](Post(samUserRegistrationUrl), label=Some("HttpSamDAO.registerUser"))
+  override def registerUser(implicit userInfo: WithAccessToken, termsOfService: Option[String]): Future[RegistrationInfo] = {
+    authedRequestToObject[RegistrationInfo](Post(samUserRegistrationUrl, termsOfService), label=Some("HttpSamDAO.registerUser"))
   }
 
   override def getRegistrationStatus(implicit userInfo: WithAccessToken): Future[RegistrationInfo] = {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/SamDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/SamDAO.scala
@@ -52,7 +52,7 @@ trait SamDAO extends LazyLogging with ReportsSubsystemStatus {
   val samResourcesBase: String = FireCloudConfig.Sam.baseUrl + s"/api/resources/v1"
   def samListResources(resourceTypeName: String): String = samResourcesBase + s"/$resourceTypeName"
 
-  def registerUser(implicit userInfo: WithAccessToken): Future[RegistrationInfo]
+  def registerUser(implicit userInfo: WithAccessToken, termsOfService: Option[String]): Future[RegistrationInfo]
   def getRegistrationStatus(implicit userInfo: WithAccessToken): Future[RegistrationInfo]
 
   def getUserIds(email: RawlsUserEmail)(implicit userInfo: WithAccessToken): Future[UserIdInfo]

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/SamDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/SamDAO.scala
@@ -52,7 +52,7 @@ trait SamDAO extends LazyLogging with ReportsSubsystemStatus {
   val samResourcesBase: String = FireCloudConfig.Sam.baseUrl + s"/api/resources/v1"
   def samListResources(resourceTypeName: String): String = samResourcesBase + s"/$resourceTypeName"
 
-  def registerUser(implicit userInfo: WithAccessToken, termsOfService: Option[String]): Future[RegistrationInfo]
+  def registerUser(termsOfService: Option[String])(implicit userInfo: WithAccessToken): Future[RegistrationInfo]
   def getRegistrationStatus(implicit userInfo: WithAccessToken): Future[RegistrationInfo]
 
   def getUserIds(email: RawlsUserEmail)(implicit userInfo: WithAccessToken): Future[UserIdInfo]

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
@@ -208,7 +208,7 @@ object ModelJsonProtocol extends WorkspaceJsonSupport with SprayJsonSupport {
   implicit val impFireCloudKeyValue = jsonFormat2(FireCloudKeyValue)
   implicit val impThurloeKeyValue = jsonFormat2(ThurloeKeyValue)
   implicit val impThurloeKeyValues = jsonFormat2(ThurloeKeyValues)
-  implicit val impBasicProfile = jsonFormat11(BasicProfile)
+  implicit val impBasicProfile = jsonFormat12(BasicProfile)
   implicit val impProfile = jsonFormat13(Profile.apply)
   implicit val impProfileWrapper = jsonFormat2(ProfileWrapper)
   implicit val impProfileKVP = jsonFormat2(ProfileKVP)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/Profile.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/Profile.scala
@@ -34,7 +34,8 @@ case class BasicProfile (
     programLocationState: String,
     programLocationCountry: String,
     pi: String,
-    nonProfitStatus: String
+    nonProfitStatus: String,
+    termsOfService: Option[String]
   ) extends mappedPropVals {
   require(ProfileValidator.nonEmpty(firstName), "first name must be non-empty")
   require(ProfileValidator.nonEmpty(lastName), "last name must be non-empty")

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/RegisterService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/RegisterService.scala
@@ -52,7 +52,7 @@ class RegisterService(val rawlsDao: RawlsDAO, val samDao: SamDAO, val thurloeDao
 
   private def registerUser(userInfo: UserInfo, termsOfService: Option[String]): Future[RegistrationInfo] = {
     for {
-      registrationInfo <- samDao.registerUser(userInfo, termsOfService)
+      registrationInfo <- samDao.registerUser(termsOfService)(userInfo)
       _ <- googleServicesDAO.publishMessages(FireCloudConfig.Notification.fullyQualifiedNotificationTopic, Seq(NotificationFormat.write(ActivationNotification(RawlsUserSubjectId(userInfo.id))).compactPrint))
     } yield {
       registrationInfo

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/RegisterService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/RegisterService.scala
@@ -33,7 +33,7 @@ class RegisterService(val rawlsDao: RawlsDAO, val samDao: SamDAO, val thurloeDao
       userStatus <- if (!isRegistered.enabled.google || !isRegistered.enabled.ldap) {
         for {
           _ <- thurloeDao.saveKeyValues(userInfo,  Map("email" -> userInfo.userEmail))
-          registerResult <- registerUser(userInfo)
+          registerResult <- registerUser(userInfo, basicProfile.termsOfService)
         } yield registerResult
       } else {
         Future.successful(isRegistered)
@@ -50,9 +50,9 @@ class RegisterService(val rawlsDao: RawlsDAO, val samDao: SamDAO, val thurloeDao
     }
   }
 
-  private def registerUser(userInfo: UserInfo): Future[RegistrationInfo] = {
+  private def registerUser(userInfo: UserInfo, termsOfService: Option[String]): Future[RegistrationInfo] = {
     for {
-      registrationInfo <- samDao.registerUser(userInfo)
+      registrationInfo <- samDao.registerUser(userInfo, termsOfService)
       _ <- googleServicesDAO.publishMessages(FireCloudConfig.Notification.fullyQualifiedNotificationTopic, Seq(NotificationFormat.write(ActivationNotification(RawlsUserSubjectId(userInfo.id))).compactPrint))
     } yield {
       registrationInfo

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/HealthChecksSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/HealthChecksSpec.scala
@@ -9,6 +9,7 @@ import org.broadinstitute.dsde.firecloud.service.BaseServiceSpec
 import org.broadinstitute.dsde.rawls.model.ErrorReport
 import org.scalatest.concurrent.ScalaFutures
 import akka.http.scaladsl.model.StatusCodes.{InternalServerError, NotFound}
+import org.broadinstitute.dsde.firecloud.HealthChecks.termsOfServiceUrl
 
 import scala.collection.mutable
 import scala.concurrent.duration._
@@ -149,12 +150,12 @@ class StartupChecksMockSamDAO(unregisteredTokens:Seq[String] = Seq.empty[String]
     }
   }
 
-  override def registerUser(implicit userInfo: WithAccessToken, termsOfService: Option[String]): Future[RegistrationInfo] = {
+  override def registerUser(termsOfService: Option[String])(implicit userInfo: WithAccessToken): Future[RegistrationInfo] = {
     if (cantRegister.contains(userInfo.accessToken.token)) {
       Future.failed(new FireCloudExceptionWithErrorReport(ErrorReport(InternalServerError, "unit test intentional registration fail")))
     } else {
       registerUserStateActor ! RegisterUserToken(userInfo.accessToken.token)
-      super.registerUser
+      super.registerUser(termsOfService)
     }
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/HealthChecksSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/HealthChecksSpec.scala
@@ -149,7 +149,7 @@ class StartupChecksMockSamDAO(unregisteredTokens:Seq[String] = Seq.empty[String]
     }
   }
 
-  override def registerUser(implicit userInfo: WithAccessToken): Future[RegistrationInfo] = {
+  override def registerUser(implicit userInfo: WithAccessToken, termsOfService: Option[String]): Future[RegistrationInfo] = {
     if (cantRegister.contains(userInfo.accessToken.token)) {
       Future.failed(new FireCloudExceptionWithErrorReport(ErrorReport(InternalServerError, "unit test intentional registration fail")))
     } else {

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockSamDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockSamDAO.scala
@@ -1,7 +1,7 @@
 package org.broadinstitute.dsde.firecloud.dataaccess
 
-import akka.stream.Materializer
 import org.broadinstitute.dsde.firecloud.FireCloudException
+import org.broadinstitute.dsde.firecloud.HealthChecks.termsOfServiceUrl
 import org.broadinstitute.dsde.firecloud.model.ManagedGroupRoles.ManagedGroupRole
 import org.broadinstitute.dsde.firecloud.model.{AccessToken, FireCloudManagedGroupMembership, RegistrationInfo, RegistrationInfoV2, SamResource, UserIdInfo, UserInfo, WithAccessToken, WorkbenchEnabled, WorkbenchUserInfo}
 import org.broadinstitute.dsde.workbench.util.health.SubsystemStatus
@@ -21,7 +21,9 @@ class MockSamDAO extends SamDAO {
     WorkbenchGroupName("TARGET-dbGaP-Authorized") -> Set(WorkbenchEmail("target-linked"), WorkbenchEmail("target-linked-expired"), WorkbenchEmail("tcga-and-target-linked"), WorkbenchEmail("tcga-and-target-linked-expired"))
   )
 
-  override def registerUser(implicit userInfo: WithAccessToken, termsOfService: Option[String]): Future[RegistrationInfo] = enabledUserInfo
+  override def registerUser(termsOfService: Option[String])(implicit userInfo: WithAccessToken): Future[RegistrationInfo] =
+    if (termsOfService.contains(termsOfServiceUrl)) enabledUserInfo
+    else Future.failed(new FireCloudException("You must accept the Terms of Service in order to register."))
 
   override def getRegistrationStatus(implicit userInfo: WithAccessToken): Future[RegistrationInfo] = enabledUserInfo
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockSamDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockSamDAO.scala
@@ -21,7 +21,7 @@ class MockSamDAO extends SamDAO {
     WorkbenchGroupName("TARGET-dbGaP-Authorized") -> Set(WorkbenchEmail("target-linked"), WorkbenchEmail("target-linked-expired"), WorkbenchEmail("tcga-and-target-linked"), WorkbenchEmail("tcga-and-target-linked-expired"))
   )
 
-  override def registerUser(implicit userInfo: WithAccessToken): Future[RegistrationInfo] = enabledUserInfo
+  override def registerUser(implicit userInfo: WithAccessToken, termsOfService: Option[String]): Future[RegistrationInfo] = enabledUserInfo
 
   override def getRegistrationStatus(implicit userInfo: WithAccessToken): Future[RegistrationInfo] = enabledUserInfo
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/model/ProfileSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/model/ProfileSpec.scala
@@ -23,7 +23,8 @@ class ProfileSpec extends AnyFreeSpec with Matchers {
           programLocationState = randomString,
           programLocationCountry = randomString,
           pi = randomString,
-          nonProfitStatus = randomString
+          nonProfitStatus = randomString,
+          termsOfService = Some("app.terra.bio/#terms-of-service")
         )
         basicProfile shouldNot be(null)
       }
@@ -91,7 +92,8 @@ class ProfileSpec extends AnyFreeSpec with Matchers {
             programLocationState = "",
             programLocationCountry = "",
             pi = "",
-            nonProfitStatus = ""
+            nonProfitStatus = "",
+            Option.empty
           )
         }
         ex shouldNot be(null)

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/model/ProfileSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/model/ProfileSpec.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.firecloud.model
 
+import org.broadinstitute.dsde.firecloud.HealthChecks.termsOfServiceUrl
 import org.broadinstitute.dsde.firecloud.mock.MockUtils
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
@@ -24,7 +25,7 @@ class ProfileSpec extends AnyFreeSpec with Matchers {
           programLocationCountry = randomString,
           pi = randomString,
           nonProfitStatus = randomString,
-          termsOfService = Some("app.terra.bio/#terms-of-service")
+          termsOfService = Some(termsOfServiceUrl)
         )
         basicProfile shouldNot be(null)
       }
@@ -85,7 +86,7 @@ class ProfileSpec extends AnyFreeSpec with Matchers {
             firstName = "",
             lastName = "",
             title = "",
-            contactEmail = Option.empty,
+            contactEmail = None,
             institute = "",
             institutionalProgram = "",
             programLocationCity = "",
@@ -93,7 +94,7 @@ class ProfileSpec extends AnyFreeSpec with Matchers {
             programLocationCountry = "",
             pi = "",
             nonProfitStatus = "",
-            Option.empty
+            None
           )
         }
         ex shouldNot be(null)

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/RegisterApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/RegisterApiServiceSpec.scala
@@ -36,7 +36,7 @@ final class RegisterApiServiceSpec extends BaseServiceSpec with RegisterApiServi
       "should succeed with multiple notifications keys" in {
         val payload = Map(
           "notifications/foo" -> "yes",
-          "notifications/bar" ->  "no",
+          "notifications/bar" -> "no",
           "notifications/baz" -> "astring"
         )
         assertPreferencesUpdate(payload, NoContent)
@@ -52,7 +52,7 @@ final class RegisterApiServiceSpec extends BaseServiceSpec with RegisterApiServi
       "should refuse with mixed notifications and disallowed keys" in {
         val payload = Map(
           "notifications/foo" -> "yes",
-          "notifications/bar" ->  "no",
+          "notifications/bar" -> "no",
           "secretsomething" -> "astring"
         )
         assertPreferencesUpdate(payload, BadRequest)
@@ -61,7 +61,7 @@ final class RegisterApiServiceSpec extends BaseServiceSpec with RegisterApiServi
       "should refuse with the string 'notifications/' in the middle of a key" in {
         val payload = Map(
           "notifications/foo" -> "yes",
-          "notifications/bar" ->  "no",
+          "notifications/bar" -> "no",
           "substring/notifications/arebad" -> "true"
         )
         assertPreferencesUpdate(payload, BadRequest)
@@ -75,48 +75,38 @@ final class RegisterApiServiceSpec extends BaseServiceSpec with RegisterApiServi
     }
 
     "register-profile API" - {
-
-      val RANDOM_STRING = MockUtils.randomAlpha()
-      val BASIC_PROFILE = BasicProfile(
-        firstName = RANDOM_STRING,
-        lastName = RANDOM_STRING,
-        title = RANDOM_STRING,
-        contactEmail = Some("me@abc.com"),
-        institute = RANDOM_STRING,
-        institutionalProgram = RANDOM_STRING,
-        programLocationCity = RANDOM_STRING,
-        programLocationState = RANDOM_STRING,
-        programLocationCountry = RANDOM_STRING,
-        pi = RANDOM_STRING,
-        nonProfitStatus = RANDOM_STRING,
-        termsOfService = Some("app.terra.bio/#terms-of-service")
-      )
       implicit val impBasicProfile: RootJsonFormat[BasicProfile] = jsonFormat12(BasicProfile)
 
       "should succeed with no terms of service" in {
-        val payload = BasicProfile(
-          firstName = RANDOM_STRING,
-          lastName = RANDOM_STRING,
-          title = RANDOM_STRING,
-          contactEmail = Some("me@abc.com"),
-          institute = RANDOM_STRING,
-          institutionalProgram = RANDOM_STRING,
-          programLocationCity = RANDOM_STRING,
-          programLocationState = RANDOM_STRING,
-          programLocationCountry = RANDOM_STRING,
-          pi = RANDOM_STRING,
-          nonProfitStatus = RANDOM_STRING,
-          termsOfService = None
-        )
+        val payload = makeBasicProfile(false)
         Post("/register/profile", payload) ~> dummyUserIdHeaders("RegisterApiServiceSpec") ~> sealRoute(registerRoutes) ~> check {
           status should be(OK)
         }
       }
 
       "should succeed with terms of service" in {
-        Post("/register/profile", BASIC_PROFILE) ~> dummyUserIdHeaders("RegisterApiServiceSpec") ~> sealRoute(registerRoutes) ~> check {
+        val payload = makeBasicProfile(true)
+        Post("/register/profile", payload) ~> dummyUserIdHeaders("RegisterApiServiceSpec") ~> sealRoute(registerRoutes) ~> check {
           status should be(OK)
         }
+      }
+
+      def makeBasicProfile(hasTermsOfService: Boolean): BasicProfile = {
+        val randomString = MockUtils.randomAlpha()
+        BasicProfile(
+          firstName = randomString,
+          lastName = randomString,
+          title = randomString,
+          contactEmail = Some("me@abc.com"),
+          institute = randomString,
+          institutionalProgram = randomString,
+          programLocationCity = randomString,
+          programLocationState = randomString,
+          programLocationCountry = randomString,
+          pi = randomString,
+          nonProfitStatus = randomString,
+          termsOfService = if (hasTermsOfService) Some("app.terra.bio/#terms-of-service") else None
+        )
       }
     }
   }
@@ -131,6 +121,5 @@ final class RegisterApiServiceSpec extends BaseServiceSpec with RegisterApiServi
   final class RegisterApiServiceSpecThurloeDAO extends MockThurloeDAO {
     override def saveKeyValues(userInfo: UserInfo, keyValues: Map[String, String])= Future.successful(Success(()))
   }
-
 }
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/RegisterApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/RegisterApiServiceSpec.scala
@@ -10,7 +10,7 @@ import akka.http.scaladsl.server.Route.{seal => sealRoute}
 import org.broadinstitute.dsde.firecloud.HealthChecks.termsOfServiceUrl
 import org.broadinstitute.dsde.firecloud.mock.MockUtils
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol.impBasicProfile
-import spray.json.{DefaultJsonProtocol, RootJsonFormat}
+import spray.json.{DefaultJsonProtocol}
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Success
@@ -77,12 +77,19 @@ final class RegisterApiServiceSpec extends BaseServiceSpec with RegisterApiServi
     "register-profile API" - {
       "should fail with no terms of service" in {
         val payload = makeBasicProfile(false)
-        Post("/register/profile", payload) ~> dummyUserIdHeaders("RegisterApiServiceSpec") ~> sealRoute(registerRoutes) ~> check {
+        Post("/register/profile", payload) ~> dummyUserIdHeaders("RegisterApiServiceSpec", "new") ~> sealRoute(registerRoutes) ~> check {
           status should be(Forbidden)
         }
       }
 
       "should succeed with terms of service" in {
+        val payload = makeBasicProfile(true)
+        Post("/register/profile", payload) ~> dummyUserIdHeaders("RegisterApiServiceSpec", "new") ~> sealRoute(registerRoutes) ~> check {
+          status should be(OK)
+        }
+      }
+
+      "should succeed user who already exists" in {
         val payload = makeBasicProfile(true)
         Post("/register/profile", payload) ~> dummyUserIdHeaders("RegisterApiServiceSpec") ~> sealRoute(registerRoutes) ~> check {
           status should be(OK)

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/RegisterApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/RegisterApiServiceSpec.scala
@@ -2,13 +2,15 @@ package org.broadinstitute.dsde.firecloud.webservice
 
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
 import org.broadinstitute.dsde.firecloud.dataaccess.MockThurloeDAO
-import org.broadinstitute.dsde.firecloud.model.UserInfo
+import org.broadinstitute.dsde.firecloud.model.{BasicProfile, UserInfo}
 import org.broadinstitute.dsde.firecloud.service.{BaseServiceSpec, RegisterService}
-import akka.http.scaladsl.model.StatusCodes.{BadRequest, NoContent}
+import akka.http.scaladsl.model.StatusCodes.{BadRequest, NoContent, OK}
 import akka.http.scaladsl.model.StatusCode
 import akka.http.scaladsl.server.Route.{seal => sealRoute}
 import org.broadinstitute.dsde.firecloud.FireCloudApiService
-import spray.json.DefaultJsonProtocol
+import org.broadinstitute.dsde.firecloud.mock.MockUtils
+import spray.json.{DefaultJsonProtocol, RootJsonFormat}
+import spray.json.DefaultJsonProtocol.jsonFormat12
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Success
@@ -70,6 +72,52 @@ final class RegisterApiServiceSpec extends BaseServiceSpec with RegisterApiServi
         assertPreferencesUpdate(payload, NoContent)
       }
 
+    }
+
+    "register-profile API" - {
+
+      val RANDOM_STRING = MockUtils.randomAlpha()
+      val BASIC_PROFILE = BasicProfile(
+        firstName = RANDOM_STRING,
+        lastName = RANDOM_STRING,
+        title = RANDOM_STRING,
+        contactEmail = Some("me@abc.com"),
+        institute = RANDOM_STRING,
+        institutionalProgram = RANDOM_STRING,
+        programLocationCity = RANDOM_STRING,
+        programLocationState = RANDOM_STRING,
+        programLocationCountry = RANDOM_STRING,
+        pi = RANDOM_STRING,
+        nonProfitStatus = RANDOM_STRING,
+        termsOfService = Some("app.terra.bio/#terms-of-service")
+      )
+      implicit val impBasicProfile: RootJsonFormat[BasicProfile] = jsonFormat12(BasicProfile)
+
+      "should succeed with no terms of service" in {
+        val payload = BasicProfile(
+          firstName = RANDOM_STRING,
+          lastName = RANDOM_STRING,
+          title = RANDOM_STRING,
+          contactEmail = Some("me@abc.com"),
+          institute = RANDOM_STRING,
+          institutionalProgram = RANDOM_STRING,
+          programLocationCity = RANDOM_STRING,
+          programLocationState = RANDOM_STRING,
+          programLocationCountry = RANDOM_STRING,
+          pi = RANDOM_STRING,
+          nonProfitStatus = RANDOM_STRING,
+          termsOfService = None
+        )
+        Post("/register/profile", payload) ~> dummyUserIdHeaders("RegisterApiServiceSpec") ~> sealRoute(registerRoutes) ~> check {
+          status should be(OK)
+        }
+      }
+
+      "should succeed with terms of service" in {
+        Post("/register/profile", BASIC_PROFILE) ~> dummyUserIdHeaders("RegisterApiServiceSpec") ~> sealRoute(registerRoutes) ~> check {
+          status should be(OK)
+        }
+      }
     }
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/UserApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/UserApiServiceSpec.scala
@@ -48,7 +48,8 @@ class UserApiServiceSpec extends BaseServiceSpec with RegisterApiService with Us
     programLocationState = randomAlpha(),
     programLocationCountry = randomAlpha(),
     pi = randomAlpha(),
-    nonProfitStatus = randomAlpha()
+    nonProfitStatus = randomAlpha(),
+    termsOfService = Option.empty
   )
   val allProperties: Map[String, String] = fullProfile.propertyValueMap
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/UserApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/UserApiServiceSpec.scala
@@ -41,7 +41,7 @@ class UserApiServiceSpec extends BaseServiceSpec with RegisterApiService with Us
     firstName= randomAlpha(),
     lastName = randomAlpha(),
     title = randomAlpha(),
-    contactEmail = Option.empty,
+    contactEmail = None,
     institute = randomAlpha(),
     institutionalProgram = randomAlpha(),
     programLocationCity = randomAlpha(),
@@ -49,7 +49,7 @@ class UserApiServiceSpec extends BaseServiceSpec with RegisterApiService with Us
     programLocationCountry = randomAlpha(),
     pi = randomAlpha(),
     nonProfitStatus = randomAlpha(),
-    termsOfService = Option.empty
+    termsOfService = None
   )
   val allProperties: Map[String, String] = fullProfile.propertyValueMap
 


### PR DESCRIPTION
On the API side, I added an optional termsOfService field to the BasicProfile object passed in the request body. This allows the client to optionally provide a String for terms of service in the request to Orch. If the user provides a string, this is propagated, and the terms of service string is included in the request to Sam, as part of the message body. The change to add the parameter is made in `model/Profile.scala` and passed in `service/RegisterService.scala`. The call to Sam is updated in `dataaccess/HttpSamDAO.scala`.

Testing:
- Updated unit tests and made sure they are completing successfully
- Ran a local Terra and local Orch on this version and registered a new user

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
