### PR TITLE
[SU-85] Change "FireCloud" to "Terra" in Orch swagger

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -46,7 +46,7 @@ paths:
     post:
       tags:
         - Billing
-      summary: create billing project in FireCloud and google
+      summary: create billing project in Terra and google
       operationId: createBillingProjectFull
       requestBody:
         description: create project request
@@ -57,10 +57,10 @@ paths:
         required: true
       responses:
         204:
-          description: Successfully Created Billing Project in FireCloud and Google
+          description: Successfully Created Billing Project in Terra and Google
           content: {}
         400:
-          description: FireCloud billing user must be an admin of the billing account
+          description: Terra billing user must be an admin of the billing account
           content:
             application/json:
               schema:
@@ -72,7 +72,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
         409:
-          description: project already exists in FireCloud or google
+          description: project already exists in Terra or google
           content: {}
         500:
           description: FireCloud Internal Error
@@ -380,9 +380,9 @@ paths:
         required: true
       responses:
         201:
-          description: Successfully Created Billing Project in FireCloud
+          description: Successfully Created Billing Project in Terra
         400:
-          description: both you and firecloud billing user must be a user of the billing account
+          description: both you and Terra billing user must be a user of the billing account
           content:
             'application/json':
               schema:
@@ -3529,7 +3529,7 @@ paths:
     get:
       tags:
         - Version
-      summary: Returns the currently deployed version of FireCloud's execution engine
+      summary: Returns the currently deployed version of Terra's execution engine
       operationId: executionEngineVersion
       responses:
         200:
@@ -6632,8 +6632,8 @@ paths:
       tags:
         - Workspaces
       summary: |
-        Get all tags used in FireCloud (for autocomplete)
-      description: list of all tags used in FireCloud and their associated frequencies
+        Get all tags used in Terra (for autocomplete)
+      description: Get all tags for workspaces that a user has access to (for autocomplete)
       operationId: getTags
       parameters:
         - name: q
@@ -6643,7 +6643,8 @@ paths:
             type: string
       responses:
         200:
-          description: list of all tags used in FireCloud
+          description: list of all tags used by workspaces that the user
+            has access to and their associated frequencies
           content:
             application/json:
               schema:
@@ -6942,7 +6943,7 @@ paths:
             approved.
           content: {}
         401:
-          description: Invalid authorization, must be a FireCloud user.
+          description: Invalid authorization, must be a Terra user.
           content: {}
         404:
           description: The consent associated with the provided name could not be
@@ -7052,14 +7053,14 @@ paths:
               schema:
                 $ref: '#/components/schemas/Me'
         401:
-          description: Unauthorized. User is not allowed in FireCloud or has not signed
+          description: Unauthorized. User is not allowed in Terra or has not signed
             in.
           content: {}
         403:
-          description: Forbidden. User is registered in FireCloud, but not activated.
+          description: Forbidden. User is registered in Terra, but not activated.
           content: {}
         404:
-          description: Not Found. User is authenticated to Google but not a FireCloud
+          description: Not Found. User is authenticated to Google but not a Terra
             member.
           content: {}
         500:
@@ -7370,7 +7371,7 @@ paths:
           description: |
             A unique identifier of the tool, scoped to this registry, for example `123456`.
 
-              *In FireCloud, this must be a namespace + ":" + name. For instance, if your namespace
+              *In Terra, this must be a namespace + ":" + name. For instance, if your namespace
               is 'foo' and name is 'bar', this must be 'foo:bar'.*
           required: true
           schema:
@@ -7380,7 +7381,7 @@ paths:
           description: |
             An identifier of the tool version for this particular tool registry, for example `v1`.
 
-              *In FireCloud, this must be an integer representing the FireCloud snapshot id.*
+              *In Terra, this must be an integer representing the Terra snapshot id.*
           required: true
           schema:
             type: string
@@ -10307,7 +10308,7 @@ components:
           example: a tag
         count:
           type: integer
-          description: number of usages of the tag across Firecloud
+          description: number of usages of the tag
           format: int32
           example: 5
     ConfigurationPayload:

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -7381,7 +7381,7 @@ paths:
           description: |
             An identifier of the tool version for this particular tool registry, for example `v1`.
 
-              *In Terra, this must be an integer representing the Terra snapshot id.*
+              *In Terra, this must be an integer representing the method snapshot id.*
           required: true
           schema:
             type: string

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -3,7 +3,7 @@ info:
   title: Terra
   description: |
     Terra API
-  termsOfService: https://github.com/broadinstitute/firecloud-orchestration
+  termsOfService: https://app.terra.bio/#terms-of-service
   license:
     name: BSD
     url: http://opensource.org/licenses/BSD-3-Clause

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -1,8 +1,8 @@
 openapi: 3.0.1
 info:
-  title: FireCloud
+  title: Terra
   description: |
-    FireCloud API
+    Terra API
   termsOfService: https://github.com/broadinstitute/firecloud-orchestration
   license:
     name: BSD

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -6632,7 +6632,7 @@ paths:
       tags:
         - Workspaces
       summary: |
-        Get all tags used in Terra (for autocomplete)
+        Get all workspace tags (for autocomplete)
       description: Get all tags for workspaces that a user has access to (for autocomplete)
       operationId: getTags
       parameters:


### PR DESCRIPTION
There are a few instances of "FireCloud" that I didn't change to Terra, I left those either to maintain consistency with other texts or because changing them will actually break something (i.e. firecloud vs flexible entity schema)