### PR TITLE
DDO-2398 Propagate branch tag names to GCR

### DIFF
--- a/script/build.sh
+++ b/script/build.sh
@@ -128,6 +128,7 @@ function docker_cmd()
             if [[ -n $GCR_REGISTRY ]]; then
                 docker tag $DOCKERHUB_REGISTRY:${HASH_TAG} $GCR_REGISTRY:${HASH_TAG}
                 gcloud docker -- push $GCR_REGISTRY:${HASH_TAG}
+                gcloud container images add-tag $GCR_REGISTRY:${HASH_TAG} $DOCKERHUB_TESTS_REGISTRY:${DOCKERTAG_SAFE_NAME}
             fi
         fi
     else

--- a/script/build.sh
+++ b/script/build.sh
@@ -126,9 +126,10 @@ function docker_cmd()
             docker push $DOCKERHUB_TESTS_REGISTRY:${DOCKERTAG_SAFE_NAME}
 
             if [[ -n $GCR_REGISTRY ]]; then
+                echo "pushing $GCR_REGISTRY:${HASH_TAG}..."
                 docker tag $DOCKERHUB_REGISTRY:${HASH_TAG} $GCR_REGISTRY:${HASH_TAG}
                 gcloud docker -- push $GCR_REGISTRY:${HASH_TAG}
-                gcloud container images add-tag $GCR_REGISTRY:${HASH_TAG} $DOCKERHUB_TESTS_REGISTRY:${DOCKERTAG_SAFE_NAME}
+                gcloud container images add-tag $GCR_REGISTRY:${HASH_TAG} $GCR_REGISTRY:${DOCKERTAG_SAFE_NAME}
             fi
         fi
     else


### PR DESCRIPTION
Simple update to the build script to propagate branch tag names to GCR as well as Docker hub.

Context here: https://broadinstitute.slack.com/archives/C029LTN5L80/p1665518666500179?thread_ts=1665502394.560979&cid=C029LTN5L80
