### PR TITLE
[WOR-263] Accept ToS when registering user in RegistrationApiSpec

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/RegistrationApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/RegistrationApiSpec.scala
@@ -64,6 +64,7 @@ class RegistrationApiSpec
       )
 
       Orchestration.profile.registerUser(basicUser)
+      Orchestration.termsOfService.accept("app.terra.bio/#terms-of-service")
 
       val userInfo = Sam.user.getUserStatusInfo()(authToken).get
       userInfo.userEmail should include (user.email)


### PR DESCRIPTION
Ticket: [WOR-263](https://broadworkbench.atlassian.net/browse/WOR-263)
* the PR to end the grace period in the QA environment (https://github.com/broadinstitute/firecloud-develop/pull/2885) has revealed that the user in this test needs to accept the ToS after registering in order to be enabled in Terra.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [x] Get two thumbsworth of review and PO signoff if necessary
- [x] Verify all tests go green
- [x] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
