### PR TITLE
upgrade workbench-libs serviceTest [AS-1018]

### DIFF
--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -7,15 +7,15 @@ object Dependencies {
   val akkaV = "2.6.15"
   val akkaHttpV = "10.1.0"
 
-  val workbenchModelV  = "0.15-5ba81aa"
+  val workbenchModelV  = "0.15-808590d"
   val workbenchModel: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-model" % workbenchModelV
   val excludeWorkbenchModel = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-model_" + scalaV)
 
-  val workbenchGoogleV = "0.21-5ba81aa"
+  val workbenchGoogleV = "0.21-808590d"
   val workbenchGoogle: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-google" % workbenchGoogleV excludeAll excludeWorkbenchModel
   val excludeWorkbenchGoogle = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-google" + scalaV)
 
-  val workbenchServiceTestV = "0.21-5ba81aa"
+  val workbenchServiceTestV = "0.21-808590d"
   val workbenchServiceTest: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-service-test" % workbenchServiceTestV % "test" classifier "tests" excludeAll (excludeWorkbenchGoogle, excludeWorkbenchModel)
 
   val rootDependencies = Seq(

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -7,15 +7,15 @@ object Dependencies {
   val akkaV = "2.6.15"
   val akkaHttpV = "10.1.0"
 
-  val workbenchModelV  = "0.13-58c913d"
+  val workbenchModelV  = "0.15-5ba81aa"
   val workbenchModel: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-model" % workbenchModelV
   val excludeWorkbenchModel = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-model_" + scalaV)
 
-  val workbenchGoogleV = "0.21-890a74f"
+  val workbenchGoogleV = "0.21-5ba81aa"
   val workbenchGoogle: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-google" % workbenchGoogleV excludeAll excludeWorkbenchModel
   val excludeWorkbenchGoogle = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-google" + scalaV)
 
-  val workbenchServiceTestV = "0.19-44c8451"
+  val workbenchServiceTestV = "0.21-5ba81aa"
   val workbenchServiceTest: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-service-test" % workbenchServiceTestV % "test" classifier "tests" excludeAll (excludeWorkbenchGoogle, excludeWorkbenchModel)
 
   val rootDependencies = Seq(

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -44,6 +44,8 @@ object Dependencies {
     "org.seleniumhq.selenium" % "selenium-java" % "3.11.0" % "test",
     "com.typesafe.scala-logging" %% "scala-logging" % "3.8.0",
 
+    "net.logstash.logback" % "logstash-logback-encoder" % "6.6", // needed by workbench-google
+
     workbenchServiceTest,
     workbenchModel,
     workbenchGoogle,


### PR DESCRIPTION
updates the workbench-libs service-test library, to gain new test logging. See broadinstitute/workbench-libs#793 and broadinstitute/workbench-libs#801 for details on the logging changes. You should be able to see the logging changes in effect in the Jenkins Automation Tests for this PR.

Also updates the workbench-model and workbench-google libraries to stay in sync with service-test, and adds the `logstash-logback-encoder` library per release notes at https://github.com/broadinstitute/workbench-libs/blob/develop/google/CHANGELOG.md#021.
