### PR TITLE
TOAZ-129: Support Google logins through B2C

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/utils/StandardUserInfoDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/utils/StandardUserInfoDirectives.scala
@@ -2,16 +2,13 @@ package org.broadinstitute.dsde.firecloud.utils
 
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import akka.http.scaladsl.server.Directive1
-import akka.http.scaladsl.server.Directives.{headerValueByName, onSuccess, optionalHeaderValueByName}
+import akka.http.scaladsl.server.Directives.{headerValueByName, optionalHeaderValueByName}
 import org.broadinstitute.dsde.firecloud.model.UserInfo
-
-import scala.concurrent.Future
 
 trait StandardUserInfoDirectives extends UserInfoDirectives {
 
-  // Note the OAUTH2_CLAIM_google_id header is populated when a user logs in to Google
-  // via B2C. We use that for the user id if present to map B2C logins to existing
-  // Google users in the system.
+  // The OAUTH2_CLAIM_google_id header is populated when a user signs in to Google via B2C.
+  // If present, use that value instead of the B2C id for backwards compatibility.
   def requireUserInfo(): Directive1[UserInfo] = (
     headerValueByName("OIDC_access_token") &
       headerValueByName("OIDC_CLAIM_user_id") &

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/utils/StandardUserInfoDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/utils/StandardUserInfoDirectives.scala
@@ -2,25 +2,25 @@ package org.broadinstitute.dsde.firecloud.utils
 
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import akka.http.scaladsl.server.Directive1
-import akka.http.scaladsl.server.Directives.{headerValueByName, onSuccess}
-import org.broadinstitute.dsde.firecloud.dataaccess.SamDAO
-import org.broadinstitute.dsde.firecloud.model.RegistrationInfoV2
+import akka.http.scaladsl.server.Directives.{headerValueByName, onSuccess, optionalHeaderValueByName}
 import org.broadinstitute.dsde.firecloud.model.UserInfo
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
 
 trait StandardUserInfoDirectives extends UserInfoDirectives {
 
+  // Note the OAUTH2_CLAIM_google_id header is populated when a user logs in to Google
+  // via B2C. We use that for the user id if present to map B2C logins to existing
+  // Google users in the system.
   def requireUserInfo(): Directive1[UserInfo] = (
     headerValueByName("OIDC_access_token") &
       headerValueByName("OIDC_CLAIM_user_id") &
       headerValueByName("OIDC_CLAIM_expires_in") &
-      headerValueByName("OIDC_CLAIM_email")
-    ) tflatMap {
-    case (token, userId, expiresIn, email) => {
-      val userInfo = UserInfo(email, OAuth2BearerToken(token), expiresIn.toLong, userId)
-      onSuccess(Future.successful(userInfo))
+      headerValueByName("OIDC_CLAIM_email") &
+      optionalHeaderValueByName("OAUTH2_CLAIM_google_id")
+    ) tmap {
+      case (token, userId, expiresIn, email, googleIdOpt) => {
+        UserInfo(email, OAuth2BearerToken(token), expiresIn.toLong, googleIdOpt.getOrElse(userId))
+      }
     }
-  }
-
 }


### PR DESCRIPTION
Orch uses `UserInfo.id` for talking to Thurloe and potentially other things. Previously this was the google user id, but with B2C enabled it's the B2C user id. Change it to still use the google id if present to support existing Google users in the system.

We'll probably need to make a similar change for other services which use the googleId.

Tested in Terra UI + fiab with B2C enabled.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
