### PR TITLE
upgrade main dependencies [AJ-387]

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -80,7 +80,7 @@ object Dependencies {
     "com.sun.mail"                   % "javax.mail"          % "1.6.2"
       exclude("javax.activation", "activation"),
     "com.univocity"                  % "univocity-parsers"   % "2.9.1",
-    "com.github.everit-org.json-schema" % "org.everit.json.schema" % "1.12.2",
+    "com.github.erosb"               % "everit-json-schema"  % "1.14.1",
     "com.github.pathikrit"          %% "better-files"        % "3.9.1",
 
     "org.scalatest"                 %% "scalatest"           % "3.2.12"   % "test",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -23,14 +23,14 @@ object Dependencies {
     "io.netty"                       % "netty-codec"         % nettyV,
     "io.netty"                       % "netty-codec-http"    % nettyV,
     "io.netty"                       % "netty-handler"       % nettyV,
-    "org.apache.lucene"              % "lucene-queryparser"  % "6.6.6",
+    "org.apache.lucene"              % "lucene-queryparser"  % "6.6.6", // pin to this version; it's the latest compatible with our elasticsearch client
     "com.google.guava"               % "guava"               % "30.1-jre",
     // END transitive dependency overrides
 
     // elasticsearch requires log4j, but we redirect log4j to logback
     "org.apache.logging.log4j"       % "log4j-to-slf4j"      % "2.17.2",
     "ch.qos.logback"                 % "logback-classic"     % "1.2.11",
-    "com.getsentry.raven"            % "raven-logback"       % "8.0.3",
+    "com.getsentry.raven"            % "raven-logback"       % "8.0.3", // TODO: should this be io.sentry / sentry-logback instead?
     "com.typesafe.scala-logging"    %% "scala-logging"       % "3.9.4",
 
     "org.parboiled" % "parboiled-core" % "1.4.1",
@@ -58,7 +58,7 @@ object Dependencies {
     "com.typesafe.akka"             %% "akka-slf4j"                % akkaV,
     "com.typesafe.akka"             %% "akka-stream"               % akkaV      excludeAll excludeAkkaActor,
 
-    "org.elasticsearch.client"       % "transport"           % "5.6.16"
+    "org.elasticsearch.client"       % "transport"           % "5.6.16" // pin to this version; it's the latest compatible with our elasticsearch server
       exclude("io.netty", "netty-codec")
       exclude("io.netty", "netty-transport")
       exclude("io.netty", "netty-resolver")
@@ -75,7 +75,7 @@ object Dependencies {
     excludeGuava("com.google.auth"     % "google-auth-library-oauth2-http"  % "0.24.1"),
     excludeGuava("com.google.apis"     % "google-api-services-admin-directory"  % "directory_v1-rev110-1.25.0"),
 
-    "com.github.jwt-scala"          %% "jwt-core"            % "7.1.1",
+    "com.github.jwt-scala"          %% "jwt-core"            % "9.0.5",
     // javax.mail is used only by MethodRepository.validatePublicOrEmail(). Consider
     // refactoring that method to remove this entire dependency.
     "com.sun.mail"                   % "javax.mail"          % "1.6.2"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -30,7 +30,7 @@ object Dependencies {
     // elasticsearch requires log4j, but we redirect log4j to logback
     "org.apache.logging.log4j"       % "log4j-to-slf4j"      % "2.17.2",
     "ch.qos.logback"                 % "logback-classic"     % "1.2.11",
-    "com.getsentry.raven"            % "raven-logback"       % "7.8.6",
+    "com.getsentry.raven"            % "raven-logback"       % "8.0.3",
     "com.typesafe.scala-logging"    %% "scala-logging"       % "3.9.4",
 
     "org.parboiled" % "parboiled-core" % "1.4.1",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -31,7 +31,7 @@ object Dependencies {
     // elasticsearch requires log4j, but we redirect log4j to logback
     "org.apache.logging.log4j"       % "log4j-to-slf4j"      % "2.17.2",
     "ch.qos.logback"                 % "logback-classic"     % "1.2.11",
-    "com.getsentry.raven"            % "raven-logback"       % "8.0.3", // TODO: should this be io.sentry / sentry-logback instead?
+    "com.getsentry.raven"            % "raven-logback"       % "8.0.3", // TODO: this should be io.sentry / sentry-logback instead
     "com.typesafe.scala-logging"    %% "scala-logging"       % "3.9.4",
 
     "org.parboiled" % "parboiled-core" % "1.4.1",
@@ -41,7 +41,7 @@ object Dependencies {
       exclude("com.google.code.findbugs", "jsr305")
       exclude("bio.terra", "workspace-manager-client")
       excludeAll(excludeAkkaHttp, excludeSprayJson),
-    excludeGuava("org.broadinstitute.dsde.workbench" %% "workbench-util"  % "0.6-bc324ba"), // upgrading to latest workbench-libs hash causes failures
+    excludeGuava("org.broadinstitute.dsde.workbench" %% "workbench-util"  % "0.6-bc324ba"), // TODO: upgrading to latest workbench-libs hash causes failures
     "org.broadinstitute.dsde.workbench" %% "workbench-google2" % s"0.24-$workbenchLibsHash",
     "org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % s"0.1-$workbenchLibsHash",
 
@@ -80,7 +80,7 @@ object Dependencies {
     "com.github.pathikrit"          %% "better-files"        % "3.9.1",
 
     "org.scalatest"                 %% "scalatest"           % "3.2.12"   % "test",
-    "org.mock-server"                % "mockserver-netty"    % "3.11"  % "test", // upgrading higher causes failures, need to investigate
+    "org.mock-server"                % "mockserver-netty"    % "3.11"  % "test", // TODO: upgrading higher causes failures, need to investigate
     // jaxb-api needed by WorkspaceApiServiceSpec.bagitService() method
     "javax.xml.bind"                 % "jaxb-api"            % "2.3.1"   % "test",
     // provides testing mocks

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -84,12 +84,12 @@ object Dependencies {
     "com.github.everit-org.json-schema" % "org.everit.json.schema" % "1.12.2",
     "com.github.pathikrit"          %% "better-files"        % "3.9.1",
 
-    "org.scalatest"                 %% "scalatest"           % "3.2.9"   % "test",
+    "org.scalatest"                 %% "scalatest"           % "3.2.12"   % "test",
     "org.mock-server"                % "mockserver-netty"    % "3.10.8"  % "test",
     // jaxb-api needed by WorkspaceApiServiceSpec.bagitService() method
     "javax.xml.bind"                 % "jaxb-api"            % "2.3.1"   % "test",
     // provides testing mocks
     "com.google.cloud"               % "google-cloud-nio"    % "0.123.16" % "test",
-    "org.scalatestplus"             %% "mockito-3-4"         % "3.2.9.0" % "test"
+    "org.scalatestplus"             %% "mockito-3-4"         % "3.2.10.0" % "test"
   )
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -90,6 +90,6 @@ object Dependencies {
     "javax.xml.bind"                 % "jaxb-api"            % "2.3.1"   % "test",
     // provides testing mocks
     "com.google.cloud"               % "google-cloud-nio"    % "0.123.16" % "test",
-    "org.scalatestplus"             %% "mockito-3-4"         % "3.2.10.0" % "test"
+    "org.scalatestplus"             %% "mockito-4-5"         % "3.2.12.0" % "test"
   )
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -46,18 +46,14 @@ object Dependencies {
     "org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % s"0.1-$workbenchLibsHash",
 
     "com.typesafe.akka"   %%  "akka-actor"           % akkaV,
-    "com.typesafe.akka"   %%  "akka-contrib"         % akkaV               excludeAll(excludeAkkaActor, excludeAkkaStream),
-    "com.typesafe.akka"   %%  "akka-http-core"       % akkaHttpV           excludeAll(excludeAkkaActor, excludeAkkaStream),
-    "com.typesafe.akka"   %%  "akka-slf4j"           % akkaV               excludeAll excludeAkkaActor,
+    "com.typesafe.akka"   %%  "akka-slf4j"           % akkaV,
     "com.typesafe.akka"   %%  "akka-http"            % akkaHttpV           excludeAll(excludeAkkaActor, excludeAkkaStream),
     "com.typesafe.akka"   %%  "akka-http-spray-json" % akkaHttpV,
+    "com.typesafe.akka"   %%  "akka-stream"          % akkaV,
     "com.typesafe.akka"   %%  "akka-testkit"         % akkaV     % "test",
     "com.typesafe.akka"   %%  "akka-http-testkit"    % akkaHttpV % "test",
 
     "net.virtual-void"              %% "json-lenses"               % "0.6.2"  % "test",
-    "com.typesafe.akka"             %% "akka-testkit"              % akkaV    % "test",
-    "com.typesafe.akka"             %% "akka-slf4j"                % akkaV,
-    "com.typesafe.akka"             %% "akka-stream"               % akkaV      excludeAll excludeAkkaActor,
 
     "org.elasticsearch.client"       % "transport"           % "5.6.16" // pin to this version; it's the latest compatible with our elasticsearch server
       exclude("io.netty", "netty-codec")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -89,7 +89,7 @@ object Dependencies {
     // jaxb-api needed by WorkspaceApiServiceSpec.bagitService() method
     "javax.xml.bind"                 % "jaxb-api"            % "2.3.1"   % "test",
     // provides testing mocks
-    "com.google.cloud"               % "google-cloud-nio"    % "0.123.16" % "test",
+    "com.google.cloud"               % "google-cloud-nio"    % "0.123.28" % "test",
     "org.scalatestplus"             %% "mockito-4-5"         % "3.2.12.0" % "test"
   )
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -17,6 +17,7 @@ object Dependencies {
   val rootDependencies: Seq[ModuleID] = Seq(
     // proactively pull in latest versions of these libraries, instead of relying on the versions
     // specified as transitive dependencies, due to OWASP DependencyCheck warnings for earlier versions.
+    // TODO: can these move to sbt's dependencyOverrides?
     "com.fasterxml.jackson.core"     % "jackson-annotations" % jacksonV,
     "com.fasterxml.jackson.core"     % "jackson-databind"    % jacksonHotfixV,
     "com.fasterxml.jackson.core"     % "jackson-core"        % jacksonV,
@@ -80,7 +81,7 @@ object Dependencies {
     "com.github.pathikrit"          %% "better-files"        % "3.9.1",
 
     "org.scalatest"                 %% "scalatest"           % "3.2.12"   % "test",
-    "org.mock-server"                % "mockserver-netty"    % "3.10.8"  % "test",
+    "org.mock-server"                % "mockserver-netty"    % "3.11"  % "test", // upgrading higher causes failures, need to investigate
     // jaxb-api needed by WorkspaceApiServiceSpec.bagitService() method
     "javax.xml.bind"                 % "jaxb-api"            % "2.3.1"   % "test",
     // provides testing mocks

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -28,10 +28,10 @@ object Dependencies {
     // END transitive dependency overrides
 
     // elasticsearch requires log4j, but we redirect log4j to logback
-    "org.apache.logging.log4j"       % "log4j-to-slf4j"      % "2.17.1",
+    "org.apache.logging.log4j"       % "log4j-to-slf4j"      % "2.17.2",
     "ch.qos.logback"                 % "logback-classic"     % "1.2.11",
     "com.getsentry.raven"            % "raven-logback"       % "7.8.6",
-    "com.typesafe.scala-logging"    %% "scala-logging"       % "3.9.2",
+    "com.typesafe.scala-logging"    %% "scala-logging"       % "3.9.4",
 
     "org.parboiled" % "parboiled-core" % "1.4.1",
     excludeGuava("org.broadinstitute.dsde"       %% "rawls-model"         % "0.1-e0584dbdc")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -21,7 +21,6 @@ object Dependencies {
     "com.fasterxml.jackson.core"     % "jackson-annotations" % jacksonV,
     "com.fasterxml.jackson.core"     % "jackson-databind"    % jacksonHotfixV,
     "com.fasterxml.jackson.core"     % "jackson-core"        % jacksonV,
-    "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonV,
     "io.netty"                       % "netty-codec"         % nettyV,
     "io.netty"                       % "netty-codec-http"    % nettyV,
     "io.netty"                       % "netty-handler"       % nettyV,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,6 +6,7 @@ object Dependencies {
   val jacksonV = "2.13.2"
   val jacksonHotfixV = "2.13.2.2" // for when only some of the Jackson libs have hotfix releases
   val nettyV = "4.1.74.Final"
+  val workbenchLibsHash = "2c48b00"
 
   def excludeGuava(m: ModuleID): ModuleID = m.exclude("com.google.guava", "guava")
   val excludeAkkaActor =        ExclusionRule(organization = "com.typesafe.akka", name = "akka-actor_2.13")
@@ -40,9 +41,9 @@ object Dependencies {
       exclude("com.google.code.findbugs", "jsr305")
       exclude("bio.terra", "workspace-manager-client")
       excludeAll(excludeAkkaHttp, excludeSprayJson),
-    excludeGuava("org.broadinstitute.dsde.workbench" %% "workbench-util"  % "0.6-bc324ba"),
-    "org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.23-11a45ad",
-    "org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.1-2c48b00",
+    excludeGuava("org.broadinstitute.dsde.workbench" %% "workbench-util"  % "0.6-bc324ba"), // upgrading to latest workbench-libs hash causes failures
+    "org.broadinstitute.dsde.workbench" %% "workbench-google2" % s"0.24-$workbenchLibsHash",
+    "org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % s"0.1-$workbenchLibsHash",
 
     "com.typesafe.akka"   %%  "akka-actor"           % akkaV,
     "com.typesafe.akka"   %%  "akka-contrib"         % akkaV               excludeAll(excludeAkkaActor, excludeAkkaStream),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -71,9 +71,7 @@ object Dependencies {
       exclude("org.apache.logging.log4j", "log4j-api")
       exclude("org.apache.logging.log4j", "log4j-core"),
 
-    excludeGuava("com.google.apis"     % "google-api-services-storage"      % "v1-rev20190910-1.30.3"),
     excludeGuava("com.google.apis"     % "google-api-services-pubsub"       % "v1-rev20191001-1.30.3"),
-    excludeGuava("com.google.auth"     % "google-auth-library-oauth2-http"  % "0.24.1"),
     excludeGuava("com.google.apis"     % "google-api-services-admin-directory"  % "directory_v1-rev110-1.25.0"),
 
     "com.github.jwt-scala"          %% "jwt-core"            % "9.0.5",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,8 +3,8 @@ import sbt._
 object Dependencies {
   val akkaV = "2.5.32"
   val akkaHttpV = "10.2.9"
-  val jacksonV = "2.12.2"
-  val jacksonHotfixV = "2.12.2" // for when only some of the Jackson libs have hotfix releases
+  val jacksonV = "2.13.2"
+  val jacksonHotfixV = "2.13.2.2" // for when only some of the Jackson libs have hotfix releases
   val nettyV = "4.1.74.Final"
 
   def excludeGuava(m: ModuleID): ModuleID = m.exclude("com.google.guava", "guava")
@@ -13,7 +13,7 @@ object Dependencies {
   val excludeAkkaHttp = ExclusionRule(organization = "com.typesafe.akka", name = "akka-http_2.13")
   val excludeSprayJson = ExclusionRule(organization = "com.typesafe.akka", name = "akka-http-spray-json_2.13")
 
-  val rootDependencies = Seq(
+  val rootDependencies: Seq[ModuleID] = Seq(
     // proactively pull in latest versions of these libraries, instead of relying on the versions
     // specified as transitive dependencies, due to OWASP DependencyCheck warnings for earlier versions.
     "com.fasterxml.jackson.core"     % "jackson-annotations" % jacksonV,
@@ -47,7 +47,7 @@ object Dependencies {
     "com.typesafe.akka"   %%  "akka-actor"           % akkaV,
     "com.typesafe.akka"   %%  "akka-contrib"         % akkaV               excludeAll(excludeAkkaActor, excludeAkkaStream),
     "com.typesafe.akka"   %%  "akka-http-core"       % akkaHttpV           excludeAll(excludeAkkaActor, excludeAkkaStream),
-    "com.typesafe.akka"   %%  "akka-slf4j"           % akkaV               excludeAll(excludeAkkaActor),
+    "com.typesafe.akka"   %%  "akka-slf4j"           % akkaV               excludeAll excludeAkkaActor,
     "com.typesafe.akka"   %%  "akka-http"            % akkaHttpV           excludeAll(excludeAkkaActor, excludeAkkaStream),
     "com.typesafe.akka"   %%  "akka-http-spray-json" % akkaHttpV,
     "com.typesafe.akka"   %%  "akka-testkit"         % akkaV     % "test",
@@ -56,7 +56,7 @@ object Dependencies {
     "net.virtual-void"              %% "json-lenses"               % "0.6.2"  % "test",
     "com.typesafe.akka"             %% "akka-testkit"              % akkaV    % "test",
     "com.typesafe.akka"             %% "akka-slf4j"                % akkaV,
-    "com.typesafe.akka"             %% "akka-stream"               % akkaV      excludeAll(excludeAkkaActor),
+    "com.typesafe.akka"             %% "akka-stream"               % akkaV      excludeAll excludeAkkaActor,
 
     "org.elasticsearch.client"       % "transport"           % "5.6.16"
       exclude("io.netty", "netty-codec")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ object Dependencies {
   val akkaHttpV = "10.2.9"
   val jacksonV = "2.13.2"
   val jacksonHotfixV = "2.13.2.2" // for when only some of the Jackson libs have hotfix releases
-  val nettyV = "4.1.74.Final"
+  val nettyV = "4.1.77.Final"
   val workbenchLibsHash = "2c48b00"
 
   def excludeGuava(m: ModuleID): ModuleID = m.exclude("com.google.guava", "guava")


### PR DESCRIPTION
* Upgrades most dependencies to latest versions. The dependencies I did not upgrade are noted below.
* Removes direct dependencies that were not necessary
* Removes duplicate dependencies
* Fixes some minor syntax warnings from IntelliJ
* adds code comments

The dependencies I did _not_ upgrade all the way are:
1. `org.apache.lucene:lucene-queryparser` and `org.elasticsearch.client:transport` - these require upgrading our backend Elasticsearch cluster (AJ-266)
2. `akka` 2.5.32 -> 2.6.19 - this requires syntax changes so I'd rather do it in a separate PR (AJ-421)
3. `org.mock-server:mockserver-netty` - upgrading past 3.11 is causing errors so I suggest tackling that as a separate effort/PR (AJ-423)
4. `com.getsentry.raven:raven-logback` -> `io.sentry:sentry-logback` - this requires syntax changes so I'd rather do it in a separate PR (AJ-422)
5. `org.broadinstitute.dsde.workbench:workbench-util` - upgrading this to the common `workbenchLibsHash` causes inscrutable errors. This needs some investigation and a decision on if it's even worth it. (AJ-424)