### PR TITLE
DDO-2343 Make proxy passthrough logic set Host header to destination

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/utils/StreamingPassthrough.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/utils/StreamingPassthrough.scala
@@ -102,7 +102,7 @@ trait StreamingPassthrough
       filter(_.isNot(`Timeout-Access`.lowercaseName)).
       filter(_.isNot(Host.lowercaseName))
 
-    val targetHeaders = filteredHeaders :+ Host.apply(targetUri.authority)
+    val targetHeaders = filteredHeaders :+ Host(targetUri.authority.host)
 
     // TODO: what should this log?
     streamingPassthroughLogger.info(s"Passthrough API called. Forwarding call: ${req.method} ${req.uri} => $targetUri")

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/utils/StreamingPassthrough.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/utils/StreamingPassthrough.scala
@@ -98,9 +98,10 @@ trait StreamingPassthrough
     //
     // Host: The Nginx ingress controller used in Terra's BEE environments uses the Host header for routing,
     // so we remove and set it with targetUri host
-    val filteredHeaders = req.headers.
-      filter(_.isNot(`Timeout-Access`.lowercaseName)).
-      filter(_.isNot(Host.lowercaseName))
+    val filteredHeaders = req.headers.filter { hdr =>
+      hdr.isNot(`Timeout-Access`.lowercaseName) &&
+        hdr.isNot(Host.lowercaseName)
+    }
 
     val targetHeaders = filteredHeaders :+ Host(targetUri.authority.host)
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/utils/StreamingPassthroughSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/utils/StreamingPassthroughSpec.scala
@@ -127,7 +127,7 @@ class StreamingPassthroughSpec extends AnyFreeSpec
       val actual = transformToPassthroughRequest(Path("/foo/bar"), Uri("https://example.com/api/version/foo"))(req)
       actual.headers should contain theSameElementsAs (expectedHeaders)
     }
-    "should NOT forward Host header" in {
+    "should rewrite Host header" in {
       val requestHeaders = fixtureHeaders :+ Host("overwritten")
       val expectedHeaders = fixtureHeaders :+ Host("example.com")
       val req = fixtureRequest.withHeaders(requestHeaders)


### PR DESCRIPTION
Configure passthrough proxy logic to update Host header to point at the destination, instead of preserving the source request's Host header.

(This was breaking Orch proxying in BEEs, which use the Nginx Ingress controller, which uses the Host header to route requests)

----
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
