### PR TITLE
[RW-9102] Add /api/convert/rmd api endpoint in fireclouid-orch

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -3055,8 +3055,11 @@ paths:
           description: Success
           content: { }
         500:
-          description: Internal Error
-          content: { }
+          description: FireCloud Internal Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
       x-passthrough: true
       x-passthrough-target: calhoun
       x-codegen-request-body-name: rmd

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -3012,6 +3012,55 @@ paths:
       x-passthrough: true
       x-passthrough-target: calhoun
       x-codegen-request-body-name: notebook
+
+  /api/staticRMarkdown/convert:
+    post:
+      tags:
+        - Static R Markdown files
+      summary: |
+        Converts an R Markdown file to HTML. Accepts the content of an .Rmd file in the request body.
+      description: |
+        Converts an R Markdown file to HTML. Accepts the content of an .Rmd file in the request body.
+      operationId: convertRmd
+      requestBody:
+        description: R Markdown file
+        content:
+          text/plain:
+            schema:
+              type: string
+              format: binary
+              example: |
+                ---
+                title: "test-rmd"
+                output: html_document
+                ---
+                ```{r setup, include=FALSE}
+                knitr::opts_chunk$set(echo = TRUE)
+                ```
+                ## R Markdown
+                This is an R Markdown document. Markdown is a simple formatting syntax for authoring HTML, PDF, and MS Word documents. For more details on using R Markdown see <http://rmarkdown.rstudio.com>.
+                When you click the **Knit** button a document will be generated that includes both content as well as the output of any embedded R code chunks within the document. You can embed an R code chunk like this:
+                ```{r cars}
+                summary(cars)
+                ```
+                ## Including Plots
+                You can also embed plots, for example:
+                ```{r pressure, echo=FALSE}
+                plot(pressure)
+                ```
+                Note that the `echo = FALSE` parameter was added to the code chunk to prevent printing of the R code that generated the plot.
+        required: true
+      responses:
+        200:
+          description: Success
+          content: { }
+        500:
+          description: Internal Error
+          content: { }
+      x-passthrough: true
+      x-passthrough-target: calhoun
+      x-codegen-request-body-name: rmd
+
   /api/storage/{bucket}/{object}:
     get:
       tags:

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -3013,7 +3013,7 @@ paths:
       x-passthrough-target: calhoun
       x-codegen-request-body-name: notebook
 
-  /api/staticRMarkdown/convert:
+  /api/staticRmd/convert:
     post:
       tags:
         - Static R Markdown files

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -3013,10 +3013,10 @@ paths:
       x-passthrough-target: calhoun
       x-codegen-request-body-name: notebook
 
-  /api/staticRmd/convert:
+  /api/staticNotebooks/convertRmd:
     post:
       tags:
-        - Static R Markdown files
+        - Static Notebooks
       summary: |
         Converts an R Markdown file to HTML. Accepts the content of an .Rmd file in the request body.
       description: |

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/StaticNotebooksApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/StaticNotebooksApiService.scala
@@ -13,6 +13,7 @@ trait StaticNotebooksApiService extends FireCloudDirectives with StandardUserInf
 
   val calhounStaticNotebooksRoot: String = FireCloudConfig.StaticNotebooks.baseUrl
   val calhounStaticNotebooksURL: String = s"$calhounStaticNotebooksRoot/api/convert"
+  val calhounStaticRMarkdownURL: String = s"$calhounStaticNotebooksRoot/api/convert/rmd"
 
   val staticNotebooksRoutes: Route = {
     path("staticNotebooks" / "convert") {
@@ -23,6 +24,23 @@ trait StaticNotebooksApiService extends FireCloudDirectives with StandardUserInf
             // can't use passthrough() here because that demands a JSON response
             // and we expect this to return text/html
             val extReq = Post(calhounStaticNotebooksURL, requestContext.request.entity)
+            userAuthedRequest(extReq)(userInfo).flatMap { resp =>
+              requestContext.complete(resp)
+            }
+        }
+      }
+    }
+  }
+
+  val staticNotebooksRoutes: Route = {
+    path("staticRMarkdown" / "convert") {
+      requireUserInfo() { userInfo =>
+        post {
+          requestContext =>
+            // call Calhoun and pass its response back to our own caller
+            // can't use passthrough() here because that demands a JSON response
+            // and we expect this to return text/html
+            val extReq = Post(calhounStaticRMarkdownURL, requestContext.request.entity)
             userAuthedRequest(extReq)(userInfo).flatMap { resp =>
               requestContext.complete(resp)
             }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/StaticNotebooksApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/StaticNotebooksApiService.scala
@@ -33,7 +33,7 @@ trait StaticNotebooksApiService extends FireCloudDirectives with StandardUserInf
   }
 
   val staticNotebooksRoutes: Route = {
-    path("staticRMarkdown" / "convert") {
+    path("staticRmd" / "convert") {
       requireUserInfo() { userInfo =>
         post {
           requestContext =>

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/StaticNotebooksApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/StaticNotebooksApiService.scala
@@ -32,7 +32,7 @@ trait StaticNotebooksApiService extends FireCloudDirectives with StandardUserInf
     }
   }
 
-  val staticNotebooksRoutes: Route = {
+  val staticRmdRoutes: Route = {
     path("staticRmd" / "convert") {
       requireUserInfo() { userInfo =>
         post {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/StaticNotebooksApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/StaticNotebooksApiService.scala
@@ -29,10 +29,7 @@ trait StaticNotebooksApiService extends FireCloudDirectives with StandardUserInf
             }
         }
       }
-    }
-  }
-
-  val staticRmdRoutes: Route = {
+    } ~
     pathPrefix("staticNotebooks" / "convertRmd") {
       streamingPassthrough(calhounStaticRMarkdownURL)
     }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/StaticNotebooksApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/StaticNotebooksApiService.scala
@@ -33,7 +33,7 @@ trait StaticNotebooksApiService extends FireCloudDirectives with StandardUserInf
   }
 
   val staticRmdRoutes: Route = {
-    path("staticRmd" / "convert") {
+    pathPrefix("staticRmd" / "convert") {
       streamingPassthrough(calhounStaticRMarkdownURL)
     }
   }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/StaticNotebooksApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/StaticNotebooksApiService.scala
@@ -3,7 +3,7 @@ package org.broadinstitute.dsde.firecloud.webservice
 import akka.http.scaladsl.server.Route
 import org.broadinstitute.dsde.firecloud.FireCloudConfig
 import org.broadinstitute.dsde.firecloud.service._
-import org.broadinstitute.dsde.firecloud.utils.{RestJsonClient, StandardUserInfoDirectives}
+import org.broadinstitute.dsde.firecloud.utils.{RestJsonClient, StandardUserInfoDirectives, StreamingPassthrough}
 
 import scala.concurrent.ExecutionContext
 
@@ -34,18 +34,7 @@ trait StaticNotebooksApiService extends FireCloudDirectives with StandardUserInf
 
   val staticRmdRoutes: Route = {
     path("staticRmd" / "convert") {
-      requireUserInfo() { userInfo =>
-        post {
-          requestContext =>
-            // call Calhoun and pass its response back to our own caller
-            // can't use passthrough() here because that demands a JSON response
-            // and we expect this to return text/html
-            val extReq = Post(calhounStaticRMarkdownURL, requestContext.request.entity)
-            userAuthedRequest(extReq)(userInfo).flatMap { resp =>
-              requestContext.complete(resp)
-            }
-        }
-      }
+      streamingPassthrough(calhounStaticRMarkdownURL)
     }
   }
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/StaticNotebooksApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/StaticNotebooksApiService.scala
@@ -33,7 +33,7 @@ trait StaticNotebooksApiService extends FireCloudDirectives with StandardUserInf
   }
 
   val staticRmdRoutes: Route = {
-    pathPrefix("staticRmd" / "convert") {
+    pathPrefix("staticNotebooks" / "convertRmd") {
       streamingPassthrough(calhounStaticRMarkdownURL)
     }
   }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/StaticNotebooksApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/StaticNotebooksApiService.scala
@@ -7,7 +7,7 @@ import org.broadinstitute.dsde.firecloud.utils.{RestJsonClient, StandardUserInfo
 
 import scala.concurrent.ExecutionContext
 
-trait StaticNotebooksApiService extends FireCloudDirectives with StandardUserInfoDirectives with RestJsonClient {
+trait StaticNotebooksApiService extends FireCloudDirectives with StandardUserInfoDirectives with RestJsonClient with StreamingPassthrough {
 
   implicit val executionContext: ExecutionContext
 


### PR DESCRIPTION
Add convert rmd API into firecloud-orch: 
https://github.com/DataBiosphere/calhoun/blob/dev/static/api-docs.yaml#L76

AoU is using firecloud-orch for most Terra calls including convert Jupyter Notebook: 
https://github.com/all-of-us/workbench/blob/main/api/src/main/resources/firecloud.yaml#L933

As we are supporting RStudio via Leo GKE, we need to expose convertRmd in firecloud-orch

Not sure if that is the best api interface. Or shall I do `staticNotebook/conver/rmd`? 


Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
