### PR TITLE
[TOAZ-146] Use separate B2C policy for sensitive scopes 

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
   val jacksonV = "2.13.2"
   val jacksonHotfixV = "2.13.2.2" // for when only some of the Jackson libs have hotfix releases
   val nettyV = "4.1.77.Final"
-  val workbenchLibsHash = "1962b9a"
+  val workbenchLibsHash = "20f9225"
 
   def excludeGuava(m: ModuleID): ModuleID = m.exclude("com.google.guava", "guava")
   val excludeAkkaActor =        ExclusionRule(organization = "com.typesafe.akka", name = "akka-actor_2.13")

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/Boot.scala
@@ -70,7 +70,8 @@ object Boot extends App with LazyLogging {
         FireCloudConfig.Auth.authorityEndpoint,
         ClientId(FireCloudConfig.Auth.oidcClientId),
         oidcClientSecret = FireCloudConfig.Auth.oidcClientSecret.map(ClientSecret),
-        extraGoogleClientId = FireCloudConfig.Auth.legacyGoogleClientId.map(ClientId)
+        extraGoogleClientId = FireCloudConfig.Auth.legacyGoogleClientId.map(ClientId),
+        extraAuthParams = Some("prompt=login")
       ).unsafeToFuture()(IORuntime.global)
 
       service = new FireCloudApiServiceImpl(


### PR DESCRIPTION
Bumps wb-libs dependency for https://github.com/broadinstitute/workbench-libs/pull/1006

Manually tested oauth functionality on a fiab.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
