### PR TITLE
fix code coverage [AJ-509]

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -34,6 +34,6 @@ jobs:
         FIRE_CLOUD_ID: 123
       run: sbt jacoco
 
-    - uses: codecov/codecov-action@v1
+    - uses: codecov/codecov-action@v3
       with:
         file: ./target/scala-2.13/jacoco/report/jacoco.xml

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -32,8 +32,7 @@ jobs:
         RAWLS_URL_ROOT: http://localhost:8990
         THURLOE_URL_ROOT: http://localhost:8991
         FIRE_CLOUD_ID: 123
-      run: sbt jacoco
+      run: sbt clean coverage test coverageReport
 
     - uses: codecov/codecov-action@v3
-      with:
-        file: ./target/scala-2.13/jacoco/report/jacoco.xml
+      if: ${{ always() }}

--- a/project/Testing.scala
+++ b/project/Testing.scala
@@ -1,8 +1,6 @@
 import sbt.Keys._
 import sbt._
 
-import com.github.sbt.jacoco.JacocoKeys._
-
 object Testing {
 
   def isIntegrationTest(name: String) = name contains "integrationtest"
@@ -22,13 +20,6 @@ object Testing {
     Test / fork := true,
     Test / parallelExecution := false,
     IntegrationTest / fork := false, // allow easy overriding of conf values via system props
-
-    jacocoReportSettings := JacocoReportSettings(
-      "Jacoco Coverage Report",
-      None,
-      JacocoThresholds(),
-      Seq(JacocoReportFormats.ScalaHTML, JacocoReportFormats.XML), // note XML formatter
-      "utf-8")
 
   )
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,4 +2,4 @@ addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.15.0")
 
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.9.1")
 
-addSbtPlugin("com.github.sbt" % "sbt-jacoco" % "3.3.0")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.0")


### PR DESCRIPTION
Code coverage was pretty broken. This repo has been at 0% coverage for … as long as codecov has been tracking PRs: https://app.codecov.io/gh/broadinstitute/firecloud-orchestration/pulls. This may go all the way back to #818 .

If nobody noticed or cared that coverage was broken, it begs the question: should we even have code coverage? I'm keeping it in place for now because it doesn't add _too_ much overhead.

### Coverage generation
switch from `sbt-jacoco` to `sbt-scoverage`. JaCoCo was consistently generating 0% coverage and I couldn't figure out why. We use scoverage elsewhere (e.g. Rawls) so I just switched. 

### Codecov uploading
Bonus fix rom https://github.com/codecov/codecov-action:
> As of February 1, 2022, v1 has been fully sunset and no longer functions

Which doesn't seem to be true; the v1 action was succeeding at uploading our 0% coverage reports. Nonetheless, let's update to their recommended version.