### PR TITLE
handle republishDocument future, which fixes a flaky unit test [AJ-350]

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceService.scala
@@ -64,10 +64,10 @@ class WorkspaceService(protected val argUserToken: WithAccessToken, val rawlsDAO
       // this is technically vulnerable to a race condition in which the workspace attributes have changed
       // between the time we retrieved them and here, where we update them.
       val allOperations = generateAttributeOperations(workspaceResponse.workspace.attributes.getOrElse(Map.empty), newAttributes, _.namespace != AttributeName.libraryNamespace)
-      rawlsDAO.patchWorkspaceAttributes(workspaceNamespace, workspaceName, allOperations) map { ws =>
-        republishDocument(ws, ontologyDAO, searchDAO, consentDAO)
-        RequestComplete(ws)
-      }
+      for {
+        ws <- rawlsDAO.patchWorkspaceAttributes(workspaceNamespace, workspaceName, allOperations)
+        _ <- republishDocument(ws, ontologyDAO, searchDAO, consentDAO)
+      } yield RequestComplete(ws)
     }
   }
 


### PR DESCRIPTION
This test:
```
Workspace setAttributes tests
[info]     when calling PATCH on workspaces/*/*/setAttributes path
[info]     - should republish if the document is already published
```
was flaky, because inside of WorkspaceService we were not waiting for the `republishDocument` Future to resolve before replying with `RequestComplete`. This caused a race condition. This PR fixes the runtime behavior, which will also fix the test.

Found during AJ-350, does not resolve that ticket. #996 has an example of the test failing.