### PR TITLE
alphanumeric loop ids for logging [QA-1239]

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/AsyncImportSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/AsyncImportSpec.scala
@@ -3,6 +3,7 @@ package org.broadinstitute.dsde.test.api.orch
 import java.util.UUID
 import akka.http.scaladsl.model.{HttpResponse, StatusCodes}
 import akka.http.scaladsl.unmarshalling.Unmarshal
+import net.bytebuddy.utility.RandomString
 import org.broadinstitute.dsde.rawls.model.EntityTypeMetadata
 import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport.EntityTypeMetadataFormat
 import org.broadinstitute.dsde.workbench.auth.AuthToken
@@ -226,7 +227,7 @@ class AsyncImportSpec extends FreeSpec with Matchers with Eventually with ScalaF
     // poll for completion as owner
     withClue(s"import job $importJobId failed its eventually assertions on job status: ") {
       eventually(timeout = Timeout(scaled(Span(10, Minutes))), interval = Interval(scaled(Span(5, Seconds)))) {
-        val requestId = scala.util.Random.nextString(8) // just to assist with logging
+        val requestId = scala.util.Random.alphanumeric.take(8).mkString // just to assist with logging
         logger.info(s"[$requestId] About to check status for import job $importJobId. Elapsed: ${humanReadableMillis(System.currentTimeMillis()-startTime)}")
         val resp: HttpResponse = Orchestration.getRequest(s"${workspaceUrl(projectName, workspaceName)}/importJob/$importJobId")
         val respStatus = resp.status

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/AsyncImportSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/AsyncImportSpec.scala
@@ -3,7 +3,6 @@ package org.broadinstitute.dsde.test.api.orch
 import java.util.UUID
 import akka.http.scaladsl.model.{HttpResponse, StatusCodes}
 import akka.http.scaladsl.unmarshalling.Unmarshal
-import net.bytebuddy.utility.RandomString
 import org.broadinstitute.dsde.rawls.model.EntityTypeMetadata
 import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport.EntityTypeMetadataFormat
 import org.broadinstitute.dsde.workbench.auth.AuthToken


### PR DESCRIPTION
part of QA-1239, does not resolve that ticket. Small tweak to use alphanumeric ids when logging instead of potential high-unicode chars. This is only used in logging, and only by tests.

Example of ids before:
```
휊衁ភ觎ⶸ幢〣⮐
2禉໑㕷畐㨠ⴙ飴
殚琪ꦝ诸谮춈佷볤
䶓켚ꃰ㖋猷飿졾군
ँ헎ᨥ间㠙䳄렿悉
```

Example of ids after:
```
fNvdXVLR
G8uCy8fH
sGrhQI8e
zleseGHo
SYvsI9T0
```




