### PR TITLE
unit tests for disabled and unregistered users at /register/profile [AJ-510]

### DIFF
--- a/src/test/scala/org/broadinstitute/dsde/firecloud/utils/TestRequestBuilding.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/utils/TestRequestBuilding.scala
@@ -13,7 +13,7 @@ trait TestRequestBuilding extends FireCloudRequestBuilding {
   }
 
   def dummyUserIdHeaders(userId: String, token: String = "access_token", email: String = "random@site.com"): WithTransformerConcatenation[HttpRequest, HttpRequest] = {
-    addCredentials(OAuth2BearerToken(dummyToken)) ~>
+    addCredentials(OAuth2BearerToken(token)) ~>
       addHeader(RawHeader("OIDC_CLAIM_user_id", userId)) ~>
       addHeader(RawHeader("OIDC_access_token", token)) ~>
       addHeader(RawHeader("OIDC_CLAIM_email", email)) ~>

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/RegisterApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/RegisterApiServiceSpec.scala
@@ -3,8 +3,8 @@ package org.broadinstitute.dsde.firecloud.webservice
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
 import org.broadinstitute.dsde.firecloud.dataaccess.MockThurloeDAO
 import org.broadinstitute.dsde.firecloud.model.{BasicProfile, UserInfo}
-import org.broadinstitute.dsde.firecloud.service.{BaseServiceSpec, RegisterService}
-import akka.http.scaladsl.model.StatusCodes.{BadRequest, Forbidden, NoContent, OK}
+import org.broadinstitute.dsde.firecloud.service.{BaseServiceSpec, RegisterService, UserService}
+import akka.http.scaladsl.model.StatusCodes.{BadRequest, Forbidden, NoContent, NotFound, OK}
 import akka.http.scaladsl.model.StatusCode
 import akka.http.scaladsl.server.Route.{seal => sealRoute}
 import org.broadinstitute.dsde.firecloud.HealthChecks.termsOfServiceUrl
@@ -12,13 +12,15 @@ import org.broadinstitute.dsde.firecloud.mock.{MockUtils, SamMockserverUtils}
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol.impBasicProfile
 import org.mockserver.integration.ClientAndServer
 import org.mockserver.integration.ClientAndServer.startClientAndServer
+import org.mockserver.model.Header
+import org.mockserver.model.HttpRequest._
 import org.scalatest.BeforeAndAfterAll
 import spray.json.DefaultJsonProtocol
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Success
 
-final class RegisterApiServiceSpec extends BaseServiceSpec with RegisterApiService
+final class RegisterApiServiceSpec extends BaseServiceSpec with RegisterApiService with UserApiService
   with DefaultJsonProtocol with SprayJsonSupport
   with BeforeAndAfterAll with SamMockserverUtils {
 
@@ -31,12 +33,50 @@ final class RegisterApiServiceSpec extends BaseServiceSpec with RegisterApiServi
 
   override def beforeAll(): Unit = {
     mockSamServer = startClientAndServer(MockUtils.samServerPort)
+    // disabled user
+    mockSamServer
+      .when(request
+        .withMethod("GET")
+        .withPath("/register/user/v2/self/info")
+        .withHeader(new Header("Authorization", "Bearer disabled")))
+      .respond(
+        org.mockserver.model.HttpResponse.response()
+          .withHeaders(MockUtils.header).withBody(
+          """{
+            |  "adminEnabled": false,
+            |  "enabled": false,
+            |  "userEmail": "disabled@nowhere.com",
+            |  "userSubjectId": "disabled-id"
+            |}""".stripMargin).withStatusCode(OK.intValue)
+      )
+
+    // unregistered user
+    mockSamServer
+      .when(request
+        .withMethod("GET")
+        .withPath("/register/user/v2/self/info")
+        .withHeader(new Header("Authorization", "Bearer unregistered")))
+      .respond(
+        org.mockserver.model.HttpResponse.response()
+          .withHeaders(MockUtils.header).withBody(
+          """{
+            |  "causes": [],
+            |  "message": "Google Id unregistered-id not found in sam",
+            |  "source": "sam",
+            |  "stackTrace": [],
+            |  "statusCode": 404
+            |}""".stripMargin).withStatusCode(NotFound.intValue)
+      )
+
     returnEnabledUser(mockSamServer)
   }
 
 
   override val registerServiceConstructor:() => RegisterService =
     RegisterService.constructor(app.copy(thurloeDAO = new RegisterApiServiceSpecThurloeDAO))
+
+  override val userServiceConstructor:(UserInfo) => UserService =
+    UserService.constructor(app.copy(thurloeDAO = new RegisterApiServiceSpecThurloeDAO))
 
   "RegisterApiService" - {
     "update-preferences API" - {
@@ -90,7 +130,7 @@ final class RegisterApiServiceSpec extends BaseServiceSpec with RegisterApiServi
 
     }
 
-    "register-profile API" - {
+    "register-profile API POST" - {
       "should fail with no terms of service" in {
         val payload = makeBasicProfile(false)
         Post("/register/profile", payload) ~> dummyUserIdHeaders("RegisterApiServiceSpec", "new") ~> sealRoute(registerRoutes) ~> check {
@@ -128,6 +168,23 @@ final class RegisterApiServiceSpec extends BaseServiceSpec with RegisterApiServi
           nonProfitStatus = randomString,
           termsOfService = if (hasTermsOfService) Some(termsOfServiceUrl) else None
         )
+      }
+    }
+
+    "register-profile API GET" - {
+      // Because this endpoint is used during the registration process, it
+      // should always return info about the user; if it blocked unregistered
+      // or disabled users, those users would not be able to proceed.
+      //
+      // These tests will fail if GET /register/profile is put behind requireEnabledUser().
+      List("enabled", "disabled", "unregistered") foreach { testCase =>
+        s"should succeed for a(n) $testCase user" in {
+          Get("/register/profile") ~> dummyUserIdHeaders(userId = testCase, token = testCase) ~> sealRoute(userServiceRoutes) ~> check {
+            withClue(s"with actual response body: ${responseAs[String]}, got error message ->") {
+              status should be(OK)
+            }
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
This is a follow-up to #989. It adds unit tests to protect against the specific case that #989 fixed: all users, even disabled or unregistered users, should be allowed to GET the /register/profile API.