### PR TITLE
snapshot import-by-copy integration tests [AJ-111]

### DIFF
--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -7,16 +7,18 @@ object Dependencies {
   val akkaV = "2.6.15"
   val akkaHttpV = "10.1.0"
 
-  val workbenchModelV  = "0.15-808590d"
+  val workbenchModelV  = "0.15-f9f0d4c"
   val workbenchModel: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-model" % workbenchModelV
   val excludeWorkbenchModel = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-model_" + scalaV)
 
-  val workbenchGoogleV = "0.21-808590d"
+  val workbenchGoogleV = "0.21-ae11b9f"
   val workbenchGoogle: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-google" % workbenchGoogleV excludeAll excludeWorkbenchModel
   val excludeWorkbenchGoogle = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-google" + scalaV)
 
-  val workbenchServiceTestV = "0.21-258d483"
+  val workbenchServiceTestV = "0.21-f84f06e"
   val workbenchServiceTest: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-service-test" % workbenchServiceTestV % "test" classifier "tests" excludeAll (excludeWorkbenchGoogle, excludeWorkbenchModel)
+
+  val dataRepoClient: ModuleID = "bio.terra" % "datarepo-client" % "1.294.0-SNAPSHOT"
 
   val rootDependencies = Seq(
     // proactively pull in latest versions of Jackson libs, instead of relying on the versions
@@ -49,6 +51,7 @@ object Dependencies {
     workbenchServiceTest,
     workbenchModel,
     workbenchGoogle,
+    dataRepoClient,
 
     // required by workbenchGoogle
     "com.typesafe.akka" %% "akka-http-spray-json" % "10.0.6" % "provided"

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/AsyncImportSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/AsyncImportSpec.scala
@@ -189,7 +189,7 @@ class AsyncImportSpec extends FreeSpec with Matchers with Eventually with ScalaF
         }
 
         withCleanBillingProject(workspaceOwner) { projectName =>
-          withWorkspace(projectName, prependUUID("owner-snapshot-import-by-copy")) { workspaceName =>
+          withWorkspace(projectName, prependUUID("owner-tdr-by-copy")) { workspaceName =>
             val startTime = System.currentTimeMillis()
 
             // verify that entity metadata for this workspace is empty
@@ -227,7 +227,7 @@ class AsyncImportSpec extends FreeSpec with Matchers with Eventually with ScalaF
         val writerWithCanShareAcl = AclEntry(writer.email, WorkspaceAccessLevel.Writer, canShare = Option(true))
 
         withCleanBillingProject(owner) { projectName =>
-          withWorkspace(projectName, prependUUID("writer-snapshot-import-by-copy"), aclEntries = List(writerWithCanShareAcl)) { workspaceName =>
+          withWorkspace(projectName, prependUUID("writer-tdr-by-copy"), aclEntries = List(writerWithCanShareAcl)) { workspaceName =>
             val startTime = System.currentTimeMillis()
 
             // verify that entity metadata for this workspace is empty
@@ -253,12 +253,11 @@ class AsyncImportSpec extends FreeSpec with Matchers with Eventually with ScalaF
     }
 
     "should asynchronously result in an error on Data Repo import-by-copy" - {
-      // TODO: failing - "Path Not Allowed - File cannot be imported from this URL.: gs://fixtures-for-tests/fixtures/this-intentionally-does-not-exist"
       "for a nonexistent manifest file" in {
         implicit val token: AuthToken = ownerAuthToken
 
         withCleanBillingProject(owner) { projectName =>
-          withWorkspace(projectName, prependUUID("snapshot-import-by-copy-404")) { workspaceName =>
+          withWorkspace(projectName, prependUUID("tdr-by-copy-404")) { workspaceName =>
             val startTime = System.currentTimeMillis()
 
             // call importPFB as owner
@@ -285,7 +284,7 @@ class AsyncImportSpec extends FreeSpec with Matchers with Eventually with ScalaF
         val writerNoCanShareAcl = AclEntry(writer.email, WorkspaceAccessLevel.Writer, canShare = Option(false))
 
         withCleanBillingProject(owner) { projectName =>
-          withWorkspace(projectName, prependUUID("writer-snapshot-import-by-copy"), aclEntries = List(writerNoCanShareAcl)) { workspaceName =>
+          withWorkspace(projectName, prependUUID("noshare-tdr-by-copy"), aclEntries = List(writerNoCanShareAcl)) { workspaceName =>
             val startTime = System.currentTimeMillis()
 
             // call importJob as writer, without can-share
@@ -310,7 +309,7 @@ class AsyncImportSpec extends FreeSpec with Matchers with Eventually with ScalaF
         val reader = UserPool.chooseStudent
 
         withCleanBillingProject(owner) { projectName =>
-          withWorkspace(projectName, prependUUID("reader-snapshot-import-by-copy"), aclEntries = List(AclEntry(reader.email, WorkspaceAccessLevel.Reader))) { workspaceName =>
+          withWorkspace(projectName, prependUUID("reader-tdr-by-copy"), aclEntries = List(AclEntry(reader.email, WorkspaceAccessLevel.Reader))) { workspaceName =>
 
             // call importJob as reader
             val exception = intercept[RestException] {

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/AsyncImportSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/AsyncImportSpec.scala
@@ -405,7 +405,7 @@ class AsyncImportSpec extends FreeSpec with Matchers with Eventually with ScalaF
     val jobResultStringResponse = blockForStringBody(jobResultHttpResponse)
     logger.info(s"Data Repo snapshot export job result for snapshotId ${snapshotModel.getId} and " +
       s"jobId ${exportJob.getId} is: $jobResultStringResponse")
-    val exportModel = jobResultStringResponse.toJson.convertTo[ExportModel]
+    val exportModel = jobResultStringResponse.parseJson.convertTo[ExportModel]
     val snapshotManifest = exportModel.format.parquet.manifest
 
     (snapshotManifest, snapshotTableNames)

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/AsyncImportSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/AsyncImportSpec.scala
@@ -440,7 +440,7 @@ class AsyncImportSpec extends FreeSpec with Matchers with Eventually with ScalaF
                                failIfStatuses: List[String] = List("Error"))
                               (implicit authToken: AuthToken) = {
     // for json deserialization
-    case class ImportJobResponse(status: String, message: String)
+    case class ImportJobResponse(status: String, message: Option[String])
     implicit val importJobResponseFormat: RootJsonFormat[ImportJobResponse] = jsonFormat2(ImportJobResponse)
 
     // poll for completion
@@ -455,11 +455,12 @@ class AsyncImportSpec extends FreeSpec with Matchers with Eventually with ScalaF
         val importResponse = blockForStringBody(resp).parseJson.convertTo[ImportJobResponse]
         val importStatus = importResponse.status
         logger.info(s"[$requestId] Import Service job status for import job $importJobId is [$importStatus]")
-        importStatus shouldBe expectedStatus
         // checking for fail conditions allows the test to exit earlier than the eventually{} timeout if we detect a problem
         withClue(s"Import job $importJobId with message [${importResponse.message}] should not be in status $importStatus: ") {
           failIfStatuses shouldNot contain (importStatus)
         }
+        importStatus shouldBe expectedStatus
+
       }
     }
 

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/AsyncImportSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/AsyncImportSpec.scala
@@ -402,7 +402,10 @@ class AsyncImportSpec extends FreeSpec with Matchers with Eventually with ScalaF
     // on export completion, get job result. The data repo client, via retrieveJobResult(), returns a LinkedHashMap
     // and is not strongly typed. So, we get the response as a string and parse it into our hacky case classes.
     val jobResultHttpResponse = Orchestration.getRequest(s"${dataRepoBaseUrl}api/repository/v1/jobs/${exportJob.getId}/result")(credentials.makeAuthToken())
-    val exportModel = blockForStringBody(jobResultHttpResponse).toJson.convertTo[ExportModel]
+    val jobResultStringResponse = blockForStringBody(jobResultHttpResponse)
+    logger.info(s"Data Repo snapshot export job result for snapshotId ${snapshotModel.getId} and " +
+      s"jobId ${exportJob.getId} is: $jobResultStringResponse")
+    val exportModel = jobResultStringResponse.toJson.convertTo[ExportModel]
     val snapshotManifest = exportModel.format.parquet.manifest
 
     (snapshotManifest, snapshotTableNames)

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/AsyncImportSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/AsyncImportSpec.scala
@@ -40,15 +40,6 @@ class AsyncImportSpec extends FreeSpec with Matchers with Eventually with ScalaF
   lazy private val expectedEntities: Map[String, EntityTypeMetadata] = Source.fromResource("AsyncImportSpec-pfb-expected-entities.json").getLines().mkString
     .parseJson.convertTo[Map[String, EntityTypeMetadata]]
 
-  "Import Service SA should be an admin in Sam" in {
-    // import-service@terra-importservice-qa.iam.gserviceaccount.com
-    val admin = UserPool.chooseAdmin
-    val userCheckUrl = s"${FireCloud.samApiUrl}api/admin/user/email/import-service@terra-importservice-qa.iam.gserviceaccount.com"
-    val userCheckResponse = Orchestration.getRequest(userCheckUrl)(admin.makeAuthToken())
-    val userCheck = blockForStringBody(userCheckResponse)
-    assert (userCheck == "this will fail")
-  }
-
   "Orchestration" - {
 
     "should import a PFB file via import service" - {

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/AsyncImportSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/AsyncImportSpec.scala
@@ -40,6 +40,15 @@ class AsyncImportSpec extends FreeSpec with Matchers with Eventually with ScalaF
   lazy private val expectedEntities: Map[String, EntityTypeMetadata] = Source.fromResource("AsyncImportSpec-pfb-expected-entities.json").getLines().mkString
     .parseJson.convertTo[Map[String, EntityTypeMetadata]]
 
+  "Import Service SA should be an admin in Sam" in {
+    // import-service@terra-importservice-qa.iam.gserviceaccount.com
+    val admin = UserPool.chooseAdmin
+    val userCheckUrl = s"${FireCloud.samApiUrl}api/admin/user/email/import-service@terra-importservice-qa.iam.gserviceaccount.com"
+    val userCheckResponse = Orchestration.getRequest(userCheckUrl)(admin.makeAuthToken())
+    val userCheck = blockForStringBody(userCheckResponse)
+    assert (userCheck == "this will fail")
+  }
+
   "Orchestration" - {
 
     "should import a PFB file via import service" - {

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/AsyncImportSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/AsyncImportSpec.scala
@@ -258,7 +258,7 @@ class AsyncImportSpec extends FreeSpec with Matchers with Eventually with ScalaF
         implicit val token: AuthToken = ownerAuthToken
 
         withCleanBillingProject(owner) { projectName =>
-          withWorkspace(projectName, prependUUID("owner-snapshot-import-by-copy-404")) { workspaceName =>
+          withWorkspace(projectName, prependUUID("snapshot-import-by-copy-404")) { workspaceName =>
             val startTime = System.currentTimeMillis()
 
             // call importPFB as owner


### PR DESCRIPTION
* new integration tests for TDR snapshot import-by-copy. These run ONLY in the real alpha env; they do not run on fiabs or PRs. This is a limitation of TDR not existing in FiaBs, and perhaps BEEs will solve this problem at some point in the future.
* refactoring of `AsyncImportSpec` for better reusability across tests

Note: because the new tests run only in alpha, you will not see them in the checks/test runs for this PR!