### PR TITLE
append routes [RW-9349]

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/RegisterApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/RegisterApiService.scala
@@ -73,7 +73,7 @@ trait RegisterApiService extends FireCloudDirectives with EnabledUserDirectives 
             }
           }
         }
-      }
+      } ~
       pathPrefix("v2" / "self" / "termsOfServiceDetails") {
         get {
           requireUserInfo() { _ =>


### PR DESCRIPTION
The routes under `"register" / "user"` were not appended to each other; the last one `"v2" / "self" / "termsOfServiceDetails"` was the only one that worked. This PR fixes that.

I manually tested each of the `"register" / "user"` routes running locally.

Followup to #1080 