### PR TITLE
passthrough for rename entity [SUP-691]

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -4527,6 +4527,44 @@ paths:
       x-passthrough: true
       x-passthrough-target: rawls
       x-codegen-request-body-name: expression
+  /api/workspaces/{workspaceNamespace}/{workspaceName}/entities/{entityType}/{entityName}/rename:
+    post:
+      tags:
+        - Entities
+      summary: rename entity in a workspace
+      description: Rename an entity
+      operationId: renameEntity
+      parameters:
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/entityTypeParam'
+        - $ref: '#/components/parameters/entityNameParam'
+      requestBody:
+        description: New entity name
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/EntityName'
+        required: true
+      responses:
+        204:
+          description: Successful Request
+          content: {}
+        404:
+          description: Workspace or Entity not found
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        409:
+          description: New name for entity already exists in workspace
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        500:
+          $ref: '#/components/responses/RawlsInternalError'
+      x-codegen-request-body-name: newEntityNameJson
   /api/workspaces/{workspaceNamespace}/{workspaceName}/exportAttributesTSV:
     get:
       tags:
@@ -8419,6 +8457,15 @@ components:
         entityName:
           type: string
           description: Entity Name
+    EntityName:
+      required:
+        - name
+      type: object
+      properties:
+        name:
+          type: string
+          description: The name of the entity
+      description: ""
     EntityQueryParameters:
       required:
         - page

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/EntityApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/EntityApiService.scala
@@ -84,7 +84,7 @@ trait EntityApiService extends FireCloudDirectives
                     } ~
                     path("rename") {
                       requireUserInfo() { _ =>
-                        passthrough(entityTypeUrl + "/" + entityName + "/rename", HttpMethods.PATCH)
+                        passthrough(entityTypeUrl + "/" + entityName + "/rename", HttpMethods.POST)
                       }
                     }
                   }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/EntityApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/EntityApiService.scala
@@ -81,6 +81,11 @@ trait EntityApiService extends FireCloudDirectives
                       requireUserInfo() { _ =>
                         passthrough(entityTypeUrl + "/" + entityName + "/evaluate", HttpMethods.POST)
                       }
+                    } ~
+                    path("rename") {
+                      requireUserInfo() { _ =>
+                        passthrough(entityTypeUrl + "/" + entityName + "/rename", HttpMethods.PATCH)
+                      }
                     }
                   }
               }


### PR DESCRIPTION
Followup to #962.

I misunderstood the original Jira ticket, SUP-474, and added the wrong passthroughs in #962 (though those passthroughs are still valuable).

In this PR, now associated with SUP-691, I am adding a passthrough for rename-entity, which is the one originally requested by the user.

Tested manually by running a local orchestration and seeing it work. No additional automated tests since this is just a passthrough.