### PR TITLE
importJob consolidation and tdr import support [AS-1035]

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -4806,6 +4806,7 @@ paths:
       x-passthrough: false
   /api/workspaces/{workspaceNamespace}/{workspaceName}/importPFB:
     get:
+      deprecated: true
       tags:
         - Entities
       summary: List PFB import jobs in this workspace
@@ -4839,7 +4840,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/PFBStatusResponse'
+                  $ref: '#/components/schemas/ImportJobStatusResponse'
         400:
           description: Bad Request
           content: {}
@@ -4943,6 +4944,103 @@ paths:
           description: Internal Error
           content: {}
       x-passthrough: false
+  /api/workspaces/{workspaceNamespace}/{workspaceName}/importJob:
+    get:
+      tags:
+        - Entities
+      summary: List asynchronous import jobs in this workspace
+      description: |
+        Lists all imports for this workspace, optionally filtered to only those imports currently in progress
+      operationId: listImportJobs
+      parameters:
+        - name: workspaceNamespace
+          in: path
+          description: Workspace Namespace
+          required: true
+          schema:
+            type: string
+        - name: workspaceName
+          in: path
+          description: Workspace Name
+          required: true
+          schema:
+            type: string
+        - name: running_only
+          in: query
+          description: When true, filters to only those imports currently in progress
+          schema:
+            type: boolean
+            default: false
+      responses:
+        200:
+          description: Successful Request
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ImportJobStatusResponse'
+        400:
+          description: Bad Request
+          content: {}
+        404:
+          description: Workspace not found
+          content: {}
+        500:
+          description: Internal Error
+          content: {}
+      x-passthrough: false
+    post:
+      tags:
+        - Entities
+      summary: Import data from a PFB file or TDR snapshot
+      description: |
+        This API will return a jobID representing the import operation. The import itself will continue asynchronously in the background.
+      operationId: createImportJob
+      parameters:
+        - name: workspaceNamespace
+          in: path
+          description: Workspace Namespace
+          required: true
+          schema:
+            type: string
+        - name: workspaceName
+          in: path
+          description: Workspace Name
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: JSON object containing URL to import
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/ImportRequest'
+        required: true
+      responses:
+        202:
+          description: Successful Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ImportResponse'
+        400:
+          description: Bad Request
+          content: {}
+        401:
+          description: Unauthorized access to Workspace
+          content: {}
+        403:
+          description: Forbidden access to Workspace
+          content: {}
+        404:
+          description: Workspace not found
+          content: {}
+        500:
+          description: Internal Error
+          content: {}
+      x-passthrough: false
+      x-codegen-request-body-name: importRequest
   /api/workspaces/{workspaceNamespace}/{workspaceName}/importJob/{jobId}:
     get:
       tags:
@@ -8783,6 +8881,18 @@ components:
         url:
           type: string
           description: link to publically accessible PFB/Avro
+    ImportRequest:
+      required:
+        - filetype
+        - url
+      type: object
+      properties:
+        filetype:
+          type: string
+          description: "'pfb' or 'tdrexport'; the type of import to perform"
+        url:
+          type: string
+          description: link to publically accessible file to import
     ImportResponse:
       required:
         - jobId

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/EntityService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/EntityService.scala
@@ -366,10 +366,6 @@ class EntityService(rawlsDAO: RawlsDAO, importServiceDAO: ImportServiceDAO, goog
     }
   }
 
-  def importPFB(workspaceNamespace: String, workspaceName: String, pfbRequest: AsyncImportRequest, userInfo: UserInfo): Future[PerRequestMessage] = {
-    importServiceDAO.importJob(workspaceNamespace, workspaceName, pfbRequest.copy(filetype = FILETYPE_PFB), isUpsert=true)(userInfo)
-  }
-
   def importJob(workspaceNamespace: String, workspaceName: String, importRequest: AsyncImportRequest, userInfo: UserInfo): Future[PerRequestMessage] = {
     // validate that filetype exists in the importRequest
     if (importRequest.filetype.isEmpty)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/EntityService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/EntityService.scala
@@ -227,7 +227,7 @@ class EntityService(rawlsDAO: RawlsDAO, importServiceDAO: ImportServiceDAO, goog
     val insertedObject = googleServicesDAO.writeObjectAsRawlsSA(bucketToWrite, fileToWrite, dataBytes)
     val gcsPath = s"gs://${insertedObject.bucketName.value}/${insertedObject.objectName.value}"
 
-    val importRequest = AsyncImportRequest(Option(gcsPath), FILETYPE_RAWLS)
+    val importRequest = AsyncImportRequest(gcsPath, FILETYPE_RAWLS)
     importServiceDAO.importJob(workspaceNamespace, workspaceName, importRequest, isUpsert)(userInfo)
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/EntityService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/EntityService.scala
@@ -9,6 +9,7 @@ import akka.http.scaladsl.model.{HttpResponse, StatusCodes}
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.EntityService._
 import org.broadinstitute.dsde.firecloud.FireCloudConfig.Rawls
+import org.broadinstitute.dsde.firecloud.dataaccess.ImportServiceFiletypes.{FILETYPE_PFB, FILETYPE_RAWLS}
 import org.broadinstitute.dsde.firecloud.dataaccess.{GoogleServicesDAO, ImportServiceDAO, RawlsDAO}
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
 import org.broadinstitute.dsde.firecloud.model.{ModelSchema, _}
@@ -226,7 +227,7 @@ class EntityService(rawlsDAO: RawlsDAO, importServiceDAO: ImportServiceDAO, goog
     val insertedObject = googleServicesDAO.writeObjectAsRawlsSA(bucketToWrite, fileToWrite, dataBytes)
     val gcsPath = s"gs://${insertedObject.bucketName.value}/${insertedObject.objectName.value}"
 
-    val importRequest = AsyncImportRequest(Option(gcsPath), Option("rawlsjson"))
+    val importRequest = AsyncImportRequest(Option(gcsPath), FILETYPE_RAWLS)
     importServiceDAO.importJob(workspaceNamespace, workspaceName, importRequest, isUpsert)(userInfo)
   }
 
@@ -366,7 +367,7 @@ class EntityService(rawlsDAO: RawlsDAO, importServiceDAO: ImportServiceDAO, goog
   }
 
   def importPFB(workspaceNamespace: String, workspaceName: String, pfbRequest: AsyncImportRequest, userInfo: UserInfo): Future[PerRequestMessage] = {
-    importServiceDAO.importJob(workspaceNamespace, workspaceName, pfbRequest.copy(filetype = Option("pfb")), isUpsert=true)(userInfo)
+    importServiceDAO.importJob(workspaceNamespace, workspaceName, pfbRequest.copy(filetype = FILETYPE_PFB), isUpsert=true)(userInfo)
   }
 
   def importJob(workspaceNamespace: String, workspaceName: String, importRequest: AsyncImportRequest, userInfo: UserInfo): Future[PerRequestMessage] = {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpImportServiceDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpImportServiceDAO.scala
@@ -26,19 +26,19 @@ class HttpImportServiceDAO(implicit val system: ActorSystem, implicit val materi
     doImport(workspaceNamespace, workspaceName, isUpsert, importRequest, importRequest.filetype)
   }
 
-  private def doImport(workspaceNamespace: String, workspaceName: String, isUpsert: Boolean, pfbRequest: AsyncImportRequest, filetype: String)(implicit userInfo: UserInfo): Future[PerRequestMessage] = {
+  private def doImport(workspaceNamespace: String, workspaceName: String, isUpsert: Boolean, importRequest: AsyncImportRequest, filetype: String)(implicit userInfo: UserInfo): Future[PerRequestMessage] = {
     // the payload to Import Service sends "path" and filetype.
-    val importServicePayload: ImportServiceRequest = ImportServiceRequest(path = pfbRequest.url, filetype = filetype, isUpsert = isUpsert)
+    val importServicePayload: ImportServiceRequest = ImportServiceRequest(path = importRequest.url, filetype = filetype, isUpsert = isUpsert)
 
     val importServiceUrl = FireCloudDirectiveUtils.encodeUri(s"${FireCloudConfig.ImportService.server}/$workspaceNamespace/$workspaceName/imports")
 
     userAuthedRequest(Post(importServiceUrl, importServicePayload))(userInfo) flatMap { isResponse =>
-      generateResponse(isResponse, workspaceNamespace, workspaceName, pfbRequest)
+      generateResponse(isResponse, workspaceNamespace, workspaceName, importRequest)
     }
   }
 
   // separate method to ease unit testing
-  protected[dataaccess] def generateResponse(isResponse: HttpResponse, workspaceNamespace: String, workspaceName: String, pfbRequest: AsyncImportRequest): Future[PerRequestMessage] = {
+  protected[dataaccess] def generateResponse(isResponse: HttpResponse, workspaceNamespace: String, workspaceName: String, importRequest: AsyncImportRequest): Future[PerRequestMessage] = {
     isResponse match {
       case resp if resp.status == Created =>
         val importServiceResponse = Unmarshal(resp).to[ImportServiceResponse]
@@ -49,7 +49,7 @@ class HttpImportServiceDAO(implicit val system: ActorSystem, implicit val materi
         importServiceResponse.map { resp =>
           val responsePayload:AsyncImportResponse = AsyncImportResponse(
             jobId = resp.jobId,
-            url = pfbRequest.url,
+            url = importRequest.url,
             workspace = WorkspaceName(workspaceNamespace, workspaceName)
           )
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpImportServiceDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpImportServiceDAO.scala
@@ -28,9 +28,7 @@ class HttpImportServiceDAO(implicit val system: ActorSystem, implicit val materi
 
   private def doImport(workspaceNamespace: String, workspaceName: String, isUpsert: Boolean, pfbRequest: AsyncImportRequest, filetype: String)(implicit userInfo: UserInfo): Future[PerRequestMessage] = {
     // the payload to Import Service sends "path" and filetype.
-    val path = pfbRequest.url.getOrElse(
-      throw new FireCloudExceptionWithErrorReport(ErrorReport(BadRequest, "url cannot be empty")))
-    val importServicePayload: ImportServiceRequest = ImportServiceRequest(path = path, filetype = filetype, isUpsert = isUpsert)
+    val importServicePayload: ImportServiceRequest = ImportServiceRequest(path = pfbRequest.url, filetype = filetype, isUpsert = isUpsert)
 
     val importServiceUrl = FireCloudDirectiveUtils.encodeUri(s"${FireCloudConfig.ImportService.server}/$workspaceNamespace/$workspaceName/imports")
 
@@ -51,7 +49,7 @@ class HttpImportServiceDAO(implicit val system: ActorSystem, implicit val materi
         importServiceResponse.map { resp =>
           val responsePayload:AsyncImportResponse = AsyncImportResponse(
             jobId = resp.jobId,
-            url = pfbRequest.url.getOrElse(""),
+            url = pfbRequest.url,
             workspace = WorkspaceName(workspaceNamespace, workspaceName)
           )
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpImportServiceDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpImportServiceDAO.scala
@@ -23,11 +23,7 @@ class HttpImportServiceDAO(implicit val system: ActorSystem, implicit val materi
   implicit val errorReportSource = ErrorReportSource("FireCloud")
 
   override def importJob(workspaceNamespace: String, workspaceName: String, importRequest: AsyncImportRequest, isUpsert: Boolean)(implicit userInfo: UserInfo): Future[PerRequestMessage] = {
-    val filetype = importRequest.filetype match {
-      case Some(s) => s
-      case None => throw new FireCloudExceptionWithErrorReport(ErrorReport(BadRequest, "filetype cannot be empty"))
-    }
-    doImport(workspaceNamespace, workspaceName, isUpsert, importRequest, filetype)
+    doImport(workspaceNamespace, workspaceName, isUpsert, importRequest, importRequest.filetype)
   }
 
   private def doImport(workspaceNamespace: String, workspaceName: String, isUpsert: Boolean, pfbRequest: AsyncImportRequest, filetype: String)(implicit userInfo: UserInfo): Future[PerRequestMessage] = {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ImportServiceDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ImportServiceDAO.scala
@@ -5,6 +5,12 @@ import org.broadinstitute.dsde.firecloud.service.PerRequest.PerRequestMessage
 
 import scala.concurrent.Future
 
+object ImportServiceFiletypes {
+  final val FILETYPE_PFB = "pfb"
+  final val FILETYPE_TDR = "tdrexport"
+  final val FILETYPE_RAWLS = "rawlsjson"
+}
+
 trait ImportServiceDAO {
 
   def importJob(workspaceNamespace: String,

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ImportServiceDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ImportServiceDAO.scala
@@ -7,8 +7,10 @@ import scala.concurrent.Future
 
 trait ImportServiceDAO {
 
-  def importPFB(workspaceNamespace: String, workspaceName: String, pfbRequest: AsyncImportRequest)(implicit userInfo: UserInfo): Future[PerRequestMessage]
-
-  def importRawlsJson(workspaceNamespace: String, workspaceName: String, isUpsert: Boolean, rawlsJsonRequest: AsyncImportRequest)(implicit userInfo: UserInfo): Future[PerRequestMessage]
+  def importJob(workspaceNamespace: String,
+                workspaceName: String,
+                importRequest: AsyncImportRequest,
+                isUpsert: Boolean)
+               (implicit userInfo: UserInfo): Future[PerRequestMessage]
 
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
@@ -229,7 +229,7 @@ object ModelJsonProtocol extends WorkspaceJsonSupport with SprayJsonSupport {
   implicit val impUserImportPermission = jsonFormat2(UserImportPermission)
 
   implicit val impBagitImportRequest = jsonFormat2(BagitImportRequest)
-  implicit val impAsyncImportRequest = jsonFormat1(AsyncImportRequest)
+  implicit val impAsyncImportRequest = jsonFormat2(AsyncImportRequest)
   implicit val impAsyncImportResponse = jsonFormat3(AsyncImportResponse)
   implicit val impImportServiceRequest = jsonFormat3(ImportServiceRequest)
   implicit val impImportServiceResponse = jsonFormat3(ImportServiceResponse)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
@@ -229,6 +229,7 @@ object ModelJsonProtocol extends WorkspaceJsonSupport with SprayJsonSupport {
   implicit val impUserImportPermission = jsonFormat2(UserImportPermission)
 
   implicit val impBagitImportRequest = jsonFormat2(BagitImportRequest)
+  implicit val impPFBImportRequest = jsonFormat1(PFBImportRequest)
   implicit val impAsyncImportRequest = jsonFormat2(AsyncImportRequest)
   implicit val impAsyncImportResponse = jsonFormat3(AsyncImportResponse)
   implicit val impImportServiceRequest = jsonFormat3(ImportServiceRequest)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/Workspace.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/Workspace.scala
@@ -29,9 +29,9 @@ case class EntityId(entityType: String, entityName: String)
 case class BagitImportRequest(bagitURL: String, format: String)
 
 // the request payload sent by users to Orchestration for async PFB and TDR snapshot imports
-case class AsyncImportRequest(url: Option[String], filetype: Option[String] = None)
+case class AsyncImportRequest(url: Option[String], filetype: String)
 
-// the response payload received by users from Orchestration for async PFB/TSV imports
+// the response payload received by users from Orchestration for async PFB/TSV/TDR snapshot imports
 case class AsyncImportResponse(url: String,
                                jobId: String,
                                workspace: WorkspaceName)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/Workspace.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/Workspace.scala
@@ -28,8 +28,10 @@ case class EntityId(entityType: String, entityName: String)
 
 case class BagitImportRequest(bagitURL: String, format: String)
 
+// legacy class specific to PFB import; prefer AsyncImportRequest instead
+case class PFBImportRequest(url: String)
 // the request payload sent by users to Orchestration for async PFB and TDR snapshot imports
-case class AsyncImportRequest(url: Option[String], filetype: String)
+case class AsyncImportRequest(url: String, filetype: String)
 
 // the response payload received by users from Orchestration for async PFB/TSV/TDR snapshot imports
 case class AsyncImportResponse(url: String,

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/Workspace.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/Workspace.scala
@@ -28,8 +28,8 @@ case class EntityId(entityType: String, entityName: String)
 
 case class BagitImportRequest(bagitURL: String, format: String)
 
-// the request payload sent by users to Orchestration for async PFB imports
-case class AsyncImportRequest(url: Option[String])
+// the request payload sent by users to Orchestration for async PFB and TDR snapshot imports
+case class AsyncImportRequest(url: Option[String], filetype: Option[String] = None)
 
 // the response payload received by users from Orchestration for async PFB/TSV imports
 case class AsyncImportResponse(url: String,

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiService.scala
@@ -146,9 +146,10 @@ trait WorkspaceApiService extends FireCloudRequestBuilding with FireCloudDirecti
                 path("importPFB") {
                   post {
                     requireUserInfo() { userInfo =>
+                      // this endpoint does not accept a filetype. We hardcode the filetype to "pfb".
                       entity(as[PFBImportRequest]) { pfbRequest =>
                         val importRequest = AsyncImportRequest(pfbRequest.url, FILETYPE_PFB)
-                        complete { entityServiceConstructor(FlexibleModelSchema).importPFB(workspaceNamespace, workspaceName, importRequest, userInfo) }
+                        complete { entityServiceConstructor(FlexibleModelSchema).importJob(workspaceNamespace, workspaceName, importRequest, userInfo) }
                       }
                     }
                   }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiService.scala
@@ -1,11 +1,11 @@
 package org.broadinstitute.dsde.firecloud.webservice
 
 import java.text.SimpleDateFormat
-
 import akka.http.scaladsl.model.Uri.Query
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import akka.http.scaladsl.model.{HttpMethods, StatusCodes, Uri}
 import akka.http.scaladsl.server.Route
+import org.broadinstitute.dsde.firecloud.dataaccess.ImportServiceFiletypes.FILETYPE_PFB
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
 import org.broadinstitute.dsde.firecloud.model._
 import org.broadinstitute.dsde.firecloud.service.{FireCloudDirectives, FireCloudRequestBuilding, PermissionReportService, WorkspaceService}
@@ -146,8 +146,9 @@ trait WorkspaceApiService extends FireCloudRequestBuilding with FireCloudDirecti
                 path("importPFB") {
                   post {
                     requireUserInfo() { userInfo =>
-                      entity(as[AsyncImportRequest]) { pfbRequest =>
-                        complete { entityServiceConstructor(FlexibleModelSchema).importPFB(workspaceNamespace, workspaceName, pfbRequest, userInfo) }
+                      entity(as[PFBImportRequest]) { pfbRequest =>
+                        val importRequest = AsyncImportRequest(pfbRequest.url, FILETYPE_PFB)
+                        complete { entityServiceConstructor(FlexibleModelSchema).importPFB(workspaceNamespace, workspaceName, importRequest, userInfo) }
                       }
                     }
                   }
@@ -155,8 +156,8 @@ trait WorkspaceApiService extends FireCloudRequestBuilding with FireCloudDirecti
                 path("importJob") {
                   post {
                     requireUserInfo() { userInfo =>
-                      entity(as[AsyncImportRequest]) { pfbRequest =>
-                        complete { entityServiceConstructor(FlexibleModelSchema).importJob(workspaceNamespace, workspaceName, pfbRequest, userInfo) }
+                      entity(as[AsyncImportRequest]) { importRequest =>
+                        complete { entityServiceConstructor(FlexibleModelSchema).importJob(workspaceNamespace, workspaceName, importRequest, userInfo) }
                       }
                     }
                   }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiService.scala
@@ -142,6 +142,7 @@ trait WorkspaceApiService extends FireCloudRequestBuilding with FireCloudDirecti
                     }
                   }
                 } ~
+                // POST importPFB will likely be deprecated in the future; use POST importJob instead
                 path("importPFB") {
                   post {
                     requireUserInfo() { userInfo =>
@@ -149,16 +150,28 @@ trait WorkspaceApiService extends FireCloudRequestBuilding with FireCloudDirecti
                         complete { entityServiceConstructor(FlexibleModelSchema).importPFB(workspaceNamespace, workspaceName, pfbRequest, userInfo) }
                       }
                     }
-                  } ~
-                    get {
-                      requireUserInfo() { _ =>
-                        extract(_.request.uri.query()) { query =>
-                          passthrough(Uri(encodeUri(s"${FireCloudConfig.ImportService.server}/$workspaceNamespace/$workspaceName/imports")).withQuery(query), HttpMethods.GET)
-                        }
+                  }
+                } ~
+                path("importJob") {
+                  post {
+                    requireUserInfo() { userInfo =>
+                      entity(as[AsyncImportRequest]) { pfbRequest =>
+                        complete { entityServiceConstructor(FlexibleModelSchema).importJob(workspaceNamespace, workspaceName, pfbRequest, userInfo) }
                       }
                     }
+                  }
                 } ~
-                // importPFB/jobId is deprecated; use importJob/jobId instead
+                // GET importPFB is deprecated; use GET importJob instead
+                path(("importPFB" | "importJob")) {
+                  get {
+                    requireUserInfo() { _ =>
+                      extract(_.request.uri.query()) { query =>
+                        passthrough(Uri(encodeUri(s"${FireCloudConfig.ImportService.server}/$workspaceNamespace/$workspaceName/imports")).withQuery(query), HttpMethods.GET)
+                      }
+                    }
+                  }
+                } ~
+                // GET importPFB/jobId is deprecated; use GET importJob/jobId instead
                 path(("importPFB" | "importJob") / Segment) { jobId =>
                   get {
                     requireUserInfo() { userInfo =>

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/EntityServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/EntityServiceSpec.scala
@@ -236,8 +236,11 @@ class EntityServiceSpec extends BaseServiceSpec with BeforeAndAfterEach {
   class SuccessfulImportServiceDAO extends MockImportServiceDAO {
     def successDefinition: RequestComplete[(StatusCodes.Success, ImportServiceResponse)] = RequestComplete(StatusCodes.Created, ImportServiceResponse("unit-test-job-id", "unit-test-created-status", None))
 
-    override def importRawlsJson(workspaceNamespace: String, workspaceName: String, isUpsert: Boolean, rawlsJsonRequest: AsyncImportRequest)(implicit userInfo: UserInfo): Future[PerRequest.PerRequestMessage] = {
-      Future.successful(successDefinition)
+    override def importJob(workspaceNamespace: String, workspaceName: String, importRequest: AsyncImportRequest, isUpsert: Boolean)(implicit userInfo: UserInfo): Future[PerRequest.PerRequestMessage] = {
+      importRequest.filetype match {
+        case Some("rawlsjson") => Future.successful(successDefinition)
+        case _ => ???
+      }
     }
   }
 
@@ -246,10 +249,12 @@ class EntityServiceSpec extends BaseServiceSpec with BeforeAndAfterEach {
     // return a 429 so unit tests have an easy way to distinguish this error vs an error somewhere else in the stack
     def errorDefinition: RequestComplete[(StatusCode, ErrorReport)] = RequestCompleteWithErrorReport(StatusCodes.TooManyRequests, "intentional ErroringImportServiceDAO error")
 
-    override def importRawlsJson(workspaceNamespace: String, workspaceName: String, isUpsert: Boolean, rawlsJsonRequest: AsyncImportRequest)(implicit userInfo: UserInfo): Future[PerRequest.PerRequestMessage] = {
-      Future.successful(errorDefinition)
+    override def importJob(workspaceNamespace: String, workspaceName: String, importRequest: AsyncImportRequest, isUpsert: Boolean)(implicit userInfo: UserInfo): Future[PerRequest.PerRequestMessage] = {
+      importRequest.filetype match {
+        case Some("rawlsjson") => Future.successful(errorDefinition)
+        case _ => ???
+      }
     }
   }
-
 
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/EntityServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/EntityServiceSpec.scala
@@ -3,6 +3,7 @@ package org.broadinstitute.dsde.firecloud
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import akka.http.scaladsl.model.{HttpResponse, StatusCode, StatusCodes}
 import com.google.cloud.storage.StorageException
+import org.broadinstitute.dsde.firecloud.dataaccess.ImportServiceFiletypes.FILETYPE_RAWLS
 import org.broadinstitute.dsde.firecloud.dataaccess.{MockImportServiceDAO, MockRawlsDAO}
 import org.broadinstitute.dsde.firecloud.mock.MockGoogleServicesDAO
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
@@ -238,7 +239,7 @@ class EntityServiceSpec extends BaseServiceSpec with BeforeAndAfterEach {
 
     override def importJob(workspaceNamespace: String, workspaceName: String, importRequest: AsyncImportRequest, isUpsert: Boolean)(implicit userInfo: UserInfo): Future[PerRequest.PerRequestMessage] = {
       importRequest.filetype match {
-        case Some("rawlsjson") => Future.successful(successDefinition)
+        case FILETYPE_RAWLS => Future.successful(successDefinition)
         case _ => ???
       }
     }
@@ -251,7 +252,7 @@ class EntityServiceSpec extends BaseServiceSpec with BeforeAndAfterEach {
 
     override def importJob(workspaceNamespace: String, workspaceName: String, importRequest: AsyncImportRequest, isUpsert: Boolean)(implicit userInfo: UserInfo): Future[PerRequest.PerRequestMessage] = {
       importRequest.filetype match {
-        case Some("rawlsjson") => Future.successful(errorDefinition)
+        case FILETYPE_RAWLS => Future.successful(errorDefinition)
         case _ => ???
       }
     }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpImportServiceDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpImportServiceDAOSpec.scala
@@ -27,7 +27,7 @@ class HttpImportServiceDAOSpec extends AsyncFlatSpec with Matchers with SprayJso
   val workspaceNamespace = "workspaceNamespace"
   val workspaceName = "workspaceName"
   val pfbUrl = "unittest-fixture-url"
-  val pfbRequest = AsyncImportRequest(Some(pfbUrl), FILETYPE_PFB)
+  val pfbRequest = AsyncImportRequest(pfbUrl, FILETYPE_PFB)
 
   val jobId = UUID.randomUUID()
   val importServicePayload = ImportServiceResponse(jobId.toString, "status", None).toJson.compactPrint

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpImportServiceDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpImportServiceDAOSpec.scala
@@ -6,8 +6,9 @@ import akka.http.scaladsl.model.StatusCodes._
 import akka.http.scaladsl.model.{ContentTypes, HttpEntity, HttpResponse}
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
-import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol.{impImportServiceResponse, impAsyncImportResponse}
-import org.broadinstitute.dsde.firecloud.model.{ImportServiceResponse, AsyncImportRequest, AsyncImportResponse, RequestCompleteWithErrorReport}
+import org.broadinstitute.dsde.firecloud.dataaccess.ImportServiceFiletypes.FILETYPE_PFB
+import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol.{impAsyncImportResponse, impImportServiceResponse}
+import org.broadinstitute.dsde.firecloud.model.{AsyncImportRequest, AsyncImportResponse, ImportServiceResponse, RequestCompleteWithErrorReport}
 import org.broadinstitute.dsde.firecloud.service.PerRequest.RequestComplete
 import org.broadinstitute.dsde.rawls.model.WorkspaceName
 import org.scalatest.flatspec.AsyncFlatSpec
@@ -26,7 +27,7 @@ class HttpImportServiceDAOSpec extends AsyncFlatSpec with Matchers with SprayJso
   val workspaceNamespace = "workspaceNamespace"
   val workspaceName = "workspaceName"
   val pfbUrl = "unittest-fixture-url"
-  val pfbRequest = AsyncImportRequest(Some(pfbUrl))
+  val pfbRequest = AsyncImportRequest(Some(pfbUrl), FILETYPE_PFB)
 
   val jobId = UUID.randomUUID()
   val importServicePayload = ImportServiceResponse(jobId.toString, "status", None).toJson.compactPrint

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockImportServiceDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockImportServiceDAO.scala
@@ -17,7 +17,7 @@ class MockImportServiceDAO extends ImportServiceDAO {
                          isUpsert: Boolean)
                         (implicit userInfo: UserInfo): Future[PerRequest.PerRequestMessage] = {
     importRequest.filetype match {
-      case FILETYPE_PFB =>
+      case FILETYPE_PFB | FILETYPE_TDR =>
         if(importRequest.url.contains("forbidden")) Future.successful(RequestComplete(Forbidden, "Missing Authorization: Bearer token in header"))
         else if(importRequest.url.contains("bad.request")) Future.successful(RequestComplete(BadRequest, "Bad request as reported by import service"))
         else if(importRequest.url.contains("its.lawsuit.time")) Future.successful(RequestComplete(UnavailableForLegalReasons, "import service message"))
@@ -28,7 +28,6 @@ class MockImportServiceDAO extends ImportServiceDAO {
         ))
         else Future.successful(RequestComplete(EnhanceYourCalm))
       case FILETYPE_RAWLS => ???
-      case FILETYPE_TDR => ???
       case _ => ???
     }
   }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockImportServiceDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockImportServiceDAO.scala
@@ -1,7 +1,7 @@
 package org.broadinstitute.dsde.firecloud.dataaccess
 import java.util.UUID
-
 import akka.http.scaladsl.model.StatusCodes._
+import org.broadinstitute.dsde.firecloud.dataaccess.ImportServiceFiletypes.{FILETYPE_PFB, FILETYPE_RAWLS, FILETYPE_TDR}
 import org.broadinstitute.dsde.firecloud.model.{AsyncImportRequest, AsyncImportResponse, UserInfo}
 import org.broadinstitute.dsde.firecloud.service.PerRequest
 import org.broadinstitute.dsde.firecloud.service.PerRequest.RequestComplete
@@ -17,7 +17,7 @@ class MockImportServiceDAO extends ImportServiceDAO {
                          isUpsert: Boolean)
                         (implicit userInfo: UserInfo): Future[PerRequest.PerRequestMessage] = {
     importRequest.filetype match {
-      case Some("pfb") =>
+      case FILETYPE_PFB =>
         importRequest.url match {
           case Some(url) => {
             if(url.contains("forbidden")) Future.successful(RequestComplete(Forbidden, "Missing Authorization: Bearer token in header"))
@@ -34,8 +34,8 @@ class MockImportServiceDAO extends ImportServiceDAO {
           }
           case None => Future.successful(RequestComplete(EnhanceYourCalm))
         }
-      case Some("rawlsjson") => ???
-      case Some("tdrexport") => ???
+      case FILETYPE_RAWLS => ???
+      case FILETYPE_TDR => ???
       case _ => ???
     }
   }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockImportServiceDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockImportServiceDAO.scala
@@ -18,22 +18,15 @@ class MockImportServiceDAO extends ImportServiceDAO {
                         (implicit userInfo: UserInfo): Future[PerRequest.PerRequestMessage] = {
     importRequest.filetype match {
       case FILETYPE_PFB =>
-        importRequest.url match {
-          case Some(url) => {
-            if(url.contains("forbidden")) Future.successful(RequestComplete(Forbidden, "Missing Authorization: Bearer token in header"))
-            else if(url.contains("bad.request")) Future.successful(RequestComplete(BadRequest, "Bad request as reported by import service"))
-            else if(url.contains("its.lawsuit.time")) Future.successful(RequestComplete(UnavailableForLegalReasons, "import service message"))
-            else if(url.contains("good")) Future.successful(RequestComplete(Accepted,
-              AsyncImportResponse(url = importRequest.url.getOrElse(""),
-                jobId = UUID.randomUUID().toString,
-                workspace = WorkspaceName(workspaceNamespace, workspaceName))
-            )
-
-            )
-            else Future.successful(RequestComplete(EnhanceYourCalm))
-          }
-          case None => Future.successful(RequestComplete(EnhanceYourCalm))
-        }
+        if(importRequest.url.contains("forbidden")) Future.successful(RequestComplete(Forbidden, "Missing Authorization: Bearer token in header"))
+        else if(importRequest.url.contains("bad.request")) Future.successful(RequestComplete(BadRequest, "Bad request as reported by import service"))
+        else if(importRequest.url.contains("its.lawsuit.time")) Future.successful(RequestComplete(UnavailableForLegalReasons, "import service message"))
+        else if(importRequest.url.contains("good")) Future.successful(RequestComplete(Accepted,
+          AsyncImportResponse(url = importRequest.url,
+            jobId = UUID.randomUUID().toString,
+            workspace = WorkspaceName(workspaceNamespace, workspaceName))
+        ))
+        else Future.successful(RequestComplete(EnhanceYourCalm))
       case FILETYPE_RAWLS => ???
       case FILETYPE_TDR => ???
       case _ => ???

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockImportServiceDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockImportServiceDAO.scala
@@ -11,24 +11,32 @@ import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
 import scala.concurrent.Future
 
 class MockImportServiceDAO extends ImportServiceDAO {
-  override def importPFB(workspaceNamespace: String, workspaceName: String, pfbRequest: AsyncImportRequest)(implicit userInfo: UserInfo): Future[PerRequest.PerRequestMessage] = {
-    pfbRequest.url match {
-      case Some(url) => {
-        if(url.contains("forbidden")) Future.successful(RequestComplete(Forbidden, "Missing Authorization: Bearer token in header"))
-        else if(url.contains("bad.request")) Future.successful(RequestComplete(BadRequest, "Bad request as reported by import service"))
-        else if(url.contains("its.lawsuit.time")) Future.successful(RequestComplete(UnavailableForLegalReasons, "import service message"))
-        else if(url.contains("good")) Future.successful(RequestComplete(Accepted,
-          AsyncImportResponse(url = pfbRequest.url.getOrElse(""),
-            jobId = UUID.randomUUID().toString,
-            workspace = WorkspaceName(workspaceNamespace, workspaceName))
-          )
+  override def importJob(workspaceNamespace: String,
+                         workspaceName: String,
+                         importRequest: AsyncImportRequest,
+                         isUpsert: Boolean)
+                        (implicit userInfo: UserInfo): Future[PerRequest.PerRequestMessage] = {
+    importRequest.filetype match {
+      case Some("pfb") =>
+        importRequest.url match {
+          case Some(url) => {
+            if(url.contains("forbidden")) Future.successful(RequestComplete(Forbidden, "Missing Authorization: Bearer token in header"))
+            else if(url.contains("bad.request")) Future.successful(RequestComplete(BadRequest, "Bad request as reported by import service"))
+            else if(url.contains("its.lawsuit.time")) Future.successful(RequestComplete(UnavailableForLegalReasons, "import service message"))
+            else if(url.contains("good")) Future.successful(RequestComplete(Accepted,
+              AsyncImportResponse(url = importRequest.url.getOrElse(""),
+                jobId = UUID.randomUUID().toString,
+                workspace = WorkspaceName(workspaceNamespace, workspaceName))
+            )
 
-        )
-        else Future.successful(RequestComplete(EnhanceYourCalm))
-      }
-      case None => Future.successful(RequestComplete(EnhanceYourCalm))
+            )
+            else Future.successful(RequestComplete(EnhanceYourCalm))
+          }
+          case None => Future.successful(RequestComplete(EnhanceYourCalm))
+        }
+      case Some("rawlsjson") => ???
+      case Some("tdrexport") => ???
+      case _ => ???
     }
   }
-
-  override def importRawlsJson(workspaceNamespace: String, workspaceName: String, isUpsert: Boolean, rawlsJsonRequest: AsyncImportRequest)(implicit userInfo: UserInfo): Future[PerRequest.PerRequestMessage] = ???
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiServiceSpec.scala
@@ -9,7 +9,7 @@ import akka.http.scaladsl.server.Route.{seal => sealRoute}
 
 import javax.net.ssl.HttpsURLConnection
 import org.apache.commons.io.IOUtils
-import org.broadinstitute.dsde.firecloud.dataaccess.ImportServiceFiletypes.FILETYPE_PFB
+import org.broadinstitute.dsde.firecloud.dataaccess.ImportServiceFiletypes.{FILETYPE_PFB, FILETYPE_TDR}
 import org.broadinstitute.dsde.firecloud.dataaccess.{MockRawlsDAO, MockShareLogDAO, WorkspaceApiServiceSpecShareLogDAO}
 import org.broadinstitute.dsde.firecloud.mock.MockUtils._
 import org.broadinstitute.dsde.firecloud.mock.{MockTSVFormData, MockUtils}
@@ -101,6 +101,7 @@ class WorkspaceApiServiceSpec extends BaseServiceSpec with WorkspaceApiService w
   private final val tsvImportFlexiblePath = workspacesRoot + "/%s/%s/flexibleImportEntities".format(workspace.namespace, workspace.name)
   private final val bagitImportPath = workspacesRoot + "/%s/%s/importBagit".format(workspace.namespace, workspace.name)
   private final val pfbImportPath = workspacesRoot + "/%s/%s/importPFB".format(workspace.namespace, workspace.name)
+  private final val importJobPath = workspacesRoot + "/%s/%s/importJob".format(workspace.namespace, workspace.name)
   private final val importJobStatusPath = workspacesRoot + "/%s/%s/importJob".format(workspace.namespace, workspace.name)
   private final val bucketUsagePath = s"$workspacesPath/bucketUsage"
   private final val usBucketStorageCostEstimatePath = workspacesRoot + "/%s/%s/storageCostEstimate".format("usBucketWorkspace", workspace.name)
@@ -1173,77 +1174,141 @@ class WorkspaceApiServiceSpec extends BaseServiceSpec with WorkspaceApiService w
 
     "WorkspaceService importPFB list-jobs tests" - {
 
-      "Successful passthrough should return OK with payload" in {
-        val responsePayload = JsArray(
-          JsObject(
-            ("id", JsString(UUID.randomUUID().toString)),
-            ("status", JsString("Running"))
-          ),
-          JsObject(
-            ("id", JsString(UUID.randomUUID().toString)),
-            ("status", JsString("Error"))
-          ),
-          JsObject(
-            ("id", JsString(UUID.randomUUID().toString)),
-            ("status", JsString("ImAUnitTest"))
-          )
-        )
+      List(pfbImportPath, importJobPath) foreach { pathUnderTest =>
 
-        importServiceServer
-          .when(request()
-            .withMethod("GET")
-            .withPath(s"/${workspace.namespace}/${workspace.name}/imports"))
-          .respond(org.mockserver.model.HttpResponse.response()
-            .withStatusCode(OK.intValue)
-            .withBody(responsePayload.compactPrint)
-            .withHeader("Content-Type", "application/json"))
+        s"for path $pathUnderTest" - {
 
-        (Get(pfbImportPath)
-          ~> dummyUserIdHeaders(dummyUserId)
-          ~> sealRoute(workspaceRoutes)) ~> check {
-          status should equal(OK)
-          responseAs[String].parseJson should be (responsePayload) // to address string-formatting issues
+          "Successful passthrough should return OK with payload" in {
+            val responsePayload = JsArray(
+              JsObject(
+                ("id", JsString(UUID.randomUUID().toString)),
+                ("status", JsString("Running"))
+              ),
+              JsObject(
+                ("id", JsString(UUID.randomUUID().toString)),
+                ("status", JsString("Error"))
+              ),
+              JsObject(
+                ("id", JsString(UUID.randomUUID().toString)),
+                ("status", JsString("ImAUnitTest"))
+              )
+            )
+
+            importServiceServer
+              .when(request()
+                .withMethod("GET")
+                .withPath(s"/${workspace.namespace}/${workspace.name}/imports"))
+              .respond(org.mockserver.model.HttpResponse.response()
+                .withStatusCode(OK.intValue)
+                .withBody(responsePayload.compactPrint)
+                .withHeader("Content-Type", "application/json"))
+
+            (Get(pathUnderTest)
+              ~> dummyUserIdHeaders(dummyUserId)
+              ~> sealRoute(workspaceRoutes)) ~> check {
+              status should equal(OK)
+              responseAs[String].parseJson should be (responsePayload) // to address string-formatting issues
+            }
+          }
+
+          "Passthrough should pass on querystrings" in {
+            val responsePayload = JsArray(
+              JsObject(
+                ("id", JsString(UUID.randomUUID().toString)),
+                ("status", JsString("Running"))
+              )
+            )
+
+            val k1 = UUID.randomUUID().toString
+            val v1 = UUID.randomUUID().toString
+            val k2 = UUID.randomUUID().toString
+            val v2 = UUID.randomUUID().toString
+
+            val queryString = s"$k1=$v1&$k2=$v2"
+
+            importServiceServer
+              .when(request()
+                .withMethod("GET")
+                .withPath(s"/${workspace.namespace}/${workspace.name}/imports")
+                .withQueryStringParameters(new Parameter(k1, v1), new Parameter(k2, v2)))
+              .respond(org.mockserver.model.HttpResponse.response()
+                .withStatusCode(OK.intValue)
+                .withBody(responsePayload.compactPrint)
+                .withHeader("Content-Type", "application/json"))
+
+            (Get(s"$pathUnderTest?$queryString")
+              ~> dummyUserIdHeaders(dummyUserId)
+              ~> sealRoute(workspaceRoutes)) ~> check {
+              status should equal(OK)
+              responseAs[String].parseJson should be (responsePayload) // to address string-formatting issues
+            }
+          }
+
+          "Passthrough should not pass unrecognized HTTP verbs" in {
+            (Delete(s"$pathUnderTest")
+              ~> dummyUserIdHeaders(dummyUserId)
+              ~> sealRoute(workspaceRoutes)) ~> check {
+              status should equal(MethodNotAllowed)
+            }
+          }
         }
       }
 
-      "Passthrough should pass on querystrings" in {
-        val responsePayload = JsArray(
-          JsObject(
-            ("id", JsString(UUID.randomUUID().toString)),
-            ("status", JsString("Running"))
-          )
-        )
+    }
 
-        val k1 = UUID.randomUUID().toString
-        val v1 = UUID.randomUUID().toString
-        val k2 = UUID.randomUUID().toString
-        val v2 = UUID.randomUUID().toString
+    "WorkspaceService POST importJob Tests" - {
 
-        val queryString = s"$k1=$v1&$k2=$v2"
+      List(FILETYPE_PFB, FILETYPE_TDR) foreach { filetype =>
 
-        importServiceServer
-          .when(request()
-            .withMethod("GET")
-            .withPath(s"/${workspace.namespace}/${workspace.name}/imports")
-            .withQueryStringParameters(new Parameter(k1, v1), new Parameter(k2, v2)))
-          .respond(org.mockserver.model.HttpResponse.response()
-            .withStatusCode(OK.intValue)
-            .withBody(responsePayload.compactPrint)
-            .withHeader("Content-Type", "application/json"))
+        s"for filetype $filetype" - {
 
-        (Get(s"$pfbImportPath?$queryString")
-          ~> dummyUserIdHeaders(dummyUserId)
-          ~> sealRoute(workspaceRoutes)) ~> check {
-          status should equal(OK)
-          responseAs[String].parseJson should be (responsePayload) // to address string-formatting issues
-        }
-      }
+          "should 400 if import service indicates a bad request" in {
 
-      "Passthrough should not pass unrecognized HTTP verbs" in {
-        (Delete(s"$pfbImportPath")
-          ~> dummyUserIdHeaders(dummyUserId)
-          ~> sealRoute(workspaceRoutes)) ~> check {
-          status should equal(MethodNotAllowed)
+            (Post(importJobPath, AsyncImportRequest("https://bad.request.avro", filetype))
+              ~> dummyUserIdHeaders(dummyUserId)
+              ~> sealRoute(workspaceRoutes)) ~> check {
+              status should equal(BadRequest)
+              responseAs[String] should include ("Bad request as reported by import service")
+            }
+          }
+
+          "should 403 if import service access is forbidden" in {
+            (Post(importJobPath, AsyncImportRequest("https://forbidden.avro", filetype))
+              ~> dummyUserIdHeaders(dummyUserId)
+              ~> sealRoute(workspaceRoutes)) ~> check {
+              status should equal(Forbidden)
+              responseAs[String] should include ("Missing Authorization: Bearer token in header")
+            }
+          }
+
+          "should propagate any other errors from import service" in {
+            // we use UnavailableForLegalReasons as a proxy for "some error we didn't expect"
+            (Post(importJobPath, AsyncImportRequest("https://its.lawsuit.time.avro", filetype))
+              ~> dummyUserIdHeaders(dummyUserId)
+              ~> sealRoute(workspaceRoutes)) ~> check {
+              status should equal(UnavailableForLegalReasons)
+              responseAs[String] should include ("import service message")
+            }
+          }
+
+          "should 202 (Accepted) if everything validated and import request was accepted" in {
+
+            val pfbPath = "https://good.avro"
+
+            val orchExpectedPayload = AsyncImportResponse(url = pfbPath,
+              jobId = "MockImportServiceDAO will generate a random UUID",
+              workspace = WorkspaceName(workspace.namespace, workspace.name))
+
+            (Post(importJobPath, AsyncImportRequest("https://good.avro", filetype))
+              ~> dummyUserIdHeaders(dummyUserId)
+              ~> sealRoute(workspaceRoutes)) ~> check {
+              status should equal(Accepted)
+              val jobResponse = responseAs[AsyncImportResponse]
+              jobResponse.url should be (orchExpectedPayload.url)
+              jobResponse.workspace should be (orchExpectedPayload.workspace)
+              jobResponse.jobId  should not be empty
+            }
+          }
         }
       }
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiServiceSpec.scala
@@ -1084,7 +1084,7 @@ class WorkspaceApiServiceSpec extends BaseServiceSpec with WorkspaceApiService w
 
       "should 400 if import service indicates a bad request" in {
 
-        (Post(pfbImportPath, AsyncImportRequest(Option("https://bad.request.avro"), FILETYPE_PFB))
+        (Post(pfbImportPath, PFBImportRequest("https://bad.request.avro"))
           ~> dummyUserIdHeaders(dummyUserId)
           ~> sealRoute(workspaceRoutes)) ~> check {
             status should equal(BadRequest)
@@ -1093,7 +1093,7 @@ class WorkspaceApiServiceSpec extends BaseServiceSpec with WorkspaceApiService w
       }
 
       "should 403 if import service access is forbidden" in {
-        (Post(pfbImportPath, AsyncImportRequest(Option("https://forbidden.avro"), FILETYPE_PFB))
+        (Post(pfbImportPath, PFBImportRequest("https://forbidden.avro"))
           ~> dummyUserIdHeaders(dummyUserId)
           ~> sealRoute(workspaceRoutes)) ~> check {
             status should equal(Forbidden)
@@ -1103,7 +1103,7 @@ class WorkspaceApiServiceSpec extends BaseServiceSpec with WorkspaceApiService w
 
       "should propagate any other errors from import service" in {
         // we use UnavailableForLegalReasons as a proxy for "some error we didn't expect"
-        (Post(pfbImportPath, AsyncImportRequest(Option("https://its.lawsuit.time.avro"), FILETYPE_PFB))
+        (Post(pfbImportPath, PFBImportRequest("https://its.lawsuit.time.avro"))
           ~> dummyUserIdHeaders(dummyUserId)
           ~> sealRoute(workspaceRoutes)) ~> check {
             status should equal(UnavailableForLegalReasons)
@@ -1119,7 +1119,7 @@ class WorkspaceApiServiceSpec extends BaseServiceSpec with WorkspaceApiService w
                                                    jobId = "MockImportServiceDAO will generate a random UUID",
                                                    workspace = WorkspaceName(workspace.namespace, workspace.name))
 
-        (Post(pfbImportPath, AsyncImportRequest(Option("https://good.avro"), FILETYPE_PFB))
+        (Post(pfbImportPath, PFBImportRequest("https://good.avro"))
           ~> dummyUserIdHeaders(dummyUserId)
           ~> sealRoute(workspaceRoutes)) ~> check {
             status should equal(Accepted)


### PR DESCRIPTION
AS-1035: goal is to get an import data flow spike working end-to-end for TDR snapshots. This spike does not yet parse the snapshot's Parquet files into real data; it always imports a single row, hardcoded by Import Service.

* deprecate `GET /api/workspaces/{workspaceNamespace}/{workspaceName}/importPFB`
* create `GET /api/workspaces/{workspaceNamespace}/{workspaceName}/importJob` as its replacement, returning the same payload
* create `POST /api/workspaces/{workspaceNamespace}/{workspaceName}/importJob` as a generic endpoint for kicking off async import requests; this supports both `pfb` and `tdrexport` filetypes
* refactor and consolidate import-service related methods; `importPFB` and `importRawlsJson` are merged into `importJob`, which also adds support for `tdrexport` filetypes
* refactor `AsyncImportRequest` class to remove `Option`s

-----

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
