### PR TITLE
AJ-635: Remove stack traces exposed in HTTP error responses

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudApiService.scala
@@ -48,9 +48,9 @@ object FireCloudApiService extends LazyLogging {
         if (logger.underlying.isDebugEnabled) {
           logger.debug(e.getMessage, e)
         } else {
-          logger.error(e.getMessage)
+          logger.error(s"$e")
         }
-        complete(StatusCodes.InternalServerError -> ErrorReport(e))
+        complete(StatusCodes.InternalServerError)
     }
   }
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudApiService.scala
@@ -48,10 +48,10 @@ object FireCloudApiService extends LazyLogging {
         if (logger.underlying.isDebugEnabled) {
           logger.debug(e.getMessage, e)
         } else {
-          logger.error(s"$e")
+          logger.error(e.toString)
         }
         // ErrorReport.apply with "message" kwarg. is specifically used to mute Stack Trace output in HTTP Error Responses
-        complete(StatusCodes.InternalServerError -> ErrorReport(message="An error occurred. Please see logs for more details."))
+        complete(StatusCodes.InternalServerError -> ErrorReport(message=e.getMessage))
     }
   }
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudApiService.scala
@@ -50,7 +50,8 @@ object FireCloudApiService extends LazyLogging {
         } else {
           logger.error(s"$e")
         }
-        complete(StatusCodes.InternalServerError)
+        // ErrorReport.apply with "message" kwarg. is specifically used to mute Stack Trace output in HTTP Error Responses
+        complete(StatusCodes.InternalServerError -> ErrorReport(message="An error occurred. Please see logs for more details."))
     }
   }
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/ImportPermissionApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/ImportPermissionApiServiceSpec.scala
@@ -90,18 +90,19 @@ class ImportPermissionApiServiceSpec extends BaseServiceSpec with UserApiService
         responseAs[UserImportPermission].writableWorkspace shouldBe false
       }
     }
+
     "should propagate an error if the call to get workspaces fails" in {
       Get(endpoint) ~> dummyUserIdHeaders("userid","thisWillError;hasProjects") ~> sealRoute(userServiceRoutes) ~> check {
         status should equal(InternalServerError)
         val err:ErrorReport = responseAs[ErrorReport]
-        err.message shouldBe "An error occurred. Please see logs for more details."
+        err.message shouldBe "intentional exception for getWorkspaces catchall case"
       }
     }
     "should propagate an error if the call to get billing projects fails" in {
       Get(endpoint) ~> dummyUserIdHeaders("userid","hasWorkspaces;thisWillError") ~> sealRoute(userServiceRoutes) ~> check {
         status should equal(InternalServerError)
         val err:ErrorReport = responseAs[ErrorReport]
-        err.message shouldBe "An error occurred. Please see logs for more details."
+        err.message shouldBe "intentional exception for getProjects catchall case"
       }
     }
   }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/ImportPermissionApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/ImportPermissionApiServiceSpec.scala
@@ -15,7 +15,7 @@ import akka.http.scaladsl.server.Route.{seal => sealRoute}
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class ImportPermissionApiServiceSpec extends BaseServiceSpec with UserApiService with SprayJsonSupport {
+class eImportPermissionApiServiceSpec extends BaseServiceSpec with UserApiService with SprayJsonSupport {
 
   def actorRefFactory = system
 
@@ -90,19 +90,18 @@ class ImportPermissionApiServiceSpec extends BaseServiceSpec with UserApiService
         responseAs[UserImportPermission].writableWorkspace shouldBe false
       }
     }
-
     "should propagate an error if the call to get workspaces fails" in {
       Get(endpoint) ~> dummyUserIdHeaders("userid","thisWillError;hasProjects") ~> sealRoute(userServiceRoutes) ~> check {
         status should equal(InternalServerError)
         val err:ErrorReport = responseAs[ErrorReport]
-        err.message shouldBe "intentional exception for getWorkspaces catchall case"
+        err.message shouldBe "An error occurred. Please see logs for more details."
       }
     }
     "should propagate an error if the call to get billing projects fails" in {
       Get(endpoint) ~> dummyUserIdHeaders("userid","hasWorkspaces;thisWillError") ~> sealRoute(userServiceRoutes) ~> check {
         status should equal(InternalServerError)
         val err:ErrorReport = responseAs[ErrorReport]
-        err.message shouldBe "intentional exception for getProjects catchall case"
+        err.message shouldBe "An error occurred. Please see logs for more details."
       }
     }
   }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/ImportPermissionApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/ImportPermissionApiServiceSpec.scala
@@ -15,7 +15,7 @@ import akka.http.scaladsl.server.Route.{seal => sealRoute}
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class eImportPermissionApiServiceSpec extends BaseServiceSpec with UserApiService with SprayJsonSupport {
+class ImportPermissionApiServiceSpec extends BaseServiceSpec with UserApiService with SprayJsonSupport {
 
   def actorRefFactory = system
 


### PR DESCRIPTION
Relates to https://broadworkbench.atlassian.net/browse/AJ-635

A vulnerability was discovered in which stack traces were included in HTTP Error responses. This PR removes the stack traces from the HTTP responses, and instead, outputs them as `logger.error`

Prior to this PR, HTTP Error responses contained stack traces such as:

```
"stackTrace":[{"className":"org.elasticsearch.search.aggregations.bucket.terms.
 TermsAggregationBuilder","fileName":"TermsAggregationBuilder.java","lineNumber":146,"methodName":"size"},{"c
 lassName":"org.broadinstitute.dsde.firecloud.dataaccess.ElasticSearchDAOQuerySupport","fileName":"ElasticSear
 chDAOQuerySupport.scala","lineNumber":124,"methodName":"$anonfun$addAggregationsToQuery$2"},{"classNa
 me":"scala.collection.IterableOnceOps","fileName":"IterableOnce.scala","lineNumber":563,"methodName":"foreach
 "},{"className":"scala.collection.IterableOnceOps","fileName":"IterableOnce.scala","lineNumber":561,"methodNa
 me":"foreach$"},{"className":"scala.collection.AbstractIterable","fileName":"Iterable.scala","lineNumber":926,"met
 hodName":"foreach"},{"className":"org.broadinstitute.dsde.firecloud.dataaccess.ElasticSearchDAOQuerySupp ort
 ","fileName":"ElasticSearchDAOQuerySupport.scala".....
```

from these changes, the error response now displays as:

```
{
  "causes": [],
  "message": "An error occurred. Please see logs for more details.",
  "source": "FireCloud",
  "stackTrace": []
}
```

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [x] Get two thumbsworth of review and PO signoff if necessary
- [x] Verify all tests go green
- [x] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
