### PR TITLE
add pr-labeler config file [AJ-557]

### DIFF
--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -1,0 +1,1 @@
+Scala_Steward: 'update/*'


### PR DESCRIPTION
Scala Steward PRs were not being automatically labeled with the "Scala_Steward" label, because the config file for the github action was missing.

This PR adds the config file, copied from Rawls.

N.B. I have manually labeled the existing PRs; the automatic labeling will only come into effect next Monday when the next batch of PRs are created.