### PR TITLE
Scala steward configuration [AJ-504]

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -1,0 +1,18 @@
+name: Update Dependency Graph
+
+on:
+  push:
+    branches:
+      - develop # default branch of the project
+
+jobs:
+  update-graph:
+    name: Update Dependency Graph
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: scalacenter/sbt-dependency-submission@v2
+        with:
+          ## Optional: Define the working directory of your build.
+          ## It should contain the build.sbt file.
+          working-directory: './'

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,14 @@
+name: PR Labeler
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  pr-labeler:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: TimonVS/pr-labeler-action@v3
+        with:
+          configuration-path: .github/pr-labeler.yml # optional, .github/pr-labeler.yml is the default value
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,111 @@
+# pullRequests.frequency allows to control how often or when Scala Steward
+# is allowed to create pull requests.
+#
+# Possible values:
+#   @asap
+#     PRs are created without delay.
+#
+#   <timespan>
+#     PRs are created only again after the given timespan since the last PR
+#     has passed. Example values are "36 hours", "1 day", or "14 days".
+
+#   <CRON expression>
+#     PRs are created roughly according to the given CRON expression.
+#
+#     CRON expressions consist of five fields:
+#     minutes, hour of day, day of month, month, and day of week.
+#
+#     See https://www.alonsodomin.me/cron4s/userguide/index.html#parsing for
+#     more information about the CRON expressions that are supported.
+#
+#     Note that the date parts of the CRON expression are matched exactly
+#     while the time parts are only used to abide to the frequency of
+#     the given expression.
+#
+#
+pullRequests.frequency = "0 0 ? * MON" # every monday at midnight
+
+
+# Only these dependencies which match the given patterns are updated.
+#
+# Each pattern must have `groupId`, and may have `artifactId` and `version`.
+# Defaults to empty `[]` which mean Scala Steward will update all dependencies.
+# updates.allow  = [ { groupId = "com.example" } ]
+
+# The dependencies which match the given version pattern are updated.
+# Dependencies that are not listed will be updated.
+#
+# Each pattern must have `groupId`, `version` and optional `artifactId`.
+# Defaults to empty `[]` which mean Scala Steward will update all dependencies.
+# the following example will allow to update foo when version is 1.1.x
+# updates.pin  = [ { groupId = "com.example", artifactId="foo", version = "1.1." } ]
+
+# The dependencies which match the given pattern are NOT updated.
+#
+# Each pattern must have `groupId`, and may have `artifactId` and `version`.
+# Defaults to empty `[]` which mean Scala Steward will not ignore dependencies.
+# updates.ignore = [ { groupId = "org.acme", artifactId="foo", version = "1.0" } ]
+
+# If set, Scala Steward will only create or update `n` PRs each time it runs (see `pullRequests.frequency` above).
+# Useful if running frequently and/or CI build are costly
+# Default: None
+updates.limit = 5
+
+# The extensions of files that should be updated.
+# Default: [".scala", ".sbt", ".sbt.shared", ".sc", ".yml", "pom.xml"]
+# updates.fileExtensions = [".scala", ".sbt", ".sbt.shared", ".sc", ".yml", ".md", ".markdown", ".txt"]
+
+# If "on-conflicts", Scala Steward will update the PR it created to resolve conflicts as
+# long as you don't change it yourself.
+# If "always", Scala Steward will always update the PR it created as long as
+# you don't change it yourself.
+# If "never", Scala Steward will never update the PR
+# Default: "on-conflicts"
+updatePullRequests = "on-conflicts"
+
+# If set, Scala Steward will use this message template for the commit messages and PR titles.
+# Supported variables: ${artifactName}, ${currentVersion}, ${nextVersion} and ${default}
+# Default: "${default}" which is equivalent to "Update ${artifactName} to ${nextVersion}"
+commits.message = "Update ${artifactName} from ${currentVersion} to ${nextVersion}"
+
+# If true and when upgrading version in .scalafmt.conf, Scala Steward will perform scalafmt
+# and add a separate commit when format changed. So you don't need reformat manually and can merge PR.
+# If false, Scala Steward will not perform scalafmt, so your CI may abort when reformat needed.
+# Default: true
+# scalafmt.runAfterUpgrading = false
+
+# It is possible to have multiple scala projects in a single repository. In that case the folders containing the projects (build.sbt folders)
+# are specified using the buildRoots property. Note that the paths used there are relative and if the repo directory itself also contains a build.sbt the dot can be used to specify it.
+# Default: ["."]
+# buildRoots = [ ".", "subfolder/projectA" ]
+
+# Define commands that are executed after an update via a hook.
+# A groupId and/or artifactId can be defined to only execute after certain dependencies are updated. If neither is defined, the hook runs for every update.
+# postUpdateHooks = [{
+#   command = ["sbt", "protobufGenerate"],
+#   commitMessage = "Regenerated protobuf files",
+#   groupId = "com.github.sbt",
+#   artifactId = "sbt-protobuf"
+# }]
+
+# You can override some config options for dependencies that matches the given pattern.
+# Currently, "pullRequests" can be overridden.
+# Each pattern must have `groupId`, and may have `artifactId` and `version`.
+# First-matched entry is used.
+# More-specific entry should be placed before less-specific entry.
+#
+# Default: empty `[]`
+# dependencyOverrides = [
+#   {
+#     dependency = { groupId = "com.example", artifactId = "foo", version = "2." },
+#     pullRequests = { frequency = "1 day" },
+#   },
+#   {
+#     dependency = { groupId = "com.example", artifactId = "foo" },
+#     pullRequests = { frequency = "30 day" },
+#   },
+#   {
+#     dependency = { groupId = "com.example" },
+#     pullRequests = { frequency = "14 day" },
+#   }
+# ]

--- a/script/build.sh
+++ b/script/build.sh
@@ -25,6 +25,9 @@ set -e
 # Set default variables
 DOCKER_CMD=
 BRANCH=${BRANCH:-$(git rev-parse --abbrev-ref HEAD)}  # default to current branch
+REGEX_TO_REPLACE_ILLEGAL_CHARACTERS_WITH_DASHES="s/[^a-zA-Z0-9_.\-]/-/g"
+REGEX_TO_REMOVE_DASHES_AND_PERIODS_FROM_BEGINNING="s/^[.\-]*//g"
+DOCKERTAG_SAFE_NAME=$(echo $BRANCH | sed -e $REGEX_TO_REPLACE_ILLEGAL_CHARACTERS_WITH_DASHES -e $REGEX_TO_REMOVE_DASHES_AND_PERIODS_FROM_BEGINNING | cut -c 1-127)  # https://docs.docker.com/engine/reference/commandline/tag/#:~:text=A%20tag%20name%20must%20be,a%20maximum%20of%20128%20characters.
 DOCKERHUB_REGISTRY=${DOCKERHUB_REGISTRY:-broadinstitute/$PROJECT}
 DOCKERHUB_TESTS_REGISTRY=${DOCKERHUB_REGISTRY}-tests
 GCR_REGISTRY=""
@@ -114,13 +117,13 @@ function docker_cmd()
         if [ $DOCKER_CMD="push" ]; then
             echo "pushing ${DOCKERHUB_REGISTRY}:${HASH_TAG}..."
             docker push $DOCKERHUB_REGISTRY:${HASH_TAG}
-            docker tag $DOCKERHUB_REGISTRY:${HASH_TAG} $DOCKERHUB_REGISTRY:${BRANCH}
-            docker push $DOCKERHUB_REGISTRY:${BRANCH}
+            docker tag $DOCKERHUB_REGISTRY:${HASH_TAG} $DOCKERHUB_REGISTRY:${DOCKERTAG_SAFE_NAME}
+            docker push $DOCKERHUB_REGISTRY:${DOCKERTAG_SAFE_NAME}
 
             echo "pushing ${DOCKERHUB_TESTS_REGISTRY}:${HASH_TAG}..."
             docker push $DOCKERHUB_TESTS_REGISTRY:${HASH_TAG}
-            docker tag $DOCKERHUB_TESTS_REGISTRY:${HASH_TAG} $DOCKERHUB_TESTS_REGISTRY:${BRANCH}
-            docker push $DOCKERHUB_TESTS_REGISTRY:${BRANCH}
+            docker tag $DOCKERHUB_TESTS_REGISTRY:${HASH_TAG} $DOCKERHUB_TESTS_REGISTRY:${DOCKERTAG_SAFE_NAME}
+            docker push $DOCKERHUB_TESTS_REGISTRY:${DOCKERTAG_SAFE_NAME}
 
             if [[ -n $GCR_REGISTRY ]]; then
                 docker tag $DOCKERHUB_REGISTRY:${HASH_TAG} $GCR_REGISTRY:${HASH_TAG}


### PR DESCRIPTION
* Add config for Scala Steward and a GHA PR labeler action to keep the PRs differentiated. Both new files are copied from Rawls.
* Add Dependabot inspection, per https://scala-lang.org/blog/2022/07/18/secure-your-dependencies-on-github.html
* Ensure build script works for branches that have a slash in their name; see https://github.com/broadinstitute/scala-steward and https://github.com/broadinstitute/sam/pull/672

https://github.com/broadinstitute/scala-steward/pull/7 is the companion PR to actually enable Scala Steward.