### PR TITLE
[RW-9349] Add Sam ToS Details passthrough

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -6209,6 +6209,19 @@ paths:
         404:
           description: User Not Found.
           content: { }
+  /register/user/v2/self/termsOfServiceDetails:
+    get:
+      tags:
+        - Terms of Service
+      summary: gets terms of service details, including user's accepted version
+      operationId: getTermsOfServiceDetails
+      responses:
+        200:
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TermsOfServiceDetails'
   /ga4gh/v1/tools/{id}:
     get:
       tags:
@@ -9902,6 +9915,27 @@ components:
         currentBillingAccountOnGoogleProject:
           type: string
           description: the billing project associated with the workspace
+    TermsOfServiceDetails:
+      required:
+        - isEnabled
+        - isGracePeriodEnabled
+        - currentVersion
+        - userAcceptedVersion
+      type: object
+      properties:
+        isEnabled:
+          type: boolean
+          description: true if terms of service is enforced in Sam
+        isGracePeriodEnabled:
+          type: boolean
+          description: true if there is currently a grace period enabled,
+            letting users use the system without accepting the terms of service
+        currentVersion:
+          type: string
+          description: the current version of terms of service for the system
+        userAcceptedVersion:
+          type: string
+          description: the version of the terms of service the user has accepted
   parameters:
     AttributeNamePathParam:
       name: attributeName

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/RegisterService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/RegisterService.scala
@@ -18,6 +18,7 @@ object RegisterService {
   val samTosTextUrl = s"${Sam.baseUrl}/tos/text"
   val samTosBaseUrl = s"${Sam.baseUrl}/register/user/v1/termsofservice"
   val samTosStatusUrl = s"${samTosBaseUrl}/status"
+  val samTosDetailsUrl = s"${Sam.baseUrl}/register/user/v2/self/termsOfServiceDetails"
 
   def constructor(app: Application)()(implicit executionContext: ExecutionContext) =
     new RegisterService(app.rawlsDAO, app.samDAO, app.thurloeDAO, app.googleServicesDAO)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/RegisterApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/RegisterApiService.scala
@@ -60,19 +60,19 @@ trait RegisterApiService extends FireCloudDirectives with EnabledUserDirectives 
               passthrough(samTosBaseUrl, POST)
             }
           } ~
-            delete {
-              requireUserInfo() { _ =>
-                passthrough(samTosBaseUrl, DELETE)
-              }
-            }
-        } ~
-          path("status") {
-            get {
-              requireUserInfo() { _ =>
-                passthrough(samTosStatusUrl, GET)
-              }
+          delete {
+            requireUserInfo() { _ =>
+              passthrough(samTosBaseUrl, DELETE)
             }
           }
+        } ~
+        path("status") {
+          get {
+            requireUserInfo() { _ =>
+              passthrough(samTosStatusUrl, GET)
+            }
+          }
+        }
       }
       pathPrefix("v2" / "self" / "termsOfServiceDetails") {
         get {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/RegisterApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/RegisterApiService.scala
@@ -80,6 +80,7 @@ trait RegisterApiService extends FireCloudDirectives with EnabledUserDirectives 
             passthrough(samTosDetailsUrl, GET)
           }
         }
+      }
     }
   }
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/RegisterApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/RegisterApiService.scala
@@ -8,7 +8,7 @@ import org.broadinstitute.dsde.firecloud.service.{FireCloudDirectives, RegisterS
 import org.broadinstitute.dsde.firecloud.utils.{EnabledUserDirectives, StandardUserInfoDirectives}
 import spray.json.DefaultJsonProtocol._
 import akka.http.scaladsl.server.Route
-import org.broadinstitute.dsde.firecloud.service.RegisterService.{samTosBaseUrl, samTosStatusUrl, samTosTextUrl}
+import org.broadinstitute.dsde.firecloud.service.RegisterService.{samTosBaseUrl, samTosDetailsUrl, samTosStatusUrl, samTosTextUrl}
 
 import scala.concurrent.ExecutionContext
 
@@ -52,28 +52,34 @@ trait RegisterApiService extends FireCloudDirectives with EnabledUserDirectives 
         passthrough(samTosTextUrl, GET)
       }
     } ~
-    pathPrefix("register") {
-      pathPrefix("user" / "v1" / "termsofservice") {
+    pathPrefix("register" / "user") {
+      pathPrefix("v1" / "termsofservice") {
         pathEndOrSingleSlash {
           post {
             requireUserInfo() { _ =>
               passthrough(samTosBaseUrl, POST)
             }
           } ~
-          delete {
-            requireUserInfo() { _ =>
-              passthrough(samTosBaseUrl, DELETE)
+            delete {
+              requireUserInfo() { _ =>
+                passthrough(samTosBaseUrl, DELETE)
+              }
+            }
+        } ~
+          path("status") {
+            get {
+              requireUserInfo() { _ =>
+                passthrough(samTosStatusUrl, GET)
+              }
             }
           }
-        } ~
-        path("status") {
-          get {
-            requireUserInfo() { _ =>
-              passthrough(samTosStatusUrl, GET)
-            }
+      }
+      pathPrefix("v2" / "self" / "termsOfServiceDetails") {
+        get {
+          requireUserInfo() { _ =>
+            passthrough(samTosDetailsUrl, GET)
           }
         }
-      }
     }
   }
 }


### PR DESCRIPTION
Add a passthrough endpoint for Sam `register/user/v2/self/termsOfServiceDetails` (added in https://github.com/broadinstitute/sam/pull/935)

The All of Us Researcher Workbench development team prefers to call Firecloud-Orchestration endpoints instead of calling Terra services directly.


Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
