### PR TITLE
upgrade swagger-ui [AJ-318]

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -67,7 +67,7 @@ object Dependencies {
     excludeGuava("com.google.auth"     % "google-auth-library-oauth2-http"  % "0.24.1"),
     excludeGuava("com.google.apis"     % "google-api-services-admin-directory"  % "directory_v1-rev110-1.25.0"),
 
-    "org.webjars.npm"                % "swagger-ui-dist"     % "3.45.0",
+    "org.webjars.npm"                % "swagger-ui-dist"     % "4.6.1",
     "org.webjars"                    % "webjars-locator"     % "0.40",
     "com.github.jwt-scala"          %% "jwt-core"            % "7.1.1",
     // javax.mail is used only by MethodRepository.validatePublicOrEmail(). Consider

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -6031,7 +6031,7 @@ paths:
       x-passthrough-target: rawls
     patch:
       tags:
-        - submissions
+        - Submissions
       summary: Update user comment for a submission
       description: Update user comment for a submission
       operationId: updateSubmissionUserComment


### PR DESCRIPTION
Upgrades swagger-ui to latest. This keeps the version of swagger-ui in Orch the same as the version in Rawls.

N.B. Since Orch was already on a slightly-later version of swagger-ui, it had already fixed the encoded-json example bug as illustrated in the Rawls PR. But, it feels right to upgrade anyway.

See also https://github.com/broadinstitute/rawls/pull/1648

