### PR TITLE
[SUP-439] Allow deletion of workspaces when owner loses membership to auth domain

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceService.scala
@@ -197,7 +197,7 @@ class WorkspaceService(protected val argUserToken: WithAccessToken, val rawlsDAO
       // from the auth domain group(s). A user is allowed to delete these workspaces, but not view them. Because Orchestration
       // has the extra step to get and unpublish a workspace, that would cause the above rawlsDAO.getWorkspace call to fail, thus
       // preventing the user from deleting the workspace. They could delete the workspace by calling Rawls directly because it does not
-      // bother unpublishing a workspace (that is strictly an Orch concept), but that is not a friendly UX, and we want to make our best
+      // bother with unpublishing a workspace (that is strictly an Orch concept), but that is not a friendly UX, and we want to make our best
       // attempt to unpublish the workspace if possible, although it is not critical. It is unlikely that this recoverWith would be
       // reached for a published workspace anyway.
       case e: FireCloudExceptionWithErrorReport if e.errorReport.statusCode.contains(StatusCodes.NotFound) => {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceService.scala
@@ -192,6 +192,19 @@ class WorkspaceService(protected val argUserToken: WithAccessToken, val rawlsDAO
         case e: FireCloudExceptionWithErrorReport => RequestComplete(e.errorReport.statusCode.getOrElse(StatusCodes.InternalServerError), ErrorReport(message = s"You cannot delete this workspace: ${e.errorReport.message}"))
         case e: Throwable => RequestComplete(StatusCodes.InternalServerError, ErrorReport(message = s"You cannot delete this workspace: ${e.getMessage}"))
       }
+    } recoverWith {
+      // This case is only possible when a user owns a workspace, but has lost access to it because they have been removed
+      // from the auth domain group(s). A user is allowed to delete these workspaces, but not view them. Because Orchestration
+      // has the extra step to get and unpublish a workspace, that would cause the above rawlsDAO.getWorkspace call to fail, thus
+      // preventing the user from deleting the workspace. They could delete the workspace by calling Rawls directly because it does not
+      // bother unpublishing a workspace (that is strictly an Orch concept), but that is not a friendly UX, and we want to make our best
+      // attempt to unpublish the workspace if possible, although it is not critical. It is unlikely that this recoverWith would be
+      // reached for a published workspace anyway.
+      case e: FireCloudExceptionWithErrorReport if e.errorReport.statusCode.contains(StatusCodes.NotFound) => {
+        rawlsDAO.deleteWorkspace(ns, name) map { wsResponse =>
+          RequestComplete(StatusCodes.Accepted, Some(wsResponse.getOrElse("")))
+        }
+      }
     }
   }
 


### PR DESCRIPTION
This is the backend piece of SUP-439: https://broadworkbench.atlassian.net/browse/SUP-439

Orch currently prevents users from deleting workspaces that they own if they'e lost membership to the auth domain. This is not consistent with the permissions that have been defined in Sam, nor is it consistent with the behavior of the Rawls deleteWorkspace API. This PR modifies the Orch deleteWorkspace logic to allow for this case.

The reason that this hasn't worked in Orch is because Orch has additional logic for deleting workspaces. Orch attempts to unpublish workspaces that have been published to Library. The unpublish step has a call to `getWorkspace`, which requires the `view` action on a workspace. `view` is auth domain constrained, so the call fails- causing the entire `deleteWorkspace` call to fail. With this change, if the `getWorkspace` call fails, we will still attempt to delete the workspace.

Supporting this is especially important for cleaning up after workshops. Users create workspaces on Broad's dime, and sometimes they protect their workspaces with an auth domain. After the workshop, User Ed likes to clean up these workspaces so we don't incur charges- but it's not currently possible in the UI because the deleteWorkspace endpoint in Orch doesn't support this case.

As mentioned, it is possible to clean these up by calling the Rawls API directly, but that is extra work for our User Ed team. Additionally, User Ed isn't the only group of users impacted by this. By supporting this case in Orchestration, we can enable the delete button in Terra UI for these cases.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
