### PR TITLE
Rawls response for delete-workspace is just a string [AJ-492]

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpRawlsDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpRawlsDAO.scala
@@ -216,8 +216,8 @@ class HttpRawlsDAO(implicit val system: ActorSystem, implicit val materializer: 
     }
   }
 
-  override def deleteWorkspace(workspaceNamespace: String, workspaceName: String)(implicit userToken: WithAccessToken): Future[WorkspaceDeleteResponse] = {
-    authedRequestToObject[WorkspaceDeleteResponse](Delete(getWorkspaceUrl(workspaceNamespace, workspaceName)))
+  override def deleteWorkspace(workspaceNamespace: String, workspaceName: String)(implicit userToken: WithAccessToken): Future[Option[String]] = {
+    authedRequestToObject[Option[String]](Delete(getWorkspaceUrl(workspaceNamespace, workspaceName)))
   }
 
   override def cloneWorkspace(workspaceNamespace: String, workspaceName: String, cloneRequest: WorkspaceRequest)(implicit userToken: WithAccessToken): Future[WorkspaceDetails] = {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/RawlsDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/RawlsDAO.scala
@@ -77,7 +77,7 @@ trait RawlsDAO extends LazyLogging with ReportsSubsystemStatus {
 
   def getAgoraMethodConfigs(workspaceNamespace: String, workspaceName: String)(implicit userToken: WithAccessToken): Future[Seq[AgoraConfigurationShort]]
 
-  def deleteWorkspace(workspaceNamespace: String, workspaceName: String)(implicit userToken: WithAccessToken): Future[WorkspaceDeleteResponse]
+  def deleteWorkspace(workspaceNamespace: String, workspaceName: String)(implicit userToken: WithAccessToken): Future[Option[String]]
 
   def cloneWorkspace(workspaceNamespace: String, workspaceName: String, cloneRequest: WorkspaceRequest)(implicit userToken: WithAccessToken): Future[WorkspaceDetails]
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
@@ -180,8 +180,6 @@ object ModelJsonProtocol extends WorkspaceJsonSupport with SprayJsonSupport {
   implicit val impConfiguration = jsonFormat10(OrchMethodRepository.Configuration)
   implicit val impAgoraConfigurationShort = jsonFormat4(OrchMethodRepository.AgoraConfigurationShort)
 
-  implicit val impWorkspaceDeleteResponse = jsonFormat1(WorkspaceDeleteResponse)
-
   implicit val impUIWorkspaceResponse = jsonFormat6(UIWorkspaceResponse)
 
   //implicit val impEntity = jsonFormat5(Entity)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/Workspace.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/Workspace.scala
@@ -7,8 +7,6 @@ import org.broadinstitute.dsde.rawls.model.WorkspaceAccessLevels.WorkspaceAccess
 import org.broadinstitute.dsde.rawls.model._
 import org.joda.time.DateTime
 
-case class WorkspaceDeleteResponse(message: Option[String] = None)
-
 case class UIWorkspaceResponse(
   accessLevel: Option[String] = None,
   canShare: Option[Boolean] = None,

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceService.scala
@@ -186,7 +186,7 @@ class WorkspaceService(protected val argUserToken: WithAccessToken, val rawlsDAO
         Future.successful(wsResponse.workspace)
       unpublishFuture flatMap { ws =>
         rawlsDAO.deleteWorkspace(ns, name) map { wsResponse =>
-          RequestComplete(wsResponse.copy(message = Some(wsResponse.message.getOrElse("") + unPublishSuccessMessage(ns, name))))
+          RequestComplete(Some(List(wsResponse.getOrElse(""), unPublishSuccessMessage(ns, name)).mkString(" ")))
         }
       } recover {
         case e: FireCloudExceptionWithErrorReport => RequestComplete(e.errorReport.statusCode.getOrElse(StatusCodes.InternalServerError), ErrorReport(message = s"You cannot delete this workspace: ${e.errorReport.message}"))

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockRawlsDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockRawlsDAO.scala
@@ -468,8 +468,8 @@ class MockRawlsDAO extends RawlsDAO {
 
   def status: Future[SubsystemStatus] = Future(SubsystemStatus(true, None))
 
-  def deleteWorkspace(workspaceNamespace: String, workspaceName: String)(implicit userToken: WithAccessToken): Future[WorkspaceDeleteResponse] = {
-    Future.successful(WorkspaceDeleteResponse(Some("Your Google bucket 'bucketId' will be deleted within 24h.")))
+  def deleteWorkspace(workspaceNamespace: String, workspaceName: String)(implicit userToken: WithAccessToken): Future[Option[String]] = {
+    Future.successful(Some("Your Google bucket 'bucketId' will be deleted within 24h."))
   }
 
   override def getProjects(implicit userToken: WithAccessToken): Future[Seq[Project.RawlsBillingProjectMembership]] = Future(Seq.empty[Project.RawlsBillingProjectMembership])

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceServiceSpec.scala
@@ -3,7 +3,7 @@ import akka.http.scaladsl.model.{StatusCode, StatusCodes}
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import akka.testkit.TestActorRef
 import org.broadinstitute.dsde.firecloud.dataaccess._
-import org.broadinstitute.dsde.firecloud.model.{AccessToken, WithAccessToken, WorkspaceDeleteResponse}
+import org.broadinstitute.dsde.firecloud.model.{AccessToken, WithAccessToken}
 import org.broadinstitute.dsde.firecloud.service.PerRequest.{RequestComplete, RequestCompleteWithHeaders}
 import org.broadinstitute.dsde.firecloud.{Application, FireCloudException}
 import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.AttributeUpdateOperation
@@ -59,19 +59,19 @@ class WorkspaceServiceSpec extends BaseServiceSpec with BeforeAndAfterEach {
       val workspaceNamespace = "projectowner"
       val rqComplete = Await.
         result(ws.deleteWorkspace(workspaceNamespace, workspaceName), Duration.Inf).
-        asInstanceOf[RequestComplete[WorkspaceDeleteResponse]]
+        asInstanceOf[RequestComplete[Option[String]]]
       val workspaceDeleteResponse = rqComplete.response
-      workspaceDeleteResponse.message.isDefined should be (true)
+      workspaceDeleteResponse.isDefined should be (true)
     }
 
     "should delete a published workspace successfully" in {
       val workspaceNamespace = "unpublishsuccess"
       val rqComplete = Await.
         result(ws.deleteWorkspace(workspaceNamespace, workspaceName), Duration.Inf).
-        asInstanceOf[RequestComplete[WorkspaceDeleteResponse]]
+        asInstanceOf[RequestComplete[Option[String]]]
       val workspaceDeleteResponse = rqComplete.response
-      workspaceDeleteResponse.message.isDefined should be (true)
-      workspaceDeleteResponse.message.get should include (ws.unPublishSuccessMessage(workspaceNamespace, workspaceName))
+      workspaceDeleteResponse.isDefined should be (true)
+      workspaceDeleteResponse.get should include (ws.unPublishSuccessMessage(workspaceNamespace, workspaceName))
     }
 
     "should not delete a published workspace if un-publish fails" in {
@@ -91,8 +91,8 @@ class WorkspaceServiceSpec extends BaseServiceSpec with BeforeAndAfterEach {
  */
 class MockRawlsDeleteWSDAO(implicit val executionContext: ExecutionContext) extends MockRawlsDAO {
 
-  override def deleteWorkspace(workspaceNamespace: String, workspaceName: String)(implicit userToken: WithAccessToken): Future[WorkspaceDeleteResponse] = {
-    Future.successful(WorkspaceDeleteResponse(Some("Your Google bucket 'bucketId' will be deleted within 24h.")))
+  override def deleteWorkspace(workspaceNamespace: String, workspaceName: String)(implicit userToken: WithAccessToken): Future[Option[String]] = {
+    Future.successful(Some("Your Google bucket 'bucketId' will be deleted within 24h."))
   }
 
   private val unpublishsuccess = publishedRawlsWorkspaceWithAttributes.copy(


### PR DESCRIPTION
Waaaaay back in https://github.com/broadinstitute/rawls/pull/1555, we changed Rawls' response payload for the delete-workspace API from a `PerRequestMessage` to a `String`. (It has since changed to an `Option[String]` but that's mostly irrelevant). Code link [here](https://github.com/broadinstitute/rawls/pull/1555/files#diff-786b2fbecdc6fe48eddc0850e532a3dfa215568f835aebdd3b9b7fed4f785bb4R355-R357).

Orchestration, however, is not a pure passthrough for delete-workspace, since it needs to handle Library unpublish duties if a user deletes a workspace. Orchestration is "strongly typed" in that it deserializes Rawls' response into a model object.

Before this PR, it was attempting to deserialize the `String` response from Rawls into a `WorkspaceDeleteResponse`. This would fail, and Orch would trigger its `recover` handler, prepending "You cannot delete this workspace: " to the Rawls response.

## Impact
All delete-workspace requests that ran through Orch would appear to fail, even if Rawls actually succeeded to delete the workspace. In the case of a successful deletion, Orch would return a 202 status code but still say "You cannot delete this workspace". This caused a lot of noise in swatomation tests, because it looked as if the tests were littered with cleanup failures.

## This PR
Remove the `WorkspaceDeleteResponse` model and, everywhere Orch works with the Rawls response, use an `Option[String]` instead.

### Alternatives Considered
_These are all larger refactors than I wanted to tackle in this PR ..._
* Refactor to remove deserialization of Rawls' response entirely, and just pass on the response.
* Refactor delete-workspace to be a passthrough with a post-response fire-and-forget unpublish


