### PR TITLE
remove GCS buckets from /status health checks [AJ-225]

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/HealthChecks.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/HealthChecks.scala
@@ -72,7 +72,6 @@ class HealthChecks(app: Application, registerSAs: Boolean = true)
     Map(
       Agora -> app.agoraDAO.status,
       Consent -> app.consentDAO.status,
-      GoogleBuckets -> app.googleServicesDAO.status,
       LibraryIndex -> app.searchDAO.status,
       OntologyIndex -> app.ontologyDAO.status,
       Rawls -> app.rawlsDAO.status,

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
@@ -577,6 +577,7 @@ class HttpGoogleServicesDAO(priceListUrl: String, defaultPriceList: GooglePriceL
   // END methods borrowed from rawls
   // ====================================================================================
 
+  // this status method is no longer called as part of Orch's health checks.
   def status: Future[SubsystemStatus] = {
     val storage = new Storage.Builder(httpTransport, jsonFactory, new HttpCredentialsAdapter(getBucketServiceAccountCredential)).setApplicationName(appName).build()
     val bucketResponseTry = Try(storage.buckets().list(FireCloudConfig.FireCloud.serviceProject).executeUsingHead())

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/StatusApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/StatusApiServiceSpec.scala
@@ -61,7 +61,7 @@ class StatusApiServiceSpec extends BaseServiceSpec with StatusApiService with Sp
     "should contain all the subsystems we care about" in {
       Get(statusPath) ~> statusRoutes ~> check {
         val statusCheckResponse = responseAs[StatusCheckResponse]
-        val expectedSystems = Set(Agora, Consent, GoogleBuckets, LibraryIndex, OntologyIndex, Rawls, Sam, Thurloe, HealthChecks.adminSaRegistered)
+        val expectedSystems = Set(Agora, Consent, LibraryIndex, OntologyIndex, Rawls, Sam, Thurloe, HealthChecks.adminSaRegistered)
         assertResult(expectedSystems) { statusCheckResponse.systems.keySet }
       }
     }


### PR DESCRIPTION
In the health-check response for Orch's `/status` API, remove the connectivity check for `GoogleBuckets`.

The buckets check feels unnecessary for Orch, and it comes at the cost of extra traffic and logs. Rawls already has a health check for buckets, and Rawls will mark itself as not-OK if those checks fail. Asking Orch to *also* check bucket connectivity doesn't seem necessary.

Open to opinions, if you think this check should remain in place!

This spun out of https://broadworkbench.atlassian.net/browse/AJ-225, in which I am investigating all the uses of the `firecloud-dev@broad-dsde-dev.iam.gserviceaccount.com` service account. The huge majority of API calls made by that SA is these health checks.

