### PR TITLE
delete storageservicespec tests that mostly just call Google

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/StorageApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/StorageApiSpec.scala
@@ -54,43 +54,6 @@ class StorageApiSpec extends AnyFreeSpec with StorageApiSpecSupport with Matcher
   // check for a 403 when requesting non-existent objects, which may seem wrong at first glance to anyone
   // reading this code.
 
-  "metadata endpoint" - {
-
-    "should return metadata response for a public object" in {
-      implicit val authToken: AuthToken = student.makeAuthToken()
-      val result:ObjectMetadata = Orchestration.storage.getObjectMetadata(publicUrl.bucketName, publicUrl.objectName)
-      assertResult(publicUrl.bucketName.value) { result.bucket }
-      assertResult(publicUrl.objectName.value) { result.name }
-    }
-
-    "should return metadata response for an object I have permissions to" in {
-      implicit val token = student.makeAuthToken()
-      withSmallFile { smallFile =>
-        setStudentAndSA(smallFile, student)
-        val result:ObjectMetadata = Orchestration.storage.getObjectMetadata(smallFile.bucketName, smallFile.objectName)
-        assertResult(smallFile.bucketName.value) { result.bucket }
-        assertResult(smallFile.objectName.value) { result.name }
-      }
-    }
-
-    "should return 403 for a non-existent object" in {
-      implicit val authToken: AuthToken = student.makeAuthToken()
-      val requestEx = intercept[RestException] {
-        Orchestration.storage.getObjectMetadata(nonExistent.bucketName, nonExistent.objectName)
-      }
-      assert(requestEx.getMessage.toLowerCase.contains("forbidden"))
-    }
-
-    "should return 403 for a file I don't have permissions to" in {
-      implicit val authToken: AuthToken = UserPool.chooseStudent.makeAuthToken()
-      val requestEx = intercept[RestException] {
-        Orchestration.storage.getObjectMetadata(noAccess.bucketName, noAccess.objectName)
-      }
-      assert(requestEx.getMessage.toLowerCase.contains("forbidden"))
-    }
-
-  }
-
   "cookie-authed download endpoint" - {
 
     "should return 403 for a non-existent object" in {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/StorageService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/StorageService.scala
@@ -1,19 +1,13 @@
 package org.broadinstitute.dsde.firecloud.service
 
-import akka.actor._
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
 import akka.http.scaladsl.model.StatusCodes
-import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
-import akka.pattern._
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.Application
 import org.broadinstitute.dsde.firecloud.dataaccess._
-import org.broadinstitute.dsde.firecloud.dataaccess.HttpGoogleServicesDAO._
-import org.broadinstitute.dsde.firecloud.model._
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
+import org.broadinstitute.dsde.firecloud.model._
 import org.broadinstitute.dsde.firecloud.service.PerRequest._
-import spray.json._
-import spray.json.DefaultJsonProtocol._
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
@@ -30,11 +24,10 @@ object StorageService {
 class StorageService(protected val argUserInfo: UserInfo, val googleServicesDAO: GoogleServicesDAO, val samDAO: SamDAO)
                     (implicit val executionContext: ExecutionContext) extends StorageServiceSupport with SprayJsonSupport with LazyLogging {
   implicit val userInfo = argUserInfo
-  import StorageService._
 
   val storageScopes: Seq[String] = HttpGoogleServicesDAO.authScopes ++ HttpGoogleServicesDAO.storageReadOnly
 
-  def getObjectStats(bucketName: String, objectName: String) = {
+  def getObjectStats(bucketName: String, objectName: String)   = {
     samDAO.getPetServiceAccountTokenForUser(userInfo, storageScopes) flatMap { petToken =>
       googleServicesDAO.getObjectMetadata(bucketName, objectName, petToken.accessToken.token).zip(googleServicesDAO.fetchPriceList) map { case (objectMetadata, googlePrices) =>
         Try(objectMetadata.size.toLong) match {

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/StorageServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/StorageServiceSpec.scala
@@ -1,29 +1,14 @@
 package org.broadinstitute.dsde.firecloud.service
 
-import akka.http.scaladsl.model.StatusCodes
-import akka.http.scaladsl.model.headers.OAuth2BearerToken
-import org.broadinstitute.dsde.firecloud.dataaccess.{MockSamDAO, UsTieredPriceItem}
-import org.broadinstitute.dsde.firecloud.mock.MockGoogleServicesDAO
-import org.broadinstitute.dsde.firecloud.model.{AccessToken, ObjectMetadata, UserInfo, WithAccessToken}
-import org.broadinstitute.dsde.firecloud.webservice.StorageApiService
-
-import scala.concurrent.duration.Duration
-import scala.concurrent.{Await, ExecutionContext, Future}
+import org.broadinstitute.dsde.firecloud.dataaccess.UsTieredPriceItem
 
 /**
  * Created by mbemis on 12/2/16.
  */
-class StorageServiceSpec extends BaseServiceSpec with StorageServiceSupport with StorageApiService {
+class StorageServiceSpec extends BaseServiceSpec with StorageServiceSupport {
 
   val sampleEgressCharges = UsTieredPriceItem(Map(1024L -> BigDecimal(0.12), 10240L -> BigDecimal(0.11), 92160L -> BigDecimal(0.08))).tiers.toList
   val sampleMissingEgressCharges = UsTieredPriceItem(Map.empty).tiers.toList
-  override val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
-
-  override val storageServiceConstructor: UserInfo => StorageService = StorageService.constructor(app.copy(samDAO = new SamMockWithUserToken, googleServicesDAO = new GoogleMock))
-
-  val userToken: UserInfo = UserInfo("me@me.com", OAuth2BearerToken(""), 3600, "111")
-
-  lazy val storageService: StorageService = storageServiceConstructor(userToken)
 
   "StorageService" - {
     "should calculate egress costs for single-tier objects" in {
@@ -43,39 +28,6 @@ class StorageServiceSpec extends BaseServiceSpec with StorageServiceSupport with
         getEgressCost(sampleMissingEgressCharges, BigDecimal(555), 0)
       }
     }
-
-    "should convert object size to positive cost" in {
-      val result = Await.result(storageService.getObjectStats("foo", "bar"), Duration.Inf)
-      val objectMetadata = result.response._2
-      val cost = objectMetadata.estimatedCostUSD.get
-      withClue("Cost should greater than zero since mocked size is greater than 0") {
-        assert(cost > 0)
-      }
-    }
-
-    "should still return 200 status even if the size is not a number" in {
-      val result = Await.result(storageService.getObjectStats("foo2", "bar"), Duration.Inf)
-      val status = result.response._1
-      assert(status == StatusCodes.OK)
-      val objectMetadata = result.response._2
-      assertResult(None){
-        objectMetadata.estimatedCostUSD
-      }
-    }
   }
-}
 
-class SamMockWithUserToken extends MockSamDAO {
-  override def getPetServiceAccountTokenForUser(user: WithAccessToken, scopes: Seq[String]): Future[AccessToken] = {
-    Future.successful(new AccessToken(OAuth2BearerToken("foo")))
-  }
-}
-
-class GoogleMock extends MockGoogleServicesDAO {
-  override def getObjectMetadata(bucketName: String, objectKey: String, authToken: String)(implicit executionContext: ExecutionContext): Future[ObjectMetadata] = {
-    if(bucketName == "foo")
-      Future.successful(ObjectMetadata("foo", "bar", "baz", "bla", "blah", None, Some("blahh"), "blahh", "10000000000000", "blahh", Some("blahh"), "blahh", Option("blahh"), Option("blahh"), Option("blahh"), None))
-    else
-      Future.successful(ObjectMetadata("foo", "bar", "baz", "bla", "blah", None, Some("blahh"), "blahh", "", "blahh", Some("blahh"), "blahh", Option("blahh"), Option("blahh"), Option("blahh"), None))
-  }
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/StorageApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/StorageApiServiceSpec.scala
@@ -1,0 +1,77 @@
+package org.broadinstitute.dsde.firecloud.webservice
+
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.StatusCodes.OK
+import akka.http.scaladsl.model.headers.OAuth2BearerToken
+import akka.http.scaladsl.server.Route.{seal => sealRoute}
+import org.broadinstitute.dsde.firecloud.FireCloudExceptionWithErrorReport
+import org.broadinstitute.dsde.firecloud.dataaccess.MockSamDAO
+import org.broadinstitute.dsde.firecloud.mock.MockGoogleServicesDAO
+import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
+import org.broadinstitute.dsde.firecloud.model.{AccessToken, ObjectMetadata, UserInfo, WithAccessToken}
+import org.broadinstitute.dsde.firecloud.service.{BaseServiceSpec, StorageService}
+import org.broadinstitute.dsde.rawls.model.ErrorReport
+
+import scala.concurrent.{ExecutionContext, Future}
+
+
+/*  We don't do much testing of the HealthMonitor itself, because that's tested as part of
+    workbench-libs. Here, we test routing, de/serialization, and the config we send into
+    the HealthMonitor.
+ */
+class StorageApiServiceSpec extends BaseServiceSpec with StorageApiService with SprayJsonSupport {
+
+  def actorRefFactory = system
+
+  override val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
+
+  override val storageServiceConstructor: UserInfo => StorageService = StorageService.constructor(app.copy(samDAO = new SamMockWithUserToken, googleServicesDAO = new GoogleMock))
+
+
+  "should return positive cost if size is positive" in {
+    Get("/api/storage/foo/bar") ~> dummyUserIdHeaders("user") ~> sealRoute(storageRoutes) ~> check {
+      status should equal(OK)
+      val response = responseAs[ObjectMetadata]
+      val cost = response.estimatedCostUSD.get
+      withClue("Cost should be greater than zero since mocked size is greater than 0") {
+        assert(cost > 0)
+      }
+      withClue("Bucket should be returned in response") {
+        assert(response.bucket == "foo")
+      }
+    }
+  }
+
+  "should still return 200 status even if the size is not a number" in {
+    Get("/api/storage/foo2/bar") ~> dummyUserIdHeaders("user") ~> sealRoute(storageRoutes) ~> check {
+      status should equal(OK)
+      val response = responseAs[ObjectMetadata]
+      assertResult(None) {
+        response.estimatedCostUSD
+      }
+      withClue("Bucket should be returned in response") {
+        assert(response.bucket == "foo2")
+      }
+    }
+  }
+
+
+  class SamMockWithUserToken extends MockSamDAO {
+    override def getPetServiceAccountTokenForUser(user: WithAccessToken, scopes: Seq[String]): Future[AccessToken] = {
+      Future.successful(new AccessToken(OAuth2BearerToken("foo")))
+    }
+  }
+
+  class GoogleMock extends MockGoogleServicesDAO {
+    override def getObjectMetadata(bucketName: String, objectKey: String, authToken: String)(implicit executionContext: ExecutionContext): Future[ObjectMetadata] = {
+      if (bucketName == "foo")
+        Future.successful(ObjectMetadata("foo", objectKey, "baz", "bla", "blah", None, Some("blahh"), "blahh", "10000000000000", "blahh", Some("blahh"), "blahh", Option("blahh"), Option("blahh"), Option("blahh"), None))
+      else if (bucketName == "exception")
+        throw new FireCloudExceptionWithErrorReport(ErrorReport(StatusCodes.Forbidden, "No access"))
+      else
+        Future.successful(ObjectMetadata(bucketName, objectKey, "baz", "bla", "blah", None, Some("blahh"), "blahh", "", "blahh", Some("blahh"), "blahh", Option("blahh"), Option("blahh"), Option("blahh"), None))
+    }
+  }
+}
+


### PR DESCRIPTION
I'm recommending deleting these tests because in terms of Broad code there are three things that these tests exercise:

1. https://github.com/broadinstitute/firecloud-orchestration/blob/219bdb1a7c4c85df5350f27be9292bb66233a355/src/main/scala/org/broadinstitute/dsde/firecloud/service/StorageService.scala#L37-L52
2. https://github.com/broadinstitute/firecloud-orchestration/blob/219bdb1a7c4c85df5350f27be9292bb66233a355/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/StorageApiService.scala#L19-L28
3. https://github.com/broadinstitute/workbench-libs/blob/258d4835c0cee75218cfb3718ea8624a0350a395/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/RestClient.scala#L143-L148

I've added unit test coverage for 1 as part of this PR.  We can add coverage for 2 (though I could probably use some Scala test help in doing so), and I hope there's unit test coverage somewhere for our RestClient that ensures that exceptions and messages are propagated as expected to the caller.  Essentially, my argument for removing these tests is twofold, first, we can rely on unit tests (either existing or new) to replace the testing of Broad code that occurs with these FIAB tests.  Second, calling Google doesn't really work well as a test.  Google can in theory change their code so that the assertions in these tests will fail (I would bet that they would never do that without versioning, deprecation warnings, sunset schedule etc), but even if they did these tests don't serve the function of protecting us from releasing buggy code.  If Google changes their API behavior, they break our tests and they simultaneous break production.  The tests don't save protect us under that scenario.  I could see some use for this type of code for the sake of monitoring so long as the application can degrade gracefully under those circumstances (not likely for terra and gcp I think).