### PR TITLE
increase max TSV columns 1024->2000 [no ticket yet]

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/utils/TSVParser.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/utils/TSVParser.scala
@@ -18,7 +18,7 @@ object TSVParser {
     val settings = new CsvParserSettings
     // Automatically detect what the line separator is (e.g. \n for Unix, \r\n for Windows).
     settings.setLineSeparatorDetectionEnabled(true)
-    settings.setMaxColumns(1024)
+    settings.setMaxColumns(2000)
     settings.setMaxCharsPerColumn(16384)
     settings.getFormat.setDelimiter('\t')
     // By default, the CsvParser returns null for missing fields, however the application expects the


### PR DESCRIPTION
provisional PR; not sure we want this yet

increase the max allowed number of columns for TSV import to 2000. This also affects BDBag/Bagit import, which uses TSV under the covers.

Tested manually using a TSV with 1681 columns.

