### PR TITLE
Ensure all APIs include an authenticated API call [AJ-510]

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/NihApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/NihApiService.scala
@@ -6,12 +6,12 @@ import akka.http.scaladsl.server.{Directives, Route}
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
 import org.broadinstitute.dsde.firecloud.model._
 import org.broadinstitute.dsde.firecloud.service.NihService
-import org.broadinstitute.dsde.firecloud.utils.StandardUserInfoDirectives
+import org.broadinstitute.dsde.firecloud.utils.{EnabledUserDirectives, StandardUserInfoDirectives}
 import org.slf4j.LoggerFactory
 
 import scala.concurrent.ExecutionContext
 
-trait NihApiService extends Directives with RequestBuilding with StandardUserInfoDirectives {
+trait NihApiService extends Directives with RequestBuilding with EnabledUserDirectives with StandardUserInfoDirectives {
 
   implicit val executionContext: ExecutionContext
   lazy val log = LoggerFactory.getLogger(getClass)
@@ -31,21 +31,23 @@ trait NihApiService extends Directives with RequestBuilding with StandardUserInf
 
   val nihRoutes: Route =
     requireUserInfo() { userInfo =>
-      pathPrefix("nih") {
-        // api/nih/callback: accept JWT, update linkage + lastlogin
-        path("callback") {
-          post {
-            entity(as[JWTWrapper]) { jwtWrapper =>
-              complete { nihServiceConstructor().updateNihLinkAndSyncSelf(userInfo, jwtWrapper) }
+      requireEnabledUser(userInfo) {
+        pathPrefix("nih") {
+          // api/nih/callback: accept JWT, update linkage + lastlogin
+          path("callback") {
+            post {
+              entity(as[JWTWrapper]) { jwtWrapper =>
+                complete { nihServiceConstructor().updateNihLinkAndSyncSelf(userInfo, jwtWrapper) }
+              }
             }
-          }
-        } ~
-        path ("status") {
-          complete { nihServiceConstructor().getNihStatus(userInfo) }
-        } ~
-        path ("account") {
-          delete {
-            complete { nihServiceConstructor().unlinkNihAccountAndSyncSelf(userInfo).map(_ => StatusCodes.NoContent) }
+          } ~
+          path ("status") {
+            complete { nihServiceConstructor().getNihStatus(userInfo) }
+          } ~
+          path ("account") {
+            delete {
+              complete { nihServiceConstructor().unlinkNihAccountAndSyncSelf(userInfo).map(_ => StatusCodes.NoContent) }
+            }
           }
         }
       }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/RegisterApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/RegisterApiService.scala
@@ -5,14 +5,14 @@ import akka.http.scaladsl.model.HttpMethods.{DELETE, GET, POST}
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
 import org.broadinstitute.dsde.firecloud.model._
 import org.broadinstitute.dsde.firecloud.service.{FireCloudDirectives, RegisterService}
-import org.broadinstitute.dsde.firecloud.utils.StandardUserInfoDirectives
+import org.broadinstitute.dsde.firecloud.utils.{EnabledUserDirectives, StandardUserInfoDirectives}
 import spray.json.DefaultJsonProtocol._
 import akka.http.scaladsl.server.Route
 import org.broadinstitute.dsde.firecloud.service.RegisterService.{samTosBaseUrl, samTosStatusUrl, samTosTextUrl}
 
 import scala.concurrent.ExecutionContext
 
-trait RegisterApiService extends FireCloudDirectives with RequestBuilding with StandardUserInfoDirectives {
+trait RegisterApiService extends FireCloudDirectives with EnabledUserDirectives with RequestBuilding with StandardUserInfoDirectives {
 
   implicit val executionContext: ExecutionContext
 
@@ -36,8 +36,10 @@ trait RegisterApiService extends FireCloudDirectives with RequestBuilding with S
       path("preferences") {
         post {
           requireUserInfo() { userInfo =>
-            entity(as[Map[String, String]]) { preferences =>
-              complete { registerServiceConstructor().updateProfilePreferences(userInfo, preferences) }
+            requireEnabledUser(userInfo) {
+              entity(as[Map[String, String]]) { preferences =>
+                complete { registerServiceConstructor().updateProfilePreferences(userInfo, preferences) }
+              }
             }
           }
         }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/UserApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/UserApiService.scala
@@ -156,7 +156,11 @@ trait UserApiService
         pathEnd {
           get {
             requireUserInfo() { userInfo =>
-              complete { userServiceConstructor(userInfo).getAllUserKeys }
+              requireEnabledUser(userInfo) {
+                complete {
+                  userServiceConstructor(userInfo).getAllUserKeys
+                }
+              }
             }
           }
         }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/mock/SamMockserverUtils.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/mock/SamMockserverUtils.scala
@@ -1,0 +1,31 @@
+package org.broadinstitute.dsde.firecloud.mock
+
+import akka.http.scaladsl.model.StatusCodes.OK
+import org.mockserver.integration.ClientAndServer
+import org.mockserver.model.HttpRequest.request
+import org.mockserver.model.HttpResponse.response
+
+trait SamMockserverUtils {
+
+  /**
+    * configures a Sam mockserver instance to return an enabled user from
+    * the /register/user/v2/self/info api.
+    *
+    * @param samMockserver the Sam mockserver to configure
+    */
+  def returnEnabledUser(samMockserver: ClientAndServer): Unit = {
+    samMockserver
+      .when(request
+        .withMethod("GET")
+        .withPath("/register/user/v2/self/info"))
+      .respond(response()
+          .withHeaders(MockUtils.header).withBody(
+          """{
+            |  "adminEnabled": true,
+            |  "enabled": true,
+            |  "userEmail": "enabled@nowhere.com",
+            |  "userSubjectId": "enabled-id"
+            |}""".stripMargin).withStatusCode(OK.intValue))
+  }
+
+}

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/RegisterApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/RegisterApiServiceSpec.scala
@@ -8,17 +8,32 @@ import akka.http.scaladsl.model.StatusCodes.{BadRequest, Forbidden, NoContent, O
 import akka.http.scaladsl.model.StatusCode
 import akka.http.scaladsl.server.Route.{seal => sealRoute}
 import org.broadinstitute.dsde.firecloud.HealthChecks.termsOfServiceUrl
-import org.broadinstitute.dsde.firecloud.mock.MockUtils
+import org.broadinstitute.dsde.firecloud.mock.{MockUtils, SamMockserverUtils}
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol.impBasicProfile
+import org.mockserver.integration.ClientAndServer
+import org.mockserver.integration.ClientAndServer.startClientAndServer
+import org.scalatest.BeforeAndAfterAll
 import spray.json.DefaultJsonProtocol
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Success
 
 final class RegisterApiServiceSpec extends BaseServiceSpec with RegisterApiService
-  with DefaultJsonProtocol with SprayJsonSupport {
+  with DefaultJsonProtocol with SprayJsonSupport
+  with BeforeAndAfterAll with SamMockserverUtils {
 
   override val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
+
+  // mockserver to return an enabled user from Sam
+  var mockSamServer: ClientAndServer = _
+
+  override def afterAll(): Unit = mockSamServer.stop()
+
+  override def beforeAll(): Unit = {
+    mockSamServer = startClientAndServer(MockUtils.samServerPort)
+    returnEnabledUser(mockSamServer)
+  }
+
 
   override val registerServiceConstructor:() => RegisterService =
     RegisterService.constructor(app.copy(thurloeDAO = new RegisterApiServiceSpecThurloeDAO))

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/ShareLogApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/ShareLogApiServiceSpec.scala
@@ -5,7 +5,7 @@ import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import akka.http.scaladsl.server.Route.{seal => sealRoute}
 import org.broadinstitute.dsde.firecloud.dataaccess.ShareLogApiServiceSpecShareLogDAO
 import org.broadinstitute.dsde.firecloud.integrationtest.ElasticSearchShareLogDAOSpecFixtures
-import org.broadinstitute.dsde.firecloud.mock.MockUtils
+import org.broadinstitute.dsde.firecloud.mock.{MockUtils, SamMockserverUtils}
 import org.broadinstitute.dsde.firecloud.model.ShareLog.ShareType
 import org.broadinstitute.dsde.firecloud.model.UserInfo
 import org.broadinstitute.dsde.firecloud.service.{BaseServiceSpec, ShareLogService}
@@ -17,7 +17,7 @@ import spray.json.DefaultJsonProtocol._
 
 import scala.concurrent.ExecutionContext
 
-final class ShareLogApiServiceSpec extends BaseServiceSpec with ShareLogApiService with BeforeAndAfterAll {
+final class ShareLogApiServiceSpec extends BaseServiceSpec with ShareLogApiService with SamMockserverUtils with BeforeAndAfterAll {
 
   override val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
 
@@ -28,21 +28,7 @@ final class ShareLogApiServiceSpec extends BaseServiceSpec with ShareLogApiServi
 
   override def beforeAll(): Unit = {
     mockSamServer = startClientAndServer(MockUtils.samServerPort)
-
-    // enabled user
-    mockSamServer
-      .when(request
-        .withMethod("GET")
-        .withPath("/register/user/v2/self/info"))
-      .respond(
-        org.mockserver.model.HttpResponse.response()
-          .withHeaders(MockUtils.header).withBody("""{
-                                                    |  "adminEnabled": true,
-                                                    |  "enabled": true,
-                                                    |  "userEmail": "enabled@nowhere.com",
-                                                    |  "userSubjectId": "enabled-id"
-                                                    |}""".stripMargin).withStatusCode(OK.intValue)
-      )
+    returnEnabledUser(mockSamServer)
   }
 
   final val sharingUser = UserInfo("fake1@gmail.com", OAuth2BearerToken(dummyToken), 3600L, "fake1")

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/UserApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/UserApiServiceSpec.scala
@@ -5,7 +5,7 @@ import akka.http.scaladsl.model.HttpMethods
 import akka.http.scaladsl.model.StatusCodes._
 import akka.http.scaladsl.server.Route.{seal => sealRoute}
 import akka.http.scaladsl.unmarshalling.Unmarshal
-import org.broadinstitute.dsde.firecloud.mock.MockUtils
+import org.broadinstitute.dsde.firecloud.mock.{MockUtils, SamMockserverUtils}
 import org.broadinstitute.dsde.firecloud.mock.MockUtils._
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
 import org.broadinstitute.dsde.firecloud.model._
@@ -19,7 +19,8 @@ import spray.json._
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, ExecutionContext}
 
-class UserApiServiceSpec extends BaseServiceSpec with RegisterApiService with UserApiService with SprayJsonSupport {
+class UserApiServiceSpec extends BaseServiceSpec with SamMockserverUtils
+  with RegisterApiService with UserApiService with SprayJsonSupport {
 
   override val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
 
@@ -117,6 +118,8 @@ class UserApiServiceSpec extends BaseServiceSpec with RegisterApiService with Us
         org.mockserver.model.HttpResponse.response()
           .withHeaders(MockUtils.header).withStatusCode(OK.intValue)
       )
+
+    returnEnabledUser(samServer)
 
     profileServer = startClientAndServer(thurloeServerPort)
     // Generate a mock response for all combinations of profile properties


### PR DESCRIPTION
This PR ensures that every API in Orchestration includes an authenticated API call to a lower service. Disabled or unregistered users will now be rejected on every API call. 

This required updating a few APIs to add a call to Sam, as well as unit test updates.

Reviewer: I recommend ignoring whitespace changes; many lines changed indentation.

Still TODO after this PR merges:
- a bunch of manual end-to-end testing using different accounts in a real environment
- a follow-on PR to remove OpenDJ checks from Orch's proxy (AJ-517)


