### PR TITLE
Swagger updates [AJ-558]

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -750,24 +750,9 @@ paths:
       summary: Get a Method Repository configuration
       operationId: getMethodRepositoryConfiguration
       parameters:
-        - name: namespace
-          in: path
-          description: Method Configuration Namespace
-          required: true
-          schema:
-            type: string
-        - name: name
-          in: path
-          description: Method Configuration Name
-          required: true
-          schema:
-            type: string
-        - name: snapshotId
-          in: path
-          description: Method Configuration snapshot ID
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/configNamespaceParam'
+        - $ref: '#/components/parameters/configNameParam'
+        - $ref: '#/components/parameters/configSnapshotId'
         - name: payloadAsObject
           in: query
           description: Instead of returning a string under key payload, return a JSON
@@ -797,24 +782,9 @@ paths:
       description: |
         Redacts a configuration and all of its associated configurations
       parameters:
-        - name: namespace
-          in: path
-          description: Method Configuration Namespace
-          required: true
-          schema:
-            type: string
-        - name: name
-          in: path
-          description: Method Configuration Name
-          required: true
-          schema:
-            type: string
-        - name: snapshotId
-          in: path
-          description: Method Configuration snapshot ID
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/configNamespaceParam'
+        - $ref: '#/components/parameters/configNameParam'
+        - $ref: '#/components/parameters/configSnapshotId'
       responses:
         200:
           description: |
@@ -839,24 +809,9 @@ paths:
       summary: get ACL permissions on a Method Repository configuration
       operationId: getConfigACL
       parameters:
-        - name: namespace
-          in: path
-          description: Method Configuration Namespace
-          required: true
-          schema:
-            type: string
-        - name: name
-          in: path
-          description: Method Configuration Name
-          required: true
-          schema:
-            type: string
-        - name: snapshotId
-          in: path
-          description: Method Configuration snapshot ID
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/configNamespaceParam'
+        - $ref: '#/components/parameters/configNameParam'
+        - $ref: '#/components/parameters/configSnapshotId'
       responses:
         200:
           description: the indicated configuration ACL
@@ -874,24 +829,9 @@ paths:
       summary: set ACL permissions on a Method Repository configuration
       operationId: setConfigACL
       parameters:
-        - name: namespace
-          in: path
-          description: Method Configuration Namespace
-          required: true
-          schema:
-            type: string
-        - name: name
-          in: path
-          description: Method Configuration Name
-          required: true
-          schema:
-            type: string
-        - name: snapshotId
-          in: path
-          description: Method Configuration snapshot ID
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/configNamespaceParam'
+        - $ref: '#/components/parameters/configNameParam'
+        - $ref: '#/components/parameters/configSnapshotId'
       requestBody:
         description: the ACLs to upsert
         content:
@@ -922,12 +862,7 @@ paths:
       summary: get ACL permissions on a Method Repository Configuration Namespace
       operationId: getConfigNamespaceACL
       parameters:
-        - name: namespace
-          in: path
-          description: Method Configuration Namespace
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/configNamespaceParam'
       responses:
         200:
           description: List of the indicated configuration namespace ACL permissions
@@ -949,12 +884,7 @@ paths:
       summary: set ACL permissions on a Method Repository Configuration Namespace
       operationId: setConfigNamespaceACL
       parameters:
-        - name: namespace
-          in: path
-          description: Method Configuration Namespace
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/configNamespaceParam'
       requestBody:
         description: the ACLs to upsert
         content:
@@ -2357,18 +2287,8 @@ paths:
         Given the namespace/name of a method, returns all configurations
         in the repository that reference that method
       parameters:
-        - name: namespace
-          in: path
-          description: Namespace of method.
-          required: true
-          schema:
-            type: string
-        - name: name
-          in: path
-          description: Name of method.
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/methodNamespaceParam'
+        - $ref: '#/components/parameters/methodNameParam'
       responses:
         200:
           description: An array of configurations.
@@ -2398,24 +2318,9 @@ paths:
         Returns one method that matches the namespace,
         name, and snapshotId.
       parameters:
-        - name: namespace
-          in: path
-          description: Method Namespace
-          required: true
-          schema:
-            type: string
-        - name: name
-          in: path
-          description: Method Name
-          required: true
-          schema:
-            type: string
-        - name: snapshotId
-          in: path
-          description: Method snapshot ID
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/methodNamespaceParam'
+        - $ref: '#/components/parameters/methodNameParam'
+        - $ref: '#/components/parameters/methodSnapshotId'
         - name: onlyPayload
           in: query
           description: Boolean to return only the payload of the method.
@@ -2448,24 +2353,9 @@ paths:
         arguments considered for the new snapshot; everything else is copied
         from the source.
       parameters:
-        - name: namespace
-          in: path
-          description: Method Namespace
-          required: true
-          schema:
-            type: string
-        - name: name
-          in: path
-          description: Method Name
-          required: true
-          schema:
-            type: string
-        - name: snapshotId
-          in: path
-          description: Method snapshot ID
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/methodNamespaceParam'
+        - $ref: '#/components/parameters/methodNameParam'
+        - $ref: '#/components/parameters/methodSnapshotId'
         - name: redact
           in: query
           description: Should the source method be redacted?
@@ -2532,24 +2422,9 @@ paths:
       description: |
         Redacts a method and all of its associated configurations
       parameters:
-        - name: namespace
-          in: path
-          description: Method Namespace
-          required: true
-          schema:
-            type: string
-        - name: name
-          in: path
-          description: Method Name
-          required: true
-          schema:
-            type: string
-        - name: snapshotId
-          in: path
-          description: Method snapshot ID
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/methodNamespaceParam'
+        - $ref: '#/components/parameters/methodNameParam'
+        - $ref: '#/components/parameters/methodSnapshotId'
       responses:
         200:
           description: |
@@ -2577,24 +2452,9 @@ paths:
         arguments as the supplied method snapshot, and 2. reference any snapshot
         of this method.
       parameters:
-        - name: namespace
-          in: path
-          description: Method Namespace
-          required: true
-          schema:
-            type: string
-        - name: name
-          in: path
-          description: Method Name
-          required: true
-          schema:
-            type: string
-        - name: snapshotId
-          in: path
-          description: Method snapshot ID
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/methodNamespaceParam'
+        - $ref: '#/components/parameters/methodNameParam'
+        - $ref: '#/components/parameters/methodSnapshotId'
       responses:
         200:
           description: An array of configurations.
@@ -2625,24 +2485,9 @@ paths:
       summary: get ACL permissions on a Method Repository method
       operationId: getMethodACL
       parameters:
-        - name: namespace
-          in: path
-          description: Method Namespace
-          required: true
-          schema:
-            type: string
-        - name: name
-          in: path
-          description: Method Name
-          required: true
-          schema:
-            type: string
-        - name: snapshotId
-          in: path
-          description: Method snapshot ID
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/methodNamespaceParam'
+        - $ref: '#/components/parameters/methodNameParam'
+        - $ref: '#/components/parameters/methodSnapshotId'
       responses:
         200:
           description: the indicated method ACL
@@ -2660,24 +2505,9 @@ paths:
       summary: set ACL permissions on a Method Repository method
       operationId: setMethodACL
       parameters:
-        - name: namespace
-          in: path
-          description: Method Namespace
-          required: true
-          schema:
-            type: string
-        - name: name
-          in: path
-          description: Method Name
-          required: true
-          schema:
-            type: string
-        - name: snapshotId
-          in: path
-          description: Method snapshot ID
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/methodNamespaceParam'
+        - $ref: '#/components/parameters/methodNameParam'
+        - $ref: '#/components/parameters/methodSnapshotId'
       requestBody:
         description: the ACLs to upsert
         content:
@@ -2708,12 +2538,7 @@ paths:
       summary: get ACL permissions on a Method Repository Method Namespace
       operationId: getMethodNamespaceACL
       parameters:
-        - name: namespace
-          in: path
-          description: Method Namespace
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/methodNamespaceParam'
       responses:
         200:
           description: List of indicated method namespace ACL permissions
@@ -2735,12 +2560,7 @@ paths:
       summary: set ACL permissions on a Method Repository Method Namespace
       operationId: setMethodNamespaceACL
       parameters:
-        - name: namespace
-          in: path
-          description: Method Namespace
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/methodNamespaceParam'
       requestBody:
         description: the ACLs to upsert
         content:

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -100,12 +100,7 @@ paths:
       summary: list members of billing project the caller owns
       operationId: listBillingProjectMembers
       parameters:
-        - name: projectId
-          in: path
-          description: Project ID
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/billingProjectPathParam'
       responses:
         200:
           description: Success
@@ -137,12 +132,7 @@ paths:
       description: get the spend report configuration for the billing project
       operationId: getSpendReportConfiguration
       parameters:
-        - name: projectId
-          in: path
-          description: Billing Project ID
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/billingProjectPathParam'
       responses:
         200:
           description: Successfully retrieved spend report configuration
@@ -179,12 +169,7 @@ paths:
       description: set the spend configuration for the billing project
       operationId: setSpendReportConfiguration
       parameters:
-        - name: projectId
-          in: path
-          description: Billing Project ID
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/billingProjectPathParam'
       requestBody:
         description: billing project spend configuration information
         content:
@@ -227,12 +212,7 @@ paths:
       description: clear the spend configuration for the billing project
       operationId: clearSpendReportConfiguration
       parameters:
-        - name: projectId
-          in: path
-          description: Billing Project ID
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/billingProjectPathParam'
       responses:
         204:
           description: Successfully cleared spend configuration
@@ -257,12 +237,7 @@ paths:
       summary: add user to billing project the caller owns
       operationId: addUserToBillingProject
       parameters:
-        - name: projectId
-          in: path
-          description: Project ID
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/billingProjectPathParam'
         - name: workbenchRole
           in: path
           description: role of user for project
@@ -308,12 +283,7 @@ paths:
       summary: remove user from billing project the caller owns
       operationId: removeUserFromBillingProject
       parameters:
-        - name: projectId
-          in: path
-          description: Project ID
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/billingProjectPathParam'
         - name: workbenchRole
           in: path
           description: role of user for project
@@ -400,12 +370,7 @@ paths:
       description: get billing project
       operationId: getBillingProject
       parameters:
-        - name: projectId
-          in: path
-          description: Id of the billing project
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/billingProjectPathParam'
       responses:
         200:
           description: OK
@@ -432,12 +397,7 @@ paths:
       description: delete billing project
       operationId: deleteBillingProject
       parameters:
-        - name: projectId
-          in: path
-          description: Id of the billing project
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/billingProjectPathParam'
       responses:
         204:
           description: OK
@@ -461,12 +421,7 @@ paths:
       description: Update the Billing Account on the Billing Project and on each Workspace in the Billing Project
       operationId: updateBillingProjectBillingAccount
       parameters:
-        - name: projectId
-          in: path
-          description: Id of the billing project
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/billingProjectPathParam'
       requestBody:
         description: update billing account request
         content:
@@ -504,12 +459,7 @@ paths:
       description: Clears the Billing Account on the Billing Project and on each Workspace in the Billing Project
       operationId: deleteBillingProjectBillingAccount
       parameters:
-        - name: projectId
-          in: path
-          description: Id of the billing project
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/billingProjectPathParam'
       responses:
         200:
           description: Billing account successfully removed
@@ -535,12 +485,7 @@ paths:
       description: list members of billing project the caller owns
       operationId: listBillingProjectMembers
       parameters:
-        - name: projectId
-          in: path
-          description: Project ID
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/billingProjectPathParam'
       responses:
         200:
           description: Success
@@ -570,12 +515,7 @@ paths:
       description: add user or group to billing project the caller owns
       operationId: addUserToBillingProject
       parameters:
-        - name: projectId
-          in: path
-          description: Project ID
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/billingProjectPathParam'
         - name: workbenchRole
           in: path
           description: role of user for project
@@ -619,12 +559,7 @@ paths:
       description: remove user or group from billing project the caller owns
       operationId: removeUserFromBillingProject
       parameters:
-        - name: projectId
-          in: path
-          description: Project ID
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/billingProjectPathParam'
         - name: workbenchRole
           in: path
           description: role of user for project
@@ -10972,6 +10907,13 @@ components:
       name: attributeName
       in: path
       description: Attribute Name
+      required: true
+      schema:
+        type: string
+    billingProjectPathParam:
+      name: projectId
+      in: path
+      description: Billing Project ID
       required: true
       schema:
         type: string

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -483,7 +483,7 @@ paths:
         - BillingV2
       summary: list members of billing project the caller owns
       description: list members of billing project the caller owns
-      operationId: listBillingProjectMembers
+      operationId: listBillingProjectMembersV2
       parameters:
         - $ref: '#/components/parameters/billingProjectPathParam'
       responses:
@@ -513,7 +513,7 @@ paths:
         - BillingV2
       summary: add user or group to billing project the caller owns
       description: add user or group to billing project the caller owns
-      operationId: addUserToBillingProject
+      operationId: addUserToBillingProjectV2
       parameters:
         - $ref: '#/components/parameters/billingProjectPathParam'
         - name: workbenchRole
@@ -557,7 +557,7 @@ paths:
         - BillingV2
       summary: remove user or group from billing project the caller owns
       description: remove user or group from billing project the caller owns
-      operationId: removeUserFromBillingProject
+      operationId: removeUserFromBillingProjectV2
       parameters:
         - $ref: '#/components/parameters/billingProjectPathParam'
         - name: workbenchRole
@@ -602,7 +602,7 @@ paths:
         - Billing
       summary: delete billing project
       description: delete billing project
-      operationId: deleteBillingProject
+      operationId: deleteBillingProjectV2
       parameters:
         - name: projectName
           in: path
@@ -9177,7 +9177,6 @@ components:
           default: false
         bucketLocation:
           type: string
-          required: false
           description: Region (NOT multi-region) in which bucket attached to the workspace should be created. If not provided, the bucket will be created in the 'US' multi-region.
       description: ""
     WorkspaceRequestClone:
@@ -9211,7 +9210,6 @@ components:
           default: false
         bucketLocation:
           type: string
-          required: false
           description: Region (NOT multi-region) in which bucket attached to the workspace should be created. If not provided, the bucket will be created in the 'US' multi-region.
       description: ""
     WorkspaceResponse:

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -127,11 +127,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
-      security:
-        - googleoauth:
-            - openid
-            - email
-            - profile
       x-passthrough: true
       x-passthrough-target: rawls
   /api/billing/v2/{projectId}/spendReportConfiguration:
@@ -305,11 +300,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
-      security:
-        - googleoauth:
-            - openid
-            - email
-            - profile
       x-passthrough: true
       x-passthrough-target: rawls
     delete:
@@ -361,11 +351,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
-      security:
-        - googleoauth:
-            - openid
-            - email
-            - profile
       x-passthrough: true
       x-passthrough-target: rawls
   /api/billing/v2:
@@ -401,7 +386,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
       security:
-        - authorization:
+        - googleoauth:
             - openid
             - email
             - profile
@@ -712,11 +697,6 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/ErrorReport'
-      security:
-        - authorization:
-            - openid
-            - email
-            - profile
   /api/configurations:
     get:
       tags:
@@ -1090,11 +1070,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
-      security:
-        - googleoauth:
-            - openid
-            - email
-            - profile
       x-passthrough: false
   /api/workflows/{version}/{id}/abort:
     post:
@@ -1134,11 +1109,6 @@ paths:
         500:
           description: Internal Error
           content: {}
-      security:
-        - googleoauth:
-            - openid
-            - email
-            - profile
       x-passthrough: true
       x-passthrough-target: cromiam
   /api/workflows/{version}/{id}/backend/metadata/{backendId}:
@@ -1176,11 +1146,6 @@ paths:
         500:
           description: Internal Error
           content: {}
-      security:
-        - googleoauth:
-            - openid
-            - email
-            - profile
       x-passthrough: true
       x-passthrough-target: rawls
   /api/workflows/{version}/{id}/labels:
@@ -1227,11 +1192,6 @@ paths:
         500:
           description: Internal Error
           content: {}
-      security:
-        - googleoauth:
-            - openid
-            - email
-            - profile
       x-passthrough: true
       x-passthrough-target: cromiam
       x-codegen-request-body-name: labels
@@ -1427,11 +1387,6 @@ paths:
         500:
           description: Internal Error
           content: {}
-      security:
-        - googleoauth:
-            - openid
-            - email
-            - profile
       x-passthrough: true
       x-passthrough-target: cromiam
   /api/workflows/{version}/{id}/releaseHold:
@@ -1617,11 +1572,6 @@ paths:
         500:
           description: Internal Error
           content: {}
-      security:
-        - googleoauth:
-            - openid
-            - email
-            - profile
       x-passthrough: true
       x-passthrough-target: cromiam
     post:
@@ -1659,11 +1609,6 @@ paths:
         500:
           description: Internal Error
           content: {}
-      security:
-        - googleoauth:
-            - openid
-            - email
-            - profile
       x-passthrough: true
       x-passthrough-target: cromiam
       x-codegen-request-body-name: parameters
@@ -1813,11 +1758,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
-      security:
-        - googleoauth:
-            - openid
-            - email
-            - profile
       x-passthrough: false
     post:
       tags:
@@ -1850,11 +1790,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
-      security:
-        - googleoauth:
-            - openid
-            - email
-            - profile
       x-passthrough: false
     delete:
       tags:
@@ -1896,11 +1831,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
-      security:
-        - googleoauth:
-            - openid
-            - email
-            - profile
       x-passthrough: false
   /api/groups/{groupName}/requestAccess:
     post:
@@ -1931,11 +1861,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
-      security:
-        - googleoauth:
-            - openid
-            - email
-            - profile
       x-passthrough: false
   /api/groups/{groupName}/{role}/{email}:
     put:
@@ -1987,11 +1912,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
-      security:
-        - googleoauth:
-            - openid
-            - email
-            - profile
       x-passthrough: false
     delete:
       tags:
@@ -2042,11 +1962,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
-      security:
-        - googleoauth:
-            - openid
-            - email
-            - profile
       x-passthrough: false
   /api/inputsOutputs:
     post:
@@ -3164,11 +3079,6 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/NotificationType'
-      security:
-        - googleoauth:
-            - openid
-            - email
-            - profile
       x-passthrough: true
       x-passthrough-target: rawls
   /api/notifications/workspace/{workspaceNamespace}/{workspaceName}:
@@ -3199,11 +3109,6 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/NotificationType'
-      security:
-        - googleoauth:
-            - openid
-            - email
-            - profile
       x-passthrough: true
       x-passthrough-target: rawls
   /api/profile/billing:
@@ -3889,11 +3794,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
-      security:
-        - googleoauth:
-            - openid
-            - email
-            - profile
       x-passthrough: true
       x-passthrough-target: rawls
   /api/workspaces/{workspaceNamespace}/{workspaceName}/bucketUsage:
@@ -5868,11 +5768,6 @@ paths:
         403:
           description: Insufficient permisions to send notification on this workspace
           content: {}
-      security:
-        - googleoauth:
-            - openid
-            - email
-            - profile
       x-passthrough: true
       x-passthrough-target: rawls
   /api/workspaces/{workspaceNamespace}/{workspaceName}/storageCostEstimate:
@@ -6075,11 +5970,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
-      security:
-        - googleoauth:
-            - openid
-            - email
-            - profile
       x-passthrough: true
       x-passthrough-target: rawls
     delete:
@@ -6400,11 +6290,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
-      security:
-        - googleoauth:
-            - openid
-            - email
-            - profile
       x-passthrough: true
       x-passthrough-target: rawls
   /api/workspaces/{workspaceNamespace}/{workspaceName}/tags:
@@ -7089,11 +6974,6 @@ paths:
         500:
           description: Internal Server Error
           content: {}
-      security:
-        - googleoauth:
-            - openid
-            - email
-            - profile
       x-passthrough: false
       x-codegen-request-body-name: body
   /api/duos/consent/orsp/{orspId}:

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -2963,18 +2963,8 @@ paths:
       summary: Gets the notifications available for a workspace
       operationId: workspaceNotifications
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: workspace namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: workspace name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
       responses:
         200:
           description: Success
@@ -3468,18 +3458,8 @@ paths:
       summary: Delete workspace
       operationId: deleteWorkspace
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
       responses:
         202:
           description: Request Accepted

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -6894,8 +6894,9 @@ paths:
             type: string
       requestBody:
         content:
-          multipart/form-data:
+          application/x-www-form-urlencoded:
             schema:
+              type: object
               required:
                 - FCtoken
               properties:

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -6686,7 +6686,7 @@ paths:
                   $ref: '#/components/schemas/ToolClass'
       x-passthrough: true
       x-passthrough-target: agora
-  /servicePerimeters/{servicePerimeterName}/projects/{projectName}:
+  /api/servicePerimeters/{servicePerimeterName}/projects/{projectName}:
     put:
       tags:
         - Service Perimeters

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -2005,8 +2005,8 @@ paths:
         get the groups that can discover this library dataset
       operationId: getDiscoverableGroups
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
       responses:
         200:
           description: The groups that can discover the dataset
@@ -2040,8 +2040,8 @@ paths:
         set the groups that can discover this library dataset
       operationId: updateDiscoverableGroups
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
       requestBody:
         description: Json array of group names, or empty array for no restrictions
         content:
@@ -2092,8 +2092,8 @@ paths:
         get the entire metadata for a library dataset
       operationId: getLibraryMetadata
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
       responses:
         200:
           description: Success
@@ -2121,8 +2121,8 @@ paths:
         put the entire metadata for a library dataset
       operationId: putLibraryMetadata
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
         - name: validate
           in: query
           description: |
@@ -2165,8 +2165,8 @@ paths:
         publish the workspace in the Library
       operationId: publishLibraryWorkspace
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
       responses:
         200:
           description: Success
@@ -2195,8 +2195,8 @@ paths:
         unpublish the workspace in the Library
       operationId: unpublishLibraryWorkspace
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
       responses:
         200:
           description: Success
@@ -2897,8 +2897,8 @@ paths:
       summary: Gets the notifications available for a workspace
       operationId: workspaceNotifications
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
       responses:
         200:
           description: Success
@@ -3356,8 +3356,8 @@ paths:
         Get a single workspace's details, optionally filtered to only the specified fields. See additional GET methods in this section to retrieve additional details about the workspace. For instance, this API only returns the workspace's owners; use the GET .../acl method to retrieve the full list of all users at all permission levels.
       operationId: getWorkspace
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
         - name: fields
           in: query
           description: |
@@ -3392,8 +3392,8 @@ paths:
       summary: Delete workspace
       operationId: deleteWorkspace
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
       responses:
         202:
           description: Request Accepted
@@ -3416,8 +3416,8 @@ paths:
       summary: Get workspace access instructions (if any)
       operationId: getWorkspaceAccessInstructions
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
       responses:
         200:
           description: Successful Request
@@ -3442,8 +3442,8 @@ paths:
       summary: Get workspace ACL
       operationId: getWorkspaceAcl
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
       responses:
         200:
           description: Successful Request
@@ -3468,8 +3468,8 @@ paths:
       summary: Update workspace ACL
       operationId: updateWorkspaceACL
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
         - name: inviteUsersNotFound
           in: query
           description: true to invite unregistered users, false to ignore
@@ -3512,8 +3512,8 @@ paths:
       description: Returns metadata about the workspace bucket.
       operationId: getWorkspaceBucketOptions
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
       responses:
         200:
           description: Successful Request
@@ -3542,8 +3542,8 @@ paths:
       summary: Get bucket usage
       operationId: getBucketUsage
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
       responses:
         200:
           description: Successful Request
@@ -3561,8 +3561,8 @@ paths:
       description: Get catalog permissions for a workspace
       operationId: getCatalog
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
       responses:
         200:
           description: Successful Request
@@ -3592,8 +3592,8 @@ paths:
       description: Set catalog permisisons for a workspace
       operationId: updateCatalog
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
       requestBody:
         description: Series of Catalog updates for workspace
         content:
@@ -3639,8 +3639,8 @@ paths:
       description: Read a workspace bucket
       operationId: readBucket
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
       responses:
         200:
           description: Successful Request
@@ -3665,8 +3665,8 @@ paths:
         Sam. Takes into account if the workspace is locked too.
       operationId: checkIamActionWithLock
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
         - name: samActionName
           in: path
           description: Sam action
@@ -3696,8 +3696,8 @@ paths:
       summary: Clone Workspace
       operationId: cloneWorkspace
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
       requestBody:
         description: Cloned workspace information
         content:
@@ -3734,8 +3734,8 @@ paths:
         List of entity types in a workspace
       operationId: getEntityTypes
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
       responses:
         200:
           description: List of entity types in workspace
@@ -3756,8 +3756,8 @@ paths:
         List of entities in a workspace with type and attribute information
       operationId: getEntitiesWithType
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
       responses:
         200:
           description: List of entities
@@ -3777,8 +3777,8 @@ paths:
         Copy entities from one workspace to another
       operationId: copyEntities
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
         - name: linkExistingEntities
           in: query
           description: true to link new entities to existing entities, false to fail
@@ -3827,8 +3827,8 @@ paths:
       summary: Bulk delete entities from a workspace
       operationId: deleteEntities
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
       requestBody:
         description: Entities to delete
         content:
@@ -3874,9 +3874,9 @@ paths:
         List of entities in a workspace
       operationId: getEntities
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
-        - $ref: '#'#/components/parameters/entityTypeParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/entityTypeParam'
       responses:
         200:
           description: List of entities in workspace
@@ -3901,10 +3901,10 @@ paths:
       summary: Get entity in a workspace
       operationId: getEntity
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
-        - $ref: '#'#/components/parameters/entityTypeParam'
-        - $ref: '#'#/components/parameters/entityNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/entityTypeParam'
+        - $ref: '#/components/parameters/entityNameParam'
       responses:
         200:
           description: Success
@@ -3924,10 +3924,10 @@ paths:
       description: Update an entity
       operationId: update_entity
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
-        - $ref: '#'#/components/parameters/entityTypeParam'
-        - $ref: '#'#/components/parameters/entityNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/entityTypeParam'
+        - $ref: '#/components/parameters/entityNameParam'
       requestBody:
         description: Update operations for attributes
         content:
@@ -3976,10 +3976,10 @@ paths:
       summary: Evaluate entity expression
       operationId: evaluateEntityExpression
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
-        - $ref: '#'#/components/parameters/entityTypeParam'
-        - $ref: '#'#/components/parameters/entityNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/entityTypeParam'
+        - $ref: '#/components/parameters/entityNameParam'
       requestBody:
         description: Expression
         content:
@@ -4049,8 +4049,8 @@ paths:
         TSV file containing workspace attributes
       operationId: exportAttributesTSV
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
       responses:
         200:
           description: Workspace attributes in TSV format
@@ -4074,9 +4074,9 @@ paths:
         TSV file containing workspace entities of the specified type
       operationId: downloadEntitiesTSV
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
-        - $ref: '#'#/components/parameters/entityTypeParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/entityTypeParam'
         - name: attributeNames
           in: query
           description: comma separated list of ordered attribute names to be in downloaded
@@ -4115,9 +4115,9 @@ paths:
       summary: Paginated query for entities in a workspace
       operationId: entityQuery
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
-        - $ref: '#'#/components/parameters/entityTypeParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/entityTypeParam'
         - name: page
           in: query
           description: Page number, 1-indexed (default 1)
@@ -4175,8 +4175,8 @@ paths:
       summary: Import workspace attributes from a tsv file
       operationId: importAttributesTSV
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
       requestBody:
         content:
           multipart/form-data:
@@ -4212,8 +4212,8 @@ paths:
         directory, whose payload contains two files - participants.tsv and samples.tsv
       operationId: importBagit
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
       requestBody:
         description: JSON object containing bagit URL
         content:
@@ -4243,8 +4243,8 @@ paths:
       summary: Import entities from a tsv file
       operationId: importEntities
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
         - name: deleteEmptyValues
           in: query
           description: Delete empty values? Values left blank in the TSV will be deleted if set to true (default is false)
@@ -4289,8 +4289,8 @@ paths:
         Lists all imports for this workspace, optionally filtered to only those imports currently in progress
       operationId: listImportPFBJobs
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
         - name: running_only
           in: query
           description: When true, filters to only those imports currently in progress
@@ -4324,8 +4324,8 @@ paths:
         This API will return a jobID representing the import operation. The import itself will continue asynchronously in the background.
       operationId: importPFB
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
       requestBody:
         description: JSON object containing PFB URL
         content:
@@ -4367,8 +4367,8 @@ paths:
         Use /api/workspaces/{workspaceNamespace}/{workspaceName}/importJob/{jobId} instead.
       operationId: importPFBStatus
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
         - name: jobId
           in: path
           description: job ID of the import to check
@@ -4398,8 +4398,8 @@ paths:
         Lists all imports for this workspace, optionally filtered to only those imports currently in progress
       operationId: listImportJobs
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
         - name: running_only
           in: query
           description: When true, filters to only those imports currently in progress
@@ -4433,8 +4433,8 @@ paths:
         This API will return a jobID representing the import operation. The import itself will continue asynchronously in the background.
       operationId: createImportJob
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
       requestBody:
         description: JSON object containing URL to import
         content:
@@ -4475,8 +4475,8 @@ paths:
         This API will return status of an import jobID. The jobID was returned from a previous import request.
       operationId: importJobStatus
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
         - name: jobId
           in: path
           description: job ID of the import to check
@@ -4504,8 +4504,8 @@ paths:
       summary: Import entities from a tsv file
       operationId: flexibleImportEntities
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
         - name: async
           in: query
           description: Import asynchronously?
@@ -4560,8 +4560,8 @@ paths:
       summary: Lock Workspace
       operationId: lockWorkspace
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
       responses:
         200:
           description: No response was specified
@@ -4587,8 +4587,8 @@ paths:
       summary: Get a method configuration in a workspace
       operationId: getWorkspaceMethodConfig
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
         - name: configNamespace
           in: path
           description: Configuration Namespace
@@ -4622,8 +4622,8 @@ paths:
         The method configuration name and namespace in the URI must match the values in the JSON.
       operationId: overwriteWorkspaceMethodConfig
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
         - name: configNamespace
           in: path
           description: Configuration Namespace
@@ -4672,8 +4672,8 @@ paths:
         If the location in the request body is different to the location in the URI, and there is a method config already at that location, 409 is returned.
       operationId: updateWorkspaceMethodConfig
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
         - name: configNamespace
           in: path
           description: Configuration Namespace
@@ -4719,8 +4719,8 @@ paths:
       summary: Delete a method configuration in a workspace
       operationId: deleteWorkspaceMethodConfig
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
         - name: configNamespace
           in: path
           description: Configuration Namespace
@@ -4752,8 +4752,8 @@ paths:
       summary: Rename a method configuration in a workspace
       operationId: renameWorkspaceMethodConfig
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
         - name: configNamespace
           in: path
           description: Configuration Namespace
@@ -4799,8 +4799,8 @@ paths:
       summary: get syntax validation information for a method configuration
       operationId: validate_method_configuration
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
         - name: configNamespace
           in: path
           description: Method Configuration Namespace
@@ -4836,8 +4836,8 @@ paths:
       summary: Copy a Method Repository Configuration into a workspace
       operationId: copyFromMethodRepo
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
       requestBody:
         description: Method Configuration to Copy
         content:
@@ -4871,8 +4871,8 @@ paths:
       summary: Copy a Method Config in a workspace to the Method Repository
       operationId: copyToMethodRepo
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
       requestBody:
         description: Method Configuration to Copy
         content:
@@ -4931,8 +4931,8 @@ paths:
         If you are only working with Agora methods, the fields `"sourceRepo"` and `"methodUri"` can be considered informational and do not need to be round-tripped (see the corresponding `POST /api/workspaces/{workspaceNamespace}/{workspaceName}/methodconfigs` for more details).
       operationId: listWorkspaceMethodConfigs
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
         - name: allRepos
           in: query
           description: Configs for all repos, not just Agora
@@ -4989,8 +4989,8 @@ paths:
         The system is specified to check for a URI first before falling back to the legacy fields. Unsupported repos will return a 400 Bad Request.
       operationId: postWorkspaceMethodConfig
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
       requestBody:
         description: Method Configuration contents
         content:
@@ -5022,8 +5022,8 @@ paths:
         references
       operationId: workspacePermissionReport
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
       requestBody:
         description: Users and/or configs on which to report, both optional
         content:
@@ -5053,8 +5053,8 @@ paths:
       summary: Sends notifications for change to workspace
       operationId: changedWorkspaceNotification
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
       responses:
         200:
           description: Success
@@ -5072,8 +5072,8 @@ paths:
         bucket
       operationId: getStorageCostEstimate
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
       responses:
         200:
           description: Successful Request
@@ -5096,8 +5096,8 @@ paths:
         List submissions.
       operationId: listSubmissions
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
       responses:
         200:
           description: List of submissions
@@ -5117,8 +5117,8 @@ paths:
         Create a submission.
       operationId: createSubmission
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
       requestBody:
         description: Post Submission
         content:
@@ -5156,8 +5156,8 @@ paths:
         Returns a map of status:count.
       operationId: countSubmissions
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
       responses:
         200:
           description: Successful Request
@@ -5187,8 +5187,8 @@ paths:
         Monitor submission status
       operationId: monitorSubmission
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
         - $ref: '#/components/parameters/submissionIdParam'
       responses:
         200:
@@ -5218,8 +5218,8 @@ paths:
         abort a submission
       operationId: abortSubmission
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
         - $ref: '#/components/parameters/submissionIdParam'
       responses:
         204:
@@ -5240,8 +5240,8 @@ paths:
       description: Update user comment for a submission
       operationId: updateSubmissionUserComment
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
         - $ref: '#/components/parameters/submissionIdParam'
       requestBody:
         description: User comment to be updated
@@ -5273,8 +5273,8 @@ paths:
       description: Validate expression syntax for a submission
       operationId: validateSubmission
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
       requestBody:
         description: Description of a submission.
         content:
@@ -5325,8 +5325,8 @@ paths:
       description: Get call-level metadata for workflow
       operationId: workflowMetadata
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
         - $ref: '#/components/parameters/submissionIdParam'
         - $ref: '#/components/parameters/workflowIdParam'
         - name: includeKey
@@ -5382,8 +5382,8 @@ paths:
         Get workflow outputs.
       operationId: workflowOutputsInSubmission
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
         - $ref: '#/components/parameters/submissionIdParam'
         - $ref: '#/components/parameters/workflowIdParam'
       responses:
@@ -5406,8 +5406,8 @@ paths:
         Retrieve workflow cost, if available.
       operationId: workflowCostInSubmission
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
         - $ref: '#/components/parameters/submissionIdParam'
         - $ref: '#/components/parameters/workflowIdParam'
       responses:
@@ -5439,8 +5439,8 @@ paths:
         Get the tags for this workspace.
       operationId: getWorkspaceTags
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
       responses:
         200:
           description: Workspace tags
@@ -5462,8 +5462,8 @@ paths:
         Replace all tags for this workspace with the user input.
       operationId: putWorkspaceTags
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
       requestBody:
         description: List of tags.
         content:
@@ -5496,8 +5496,8 @@ paths:
         Remove the user-supplied tags from the workspace.
       operationId: deleteWorkspaceTags
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
       requestBody:
         description: List of tags.
         content:
@@ -5530,8 +5530,8 @@ paths:
         Add tags to the workspace without modifying pre-existing tags.
       operationId: patchWorkspaceTags
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
       requestBody:
         description: List of tags.
         content:
@@ -5564,8 +5564,8 @@ paths:
       summary: Unlock Workspace
       operationId: unlockWorkspace
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
       responses:
         200:
           description: No response was specified
@@ -5592,8 +5592,8 @@ paths:
         Modify attributes on a workspace.
       operationId: updateAttributes
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
       requestBody:
         description: Attribute operations. WARNING! This should not be used to change
           library metadata (republish will not happen). Use UpdateAttributes in the
@@ -5629,8 +5629,8 @@ paths:
         Set attributes on a workspace.
       operationId: setAttributes
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
       requestBody:
         description: New attribute values, as Map[String, Attribute]. WARNING! This
           should not be used to change library metadata (republish will not happen).
@@ -5731,8 +5731,8 @@ paths:
         TSV file containing workspace attributes (allows cookie-based authentication)
       operationId: browserDownloadAttributes
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
       responses:
         200:
           description: Workspace attributes in TSV format
@@ -5759,9 +5759,9 @@ paths:
         It is here for documentation purposes only.
       operationId: browserDownloadEntitiesTSVGet
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
-        - $ref: '#'#/components/parameters/entityTypeParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/entityTypeParam'
         - name: attributeNames
           in: query
           description: comma separated list of ordered attribute names to be in downloaded
@@ -5803,9 +5803,9 @@ paths:
         It is here for documentation purposes only.
       operationId: browserDownloadEntitiesTSV
       parameters:
-        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#'#/components/parameters/workspaceNameParam'
-        - $ref: '#'#/components/parameters/entityTypeParam'
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/entityTypeParam'
       requestBody:
         content:
           application/x-www-form-urlencoded:

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -3904,12 +3904,7 @@ paths:
         - $ref: '#'#/components/parameters/workspaceNamespaceParam'
         - $ref: '#'#/components/parameters/workspaceNameParam'
         - $ref: '#'#/components/parameters/entityTypeParam'
-        - name: entityName
-          in: path
-          description: Entity Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/entityNameParam'
       responses:
         200:
           description: Success
@@ -3932,12 +3927,7 @@ paths:
         - $ref: '#'#/components/parameters/workspaceNamespaceParam'
         - $ref: '#'#/components/parameters/workspaceNameParam'
         - $ref: '#'#/components/parameters/entityTypeParam'
-        - name: entityName
-          in: path
-          description: Entity Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/entityNameParam'
       requestBody:
         description: Update operations for attributes
         content:
@@ -3989,12 +3979,7 @@ paths:
         - $ref: '#'#/components/parameters/workspaceNamespaceParam'
         - $ref: '#'#/components/parameters/workspaceNameParam'
         - $ref: '#'#/components/parameters/entityTypeParam'
-        - name: entityName
-          in: path
-          description: Entity Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/entityNameParam'
       requestBody:
         description: Expression
         content:
@@ -5204,12 +5189,7 @@ paths:
       parameters:
         - $ref: '#'#/components/parameters/workspaceNamespaceParam'
         - $ref: '#'#/components/parameters/workspaceNameParam'
-        - name: submissionId
-          in: path
-          description: Submission ID
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/submissionIdParam'
       responses:
         200:
           description: Successful Request
@@ -5240,12 +5220,7 @@ paths:
       parameters:
         - $ref: '#'#/components/parameters/workspaceNamespaceParam'
         - $ref: '#'#/components/parameters/workspaceNameParam'
-        - name: submissionId
-          in: path
-          description: Submission ID
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/submissionIdParam'
       responses:
         204:
           description: Aborted successfully
@@ -5267,12 +5242,7 @@ paths:
       parameters:
         - $ref: '#'#/components/parameters/workspaceNamespaceParam'
         - $ref: '#'#/components/parameters/workspaceNameParam'
-        - name: submissionId
-          in: path
-          description: Submission Id
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/submissionIdParam'
       requestBody:
         description: User comment to be updated
         content:
@@ -5357,18 +5327,8 @@ paths:
       parameters:
         - $ref: '#'#/components/parameters/workspaceNamespaceParam'
         - $ref: '#'#/components/parameters/workspaceNameParam'
-        - name: submissionId
-          in: path
-          description: Submission ID
-          required: true
-          schema:
-            type: string
-        - name: workflowId
-          in: path
-          description: Workflow ID
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/submissionIdParam'
+        - $ref: '#/components/parameters/workflowIdParam'
         - name: includeKey
           in: query
           description: |
@@ -5424,18 +5384,8 @@ paths:
       parameters:
         - $ref: '#'#/components/parameters/workspaceNamespaceParam'
         - $ref: '#'#/components/parameters/workspaceNameParam'
-        - name: submissionId
-          in: path
-          description: Submission ID
-          required: true
-          schema:
-            type: string
-        - name: workflowId
-          in: path
-          description: Workflow ID
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/submissionIdParam'
+        - $ref: '#/components/parameters/workflowIdParam'
       responses:
         200:
           description: Get workflow outputs
@@ -5458,18 +5408,8 @@ paths:
       parameters:
         - $ref: '#'#/components/parameters/workspaceNamespaceParam'
         - $ref: '#'#/components/parameters/workspaceNameParam'
-        - name: submissionId
-          in: path
-          description: Submission ID
-          required: true
-          schema:
-            type: string
-        - name: workflowId
-          in: path
-          description: Workflow ID
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/submissionIdParam'
+        - $ref: '#/components/parameters/workflowIdParam'
       responses:
         200:
           description: Successful Request

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -1012,13 +1012,7 @@ paths:
         - CromIAM Workflows (for Job Manager)
       summary: Abort a workflow based on workflow id
       parameters:
-        - name: version
-          in: path
-          description: API Version
-          required: true
-          schema:
-            type: string
-            default: v1
+        - $ref: '#/components/parameters/versionParam'
         - name: id
           in: path
           description: Workflow ID
@@ -1052,13 +1046,7 @@ paths:
         - CromIAM Workflows (for Job Manager)
       summary: Get backend (e.g. PAPI) metadata for a job
       parameters:
-        - name: version
-          in: path
-          description: API Version
-          required: true
-          schema:
-            type: string
-            default: v1
+        - $ref: '#/components/parameters/versionParam'
         - name: id
           in: path
           description: Workflow ID
@@ -1090,13 +1078,7 @@ paths:
       summary: Add new labels or update values for existing label keys by workflow
         id.
       parameters:
-        - name: version
-          in: path
-          description: API Version
-          required: true
-          schema:
-            type: string
-            default: v1
+        - $ref: '#/components/parameters/versionParam'
         - name: id
           in: path
           description: Workflow ID
@@ -1136,13 +1118,7 @@ paths:
         - CromIAM Workflows (for Job Manager)
       summary: Query for workflow and call-level metadata for a specified workflow
       parameters:
-        - name: version
-          in: path
-          description: API Version
-          required: true
-          schema:
-            type: string
-            default: v1
+        - $ref: '#/components/parameters/versionParam'
         - name: id
           in: path
           description: Workflow ID
@@ -1333,13 +1309,7 @@ paths:
         for running. For instance this might be necessary in cases where you have
         submitted a workflow with workflowOnHold = true.
       parameters:
-        - name: version
-          in: path
-          description: API Version
-          required: true
-          schema:
-            type: string
-            default: v1
+        - $ref: '#/components/parameters/versionParam'
         - name: id
           in: path
           description: Workflow ID
@@ -1373,13 +1343,7 @@ paths:
         - CromIAM Workflows (for Admin)
       summary: Return the hash differential between two calls
       parameters:
-        - name: version
-          in: path
-          description: API Version
-          required: true
-          schema:
-            type: string
-            default: v1
+        - $ref: '#/components/parameters/versionParam'
         - name: workflowA
           in: query
           description: Workflow Id of the first workflow
@@ -1436,13 +1400,7 @@ paths:
         - CromIAM Workflows (for Job Manager)
       summary: Query workflows by start dates, end dates, names, ids, or statuses.
       parameters:
-        - name: version
-          in: path
-          description: API Version
-          required: true
-          schema:
-            type: string
-            default: v1
+        - $ref: '#/components/parameters/versionParam'
         - name: start
           in: query
           description: |
@@ -1514,13 +1472,7 @@ paths:
         - CromIAM Workflows (for Job Manager)
       summary: Query workflows by start dates, end dates, names, ids, or statuses.
       parameters:
-        - name: version
-          in: path
-          description: API version
-          required: true
-          schema:
-            type: string
-            default: v1
+        - $ref: '#/components/parameters/versionParam'
       requestBody:
         description: |
           Same query parameters as GET /query endpoint, submitted as a json list. Example: [{"status":"Success"},{"status":"Failed"}]
@@ -1554,13 +1506,7 @@ paths:
       summary: Machine-readable description of a workflow, including inputs and outputs
       operationId: describe
       parameters:
-        - name: version
-          in: path
-          description: Cromwell API Version
-          required: true
-          schema:
-            type: string
-            default: v1
+        - $ref: '#/components/parameters/versionParam'
       requestBody:
         content:
           multipart/form-data:
@@ -1611,13 +1557,7 @@ paths:
         - CromIAM Engine (for Job Manager)
       summary: Returns the version of the Cromwell Engine
       parameters:
-        - name: version
-          in: path
-          description: API Version
-          required: true
-          schema:
-            type: string
-            default: v1
+        - $ref: '#/components/parameters/versionParam'
       responses:
         200:
           description: Successful Request
@@ -1633,13 +1573,7 @@ paths:
         - CromIAM Engine (for Job Manager)
       summary: Returns the current health status of any monitored subsystems
       parameters:
-        - name: version
-          in: path
-          description: API Version
-          required: true
-          schema:
-            type: string
-            default: v1
+        - $ref: '#/components/parameters/versionParam'
       responses:
         200:
           description: All subsystems report an "ok" status

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -3876,12 +3876,7 @@ paths:
       parameters:
         - $ref: '#'#/components/parameters/workspaceNamespaceParam'
         - $ref: '#'#/components/parameters/workspaceNameParam'
-        - name: entityType
-          in: path
-          description: Entity Type
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/entityTypeParam'
       responses:
         200:
           description: List of entities in workspace
@@ -3908,12 +3903,7 @@ paths:
       parameters:
         - $ref: '#'#/components/parameters/workspaceNamespaceParam'
         - $ref: '#'#/components/parameters/workspaceNameParam'
-        - name: entityType
-          in: path
-          description: Entity Type
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/entityTypeParam'
         - name: entityName
           in: path
           description: Entity Name
@@ -3941,12 +3931,7 @@ paths:
       parameters:
         - $ref: '#'#/components/parameters/workspaceNamespaceParam'
         - $ref: '#'#/components/parameters/workspaceNameParam'
-        - name: entityType
-          in: path
-          description: Entity Type
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/entityTypeParam'
         - name: entityName
           in: path
           description: Entity Name
@@ -4003,12 +3988,7 @@ paths:
       parameters:
         - $ref: '#'#/components/parameters/workspaceNamespaceParam'
         - $ref: '#'#/components/parameters/workspaceNameParam'
-        - name: entityType
-          in: path
-          description: Entity Type
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/entityTypeParam'
         - name: entityName
           in: path
           description: Entity Name
@@ -4111,12 +4091,7 @@ paths:
       parameters:
         - $ref: '#'#/components/parameters/workspaceNamespaceParam'
         - $ref: '#'#/components/parameters/workspaceNameParam'
-        - name: entityType
-          in: path
-          description: Entity Type
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/entityTypeParam'
         - name: attributeNames
           in: query
           description: comma separated list of ordered attribute names to be in downloaded
@@ -4157,12 +4132,7 @@ paths:
       parameters:
         - $ref: '#'#/components/parameters/workspaceNamespaceParam'
         - $ref: '#'#/components/parameters/workspaceNameParam'
-        - name: entityType
-          in: path
-          description: Entity Type
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/entityTypeParam'
         - name: page
           in: query
           description: Page number, 1-indexed (default 1)
@@ -5851,12 +5821,7 @@ paths:
       parameters:
         - $ref: '#'#/components/parameters/workspaceNamespaceParam'
         - $ref: '#'#/components/parameters/workspaceNameParam'
-        - name: entityType
-          in: path
-          description: Entity Type
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/entityTypeParam'
         - name: attributeNames
           in: query
           description: comma separated list of ordered attribute names to be in downloaded
@@ -5900,12 +5865,7 @@ paths:
       parameters:
         - $ref: '#'#/components/parameters/workspaceNamespaceParam'
         - $ref: '#'#/components/parameters/workspaceNameParam'
-        - name: entityType
-          in: path
-          description: Entity Type
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/entityTypeParam'
       requestBody:
         content:
           application/x-www-form-urlencoded:

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -2071,18 +2071,8 @@ paths:
         get the groups that can discover this library dataset
       operationId: getDiscoverableGroups
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
       responses:
         200:
           description: The groups that can discover the dataset
@@ -2116,18 +2106,8 @@ paths:
         set the groups that can discover this library dataset
       operationId: updateDiscoverableGroups
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
       requestBody:
         description: Json array of group names, or empty array for no restrictions
         content:
@@ -2178,18 +2158,8 @@ paths:
         get the entire metadata for a library dataset
       operationId: getLibraryMetadata
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
       responses:
         200:
           description: Success
@@ -2217,18 +2187,8 @@ paths:
         put the entire metadata for a library dataset
       operationId: putLibraryMetadata
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
         - name: validate
           in: query
           description: |
@@ -2271,18 +2231,8 @@ paths:
         publish the workspace in the Library
       operationId: publishLibraryWorkspace
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
       responses:
         200:
           description: Success
@@ -2311,18 +2261,8 @@ paths:
         unpublish the workspace in the Library
       operationId: unpublishLibraryWorkspace
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
       responses:
         200:
           description: Success
@@ -3492,18 +3432,8 @@ paths:
         Get a single workspace's details, optionally filtered to only the specified fields. See additional GET methods in this section to retrieve additional details about the workspace. For instance, this API only returns the workspace's owners; use the GET .../acl method to retrieve the full list of all users at all permission levels.
       operationId: getWorkspace
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
         - name: fields
           in: query
           description: |
@@ -3572,18 +3502,8 @@ paths:
       summary: Get workspace access instructions (if any)
       operationId: getWorkspaceAccessInstructions
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
       responses:
         200:
           description: Successful Request
@@ -3608,18 +3528,8 @@ paths:
       summary: Get workspace ACL
       operationId: getWorkspaceAcl
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
       responses:
         200:
           description: Successful Request
@@ -3644,18 +3554,8 @@ paths:
       summary: Update workspace ACL
       operationId: updateWorkspaceACL
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
         - name: inviteUsersNotFound
           in: query
           description: true to invite unregistered users, false to ignore
@@ -3698,18 +3598,8 @@ paths:
       description: Returns metadata about the workspace bucket.
       operationId: getWorkspaceBucketOptions
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
       responses:
         200:
           description: Successful Request
@@ -3738,18 +3628,8 @@ paths:
       summary: Get bucket usage
       operationId: getBucketUsage
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
       responses:
         200:
           description: Successful Request
@@ -3767,18 +3647,8 @@ paths:
       description: Get catalog permissions for a workspace
       operationId: getCatalog
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
       responses:
         200:
           description: Successful Request
@@ -3808,18 +3678,8 @@ paths:
       description: Set catalog permisisons for a workspace
       operationId: updateCatalog
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
       requestBody:
         description: Series of Catalog updates for workspace
         content:
@@ -3865,18 +3725,8 @@ paths:
       description: Read a workspace bucket
       operationId: readBucket
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
       responses:
         200:
           description: Successful Request
@@ -3901,18 +3751,8 @@ paths:
         Sam. Takes into account if the workspace is locked too.
       operationId: checkIamActionWithLock
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
         - name: samActionName
           in: path
           description: Sam action
@@ -3942,18 +3782,8 @@ paths:
       summary: Clone Workspace
       operationId: cloneWorkspace
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
       requestBody:
         description: Cloned workspace information
         content:
@@ -3990,18 +3820,8 @@ paths:
         List of entity types in a workspace
       operationId: getEntityTypes
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
       responses:
         200:
           description: List of entity types in workspace
@@ -4022,18 +3842,8 @@ paths:
         List of entities in a workspace with type and attribute information
       operationId: getEntitiesWithType
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
       responses:
         200:
           description: List of entities
@@ -4053,18 +3863,8 @@ paths:
         Copy entities from one workspace to another
       operationId: copyEntities
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Destination Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Destination Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
         - name: linkExistingEntities
           in: query
           description: true to link new entities to existing entities, false to fail
@@ -4113,18 +3913,8 @@ paths:
       summary: Bulk delete entities from a workspace
       operationId: deleteEntities
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
       requestBody:
         description: Entities to delete
         content:
@@ -4170,18 +3960,8 @@ paths:
         List of entities in a workspace
       operationId: getEntities
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
         - name: entityType
           in: path
           description: Entity Type
@@ -4212,18 +3992,8 @@ paths:
       summary: Get entity in a workspace
       operationId: getEntity
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
         - name: entityType
           in: path
           description: Entity Type
@@ -4255,18 +4025,8 @@ paths:
       description: Update an entity
       operationId: update_entity
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
         - name: entityType
           in: path
           description: Entity Type
@@ -4327,18 +4087,8 @@ paths:
       summary: Evaluate entity expression
       operationId: evaluateEntityExpression
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
         - name: entityType
           in: path
           description: Entity Type
@@ -4420,18 +4170,8 @@ paths:
         TSV file containing workspace attributes
       operationId: exportAttributesTSV
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
       responses:
         200:
           description: Workspace attributes in TSV format
@@ -4455,18 +4195,8 @@ paths:
         TSV file containing workspace entities of the specified type
       operationId: downloadEntitiesTSV
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
         - name: entityType
           in: path
           description: Entity Type
@@ -4511,18 +4241,8 @@ paths:
       summary: Paginated query for entities in a workspace
       operationId: entityQuery
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
         - name: entityType
           in: path
           description: Entity Type
@@ -4586,18 +4306,8 @@ paths:
       summary: Import workspace attributes from a tsv file
       operationId: importAttributesTSV
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
       requestBody:
         content:
           multipart/form-data:
@@ -4633,18 +4343,8 @@ paths:
         directory, whose payload contains two files - participants.tsv and samples.tsv
       operationId: importBagit
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
       requestBody:
         description: JSON object containing bagit URL
         content:
@@ -4674,18 +4374,8 @@ paths:
       summary: Import entities from a tsv file
       operationId: importEntities
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Destination Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Destination Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
         - name: deleteEmptyValues
           in: query
           description: Delete empty values? Values left blank in the TSV will be deleted if set to true (default is false)
@@ -4730,18 +4420,8 @@ paths:
         Lists all imports for this workspace, optionally filtered to only those imports currently in progress
       operationId: listImportPFBJobs
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
         - name: running_only
           in: query
           description: When true, filters to only those imports currently in progress
@@ -4775,18 +4455,8 @@ paths:
         This API will return a jobID representing the import operation. The import itself will continue asynchronously in the background.
       operationId: importPFB
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
       requestBody:
         description: JSON object containing PFB URL
         content:
@@ -4828,18 +4498,8 @@ paths:
         Use /api/workspaces/{workspaceNamespace}/{workspaceName}/importJob/{jobId} instead.
       operationId: importPFBStatus
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
         - name: jobId
           in: path
           description: job ID of the import to check
@@ -4869,18 +4529,8 @@ paths:
         Lists all imports for this workspace, optionally filtered to only those imports currently in progress
       operationId: listImportJobs
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
         - name: running_only
           in: query
           description: When true, filters to only those imports currently in progress
@@ -4914,18 +4564,8 @@ paths:
         This API will return a jobID representing the import operation. The import itself will continue asynchronously in the background.
       operationId: createImportJob
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
       requestBody:
         description: JSON object containing URL to import
         content:
@@ -4966,18 +4606,8 @@ paths:
         This API will return status of an import jobID. The jobID was returned from a previous import request.
       operationId: importJobStatus
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
         - name: jobId
           in: path
           description: job ID of the import to check
@@ -5005,18 +4635,8 @@ paths:
       summary: Import entities from a tsv file
       operationId: flexibleImportEntities
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Destination Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Destination Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
         - name: async
           in: query
           description: Import asynchronously?
@@ -5071,18 +4691,8 @@ paths:
       summary: Lock Workspace
       operationId: lockWorkspace
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
       responses:
         200:
           description: No response was specified
@@ -5108,18 +4718,8 @@ paths:
       summary: Get a method configuration in a workspace
       operationId: getWorkspaceMethodConfig
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
         - name: configNamespace
           in: path
           description: Configuration Namespace
@@ -5153,18 +4753,8 @@ paths:
         The method configuration name and namespace in the URI must match the values in the JSON.
       operationId: overwriteWorkspaceMethodConfig
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
         - name: configNamespace
           in: path
           description: Configuration Namespace
@@ -5213,18 +4803,8 @@ paths:
         If the location in the request body is different to the location in the URI, and there is a method config already at that location, 409 is returned.
       operationId: updateWorkspaceMethodConfig
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
         - name: configNamespace
           in: path
           description: Configuration Namespace
@@ -5270,18 +4850,8 @@ paths:
       summary: Delete a method configuration in a workspace
       operationId: deleteWorkspaceMethodConfig
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
         - name: configNamespace
           in: path
           description: Configuration Namespace
@@ -5313,18 +4883,8 @@ paths:
       summary: Rename a method configuration in a workspace
       operationId: renameWorkspaceMethodConfig
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
         - name: configNamespace
           in: path
           description: Configuration Namespace
@@ -5370,18 +4930,8 @@ paths:
       summary: get syntax validation information for a method configuration
       operationId: validate_method_configuration
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
         - name: configNamespace
           in: path
           description: Method Configuration Namespace
@@ -5417,18 +4967,8 @@ paths:
       summary: Copy a Method Repository Configuration into a workspace
       operationId: copyFromMethodRepo
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
       requestBody:
         description: Method Configuration to Copy
         content:
@@ -5462,18 +5002,8 @@ paths:
       summary: Copy a Method Config in a workspace to the Method Repository
       operationId: copyToMethodRepo
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
       requestBody:
         description: Method Configuration to Copy
         content:
@@ -5532,18 +5062,8 @@ paths:
         If you are only working with Agora methods, the fields `"sourceRepo"` and `"methodUri"` can be considered informational and do not need to be round-tripped (see the corresponding `POST /api/workspaces/{workspaceNamespace}/{workspaceName}/methodconfigs` for more details).
       operationId: listWorkspaceMethodConfigs
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
         - name: allRepos
           in: query
           description: Configs for all repos, not just Agora
@@ -5600,18 +5120,8 @@ paths:
         The system is specified to check for a URI first before falling back to the legacy fields. Unsupported repos will return a 400 Bad Request.
       operationId: postWorkspaceMethodConfig
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
       requestBody:
         description: Method Configuration contents
         content:
@@ -5643,18 +5153,8 @@ paths:
         references
       operationId: workspacePermissionReport
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
       requestBody:
         description: Users and/or configs on which to report, both optional
         content:
@@ -5684,18 +5184,8 @@ paths:
       summary: Sends notifications for change to workspace
       operationId: changedWorkspaceNotification
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: workspace namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: workspace name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
       responses:
         200:
           description: Success
@@ -5713,18 +5203,8 @@ paths:
         bucket
       operationId: getStorageCostEstimate
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
       responses:
         200:
           description: Successful Request
@@ -5747,18 +5227,8 @@ paths:
         List submissions.
       operationId: listSubmissions
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
       responses:
         200:
           description: List of submissions
@@ -5778,18 +5248,8 @@ paths:
         Create a submission.
       operationId: createSubmission
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
       requestBody:
         description: Post Submission
         content:
@@ -5827,18 +5287,8 @@ paths:
         Returns a map of status:count.
       operationId: countSubmissions
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
       responses:
         200:
           description: Successful Request
@@ -5868,18 +5318,8 @@ paths:
         Monitor submission status
       operationId: monitorSubmission
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
         - name: submissionId
           in: path
           description: Submission ID
@@ -5914,18 +5354,8 @@ paths:
         abort a submission
       operationId: abortSubmission
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
         - name: submissionId
           in: path
           description: Submission ID
@@ -5951,18 +5381,8 @@ paths:
       description: Update user comment for a submission
       operationId: updateSubmissionUserComment
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
         - name: submissionId
           in: path
           description: Submission Id
@@ -5999,18 +5419,8 @@ paths:
       description: Validate expression syntax for a submission
       operationId: validateSubmission
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
       requestBody:
         description: Description of a submission.
         content:
@@ -6061,18 +5471,8 @@ paths:
       description: Get call-level metadata for workflow
       operationId: workflowMetadata
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
         - name: submissionId
           in: path
           description: Submission ID
@@ -6138,18 +5538,8 @@ paths:
         Get workflow outputs.
       operationId: workflowOutputsInSubmission
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
         - name: submissionId
           in: path
           description: Submission ID
@@ -6182,18 +5572,8 @@ paths:
         Retrieve workflow cost, if available.
       operationId: workflowCostInSubmission
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
         - name: submissionId
           in: path
           description: Submission ID
@@ -6235,18 +5615,8 @@ paths:
         Get the tags for this workspace.
       operationId: getWorkspaceTags
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
       responses:
         200:
           description: Workspace tags
@@ -6268,18 +5638,8 @@ paths:
         Replace all tags for this workspace with the user input.
       operationId: putWorkspaceTags
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
       requestBody:
         description: List of tags.
         content:
@@ -6312,18 +5672,8 @@ paths:
         Remove the user-supplied tags from the workspace.
       operationId: deleteWorkspaceTags
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
       requestBody:
         description: List of tags.
         content:
@@ -6356,18 +5706,8 @@ paths:
         Add tags to the workspace without modifying pre-existing tags.
       operationId: patchWorkspaceTags
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
       requestBody:
         description: List of tags.
         content:
@@ -6400,18 +5740,8 @@ paths:
       summary: Unlock Workspace
       operationId: unlockWorkspace
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
       responses:
         200:
           description: No response was specified
@@ -6438,18 +5768,8 @@ paths:
         Modify attributes on a workspace.
       operationId: updateAttributes
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
       requestBody:
         description: Attribute operations. WARNING! This should not be used to change
           library metadata (republish will not happen). Use UpdateAttributes in the
@@ -6485,18 +5805,8 @@ paths:
         Set attributes on a workspace.
       operationId: setAttributes
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
       requestBody:
         description: New attribute values, as Map[String, Attribute]. WARNING! This
           should not be used to change library metadata (republish will not happen).
@@ -6597,18 +5907,8 @@ paths:
         TSV file containing workspace attributes (allows cookie-based authentication)
       operationId: browserDownloadAttributes
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
       responses:
         200:
           description: Workspace attributes in TSV format
@@ -6635,18 +5935,8 @@ paths:
         It is here for documentation purposes only.
       operationId: browserDownloadEntitiesTSVGet
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
         - name: entityType
           in: path
           description: Entity Type
@@ -6694,18 +5984,8 @@ paths:
         It is here for documentation purposes only.
       operationId: browserDownloadEntitiesTSV
       parameters:
-        - name: workspaceNamespace
-          in: path
-          description: Workspace Namespace
-          required: true
-          schema:
-            type: string
-        - name: workspaceName
-          in: path
-          description: Workspace Name
-          required: true
-          schema:
-            type: string
+        - $ref: '#'#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#'#/components/parameters/workspaceNameParam'
         - name: entityType
           in: path
           description: Entity Type


### PR DESCRIPTION
Swagger updates:
* fix the form fields for the `browserDownloadEntitiesTSV` endpoint
* remove extraneous `security:` declarations and rely on the default instead
* fix one errant `security:` declaration that still used "authorization"
* move billing `projectId`, `workspaceNamespace`, `workspaceName` to reusable parameters
* use the pre-existing path parameters e.g. `versionParam` everywhere they apply
* ensure all endpoints have a unique `operationId`
* fix editor.swagger.io validation errors with extraneous `required: false` on object properties