### PR TITLE
include filetype when listing import jobs [AS-945]

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -8923,6 +8923,9 @@ components:
         jobId:
           type: string
           description: unique id for the import job.
+        filetype:
+          type: string
+          description: type of the import job.
         status:
           type: string
           description: short status for the import job.


### PR DESCRIPTION
companion to broadinstitute/import-service#78

for the get/list importJob/importPFB endpoints, change the response payload change from
```
  {
    "jobId": "string",
    "status": "string",
    "message": "string"
  }
```
to
```
  {
    "jobId": "string",
    "filetype": "string",
    "status": "string",
    "message": "string"
  }
```
these endpoints are passthroughs, so there's no functional code change necessary in orch; it's just the swagger definition.