### PR TITLE
quote TSV values if they contain a tab [AJ-523]

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/utils/TSVParser.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/utils/TSVParser.scala
@@ -11,6 +11,8 @@ case class TSVLoadFile(
 )
 
 object TSVParser {
+  final val DELIMITER = '\t'
+
   private def makeParser = {
     // Note we're using a CsvParser with a tab delimiter rather a TsvParser.
     // This is because the CSV formatter handles quotations correctly while the TSV formatter doesn't.
@@ -21,7 +23,7 @@ object TSVParser {
     settings.setMaxColumns(1024)
     //64 mb in bytes/4 (assumes 4 bytes per character)
     settings.setMaxCharsPerColumn(16777216)
-    settings.getFormat.setDelimiter('\t')
+    settings.getFormat.setDelimiter(DELIMITER)
     settings.setErrorContentLength(16384)
     // By default, the CsvParser returns null for missing fields, however the application expects the
     // empty string. These replace all nulls with the empty string.

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockRawlsDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockRawlsDAO.scala
@@ -171,7 +171,7 @@ class MockRawlsDAO extends RawlsDAO {
       AttributeName("default", "b") -> AttributeNumber(1.23),
       AttributeName("default", "c") -> AttributeString(""),
       AttributeName("default", "d") -> AttributeString("escape quo\"te"),
-      AttributeName("default", "e") -> AttributeString("v1"),
+      AttributeName("default", "e") -> AttributeString("this\thas\ttabs\tin\tit"),
       AttributeName("default", "f") -> AttributeValueList(Seq(
         AttributeString("v6"),
         AttributeNumber(999),

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceServiceSpec.scala
@@ -42,7 +42,7 @@ class WorkspaceServiceSpec extends BaseServiceSpec with BeforeAndAfterEach {
 
       val tsvReturnString = List(
         List("workspace:e", "d", "b", "c", "a", "f").mkString("\t"),
-        List("v1", "escape quo\\\"te", 1.23, "", "true", "[\"v6\",999,true]").mkString("\t")).mkString("\n")
+        List("\"this\thas\ttabs\tin\tit\"", "escape quo\"te", 1.23, "", "true", "[\"v6\",999,true]").mkString("\t")).mkString("\n")
 
       assertResult(tsvReturnString) {
         tsvString

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/utils/TSVFormatterSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/utils/TSVFormatterSpec.scala
@@ -201,20 +201,20 @@ class TSVFormatterSpec extends AnyFreeSpec with ScalaFutures with Matchers with 
       )
     }
 
-    val cleanValueTestData = Map(
-      JsString("foo") -> "foo",
-      JsString(""""quoted string"""") -> """"quoted string"""",
-      JsNumber(123.45) -> "123.45",
-      JsTrue -> "true",
-      JsFalse -> "false",
-      JsArray(JsString("one"), JsString("two"), JsString("three")) -> """["one","two","three"]""",
-      JsObject(Map("foo" -> JsString("bar"), "baz" -> JsNumber(123))) -> """{"foo":"bar","baz":123}"""
+    val tsvSafeAttributeTestData = Map(
+      AttributeString("foo") -> "foo",
+      AttributeString(""""quoted string"""") -> """"quoted string"""",
+      AttributeNumber(123.45) -> "123.45",
+      AttributeBoolean(true) -> "true",
+      AttributeBoolean(false) -> "false",
+      AttributeValueList(Seq(AttributeString("one"), AttributeString("two"), AttributeString("three"))) -> """["one","two","three"]""",
+      AttributeValueRawJson(JsObject(Map("foo" -> JsString("bar"), "baz" -> JsNumber(123)))) -> """{"foo":"bar","baz":123}"""
     )
-    "cleanValue() method" - {
-      cleanValueTestData foreach {
+    "tsvSafeAttribute() method" - {
+      tsvSafeAttributeTestData foreach {
         case (input, expected) =>
           s"should stringify correctly for input $input" in {
-            TSVFormatter.cleanValue(input) shouldBe expected
+            TSVFormatter.tsvSafeAttribute(input) shouldBe expected
           }
       }
     }


### PR DESCRIPTION
If an entity attribute value contains a tab, wrap that value in double-quotes when outputting it to a TSV. This prevents the embedded tab from breaking the format of the TSV.

I've added/updated unit tests as well as tested manually by running locally.