### PR TITLE
SU-34: Optionally allow for TSV parser to process blank values as removals

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -5109,6 +5109,13 @@ paths:
           schema:
             type: boolean
             default: false
+        - name: processBlanksAsNull
+          in: query
+          description: Replace blank values with null values? todo- better description
+          required: false
+          schema:
+            type: boolean
+            default: false
       requestBody:
         content:
           multipart/form-data:

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -4778,6 +4778,13 @@ paths:
           required: true
           schema:
             type: string
+        - name: deleteEmptyValues
+          in: query
+          description: Delete empty values? Values left blank in the TSV will be deleted if set to true (default is false)
+          required: false
+          schema:
+            type: boolean
+            default: false
       requestBody:
         content:
           multipart/form-data:

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -5109,9 +5109,9 @@ paths:
           schema:
             type: boolean
             default: false
-        - name: processBlanksAsNull
+        - name: deleteEmptyValues
           in: query
-          description: Replace blank values with null values? Column values left blank will be deleted if true (default is false)
+          description: Delete empty values? Values left blank will be deleted if true (default is false)
           required: false
           schema:
             type: boolean

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -5111,7 +5111,7 @@ paths:
             default: false
         - name: processBlanksAsNull
           in: query
-          description: Replace blank values with null values? todo- better description
+          description: Replace blank values with null values? Column values left blank will be deleted if true (default is false)
           required: false
           schema:
             type: boolean

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -5111,7 +5111,7 @@ paths:
             default: false
         - name: deleteEmptyValues
           in: query
-          description: Delete empty values? Values left blank will be deleted if true (default is false)
+          description: Delete empty values? Values left blank in the TSV will be deleted if set to true (default is false)
           required: false
           schema:
             type: boolean

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/EntityService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/EntityService.scala
@@ -179,8 +179,6 @@ class EntityService(rawlsDAO: RawlsDAO, importServiceDAO: ImportServiceDAO, goog
    * Updates existing entities from TSV. All entities must already exist. */
   private def importUpdateTSV(
     workspaceNamespace: String, workspaceName: String, tsv: TSVLoadFile, entityType: String, userInfo: UserInfo, isAsync: Boolean, processBlanksAsNull: Boolean ): Future[PerRequestMessage] = {
-    println("x")
-    println(processBlanksAsNull)
     //we're setting attributes on a bunch of entities
     checkFirstColumnDistinct(tsv) {
       withMemberCollectionType(entityType, modelSchema) { memberTypeOpt =>
@@ -250,7 +248,6 @@ class EntityService(rawlsDAO: RawlsDAO, importServiceDAO: ImportServiceDAO, goog
   }
 
   private def importEntitiesFromTSVLoadFile(workspaceNamespace: String, workspaceName: String, tsv: TSVLoadFile, tsvType: TsvType, entityType: String, userInfo: UserInfo, isAsync: Boolean, processBlanksAsNull: Boolean): Future[PerRequestMessage] = {
-    println(processBlanksAsNull)
     tsvType match {
       case TsvTypes.MEMBERSHIP => importMembershipTSV(workspaceNamespace, workspaceName, tsv, entityType, userInfo, isAsync)
       case TsvTypes.ENTITY => importEntityTSV(workspaceNamespace, workspaceName, tsv, entityType, userInfo, isAsync, processBlanksAsNull)
@@ -263,7 +260,6 @@ class EntityService(rawlsDAO: RawlsDAO, importServiceDAO: ImportServiceDAO, goog
    * Determines the TSV type from the first column header and routes it to the correct import function. */
   def importEntitiesFromTSV(workspaceNamespace: String, workspaceName: String, tsvString: String, userInfo: UserInfo, isAsync: Boolean = false, processBlanksAsNull: Boolean = false): Future[PerRequestMessage] = {
 
-    println(processBlanksAsNull)
     def stripEntityType(entityTypeString: String): String = {
       val entityType = entityTypeString.stripSuffix("_id")
       if (entityType == entityTypeString)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/TSVFileSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/TSVFileSupport.scala
@@ -146,9 +146,7 @@ trait TSVFileSupport {
     * colInfo is a list of (headerName, refType), where refType is the type of the entity if the headerName is an AttributeRef
     * e.g. on TCGA Pairs, there's a header called case_sample_id where the refType would be Sample */
   def setAttributesOnEntity(entityType: String, memberTypeOpt: Option[String], row: Seq[String], colInfo: Seq[(String,Option[String])], modelSchema: ModelSchema, processBlanksAsNullOpt: Option[Boolean] = Some(false)): EntityUpdateDefinition = {
-    println(processBlanksAsNullOpt)
     val processBlanksAsNull = processBlanksAsNullOpt.getOrElse(false)
-    println(processBlanksAsNull)
     //Iterate over the attribute names and their values
     //I (hussein) think the refTypeOpt.isDefined is to ensure that if required attributes are left empty, the empty
     //string gets passed to Rawls, which should error as they're required?

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/TSVFileSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/TSVFileSupport.scala
@@ -144,9 +144,14 @@ trait TSVFileSupport {
 
   /**
     * colInfo is a list of (headerName, refType), where refType is the type of the entity if the headerName is an AttributeRef
-    * e.g. on TCGA Pairs, there's a header called case_sample_id where the refType would be Sample */
-  def setAttributesOnEntity(entityType: String, memberTypeOpt: Option[String], row: Seq[String], colInfo: Seq[(String,Option[String])], modelSchema: ModelSchema, processBlanksAsNullOpt: Option[Boolean] = Some(false)): EntityUpdateDefinition = {
-    val processBlanksAsNull = processBlanksAsNullOpt.getOrElse(false)
+    * e.g. on TCGA Pairs, there's a header called case_sample_id where the refType would be Sample
+    *
+    * processBlanksAsNull is a boolean value representing the users intention when uploading a TSV that contains blank values.
+    * Historically, these values have been ignored by the TSV parser as a no-op. Users have expressed that they'd like to be able
+    * to tell the TSV uploader to honor the blanks and delete any values. To preserve backwards compatibility, we will now allow
+    * the user to optionally set processBlanksAsNull to true.
+    * */
+  def setAttributesOnEntity(entityType: String, memberTypeOpt: Option[String], row: Seq[String], colInfo: Seq[(String,Option[String])], modelSchema: ModelSchema, processBlanksAsNull: Boolean = false): EntityUpdateDefinition = {
     //Iterate over the attribute names and their values
     //I (hussein) think the refTypeOpt.isDefined is to ensure that if required attributes are left empty, the empty
     //string gets passed to Rawls, which should error as they're required?

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/TSVFileSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/TSVFileSupport.scala
@@ -148,8 +148,8 @@ trait TSVFileSupport {
     *
     * deleteEmptyValues is a boolean value representing the users intention when uploading a TSV that contains blank values.
     * Historically, these values have been ignored by the TSV parser as a no-op. Users have expressed that they'd like to be able
-    * to tell the TSV uploader to honor the blanks and delete any values. To preserve backwards compatibility, we will now allow
-    * the user to optionally set deleteEmptyValues to true.
+    * to tell the TSV uploader to honor the blanks and delete those values. To preserve backwards compatibility, we will now allow
+    * the user to optionally set deleteEmptyValues to true. The default is the original behavior.
     * */
   def setAttributesOnEntity(entityType: String, memberTypeOpt: Option[String], row: Seq[String], colInfo: Seq[(String,Option[String])], modelSchema: ModelSchema, deleteEmptyValues: Boolean = false): EntityUpdateDefinition = {
     //Iterate over the attribute names and their values

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/TSVFileSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/TSVFileSupport.scala
@@ -146,22 +146,22 @@ trait TSVFileSupport {
     * colInfo is a list of (headerName, refType), where refType is the type of the entity if the headerName is an AttributeRef
     * e.g. on TCGA Pairs, there's a header called case_sample_id where the refType would be Sample
     *
-    * processBlanksAsNull is a boolean value representing the users intention when uploading a TSV that contains blank values.
+    * deleteEmptyValues is a boolean value representing the users intention when uploading a TSV that contains blank values.
     * Historically, these values have been ignored by the TSV parser as a no-op. Users have expressed that they'd like to be able
     * to tell the TSV uploader to honor the blanks and delete any values. To preserve backwards compatibility, we will now allow
-    * the user to optionally set processBlanksAsNull to true.
+    * the user to optionally set deleteEmptyValues to true.
     * */
-  def setAttributesOnEntity(entityType: String, memberTypeOpt: Option[String], row: Seq[String], colInfo: Seq[(String,Option[String])], modelSchema: ModelSchema, processBlanksAsNull: Boolean = false): EntityUpdateDefinition = {
+  def setAttributesOnEntity(entityType: String, memberTypeOpt: Option[String], row: Seq[String], colInfo: Seq[(String,Option[String])], modelSchema: ModelSchema, deleteEmptyValues: Boolean = false): EntityUpdateDefinition = {
     //Iterate over the attribute names and their values
     //I (hussein) think the refTypeOpt.isDefined is to ensure that if required attributes are left empty, the empty
     //string gets passed to Rawls, which should error as they're required?
-    val ops = for { (attributeValue,(attributeName,refTypeOpt)) <- row.tail zip colInfo if refTypeOpt.isDefined || (attributeValue.nonEmpty || processBlanksAsNull)} yield {
+    val ops = for { (attributeValue,(attributeName,refTypeOpt)) <- row.tail zip colInfo if refTypeOpt.isDefined || (attributeValue.nonEmpty || deleteEmptyValues)} yield {
       refTypeOpt match {
         case Some(refType) => Seq(Map(upsertAttrOperation,nameEntry(attributeName),valEntry(AttributeEntityReference(refType,attributeValue))))
         case None =>
           attributeValue match {
             case "__DELETE__" => Seq(Map(removeAttrOperation,nameEntry(attributeName)))
-            case value if processBlanksAsNull && value.trim.isEmpty => Seq(Map(removeAttrOperation,nameEntry(attributeName)))
+            case value if deleteEmptyValues && value.trim.isEmpty => Seq(Map(removeAttrOperation,nameEntry(attributeName)))
             case value if modelSchema.isAttributeArray(value) => generateAttributeArrayOperations(value, attributeName)
             case _ => Seq(Map(upsertAttrOperation,nameEntry(attributeName),valEntry(AttributeString(attributeValue))))
           }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiService.scala
@@ -114,10 +114,14 @@ trait WorkspaceApiService extends FireCloudRequestBuilding with FireCloudDirecti
                   post {
                     requireUserInfo() { userInfo =>
                       parameter("async" ? "false") { asyncStr =>
-                        formFields('entities) { entitiesTSV =>
-                          complete {
-                            val isAsync = java.lang.Boolean.valueOf(asyncStr) // for lenient parsing
-                            entityServiceConstructor(FlexibleModelSchema).importEntitiesFromTSV(workspaceNamespace, workspaceName, entitiesTSV, userInfo, isAsync)
+                        parameter("processBlanksAsNull" ? "false") { processBlanksStr =>
+                          formFields('entities) { entitiesTSV =>
+                            complete {
+                              val isAsync = java.lang.Boolean.valueOf(asyncStr) // for lenient parsing
+                              val processBlanksAsNull = java.lang.Boolean.valueOf(processBlanksStr) // for lenient parsing
+                              println(processBlanksAsNull)
+                              entityServiceConstructor(FlexibleModelSchema).importEntitiesFromTSV(workspaceNamespace, workspaceName, entitiesTSV, userInfo, isAsync, processBlanksAsNull)
+                            }
                           }
                         }
                       }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiService.scala
@@ -114,12 +114,12 @@ trait WorkspaceApiService extends FireCloudRequestBuilding with FireCloudDirecti
                   post {
                     requireUserInfo() { userInfo =>
                       parameter("async" ? "false") { asyncStr =>
-                        parameter("processBlanksAsNull" ? "false") { processBlanksStr =>
+                        parameter("deleteEmptyValues" ? "false") { deleteEmptyValuesStr =>
                           formFields('entities) { entitiesTSV =>
                             complete {
                               val isAsync = java.lang.Boolean.valueOf(asyncStr) // for lenient parsing
-                              val processBlanksAsNull = java.lang.Boolean.valueOf(processBlanksStr) // for lenient parsing
-                              entityServiceConstructor(FlexibleModelSchema).importEntitiesFromTSV(workspaceNamespace, workspaceName, entitiesTSV, userInfo, isAsync, processBlanksAsNull)
+                              val deleteEmptyValues = java.lang.Boolean.valueOf(deleteEmptyValuesStr) // for lenient parsing
+                              entityServiceConstructor(FlexibleModelSchema).importEntitiesFromTSV(workspaceNamespace, workspaceName, entitiesTSV, userInfo, isAsync, deleteEmptyValues)
                             }
                           }
                         }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiService.scala
@@ -130,8 +130,13 @@ trait WorkspaceApiService extends FireCloudRequestBuilding with FireCloudDirecti
                 path("importEntities") {
                   post {
                     requireUserInfo() { userInfo =>
-                      formFields('entities) { entitiesTSV =>
-                        complete { entityServiceConstructor(FirecloudModelSchema).importEntitiesFromTSV(workspaceNamespace, workspaceName, entitiesTSV, userInfo) }
+                      parameter("deleteEmptyValues" ? "false") { deleteEmptyValuesStr =>
+                        formFields('entities) { entitiesTSV =>
+                          complete {
+                            val deleteEmptyValues = java.lang.Boolean.valueOf(deleteEmptyValuesStr) // for lenient parsing
+                            entityServiceConstructor(FirecloudModelSchema).importEntitiesFromTSV(workspaceNamespace, workspaceName, entitiesTSV, userInfo, deleteEmptyValues = deleteEmptyValues)
+                          }
+                        }
                       }
                     }
                   }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiService.scala
@@ -119,7 +119,6 @@ trait WorkspaceApiService extends FireCloudRequestBuilding with FireCloudDirecti
                             complete {
                               val isAsync = java.lang.Boolean.valueOf(asyncStr) // for lenient parsing
                               val processBlanksAsNull = java.lang.Boolean.valueOf(processBlanksStr) // for lenient parsing
-                              println(processBlanksAsNull)
                               entityServiceConstructor(FlexibleModelSchema).importEntitiesFromTSV(workspaceNamespace, workspaceName, entitiesTSV, userInfo, isAsync, processBlanksAsNull)
                             }
                           }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockTSV.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockTSV.scala
@@ -305,6 +305,10 @@ object MockTSVLoadFiles {
       Seq("woop", "de", "doo"),
       Seq("hip", "hip", "hooray")))
 
+  val validWithBlanks = TSVLoadFile("foo",
+    Seq("foo", "bar", "baz"),
+    Seq(Seq("woop", "", "doo")))
+
   val validWorkspaceAttributes = TSVLoadFile("workspace", Seq("a1", "a2", "a3"), Seq(Seq("v1", "2", "[1,2,3]")))
   val validOneWorkspaceAttribute = TSVLoadFile("workspace", Seq("a1"), Seq(Seq("v1")))
   val validEmptyStrWSAttribute = TSVLoadFile("workspace", Seq("a1"), Seq(Seq("")))

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/TSVFileSupportSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/TSVFileSupportSpec.scala
@@ -160,7 +160,7 @@ class TSVFileSupportSpec extends AnyFreeSpec with TSVFileSupport {
 
       resultingOps.operations.size shouldBe 1
 
-      //TSV is 1 entity with 2 attributes, one of which is blank. deleteEmptyValues is set to true
+      //TSV is 1 entity with 2 attributes, one of which is blank. deleteEmptyValues is set to false
       //We should only see an AddUpdateAttribute op for the non-null value
       val firstOp = resultingOps.operations.head
       firstOp.keySet should contain theSameElementsAs List("op", "attributeName", "addUpdateAttribute")

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/TSVFileSupportSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/TSVFileSupportSpec.scala
@@ -133,6 +133,24 @@ class TSVFileSupportSpec extends AnyFreeSpec with TSVFileSupport {
       lastOp("op") shouldBe AttributeString("CreateAttributeValueList")
       lastOp("attributeName") shouldBe AttributeString("arrays")
     }
+
+    "remove attribute values when deleteEmptyValues is set to true" in {
+      val resultingOps = setAttributesOnEntity("some_type", None, MockTSVLoadFiles.entityWithEmptyAttributeArray.tsvData.head, Seq(("arrays", None)), FlexibleModelSchema)
+
+      resultingOps.operations.size shouldBe 2 //1 to remove any existing attribute with this name, 1 to create the empty attr value list
+
+      // firstOp should be the RemoveAttribute
+      val firstOp = resultingOps.operations.head
+      firstOp.keySet should contain theSameElementsAs List("op", "attributeName")
+      firstOp("op") shouldBe AttributeString("RemoveAttribute")
+      firstOp("attributeName") shouldBe AttributeString("arrays")
+
+      // second and final op should be the CreateAttributeValueList
+      val lastOp = resultingOps.operations.last
+      lastOp.keySet should contain theSameElementsAs List("op", "attributeName")
+      lastOp("op") shouldBe AttributeString("CreateAttributeValueList")
+      lastOp("attributeName") shouldBe AttributeString("arrays")
+    }
   }
 
 }


### PR DESCRIPTION
\<your comments for this PR go here\>

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
