### PR TITLE
preselect scopes in swagger [AJ-352]

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/SwaggerApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/SwaggerApiService.scala
@@ -56,6 +56,7 @@ trait SwaggerApiService extends LazyLogging {
                                         |        clientSecret: "${FireCloudConfig.Auth.swaggerRealm}",
                                         |        realm: "${FireCloudConfig.Auth.swaggerRealm}",
                                         |        appName: "firecloud",
+                                        |        scopes: ["openid", "email", "profile"],
                                         |        scopeSeparator: " ",
                                         |        additionalQueryStringParams: {}
                                         |      })


### PR DESCRIPTION
in swagger-ui, preselect the "openid", "email", and "profile" scopes - these are the required/default scopes for most APIs.

This only affects swagger-ui, it does not affect behavior of the app itself.