### PR TITLE
do not require enabled user for register/profile [AJ-510]

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/UserApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/UserApiService.scala
@@ -156,10 +156,8 @@ trait UserApiService
         pathEnd {
           get {
             requireUserInfo() { userInfo =>
-              requireEnabledUser(userInfo) {
-                complete {
-                  userServiceConstructor(userInfo).getAllUserKeys
-                }
+              complete {
+                userServiceConstructor(userInfo).getAllUserKeys
               }
             }
           }


### PR DESCRIPTION
don't require an enabled+registered user for the /register/profile endpoint - that endpoint is used DURING registration so should be unprotected.