### PR TITLE
exclude log4j entirely [AS-1078]

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -23,9 +23,8 @@ object Dependencies {
     "com.google.guava"               % "guava"               % "30.1-jre",
     // END transitive dependency overrides
 
-    "org.apache.logging.log4j"       % "log4j-api"           % "2.17.1", // elasticsearch requires log4j ...
-    "org.apache.logging.log4j"       % "log4j-core"          % "2.17.1",
-    "org.apache.logging.log4j"       % "log4j-to-slf4j"      % "2.17.1", // ... but we redirect log4j to logback.
+    // elasticsearch requires log4j, but we redirect log4j to logback
+    "org.apache.logging.log4j"       % "log4j-to-slf4j"      % "2.17.1",
     "ch.qos.logback"                 % "logback-classic"     % "1.2.3",
     "com.getsentry.raven"            % "raven-logback"       % "7.8.6",
     "com.typesafe.scala-logging"    %% "scala-logging"       % "3.9.2",
@@ -59,7 +58,9 @@ object Dependencies {
       exclude("io.netty", "netty-transport")
       exclude("io.netty", "netty-resolver")
       exclude("io.netty", "netty-buffer")
-      exclude("io.netty", "netty-common"),
+      exclude("io.netty", "netty-common")
+      exclude("org.apache.logging.log4j", "log4j-api")
+      exclude("org.apache.logging.log4j", "log4j-core"),
 
     excludeGuava("com.google.apis"     % "google-api-services-storage"      % "v1-rev20190910-1.30.3"),
     excludeGuava("com.google.apis"     % "google-api-services-pubsub"       % "v1-rev20191001-1.30.3"),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -24,6 +24,7 @@ object Dependencies {
     // END transitive dependency overrides
 
     "org.apache.logging.log4j"       % "log4j-api"           % "2.17.1", // elasticsearch requires log4j ...
+    "org.apache.logging.log4j"       % "log4j-core"          % "2.17.1",
     "org.apache.logging.log4j"       % "log4j-to-slf4j"      % "2.17.1", // ... but we redirect log4j to logback.
     "ch.qos.logback"                 % "logback-classic"     % "1.2.3",
     "com.getsentry.raven"            % "raven-logback"       % "7.8.6",


### PR DESCRIPTION
instead of upgrading and patching log4j, omit it entirely

this is passing integration tests, and I have manually tested it inside a fiab - I published a couple workspaces to the Data Library, then was able to list/search their results. It seems that omitting log4j entirely has no ill effect.