### PR TITLE
entity references in tsv [AJ-526]

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/TSVFileSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/TSVFileSupport.scala
@@ -146,14 +146,19 @@ trait TSVFileSupport {
   /*
   Creates an AttributeValue whose implementation is more closely tied to the value of the input.
    */
-  def stringToTypedAttribute(value: String): AttributeValue = {
+  def stringToTypedAttribute(value: String): Attribute = {
     Try (java.lang.Integer.parseInt(value)) match {
       case Success(intValue) => AttributeNumber(intValue)
       case Failure(_) => Try (java.lang.Double.parseDouble(value)) match {
         case Success(doubleValue) => AttributeNumber(doubleValue)
         case Failure(_) => Try(BooleanUtils.toBoolean(value.toLowerCase, "true", "false")) match {
           case Success(booleanValue) => AttributeBoolean(booleanValue)
-          case Failure(_) => AttributeString(value)
+          case Failure(_) =>
+            Try(value.parseJson.convertTo[AttributeEntityReference]) match {
+              case Success(ref) => ref
+              case Failure(_) => AttributeString(value)
+            }
+
         }
       }
     }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/utils/TSVFormatter.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/utils/TSVFormatter.scala
@@ -6,6 +6,9 @@ import org.broadinstitute.dsde.firecloud.service.TsvTypes
 
 object TSVFormatter {
 
+  // for serializing entity references
+  val attributeFormat = new AttributeFormat with PlainArrayAttributeListSerializer
+
   /**
     * Generate file content from headers and rows.
     *
@@ -71,7 +74,14 @@ object TSVFormatter {
     * @param value The input attribute to make safe
     * @return the safe value
     */
-  def tsvSafeAttribute(attribute: Attribute): String = tsvSafeString(AttributeStringifier(attribute))
+  def tsvSafeAttribute(attribute: Attribute): String = {
+    val intermediateString = attribute match {
+      case ref:AttributeEntityReference => attributeFormat.write(ref).compactPrint
+      case refs:AttributeEntityReferenceList => attributeFormat.write(refs).compactPrint
+      case _ => AttributeStringifier(attribute)
+    }
+    tsvSafeString(intermediateString)
+  }
 
   /**
     * Creates a string that is safe to output into a TSV as a cell value.

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/utils/TSVFormatter.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/utils/TSVFormatter.scala
@@ -75,9 +75,10 @@ object TSVFormatter {
     * @return the safe value
     */
   def tsvSafeAttribute(attribute: Attribute): String = {
+    // AttributeStringifier works for everything except single entity references;
+    // it even works for AttributeEntityReferenceList
     val intermediateString = attribute match {
       case ref:AttributeEntityReference => attributeFormat.write(ref).compactPrint
-      case refs:AttributeEntityReferenceList => attributeFormat.write(refs).compactPrint
       case _ => AttributeStringifier(attribute)
     }
     tsvSafeString(intermediateString)

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/TSVFileSupportSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/TSVFileSupportSpec.scala
@@ -103,6 +103,9 @@ class TSVFileSupportSpec extends AnyFreeSpec with TSVFileSupport {
       Double.MaxValue.toString -> AttributeNumber(Double.MaxValue)
     )
     val stringTestCases = List("", "string", "true525600", ",")
+    val referenceTestCases = Map(
+      """{"entityType":"targetType","entityName":"targetName"}""" -> AttributeEntityReference("targetType", "targetName")
+    )
 
     "should detect boolean values when applicable" in {
       booleanTestCases foreach {
@@ -123,6 +126,14 @@ class TSVFileSupportSpec extends AnyFreeSpec with TSVFileSupport {
     "should detect double values when applicable" in {
       doubleTestCases foreach {
         case (input, expected) => withClue(s"should handle potential double: $input") {
+          stringToTypedAttribute(input) shouldBe expected
+        }
+      }
+    }
+
+    "should detect entity references when applicable" in {
+      referenceTestCases foreach {
+        case (input, expected) => withClue(s"should handle potential reference: $input") {
           stringToTypedAttribute(input) shouldBe expected
         }
       }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/utils/TSVFormatterSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/utils/TSVFormatterSpec.scala
@@ -208,7 +208,11 @@ class TSVFormatterSpec extends AnyFreeSpec with ScalaFutures with Matchers with 
       AttributeBoolean(true) -> "true",
       AttributeBoolean(false) -> "false",
       AttributeValueList(Seq(AttributeString("one"), AttributeString("two"), AttributeString("three"))) -> """["one","two","three"]""",
-      AttributeValueRawJson(JsObject(Map("foo" -> JsString("bar"), "baz" -> JsNumber(123)))) -> """{"foo":"bar","baz":123}"""
+      AttributeValueRawJson(JsObject(Map("foo" -> JsString("bar"), "baz" -> JsNumber(123)))) -> """{"foo":"bar","baz":123}""",
+      AttributeEntityReference("targetType", "targetName") -> """{"entityType":"targetType","entityName":"targetName"}""",
+      AttributeEntityReferenceList(Seq(
+        AttributeEntityReference("type1", "name1"),
+        AttributeEntityReference("type2", "name2"))) -> """[{"entityType":"type1","entityName":"name1"},{"entityType":"type2","entityName":"name2"}]"""
     )
     "tsvSafeAttribute() method" - {
       tsvSafeAttributeTestData foreach {


### PR DESCRIPTION
single entity references were neither downloaded nor uploaded properly via TSV. On download, they were converted to a string of the referenced entity's name (the referenced entity's type was left out). 

If a power user magically knew the proper json format for an entity reference and tried to upload it in a TSV, the json in the TSV was saved as a string.

This PR fixes both. If a data table contains an entity reference, it can now be downloaded and re-uploaded with full fidelity.

Entity reference _*lists*_ were working properly before this PR and continue to work properly.