### PR TITLE
use java 17/scala 2.13/sbt 1.6.2/parboiled 1.4.1 for jenkins building [AJ-414]

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -33,7 +33,7 @@ object Dependencies {
     "com.getsentry.raven"            % "raven-logback"       % "7.8.6",
     "com.typesafe.scala-logging"    %% "scala-logging"       % "3.9.2",
 
-    "org.parboiled" % "parboiled-core" % "1.3.2",
+    "org.parboiled" % "parboiled-core" % "1.4.1",
     excludeGuava("org.broadinstitute.dsde"       %% "rawls-model"         % "0.1-e0584dbdc")
       exclude("com.typesafe.scala-logging", "scala-logging_2.13")
       exclude("com.typesafe.akka", "akka-stream_2.13")

--- a/script/build.sh
+++ b/script/build.sh
@@ -93,7 +93,7 @@ function make_jar()
 
     docker run --rm -e GIT_MODEL_HASH=${GIT_MODEL_HASH} \
         -v $PWD:/working -w /working -v jar-cache:/root/.ivy -v jar-cache:/root/.ivy2 \
-        broadinstitute/scala-baseimage:jdk11-2.12.12-1.4.9 /working/src/docker/install.sh /working
+        hseeberger/scala-sbt:eclipse-temurin-17.0.2_1.6.2_2.13.8 /working/src/docker/install.sh /working
 }
 
 function docker_cmd()


### PR DESCRIPTION
`build.sh` is used by Jenkins to build Orchestration. Specifically, the Jenkins [firecloud-orchestration-build](https://fc-jenkins.dsp-techops.broadinstitute.org/job/firecloud-orchestration-build/) job calls `/jenkins/jenkins_build.sh`, which in turn calls `script/buid.sh`: `https://github.com/broadinstitute/firecloud-orchestration/blob/106f41484f723e85a185b3e8cb9a11c08f8f7b17/jenkins/jenkins_build.sh#L12

Inside build.sh, let's use the same `hseeberger` docker image we use elsewhere, which already includes java 17, scala 2.13, and sbt 1.6.2. This should prevent Jenkins from needing to download any libs during builds, as well as being consistent with other build/test processes. 

Additionally, upgrade parboiled to 1.4.1, which is latest and widely available, to avoid any problems downloading the previous parboiled 1.3.2 version.