### PR TITLE
Hotfix: Revert "[AJ-339] Use AttributeBoolean and AttributeNumber classes during TSV upload (#929)"

### DIFF
--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -7,18 +7,22 @@ object Dependencies {
   val akkaV = "2.6.15"
   val akkaHttpV = "10.2.0"
 
+  val excludeStatsDMetrics = ExclusionRule(organization = "com.readytalk")
+
   val workbenchModelV  = "0.15-808590d"
-  val workbenchModel: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-model" % workbenchModelV
+  val workbenchModel: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-model" % workbenchModelV excludeAll (excludeStatsDMetrics)
   val excludeWorkbenchModel = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-model_" + scalaV)
 
-  val excludeWorkbenchMetrics = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-metrics_" + scalaV)
+  // val excludeWorkbenchMetrics = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-metrics_" + scalaV)
+
+
 
   val workbenchGoogleV = "0.21-808590d"
-  val workbenchGoogle: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-google" % workbenchGoogleV excludeAll (excludeWorkbenchModel, excludeWorkbenchMetrics)
+  val workbenchGoogle: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-google" % workbenchGoogleV excludeAll (excludeWorkbenchModel, excludeStatsDMetrics)
   val excludeWorkbenchGoogle = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-google" + scalaV)
 
   val workbenchServiceTestV = "2.0-89b188f"
-  val workbenchServiceTest: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-service-test" % workbenchServiceTestV % "test" classifier "tests" excludeAll (excludeWorkbenchGoogle, excludeWorkbenchModel)
+  val workbenchServiceTest: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-service-test" % workbenchServiceTestV % "test" classifier "tests" excludeAll (excludeWorkbenchGoogle, excludeWorkbenchModel, excludeStatsDMetrics)
 
   val rootDependencies = Seq(
     // proactively pull in latest versions of Jackson libs, instead of relying on the versions

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -11,8 +11,10 @@ object Dependencies {
   val workbenchModel: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-model" % workbenchModelV
   val excludeWorkbenchModel = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-model_" + scalaV)
 
+  val excludeWorkbenchMetrics = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-metrics_" + scalaV)
+
   val workbenchGoogleV = "0.21-808590d"
-  val workbenchGoogle: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-google" % workbenchGoogleV excludeAll excludeWorkbenchModel
+  val workbenchGoogle: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-google" % workbenchGoogleV excludeAll (excludeWorkbenchModel, excludeWorkbenchMetrics)
   val excludeWorkbenchGoogle = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-google" + scalaV)
 
   val workbenchServiceTestV = "2.0-89b188f"

--- a/automation/project/build.properties
+++ b/automation/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.4.9
+sbt.version = 1.6.2

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -33,7 +33,7 @@ object Dependencies {
     "com.getsentry.raven"            % "raven-logback"       % "7.8.6",
     "com.typesafe.scala-logging"    %% "scala-logging"       % "3.9.2",
 
-    "org.parboiled" % "parboiled-core" % "1.3.2",
+    "org.parboiled" % "parboiled-core" % "1.4.1",
     excludeGuava("org.broadinstitute.dsde"       %% "rawls-model"         % "0.1-e0584dbdc")
       exclude("com.typesafe.scala-logging", "scala-logging_2.13")
       exclude("com.typesafe.akka", "akka-stream_2.13")

--- a/script/build.sh
+++ b/script/build.sh
@@ -93,7 +93,7 @@ function make_jar()
 
     docker run --rm -e GIT_MODEL_HASH=${GIT_MODEL_HASH} \
         -v $PWD:/working -w /working -v jar-cache:/root/.ivy -v jar-cache:/root/.ivy2 \
-        broadinstitute/scala-baseimage:jdk11-2.12.12-1.4.9 /working/src/docker/install.sh /working
+        hseeberger/scala-sbt:eclipse-temurin-17.0.2_1.6.2_2.13.8 /working/src/docker/install.sh /working
 }
 
 function docker_cmd()

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockTSV.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockTSV.scala
@@ -327,7 +327,6 @@ object MockTSVLoadFiles {
   val entityWithAttributeMixedArray = TSVLoadFile("array", Seq("array"), Seq(Seq("bla", """[false,"foo",1]""")))
   val entityWithAttributeArrayOfObjects = TSVLoadFile("array", Seq("array"), Seq(Seq("bla", """[{"one":"two"},{"three":"four"},{"five":"six"}]""")))
   val entityWithEmptyAttributeArray = TSVLoadFile("array", Seq("array"), Seq(Seq("bla", """[]""")))
-  val entityWithBooleanAndNumberAttributes = TSVLoadFile("foo", Seq("foo", "booleans", "numbers", "strings"), Seq(Seq("e1", "true", "0", "string"), Seq("e2", "false", "3.14", ",")))
 
   val validHugeFile = TSVLoadFile("header1",
     (1 to 1000).map(num => s"header$num"),

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/TSVFileSupportSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/TSVFileSupportSpec.scala
@@ -58,85 +58,6 @@ class TSVFileSupportSpec extends AnyFreeSpec with TSVFileSupport {
     }
   }
 
-  "stringToTypedAttribute" - {
-    val booleanTestCases = Map(
-      "true" -> AttributeBoolean(true),
-      "True" -> AttributeBoolean(true),
-      "TRUE" -> AttributeBoolean(true),
-      "false" -> AttributeBoolean(false),
-      "False" -> AttributeBoolean(false),
-      "FALSE" -> AttributeBoolean(false),
-      "yes" -> AttributeString("yes"),
-      "no" -> AttributeString("no"),
-      "0" -> AttributeNumber(0),
-      "1" -> AttributeNumber(1)
-    )
-    val integerTestCases = Map(
-      "525600" -> AttributeNumber(525600),
-      "525,600" -> AttributeString("525,600"),
-      "525_600" -> AttributeString("525_600"),
-      "-525600" -> AttributeNumber(-525600),
-      "-525,600" -> AttributeString("-525,600"),
-      "-525_600" -> AttributeString("-525_600"),
-      "0" -> AttributeNumber(0),
-      "00" -> AttributeNumber(0),
-      "-0" -> AttributeNumber(0),
-      "-00" -> AttributeNumber(0),
-      Int.MinValue.toString -> AttributeNumber(Int.MinValue),
-      Int.MaxValue.toString -> AttributeNumber(Int.MaxValue)
-    )
-    val doubleTestCases = Map(
-      "4.2" -> AttributeNumber(4.2),
-      ".42" -> AttributeNumber(0.42),
-      "0.42" -> AttributeNumber(0.42),
-      "42." -> AttributeNumber(42),
-      "42.0" -> AttributeNumber(42),
-      "." -> AttributeString("."),
-      "-4.2" -> AttributeNumber(-4.2),
-      "-.42" -> AttributeNumber(-0.42),
-      "-0.42" -> AttributeNumber(-0.42),
-      "-42." -> AttributeNumber(-42),
-      "-42.0" -> AttributeNumber(-42),
-      "-." -> AttributeString("-."),
-      Double.MinValue.toString -> AttributeNumber(Double.MinValue),
-      Double.MinPositiveValue.toString -> AttributeNumber(Double.MinPositiveValue),
-      Double.MaxValue.toString -> AttributeNumber(Double.MaxValue)
-    )
-    val stringTestCases = List("", "string", "true525600", ",")
-
-    "should detect boolean values when applicable" in {
-      booleanTestCases foreach {
-        case (input, expected) => withClue(s"should handle potential boolean: $input") {
-          stringToTypedAttribute(input) shouldBe expected
-        }
-      }
-    }
-
-    "should detect int values when applicable" in {
-      integerTestCases foreach {
-        case (input, expected) => withClue(s"should handle potential int: $input") {
-          stringToTypedAttribute(input) shouldBe expected
-        }
-      }
-    }
-
-    "should detect double values when applicable" in {
-      doubleTestCases foreach {
-        case (input, expected) => withClue(s"should handle potential double: $input") {
-          stringToTypedAttribute(input) shouldBe expected
-        }
-      }
-    }
-
-    "should detect string values when applicable" in {
-      stringTestCases foreach {
-        str => withClue(s"should handle string: $str") {
-          stringToTypedAttribute(str) shouldBe AttributeString(str)
-        }
-      }
-    }
-  }
-
   "setAttributesOnEntity" - {
 
     case class TsvArrayTestCase(loadFile: TSVLoadFile,
@@ -247,17 +168,6 @@ class TSVFileSupportSpec extends AnyFreeSpec with TSVFileSupport {
       firstOp("attributeName") shouldBe AttributeString("baz")
 
     }
-
-    "create AttributeBoolean and AttributeNumber when applicable" in {
-      val colInfo = colNamesToAttributeNames(MockTSVLoadFiles.entityWithBooleanAndNumberAttributes.headers, Map.empty)
-      val resultingOpsFirst = setAttributesOnEntity("foo", None, MockTSVLoadFiles.entityWithBooleanAndNumberAttributes.tsvData.head, colInfo, FlexibleModelSchema)
-      val resultingOpsSecond = setAttributesOnEntity("foo", None, MockTSVLoadFiles.entityWithBooleanAndNumberAttributes.tsvData(1), colInfo, FlexibleModelSchema)
-
-      val expectedOpsFirst = List(AttributeBoolean(true), AttributeNumber(0), AttributeString("string"))
-      val expectedOpsSecond = List(AttributeBoolean(false), AttributeNumber(3.14), AttributeString(","))
-
-      resultingOpsFirst.operations.map(_("addUpdateAttribute")) should contain theSameElementsInOrderAs expectedOpsFirst
-      resultingOpsSecond.operations.map(_("addUpdateAttribute")) should contain theSameElementsInOrderAs expectedOpsSecond
-    }
   }
+
 }


### PR DESCRIPTION
This reverts commit 758965176860478b4e69d2d5dd98adface22c6f5.

\<your comments for this PR go here\>

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
