### PR TITLE
github actions should use java 17 too [AJ-382]

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -20,11 +20,11 @@ jobs:
     - name: coursier-cache-action
       uses: coursier/cache-action@v5
 
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v2
       with:
-        distribution: 'adopt-hotspot'
-        java-version: '11'
+        distribution: 'temurin'
+        java-version: 17
 
     - name: Run tests
       env:


### PR DESCRIPTION
missed this in #938 … the github actions should run on Java 17 now too.