### PR TITLE
[QA-1728] Do not accept TOS during registration

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/RegistrationApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/RegistrationApiSpec.scala
@@ -64,7 +64,6 @@ class RegistrationApiSpec
       )
 
       Orchestration.profile.registerUser(basicUser)
-      Orchestration.termsOfService.accept("app.terra.bio/#terms-of-service")
 
       val userInfo = Sam.user.getUserStatusInfo()(authToken).get
       userInfo.userEmail should include (user.email)


### PR DESCRIPTION
[Relevant ticket](https://broadworkbench.atlassian.net/browse/QA-1728) 
SAM is occasionally giving back a 403 when we go to accept TOS for a newly registered user, saying the user does not exist. We are turning the TOS grace period back on so, the acceptance is not necessary. (related follow up ticket [here](https://broadworkbench.atlassian.net/browse/WOR-289) )

--------

\<your comments for this PR go here\>

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
