### PR TITLE
upgrade workbench-google2 [AS-1025]

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -36,7 +36,7 @@ object Dependencies {
       exclude("com.google.code.findbugs", "jsr305")
       exclude("bio.terra", "workspace-manager-client")
       excludeAll(excludeAkkaHttp, excludeSprayJson),
-    excludeGuava("org.broadinstitute.dsde.workbench" %% "workbench-util"  % "0.6-d7ed6bf"),
+    excludeGuava("org.broadinstitute.dsde.workbench" %% "workbench-util"  % "0.5-4bc7050"),
     "org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.23-7ddf186",
 
     "com.typesafe.akka"   %%  "akka-actor"           % akkaV,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -36,8 +36,8 @@ object Dependencies {
       exclude("com.google.code.findbugs", "jsr305")
       exclude("bio.terra", "workspace-manager-client")
       excludeAll(excludeAkkaHttp, excludeSprayJson),
-    excludeGuava("org.broadinstitute.dsde.workbench" %% "workbench-util"  % "0.5-4bc7050"),
-    "org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.22-82a345c",
+    excludeGuava("org.broadinstitute.dsde.workbench" %% "workbench-util"  % "0.6-d7ed6bf"),
+    "org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.23-7ddf186",
 
     "com.typesafe.akka"   %%  "akka-actor"           % akkaV,
     "com.typesafe.akka"   %%  "akka-contrib"         % akkaV               excludeAll(excludeAkkaActor, excludeAkkaStream),
@@ -81,7 +81,7 @@ object Dependencies {
     // jaxb-api needed by WorkspaceApiServiceSpec.bagitService() method
     "javax.xml.bind"                 % "jaxb-api"            % "2.3.1"   % "test",
     // provides testing mocks
-    "com.google.cloud"               % "google-cloud-nio"    % "0.123.7" % "test",
+    "com.google.cloud"               % "google-cloud-nio"    % "0.123.16" % "test",
     "org.scalatestplus"             %% "mockito-3-4"         % "3.2.9.0" % "test"
   )
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -37,7 +37,7 @@ object Dependencies {
       exclude("bio.terra", "workspace-manager-client")
       excludeAll(excludeAkkaHttp, excludeSprayJson),
     excludeGuava("org.broadinstitute.dsde.workbench" %% "workbench-util"  % "0.5-4bc7050"),
-    "org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.21-bf66e61",
+    "org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.22-82a345c",
 
     "com.typesafe.akka"   %%  "akka-actor"           % akkaV,
     "com.typesafe.akka"   %%  "akka-contrib"         % akkaV               excludeAll(excludeAkkaActor, excludeAkkaStream),

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
@@ -216,7 +216,7 @@ class HttpGoogleServicesDAO(priceListUrl: String, defaultPriceList: GooglePriceL
       // N.B. workbench-libs' streamUploadBlob does not allow setting the Content-Type, so we don't set it
       val uploadPipe = storageService.streamUploadBlob(bucketName, GcsBlobName(objectKey.value))
       // stream the data to the destination pipe
-      dataStream.through(uploadPipe).compile.lastOrError
+      dataStream.through(uploadPipe).compile.drain
     }
 
     // execute the upload

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
@@ -8,7 +8,8 @@ import akka.http.scaladsl.model.headers.{Location, `Content-Type`}
 import akka.http.scaladsl.model.{HttpResponse, StatusCodes, Uri}
 import akka.http.scaladsl.unmarshalling.Unmarshaller
 import akka.stream.Materializer
-import cats.effect.{Blocker, ContextShift, IO, Resource, Timer}
+import cats.effect.{IO, Resource}
+import cats.effect.unsafe.implicits.global
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport
 import com.google.api.client.googleapis.json.GoogleJsonResponseException
 import com.google.api.client.googleapis.services.AbstractGoogleClientRequest
@@ -42,6 +43,9 @@ import spray.json.{DefaultJsonProtocol, _}
 import collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
+import cats.effect.Temporal
+import cats.effect.std.Semaphore
+import cats.effect.unsafe.IORuntime
 
 /** Result from Google's pricing calculator price list
   * (https://cloudpricingcalculator.appspot.com/static/data/pricelist.json).
@@ -190,14 +194,11 @@ class HttpGoogleServicesDAO(priceListUrl: String, defaultPriceList: GooglePriceL
   override def writeObjectAsRawlsSA(bucketName: GcsBucketName, objectKey: GcsObjectName, objectContents: Array[Byte]): GcsPath = {
     // if other methods in this class use google2/need these implicits, consider moving to the class level
     // instead of here at the method level
-    implicit val cs: ContextShift[IO] = IO.contextShift(executionContext)
-    implicit val t: Timer[IO] = IO.timer(executionContext)
     implicit val logger: SelfAwareStructuredLogger[IO] = Slf4jLogger.getLogger[IO]
-    val blocker = Blocker.liftExecutionContext(executionContext)
 
     // create the storage service, using the Rawls SA credentials
     // the Rawls SA json creds do not contain a project, so also specify the project explicitly
-    val storageResource = GoogleStorageService.resource(FireCloudConfig.Auth.rawlsSAJsonFile, blocker,
+    val storageResource = GoogleStorageService.resource(FireCloudConfig.Auth.rawlsSAJsonFile, Option.empty[Semaphore[IO]],
        project = Some(GoogleProject(FireCloudConfig.FireCloud.serviceProject)))
 
     // call the upload implementation


### PR DESCRIPTION
AS-1025: `blaze-client` is out of date; it needs updating. it is a transitive dependency from `workbench-google2`. So, let's take the hit and upgrade `workbench-google2`, along with its upgrade of `cats`.

I have verified that this branch fixes the `blaze-client` warning by running a manual scan using the [SourceClear CLI](https://help.veracode.com/r/t_sc_cli_agent) (I don't believe we have enough seats for everyone to install this)

-----

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
