### PR TITLE
user-enabled checks [AJ-510]

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -44,6 +44,7 @@ object Dependencies {
     excludeGuava("org.broadinstitute.dsde.workbench" %% "workbench-util"  % "0.6-bc324ba"), // TODO: upgrading to latest workbench-libs hash causes failures
     "org.broadinstitute.dsde.workbench" %% "workbench-google2" % s"0.24-$workbenchLibsHash",
     "org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % s"0.2-$workbenchLibsHash",
+    "org.broadinstitute.dsde.workbench" %% "sam-client"       % "0.1-ef83073",
 
     "com.typesafe.akka"   %%  "akka-actor"           % akkaV,
     "com.typesafe.akka"   %%  "akka-slf4j"           % akkaV,

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/utils/EnabledUserDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/utils/EnabledUserDirectives.scala
@@ -32,8 +32,8 @@ trait EnabledUserDirectives extends LazyLogging  with SprayJsonSupport {
           innerRoute
         case Success(false) =>
           logger.warn(s"User ${userInfo.userEmail} is disabled: $uri")
-          // TODO: do we want a more helpful message like "user is disabled"?
-          throwErrorReport(StatusCodes.Forbidden, StatusCodes.Forbidden.defaultMessage)
+          // the 401/"User is disabled." response mirrors what Sam returns in this case.
+          throwErrorReport(StatusCodes.Unauthorized, "User is disabled.")
         case Failure(ex) => ex match {
           case apiex:ApiException =>
             logger.error(s"Exception checking enabled status for user ${userInfo.userEmail}: (${apiex.getMessage}) while calling $uri", apiex)
@@ -54,7 +54,11 @@ trait EnabledUserDirectives extends LazyLogging  with SprayJsonSupport {
     val sam = new UsersApi(apiClient)
     val userStatus = sam.getUserStatusInfo
     // TODO: is it enough to check this one `getEnabled` boolean?
-    // TODO: retries?
+    // TODO: should we use retries here?
+    /* TODO: instead of directly calling Sam's userStatusInfo API, should we call a "real" api and, if that api returns
+        401, echo its response? That would allow Orch to always give the same error response that Sam gives, but
+        it is likely to be more expensive in the common case of the user being enabled.
+     */
     userStatus.getEnabled
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/utils/EnabledUserDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/utils/EnabledUserDirectives.scala
@@ -2,12 +2,11 @@ package org.broadinstitute.dsde.firecloud.utils
 
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
 import akka.http.scaladsl.model.{StatusCode, StatusCodes}
-import akka.http.scaladsl.server.Directives.{complete, extractUri}
+import akka.http.scaladsl.server.Directives.extractUri
 import akka.http.scaladsl.server.{RequestContext, Route, RouteResult}
 import com.typesafe.scalalogging.LazyLogging
-import org.broadinstitute.dsde.firecloud.{FireCloudConfig, FireCloudExceptionWithErrorReport}
 import org.broadinstitute.dsde.firecloud.model.UserInfo
-import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport.ErrorReportFormat
+import org.broadinstitute.dsde.firecloud.{FireCloudConfig, FireCloudExceptionWithErrorReport}
 import org.broadinstitute.dsde.rawls.model.{ErrorReport, ErrorReportSource}
 import org.broadinstitute.dsde.workbench.client.sam.api.UsersApi
 import org.broadinstitute.dsde.workbench.client.sam.{ApiClient, ApiException}
@@ -16,8 +15,6 @@ import scala.concurrent.Future
 import scala.util.{Failure, Success, Try}
 
 trait EnabledUserDirectives extends LazyLogging  with SprayJsonSupport {
-
-  implicit val errorReportSource: ErrorReportSource = ErrorReportSource("enabled-check")
 
   /**
     * Queries Sam to see if the current user is enabled. If the user is disabled,
@@ -31,22 +28,20 @@ trait EnabledUserDirectives extends LazyLogging  with SprayJsonSupport {
     extractUri { uri =>
       Try(getUserEnabled(userInfo.accessToken.token, samBaseUrl)) match {
         case Success(true) =>
-          logger.debug(s"User ${userInfo.userEmail} is enabled: ${uri}")
+          logger.debug(s"User ${userInfo.userEmail} is enabled: $uri")
           innerRoute
         case Success(false) =>
-          logger.warn(s"User ${userInfo.userEmail} is disabled: ${uri}")
-          throw new FireCloudExceptionWithErrorReport(ErrorReport(StatusCodes.Forbidden, StatusCodes.Forbidden.defaultMessage))
-          // complete(StatusCodes.Forbidden) // TODO: do we want a more helpful message like "user is disabled"?
+          logger.warn(s"User ${userInfo.userEmail} is disabled: $uri")
+          // TODO: do we want a more helpful message like "user is disabled"?
+          throwErrorReport(StatusCodes.Forbidden, StatusCodes.Forbidden.defaultMessage)
         case Failure(ex) => ex match {
           case apiex:ApiException =>
-            logger.error(s"Exception checking enabled status for user ${userInfo.userEmail}: (${apiex.getMessage}) while calling ${uri}", apiex)
+            logger.error(s"Exception checking enabled status for user ${userInfo.userEmail}: (${apiex.getMessage}) while calling $uri", apiex)
             val code = StatusCode.int2StatusCode(apiex.getCode)
-            throw new FireCloudExceptionWithErrorReport(ErrorReport(code, apiex.getMessage))
-//            complete(code, ErrorReport(code, apiex.getMessage))
+            throwErrorReport(code, apiex.getMessage)
           case ex =>
-            logger.error(s"Exception checking enabled status for user ${userInfo.userEmail}: (${ex.getMessage}) while calling ${uri}", ex)
-            throw new FireCloudExceptionWithErrorReport(ErrorReport(StatusCodes.InternalServerError, ex.getMessage))
-//            complete(StatusCodes.InternalServerError, ErrorReport(StatusCodes.InternalServerError, ex.getMessage))
+            logger.error(s"Exception checking enabled status for user ${userInfo.userEmail}: (${ex.getMessage}) while calling $uri", ex)
+            throwErrorReport(StatusCodes.InternalServerError, ex.getMessage)
         }
       }
     }
@@ -58,7 +53,23 @@ trait EnabledUserDirectives extends LazyLogging  with SprayJsonSupport {
     apiClient.setBasePath(samBaseUrl)
     val sam = new UsersApi(apiClient)
     val userStatus = sam.getUserStatusInfo
+    // TODO: is it enough to check this one `getEnabled` boolean?
+    // TODO: retries?
     userStatus.getEnabled
+  }
+
+  /**
+    * Constructs and throws a FireCloudExceptionWithErrorReport in response to the
+    * enabled-user check. Hardcodes an ErrorReportSource to allow differentiating
+    * between enabled-user errors and other errors.
+    *
+    * @param statusCode the http status code to throw
+    * @param message message to use in the thrown exception
+    * @return nothing
+    */
+  private def throwErrorReport(statusCode: StatusCode, message: String): Nothing = {
+    val errRpt = ErrorReport(statusCode, message)(ErrorReportSource("enabled-check"))
+    throw new FireCloudExceptionWithErrorReport(errRpt)
   }
 
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/utils/EnabledUserDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/utils/EnabledUserDirectives.scala
@@ -51,8 +51,12 @@ trait EnabledUserDirectives extends LazyLogging  with SprayJsonSupport {
         case Failure(apiex:ApiException) =>
           logger.error(s"ApiException exception checking enabled status for user ${userInfo.userEmail}: (${apiex.getMessage}) while calling $uri", apiex)
           val code = StatusCode.int2StatusCode(apiex.getCode)
-          val message = if (Option(apiex.getMessage).isEmpty || apiex.getMessage.isEmpty) code.defaultMessage() else apiex.getMessage
-          throwErrorReport(code, message)
+          if (code == StatusCodes.NotFound) {
+            throwErrorReport(StatusCodes.Unauthorized, "User is not registered.")
+          } else {
+            val message = if (Option(apiex.getMessage).isEmpty || apiex.getMessage.isEmpty) code.defaultMessage() else apiex.getMessage
+            throwErrorReport(code, message)
+          }
         case Failure(ex) =>
           logger.error(s"Unexpected exception checking enabled status for user ${userInfo.userEmail}: (${ex.getMessage}) while calling $uri", ex)
           throwErrorReport(StatusCodes.InternalServerError, ex.getMessage)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/utils/EnabledUserDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/utils/EnabledUserDirectives.scala
@@ -2,19 +2,28 @@ package org.broadinstitute.dsde.firecloud.utils
 
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
 import akka.http.scaladsl.model.{StatusCode, StatusCodes}
-import akka.http.scaladsl.server.Directives.extractUri
+import akka.http.scaladsl.server.Directives.{extractUri, onComplete}
 import akka.http.scaladsl.server.{RequestContext, Route, RouteResult}
+import akka.http.scaladsl.unmarshalling.Unmarshal
+import akka.stream.Materializer
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.model.UserInfo
 import org.broadinstitute.dsde.firecloud.{FireCloudConfig, FireCloudExceptionWithErrorReport}
 import org.broadinstitute.dsde.rawls.model.{ErrorReport, ErrorReportSource}
 import org.broadinstitute.dsde.workbench.client.sam.api.UsersApi
-import org.broadinstitute.dsde.workbench.client.sam.{ApiClient, ApiException}
+import org.broadinstitute.dsde.workbench.client.sam.model.UserStatusInfo
+import org.broadinstitute.dsde.workbench.client.sam.{ApiCallback, ApiClient, ApiException}
+import org.broadinstitute.dsde.workbench.util.FutureSupport.toFutureTry
 
-import scala.concurrent.Future
-import scala.util.{Failure, Success, Try}
+import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.util.{Failure, Success}
 
 trait EnabledUserDirectives extends LazyLogging  with SprayJsonSupport {
+
+  // Hardcode an ErrorReportSource to allow differentiating between enabled-user errors and other errors.
+  implicit val errorReportSource: ErrorReportSource = ErrorReportSource("Orchestration-enabled-check")
+  implicit val executionContext: ExecutionContext
+  implicit val materializer: Materializer
 
   /**
     * Queries Sam to see if the current user is enabled. If the user is disabled,
@@ -26,7 +35,7 @@ trait EnabledUserDirectives extends LazyLogging  with SprayJsonSupport {
     */
   def requireEnabledUser(userInfo: UserInfo, samBaseUrl: String = FireCloudConfig.Sam.baseUrl)(innerRoute: RequestContext => Future[RouteResult]): Route = {
     extractUri { uri =>
-      Try(getUserEnabled(userInfo.accessToken.token, samBaseUrl)) match {
+      onComplete(getUserEnabled(userInfo.accessToken.token, samBaseUrl)) {
         case Success(true) =>
           logger.debug(s"User ${userInfo.userEmail} is enabled: $uri")
           innerRoute
@@ -34,45 +43,83 @@ trait EnabledUserDirectives extends LazyLogging  with SprayJsonSupport {
           logger.warn(s"User ${userInfo.userEmail} is disabled: $uri")
           // the 401/"User is disabled." response mirrors what Sam returns in this case.
           throwErrorReport(StatusCodes.Unauthorized, "User is disabled.")
-        case Failure(ex) => ex match {
-          case apiex:ApiException =>
-            logger.error(s"Exception checking enabled status for user ${userInfo.userEmail}: (${apiex.getMessage}) while calling $uri", apiex)
-            val code = StatusCode.int2StatusCode(apiex.getCode)
-            throwErrorReport(code, apiex.getMessage)
-          case ex =>
-            logger.error(s"Exception checking enabled status for user ${userInfo.userEmail}: (${ex.getMessage}) while calling $uri", ex)
-            throwErrorReport(StatusCodes.InternalServerError, ex.getMessage)
-        }
+        case Failure(fcerr: FireCloudExceptionWithErrorReport) =>
+          logger.error(s"FireCloudExceptionWithErrorReport exception checking enabled status for user ${userInfo.userEmail}: (${fcerr.getMessage}) while calling $uri", fcerr)
+          // rebuild the FireCloudExceptionWithErrorReport to ensure we're not passing along stack traces
+          val code = fcerr.errorReport.statusCode.getOrElse(StatusCodes.InternalServerError)
+          throwErrorReport(code, fcerr.getMessage)
+        case Failure(apiex:ApiException) =>
+          logger.error(s"ApiException exception checking enabled status for user ${userInfo.userEmail}: (${apiex.getMessage}) while calling $uri", apiex)
+          val code = StatusCode.int2StatusCode(apiex.getCode)
+          val message = if (Option(apiex.getMessage).isEmpty || apiex.getMessage.isEmpty) code.defaultMessage() else apiex.getMessage
+          throwErrorReport(code, message)
+        case Failure(ex) =>
+          logger.error(s"Unexpected exception checking enabled status for user ${userInfo.userEmail}: (${ex.getMessage}) while calling $uri", ex)
+          throwErrorReport(StatusCodes.InternalServerError, ex.getMessage)
       }
     }
   }
 
-  private def getUserEnabled(token: String, samBaseUrl: String): Boolean = {
+
+  private class SamApiCallback[T](functionName: String = "userStatusInfo") extends ApiCallback[T] {
+    private val promise = Promise[T]()
+
+    override def onFailure(e: ApiException, statusCode: Int, responseHeaders: java.util.Map[String, java.util.List[String]]): Unit = {
+      val response = e.getResponseBody
+      // attempt to propagate an ErrorReport from Sam. If we can't understand Sam's response as an ErrorReport,
+      // create our own error message.
+      import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport.ErrorReportFormat
+      toFutureTry(Unmarshal(response).to[ErrorReport]) flatMap {
+        case Success(err) =>
+          logger.error(s"Sam call to $functionName failed with error $err")
+          throw new FireCloudExceptionWithErrorReport(err)
+        case Failure(_) =>
+          // attempt to extract something useful from the response entity, even though it's not an ErrorReport
+          toFutureTry(Unmarshal(response).to[String]) map { maybeString =>
+            val stringErrMsg = maybeString match {
+              case Success(stringErr) => stringErr
+              case Failure(_) => response
+            }
+            throw new FireCloudExceptionWithErrorReport(ErrorReport(StatusCode.int2StatusCode(statusCode), s"Sam call to $functionName failed with error '$stringErrMsg'"))
+          }
+      }
+      promise.failure(e)
+    }
+    override def onSuccess(result: T, statusCode: Int, responseHeaders: java.util.Map[String, java.util.List[String]]): Unit = promise.success(result)
+
+    override def onUploadProgress(bytesWritten: Long, contentLength: Long, done: Boolean): Unit = ()
+
+    override def onDownloadProgress(bytesRead: Long, contentLength: Long, done: Boolean): Unit = ()
+
+    def future: Future[T] = promise.future
+  }
+
+  private def getUserEnabled(token: String, samBaseUrl: String): Future[Boolean] = {
     val apiClient = new ApiClient()
     apiClient.setAccessToken(token)
     apiClient.setBasePath(samBaseUrl)
     val sam = new UsersApi(apiClient)
-    val userStatus = sam.getUserStatusInfo
-    // TODO: is it enough to check this one `getEnabled` boolean?
+    val callback = new SamApiCallback[UserStatusInfo]
     // TODO: should we use retries here?
     /* TODO: instead of directly calling Sam's userStatusInfo API, should we call a "real" api and, if that api returns
         401, echo its response? That would allow Orch to always give the same error response that Sam gives, but
         it is likely to be more expensive in the common case of the user being enabled.
      */
-    userStatus.getEnabled
+    sam.getUserStatusInfoAsync(callback)
+    // TODO: is it enough to check this one `getEnabled` boolean?
+    callback.future map (userStatus => Boolean.unbox(userStatus.getEnabled))
   }
 
   /**
     * Constructs and throws a FireCloudExceptionWithErrorReport in response to the
-    * enabled-user check. Hardcodes an ErrorReportSource to allow differentiating
-    * between enabled-user errors and other errors.
+    * enabled-user check.
     *
     * @param statusCode the http status code to throw
     * @param message message to use in the thrown exception
     * @return nothing
     */
   private def throwErrorReport(statusCode: StatusCode, message: String): Nothing = {
-    val errRpt = ErrorReport(statusCode, message)(ErrorReportSource("enabled-check"))
+    val errRpt = ErrorReport(statusCode, message)
     throw new FireCloudExceptionWithErrorReport(errRpt)
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/utils/EnabledUserDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/utils/EnabledUserDirectives.scala
@@ -1,0 +1,64 @@
+package org.broadinstitute.dsde.firecloud.utils
+
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
+import akka.http.scaladsl.model.{StatusCode, StatusCodes}
+import akka.http.scaladsl.server.Directives.{complete, extractUri}
+import akka.http.scaladsl.server.{RequestContext, Route, RouteResult}
+import com.typesafe.scalalogging.LazyLogging
+import org.broadinstitute.dsde.firecloud.{FireCloudConfig, FireCloudExceptionWithErrorReport}
+import org.broadinstitute.dsde.firecloud.model.UserInfo
+import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport.ErrorReportFormat
+import org.broadinstitute.dsde.rawls.model.{ErrorReport, ErrorReportSource}
+import org.broadinstitute.dsde.workbench.client.sam.api.UsersApi
+import org.broadinstitute.dsde.workbench.client.sam.{ApiClient, ApiException}
+
+import scala.concurrent.Future
+import scala.util.{Failure, Success, Try}
+
+trait EnabledUserDirectives extends LazyLogging  with SprayJsonSupport {
+
+  implicit val errorReportSource: ErrorReportSource = ErrorReportSource("enabled-check")
+
+  /**
+    * Queries Sam to see if the current user is enabled. If the user is disabled,
+    * responds with Forbidden and prevents the rest of the route from executing.
+    *
+    * @param userInfo credentials for the current user
+    * @param samBaseUrl where to find Sam - used for unit testing
+    * @return n/a
+    */
+  def requireEnabledUser(userInfo: UserInfo, samBaseUrl: String = FireCloudConfig.Sam.baseUrl)(innerRoute: RequestContext => Future[RouteResult]): Route = {
+    extractUri { uri =>
+      Try(getUserEnabled(userInfo.accessToken.token, samBaseUrl)) match {
+        case Success(true) =>
+          logger.debug(s"User ${userInfo.userEmail} is enabled: ${uri}")
+          innerRoute
+        case Success(false) =>
+          logger.warn(s"User ${userInfo.userEmail} is disabled: ${uri}")
+          throw new FireCloudExceptionWithErrorReport(ErrorReport(StatusCodes.Forbidden, StatusCodes.Forbidden.defaultMessage))
+          // complete(StatusCodes.Forbidden) // TODO: do we want a more helpful message like "user is disabled"?
+        case Failure(ex) => ex match {
+          case apiex:ApiException =>
+            logger.error(s"Exception checking enabled status for user ${userInfo.userEmail}: (${apiex.getMessage}) while calling ${uri}", apiex)
+            val code = StatusCode.int2StatusCode(apiex.getCode)
+            throw new FireCloudExceptionWithErrorReport(ErrorReport(code, apiex.getMessage))
+//            complete(code, ErrorReport(code, apiex.getMessage))
+          case ex =>
+            logger.error(s"Exception checking enabled status for user ${userInfo.userEmail}: (${ex.getMessage}) while calling ${uri}", ex)
+            throw new FireCloudExceptionWithErrorReport(ErrorReport(StatusCodes.InternalServerError, ex.getMessage))
+//            complete(StatusCodes.InternalServerError, ErrorReport(StatusCodes.InternalServerError, ex.getMessage))
+        }
+      }
+    }
+  }
+
+  private def getUserEnabled(token: String, samBaseUrl: String): Boolean = {
+    val apiClient = new ApiClient()
+    apiClient.setAccessToken(token)
+    apiClient.setBasePath(samBaseUrl)
+    val sam = new UsersApi(apiClient)
+    val userStatus = sam.getUserStatusInfo
+    userStatus.getEnabled
+  }
+
+}

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/ShareLogApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/ShareLogApiService.scala
@@ -4,12 +4,13 @@ import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
 import akka.http.scaladsl.server.Route
 import org.broadinstitute.dsde.firecloud.model.ShareLog.ShareType
 import org.broadinstitute.dsde.firecloud.service.{FireCloudDirectives, ShareLogService}
-import org.broadinstitute.dsde.firecloud.utils.StandardUserInfoDirectives
+import org.broadinstitute.dsde.firecloud.utils.{EnabledUserDirectives, StandardUserInfoDirectives}
 
 import scala.concurrent.ExecutionContext
 
 trait ShareLogApiService extends FireCloudDirectives
-  with StandardUserInfoDirectives with SprayJsonSupport {
+  with StandardUserInfoDirectives with EnabledUserDirectives
+  with SprayJsonSupport {
 
   implicit val executionContext: ExecutionContext
   val shareLogServiceConstructor: () => ShareLogService
@@ -20,7 +21,9 @@ trait ShareLogApiService extends FireCloudDirectives
         get {
           parameter("shareType".?) { shareType =>
             requireUserInfo() { userInfo =>
-              complete { shareLogServiceConstructor().getSharees(userInfo.id, shareType.map(ShareType.withName)) }
+               requireEnabledUser(userInfo) {
+                complete { shareLogServiceConstructor().getSharees(userInfo.id, shareType.map(ShareType.withName)) }
+               }
             }
           }
         }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/UserApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/UserApiService.scala
@@ -9,7 +9,7 @@ import org.broadinstitute.dsde.firecloud.FireCloudConfig
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
 import org.broadinstitute.dsde.firecloud.model._
 import org.broadinstitute.dsde.firecloud.service._
-import org.broadinstitute.dsde.firecloud.utils.{RestJsonClient, StandardUserInfoDirectives}
+import org.broadinstitute.dsde.firecloud.utils.{EnabledUserDirectives, RestJsonClient, StandardUserInfoDirectives}
 import org.broadinstitute.dsde.rawls.model.ErrorReport
 import org.slf4j.LoggerFactory
 
@@ -52,7 +52,12 @@ object UserApiService {
 
 // TODO: this should use UserInfoDirectives, not StandardUserInfoDirectives. That would require a refactoring
 // of how we create service actors, so I'm pushing that work out to later.
-trait UserApiService extends FireCloudRequestBuilding with FireCloudDirectives with StandardUserInfoDirectives with RestJsonClient {
+trait UserApiService
+  extends FireCloudRequestBuilding
+    with FireCloudDirectives
+    with StandardUserInfoDirectives
+    with EnabledUserDirectives
+    with RestJsonClient {
 
   implicit val executionContext: ExecutionContext
 
@@ -115,19 +120,17 @@ trait UserApiService extends FireCloudRequestBuilding with FireCloudDirectives w
         }
       } ~
       path("profile" / "terra") {
-        get {
-          requireUserInfo() { userInfo =>
-            complete { userServiceConstructor(userInfo).getTerraPreference }
-          }
-        } ~
-        post {
-          requireUserInfo() { userInfo =>
-            complete { userServiceConstructor(userInfo).setTerraPreference() }
-          }
-        } ~
-        delete {
-          requireUserInfo() { userInfo =>
-            complete { userServiceConstructor(userInfo).deleteTerraPreference() }
+        requireUserInfo() { userInfo =>
+          requireEnabledUser(userInfo) {
+            get {
+              complete { userServiceConstructor(userInfo).getTerraPreference }
+            } ~
+            post {
+              complete { userServiceConstructor(userInfo).setTerraPreference() }
+            } ~
+            delete {
+              complete { userServiceConstructor(userInfo).deleteTerraPreference() }
+            }
           }
         }
       } ~

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/utils/EnabledUserDirectivesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/utils/EnabledUserDirectivesSpec.scala
@@ -1,0 +1,136 @@
+package org.broadinstitute.dsde.firecloud.utils
+
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.StatusCodes.{ImATeapot, OK}
+import akka.http.scaladsl.model.headers.OAuth2BearerToken
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.Route.seal
+import akka.http.scaladsl.server._
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import org.broadinstitute.dsde.firecloud.FireCloudApiService
+import org.broadinstitute.dsde.firecloud.mock.MockUtils
+import org.broadinstitute.dsde.firecloud.model.UserInfo
+import org.broadinstitute.dsde.rawls.model.ErrorReport
+import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport.ErrorReportFormat
+import org.mockserver.integration.ClientAndServer
+import org.mockserver.integration.ClientAndServer.startClientAndServer
+import org.mockserver.model.Header
+import org.mockserver.model.HttpRequest.request
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+class EnabledUserDirectivesSpec
+  extends AnyFreeSpec
+    with EnabledUserDirectives
+    with Matchers
+    with ScalatestRouteTest
+    with BeforeAndAfterAll
+    with SprayJsonSupport {
+
+  val enabledUser: UserInfo = UserInfo("enabled@nowhere.com", OAuth2BearerToken("enabled"), 123456, "enabled-id")
+  val disabledUser: UserInfo = UserInfo("disabled@nowhere.com", OAuth2BearerToken("disabled"), 123456, "disabled-id")
+  val samApiExceptionUser: UserInfo = UserInfo("samapiexception@nowhere.com", OAuth2BearerToken("samapiexception"), 123456, "samapiexception-id")
+
+  val samUserInfoPath = "/register/user/v2/self/info"
+
+  var mockSamServer: ClientAndServer = _
+
+  def stopMockSamServer(): Unit = {
+    mockSamServer.stop()
+  }
+
+  def startMockSamServer(): Unit = {
+    mockSamServer = startClientAndServer(MockUtils.samServerPort)
+
+    // enabled user
+    mockSamServer
+      .when(request
+        .withMethod("GET")
+        .withPath(samUserInfoPath)
+        .withHeader(new Header("Authorization", "Bearer enabled")))
+      .respond(
+        org.mockserver.model.HttpResponse.response()
+          .withHeaders(MockUtils.header).withBody("""{
+                                                    |  "adminEnabled": true,
+                                                    |  "enabled": true,
+                                                    |  "userEmail": "enabled@nowhere.com",
+                                                    |  "userSubjectId": "enabled-id"
+                                                    |}""".stripMargin).withStatusCode(OK.intValue)
+      )
+
+    // disabled user
+    mockSamServer
+      .when(request
+        .withMethod("GET")
+        .withPath(samUserInfoPath)
+        .withHeader(new Header("Authorization", "Bearer disabled")))
+      .respond(
+        org.mockserver.model.HttpResponse.response()
+          .withHeaders(MockUtils.header).withBody("""{
+                                                    |  "adminEnabled": false,
+                                                    |  "enabled": false,
+                                                    |  "userEmail": "disabled@nowhere.com",
+                                                    |  "userSubjectId": "disabled-id"
+                                                    |}""".stripMargin).withStatusCode(OK.intValue)
+      )
+
+    // ApiException from the Sam client
+    mockSamServer
+      .when(request
+        .withMethod("GET")
+        .withPath(samUserInfoPath)
+        .withHeader(new Header("Authorization", "Bearer samapiexception")))
+      .respond(
+        org.mockserver.model.HttpResponse.response()
+          .withHeaders(MockUtils.header).withBody("""{
+                                                    |  "source": "Sam",
+                                                    |  "message": "unit test error",
+                                                    |  "statusCode": 418,
+                                                    |  "causes": [],
+                                                    |}""".stripMargin).withStatusCode(ImATeapot.intValue)
+      )
+
+  }
+
+  override def beforeAll(): Unit = startMockSamServer()
+  override def afterAll(): Unit = stopMockSamServer()
+
+  // make sure to bring the exception handler into scope. This is what translates
+  // the exceptions into http responses, and it's used by FireCloudApiService, so
+  // we also use it here.
+  implicit val exceptionHandler: ExceptionHandler = FireCloudApiService.exceptionHandler
+
+  // define a simple route that uses requireEnabledUser
+  def userEnabledRoute(userInfo: UserInfo): Route = seal({
+    get {
+      requireEnabledUser(userInfo, s"http://localhost:${MockUtils.samServerPort}") {
+        complete("route was successful")
+      }
+    }
+  })
+
+  "requireEnabledUser" - {
+    "should allow enabled users" in {
+      Get() ~> userEnabledRoute(enabledUser) ~> check {
+        status shouldBe StatusCodes.OK
+        responseAs[String] shouldBe "route was successful"
+      }
+    }
+    "should 403 for disabled users" in {
+      Get() ~> userEnabledRoute(disabledUser) ~> check {
+        status shouldBe StatusCodes.Forbidden
+        val err = responseAs[ErrorReport]
+        err.message shouldBe StatusCodes.Forbidden.defaultMessage
+      }
+    }
+    "should bubble up exceptions encountered while calling Sam" in {
+      Get() ~> userEnabledRoute(samApiExceptionUser) ~> check {
+        status shouldBe StatusCodes.ImATeapot
+        val err = responseAs[ErrorReport]
+        err.message shouldBe s"Client Error (${StatusCodes.ImATeapot.intValue})"
+      }
+    }
+  }
+}

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/utils/EnabledUserDirectivesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/utils/EnabledUserDirectivesSpec.scala
@@ -21,6 +21,8 @@ import org.scalatest.BeforeAndAfterAll
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 
+import scala.concurrent.ExecutionContext
+
 class EnabledUserDirectivesSpec
   extends AnyFreeSpec
     with EnabledUserDirectives
@@ -28,6 +30,8 @@ class EnabledUserDirectivesSpec
     with ScalatestRouteTest
     with BeforeAndAfterAll
     with SprayJsonSupport {
+
+  override implicit val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
 
   val enabledUser: UserInfo = UserInfo("enabled@nowhere.com", OAuth2BearerToken("enabled"), 123456, "enabled-id")
   val disabledUser: UserInfo = UserInfo("disabled@nowhere.com", OAuth2BearerToken("disabled"), 123456, "disabled-id")
@@ -133,4 +137,5 @@ class EnabledUserDirectivesSpec
       }
     }
   }
+
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/utils/EnabledUserDirectivesSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/utils/EnabledUserDirectivesSpec.scala
@@ -120,9 +120,9 @@ class EnabledUserDirectivesSpec
     }
     "should 403 for disabled users" in {
       Get() ~> userEnabledRoute(disabledUser) ~> check {
-        status shouldBe StatusCodes.Forbidden
+        status shouldBe StatusCodes.Unauthorized
         val err = responseAs[ErrorReport]
-        err.message shouldBe StatusCodes.Forbidden.defaultMessage
+        err.message shouldBe "User is disabled."
       }
     }
     "should bubble up exceptions encountered while calling Sam" in {

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/ShareLogApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/ShareLogApiServiceSpec.scala
@@ -1,21 +1,49 @@
 package org.broadinstitute.dsde.firecloud.webservice
 
-import akka.actor.ActorRefFactory
-import org.broadinstitute.dsde.firecloud.dataaccess.ShareLogApiServiceSpecShareLogDAO
-import org.broadinstitute.dsde.firecloud.integrationtest.ElasticSearchShareLogDAOSpecFixtures
-import org.broadinstitute.dsde.firecloud.model.UserInfo
-import org.broadinstitute.dsde.firecloud.model.ShareLog.ShareType
-import org.broadinstitute.dsde.firecloud.service.{BaseServiceSpec, ShareLogService}
-import akka.http.scaladsl.server.Route.{seal => sealRoute}
 import akka.http.scaladsl.model.StatusCodes._
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
+import akka.http.scaladsl.server.Route.{seal => sealRoute}
+import org.broadinstitute.dsde.firecloud.dataaccess.ShareLogApiServiceSpecShareLogDAO
+import org.broadinstitute.dsde.firecloud.integrationtest.ElasticSearchShareLogDAOSpecFixtures
+import org.broadinstitute.dsde.firecloud.mock.MockUtils
+import org.broadinstitute.dsde.firecloud.model.ShareLog.ShareType
+import org.broadinstitute.dsde.firecloud.model.UserInfo
+import org.broadinstitute.dsde.firecloud.service.{BaseServiceSpec, ShareLogService}
+import org.mockserver.integration.ClientAndServer
+import org.mockserver.integration.ClientAndServer.startClientAndServer
+import org.mockserver.model.HttpRequest.request
+import org.scalatest.BeforeAndAfterAll
 import spray.json.DefaultJsonProtocol._
 
 import scala.concurrent.ExecutionContext
 
-final class ShareLogApiServiceSpec extends BaseServiceSpec with ShareLogApiService {
+final class ShareLogApiServiceSpec extends BaseServiceSpec with ShareLogApiService with BeforeAndAfterAll {
 
   override val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
+
+  // mockserver to return an enabled user from Sam
+  var mockSamServer: ClientAndServer = _
+
+  override def afterAll(): Unit = mockSamServer.stop()
+
+  override def beforeAll(): Unit = {
+    mockSamServer = startClientAndServer(MockUtils.samServerPort)
+
+    // enabled user
+    mockSamServer
+      .when(request
+        .withMethod("GET")
+        .withPath("/register/user/v2/self/info"))
+      .respond(
+        org.mockserver.model.HttpResponse.response()
+          .withHeaders(MockUtils.header).withBody("""{
+                                                    |  "adminEnabled": true,
+                                                    |  "enabled": true,
+                                                    |  "userEmail": "enabled@nowhere.com",
+                                                    |  "userSubjectId": "enabled-id"
+                                                    |}""".stripMargin).withStatusCode(OK.intValue)
+      )
+  }
 
   final val sharingUser = UserInfo("fake1@gmail.com", OAuth2BearerToken(dummyToken), 3600L, "fake1")
 


### PR DESCRIPTION
- [ ] TODO: update the error handler to provide better error messages for the APIs that have implicit protection and don't use `requireEnabledUser`

-----

This PR adds the ability to wrap an API with a Sam call. The Sam call will verify if the current user is enabled or not; if the user is not enabled, the API will short-circuit and return a 401.

In this PR, I protect only a few APIs, in `UserApiService` and `ShareLogApiService`. Orch will need to implement this for multiple additional APIs; I'll do that in a follow-on PR once this is approved and merged and shown to be working well.

See the `TODO` comments in `EnabledUserDirectives` for areas where I'd love additional feedback.

response for an unregistered user:
```json
{
  "causes": [],
  "message": "User is not registered.",
  "source": "Orchestration-enabled-check",
  "stackTrace": [],
  "statusCode": 401
}
```

response for a registered but disabled user:
```json
{
  "causes": [],
  "message": "User is disabled.",
  "source": "Orchestration-enabled-check",
  "stackTrace": [],
  "statusCode": 401
}
```

compare also to https://github.com/broadinstitute/agora/pull/323 and https://github.com/broadinstitute/cromwell/pull/6826
