### PR TITLE
SU-146: Make valid preference keys configurable, add support for starredWorkspaces key

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -41,6 +41,8 @@ userprofile {
   getAll="/thurloe/%s"
   getQuery="/thurloe"
   delete="/thurloe/%s/%s"
+  validPreferenceKeyPrefixes=["notifications/"]
+  validPreferenceKeys=["starredWorkspaces"]
 }
 
 googlecloud {

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -3327,6 +3327,9 @@ paths:
         204:
           description: Success (No Content)
           content: {}
+        400:
+          description: Bad Request
+          content: { }
         500:
           description: Internal Server Error
           content: {}

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
@@ -116,6 +116,8 @@ object FireCloudConfig {
     val getAll = profile.getString("getAll")
     val getQuery = profile.getString("getQuery")
     val delete = profile.getString("delete")
+    val validPreferenceKeyPrefixes = profile.getStringList("validPreferenceKeyPrefixes").asScala.toSet
+    val validPreferenceKeys = profile.getStringList("validPreferenceKeys").asScala.toSet
   }
 
   object FireCloud {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/RegisterService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/RegisterService.scala
@@ -60,12 +60,12 @@ class RegisterService(val rawlsDao: RawlsDAO, val samDao: SamDAO, val thurloeDao
     }
   }
 
-  /*  utility method to determine if a preferences key headed to Thurloe is valid for user input.
-      Add whitelist logic here if you need to allow more keys.
-      If we find we update this logic frequently, I suggest moving the predicates to a config file!
-   */
+  //  utility method to determine if a preferences key headed to Thurloe is valid for user input.
   private def isValidPreferenceKey(key: String): Boolean = {
-    key.startsWith("notifications/")
+    val validKeyPrefixes = FireCloudConfig.Thurloe.validPreferenceKeyPrefixes
+    val validKeys = FireCloudConfig.Thurloe.validPreferenceKeys
+
+    validKeyPrefixes.exists(prefix => key.startsWith(prefix)) || validKeys.contains(key)
   }
 
   def updateProfilePreferences(userInfo: UserInfo, preferences: Map[String, String]): Future[PerRequestMessage] = {

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/RegisterApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/RegisterApiServiceSpec.scala
@@ -33,11 +33,12 @@ final class RegisterApiServiceSpec extends BaseServiceSpec with RegisterApiServi
         assertPreferencesUpdate(payload, NoContent)
       }
 
-      "should succeed with multiple notifications keys" in {
+      "should succeed with multiple valid preference keys" in {
         val payload = Map(
           "notifications/foo" -> "yes",
           "notifications/bar" -> "no",
-          "notifications/baz" -> "astring"
+          "notifications/baz" -> "astring",
+          "starredWorkspaces" -> "fooId,barId,bazId"
         )
         assertPreferencesUpdate(payload, NoContent)
       }


### PR DESCRIPTION
The purpose of this PR is to add a new allowed Thurloe preference key, `starredWorkspaces`. This key will store the list of workspace IDs that the user has starred. We've chosen to put this in Thurloe because this feature needs to be per-user (so a workspace attribute isn't ideal, and readers need to be able to star workspaces as well) and it must be preserved across browsers/computers (so local storage is not suitable).

Terra UI will look something like this:
<img width="1761" alt="Screen Shot 2022-07-13 at 3 36 40 PM" src="https://user-images.githubusercontent.com/7257391/178817566-303eea5b-739e-487d-b9d9-cd3c3e4cc609.png">


Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
