### PR TITLE
update snakeyaml via dependencyOverrides [AJ-606]

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,6 +14,14 @@ object Dependencies {
   val excludeAkkaHttp = ExclusionRule(organization = "com.typesafe.akka", name = "akka-http_2.13")
   val excludeSprayJson = ExclusionRule(organization = "com.typesafe.akka", name = "akka-http-spray-json_2.13")
 
+  // Overrides for transitive dependencies. These apply - via Settings.scala - to all projects in this codebase.
+  // These are overrides only; if the direct dependencies stop including any of these, they will not be included
+  // by being listed here.
+  // One reason to specify an override here is to avoid static-analysis security warnings.
+  val transitiveDependencyOverrides: Seq[ModuleID] = Seq(
+    "org.yaml" % "snakeyaml" % "1.33"
+  )
+
   val rootDependencies: Seq[ModuleID] = Seq(
     // proactively pull in latest versions of these libraries, instead of relying on the versions
     // specified as transitive dependencies, due to OWASP DependencyCheck warnings for earlier versions.

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -42,7 +42,8 @@ object Settings {
     organization  := "org.broadinstitute.dsde.firecloud",
     scalaVersion  := "2.13.9",
     resolvers ++= commonResolvers,
-    scalacOptions ++= commonCompilerSettings
+    scalacOptions ++= commonCompilerSettings,
+    dependencyOverrides ++= transitiveDependencyOverrides
   )
 
   //the full list of settings for the root project that's ultimately the one we build into a fat JAR and run

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,3 +3,5 @@ addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.2.0")
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.9.1")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.4")
+
+addDependencyTreePlugin


### PR DESCRIPTION
* sets up `dependencyOverrides` for the build
* adds `snakeyaml` to `dependencyOverrides` to update from a version with security warnings
* adds the [dependency tree plugin](https://github.com/sbt/sbt-dependency-graph#main-tasks) to help with future updates. This last item is not strictly necessary but feels good for future developers.

does NOT move any other library updates to `dependencyOverrides`, e.g. https://github.com/broadinstitute/firecloud-orchestration/blob/f3573580c681d79670c81442e49fb72155a70395/project/Dependencies.scala#L28. I suggest doing that in a separate PR.