### PR TITLE
[QA-1620] Fix WorkspaceApiSpec/Orchestration/should return a storage cost estimate/for writers of a workspace

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/WorkspaceApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/WorkspaceApiSpec.scala
@@ -39,13 +39,11 @@ class WorkspaceApiSpec extends FreeSpec with Matchers with Eventually
 
         withCleanBillingProject(owner) { projectName =>
           withWorkspace(projectName, prependUUID("writer-storage-cost"), aclEntries = List(AclEntry(writer.email, WorkspaceAccessLevel.Writer))) { workspaceName =>
-            Orchestration.workspaces.waitForBucketReadAccess(projectName, workspaceName)(ownerAuthToken)
-
-            implicit val patienceConfig = PatienceConfig(Span(5, Minutes), Span(15, Seconds))
-            eventually { // This was added as a workaround for https://broadworkbench.atlassian.net/browse/QA-1534
-              val storageCostEstimate = Orchestration.workspaces.getStorageCostEstimate(projectName, workspaceName)(writer.makeAuthToken()).parseJson.convertTo[StorageCostEstimate]
-              storageCostEstimate.estimate should be ("$0.00")
-            }
+            implicit val writerAuthToken: AuthToken = writer.makeAuthToken
+            Orchestration.workspaces.waitForBucketReadAccess(projectName, workspaceName)
+            Orchestration.workspaces.getStorageCostEstimate(projectName, workspaceName)
+              .parseJson.convertTo[StorageCostEstimate]
+              .estimate should be("$0.00")
           } (ownerAuthToken)
         }
       }
@@ -57,10 +55,11 @@ class WorkspaceApiSpec extends FreeSpec with Matchers with Eventually
 
         withCleanBillingProject(owner) { projectName =>
           withWorkspace(projectName, prependUUID("reader-storage-cost"), aclEntries = List(AclEntry(reader.email, WorkspaceAccessLevel.Reader))) { workspaceName =>
-            Orchestration.workspaces.waitForBucketReadAccess(projectName, workspaceName)(ownerAuthToken)
+            implicit val readerAuthToken: AuthToken = reader.makeAuthToken
+            Orchestration.workspaces.waitForBucketReadAccess(projectName, workspaceName)
 
             val exception = intercept[RestException] {
-              Orchestration.workspaces.getStorageCostEstimate(projectName, workspaceName)(reader.makeAuthToken())
+              Orchestration.workspaces.getStorageCostEstimate(projectName, workspaceName)
             }
             val exceptionMessage = exception.message.parseJson.asJsObject.fields("message").convertTo[String]
 


### PR DESCRIPTION
RR: https://broadworkbench.atlassian.net/browse/QA-1620

Wait for the bucket to be readable by the writer, not the owner.

\<your comments for this PR go here\>

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
