### PR TITLE
increase timeout, one more logging statement [QA-1239]

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/AsyncImportSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/AsyncImportSpec.scala
@@ -226,13 +226,14 @@ class AsyncImportSpec extends FreeSpec with Matchers with Eventually with ScalaF
     // poll for completion as owner
     withClue(s"import job $importJobId failed its eventually assertions on job status: ") {
       eventually(timeout = Timeout(scaled(Span(10, Minutes))), interval = Interval(scaled(Span(5, Seconds)))) {
-        logger.info(s"About to check status for import job $importJobId. Elapsed: ${humanReadableMillis(System.currentTimeMillis()-startTime)}")
+        val requestId = scala.util.Random.nextString(8) // just to assist with logging
+        logger.info(s"[$requestId] About to check status for import job $importJobId. Elapsed: ${humanReadableMillis(System.currentTimeMillis()-startTime)}")
         val resp: HttpResponse = Orchestration.getRequest(s"${workspaceUrl(projectName, workspaceName)}/importJob/$importJobId")
         val respStatus = resp.status
-        logger.info(s"HTTP response status for import job $importJobId status request is [${respStatus.intValue()}]. Elapsed: ${humanReadableMillis(System.currentTimeMillis()-startTime)}")
+        logger.info(s"[$requestId] HTTP response status for import job $importJobId status request is [${respStatus.intValue()}]. Elapsed: ${humanReadableMillis(System.currentTimeMillis()-startTime)}")
         respStatus shouldBe StatusCodes.OK
         val importStatus = blockForStringBody(resp).parseJson.asJsObject.fields.get("status").value
-        logger.info(s"Import Service job status for import job $importJobId is [$importStatus]")
+        logger.info(s"[$requestId] Import Service job status for import job $importJobId is [$importStatus]")
         importStatus shouldBe JsString ("Done")
       }
     }

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/AsyncImportSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/AsyncImportSpec.scala
@@ -15,7 +15,7 @@ import org.parboiled.common.FileUtils
 import org.scalatest.OptionValues._
 import org.scalatest.concurrent.PatienceConfiguration.{Interval, Timeout}
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
-import org.scalatest.time.{Seconds, Span}
+import org.scalatest.time.{Minutes, Seconds, Span}
 import org.scalatest.{FreeSpec, Matchers}
 import spray.json._
 
@@ -225,7 +225,8 @@ class AsyncImportSpec extends FreeSpec with Matchers with Eventually with ScalaF
 
     // poll for completion as owner
     withClue(s"import job $importJobId failed its eventually assertions on job status: ") {
-      eventually(Interval(scaled(Span(5, Seconds)))) {
+      eventually(timeout = Timeout(scaled(Span(10, Minutes))), interval = Interval(scaled(Span(5, Seconds)))) {
+        logger.info(s"About to check status for import job $importJobId. Elapsed: ${humanReadableMillis(System.currentTimeMillis()-startTime)}")
         val resp: HttpResponse = Orchestration.getRequest(s"${workspaceUrl(projectName, workspaceName)}/importJob/$importJobId")
         val respStatus = resp.status
         logger.info(s"HTTP response status for import job $importJobId status request is [${respStatus.intValue()}]. Elapsed: ${humanReadableMillis(System.currentTimeMillis()-startTime)}")


### PR DESCRIPTION
* increase the timeout from 5 to 10 minutes for async-TSV jobs to reach `Done`
* add an extra logging statement about the job-status requests

I am hesitant to increase the timeout, because I don't think that's the issue and it will just cause our tests to be 5 minutes slower. But I'd like to see what happens, and once we get to the bottom of this we should consider turning the timeout back down.

-----

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
