### PR TITLE
ignore elasticsearch/lucene for scala steward [AJ-576]

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -46,6 +46,11 @@ pullRequests.frequency = "0 0 ? * MON" # every monday at midnight
 # Defaults to empty `[]` which mean Scala Steward will not ignore dependencies.
 # updates.ignore = [ { groupId = "org.acme", artifactId="foo", version = "1.0" } ]
 
+# Elasticsearch and its Lucene dependency should not be automatically updated;
+# these require nontrivial changes to calling code and business logic. See AJ-266.
+updates.ignore = [ { groupId = "org.elasticsearch.client", artifactId = "transport" } ]
+updates.ignore = [ { groupId = "org.apache.lucene", artifactId = "lucene-queryparser" } ]
+
 # If set, Scala Steward will only create or update `n` PRs each time it runs (see `pullRequests.frequency` above).
 # Useful if running frequently and/or CI build are costly
 # Default: None


### PR DESCRIPTION
Elasticsearch and its Lucene dependency should not be automatically updated by Scala Steward;
these require nontrivial changes to calling code and business logic. See AJ-266.

Once this merges I will close the following PRs. See those PRs for the ignore syntax I copy/pasted into this PR.
* #1008 
* #1015 
