### PR TITLE
Update sbt-assembly from 1.2.0 to 2.1.0 [AJ-737]

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.2.0")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.1.0")
 
 addSbtPlugin("io.spray" % "sbt-revolver" % "0.9.1")
 

--- a/src/docker/install.sh
+++ b/src/docker/install.sh
@@ -7,7 +7,7 @@ cd $ORCH_DIR
 
 sbt -batch -d clean reload update compile
 sbt -batch test
-sbt -batch assembly
+sbt --mem 2048 -batch assembly
 
 ORCH_JAR=$(find target | grep 'FireCloud-Orchestration.*\.jar')
 mv $ORCH_JAR .


### PR DESCRIPTION
supersedes #1073.

#1073 updates to `sbt-assembly 2.1.0`, but Jenkins is consistently hitting an OOM during assembly.

The `sbt-assembly` 2.x release switched to in-memory processing (https://github.com/sbt/sbt-assembly/releases/tag/v2.0.0), so this makes sense.

This PR both upgrades to 2.1.0 _AND_ specifies 2g for assembly in Jenkins.