### PR TITLE
ID-155 fix swagger documentation

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -7274,7 +7274,7 @@ paths:
     get:
       tags:
         - Profile
-      summary: Passes through to the Rawls userinfo API and returns its response
+      summary: Passes through to the Sam userinfo API and returns its response
       operationId: getUserStatus
       responses:
         200:


### PR DESCRIPTION
one liner to update swagger documentation

this API calls
https://github.com/broadinstitute/firecloud-orchestration/blob/219bdb1a7c4c85df5350f27be9292bb66233a355/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/UserApiService.scala#L140

which points to sam
https://github.com/broadinstitute/firecloud-orchestration/blob/219bdb1a7c4c85df5350f27be9292bb66233a355/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/UserApiService.scala#L41

--- 
this is a drive-by fix (while working on https://broadworkbench.atlassian.net/browse/ID-155)


\<your comments for this PR go here\>

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
