### PR TITLE
[SUP-757]  Fix for Rawls workflow passthough

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -1002,8 +1002,8 @@ paths:
   /api/workflows/{version}/{id}/backend/metadata/{backendId}:
     get:
       tags:
-        - CromIAM Workflows (for Job Manager)
-      summary: Get backend (e.g. PAPI) metadata for a job
+        - Rawls Workflows (for Job Manager)
+      summary: Get backend (e.g. PAPI, Google Life Sciences) metadata for a job
       parameters:
         - $ref: '#/components/parameters/versionParam'
         - name: id

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/utils/StreamingPassthrough.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/utils/StreamingPassthrough.scala
@@ -125,7 +125,7 @@ trait StreamingPassthrough
     * @param modifiedRemotePath a modified path value to be used over requestUri.path.toString if provided
     * @return the URI suitable for sending to the remote system
     */
-  def convertToRemoteUri(requestUri: Uri, localBasePath: Uri.Path, remoteBaseUri: Uri, modifiedRemotePath: Option[String]): Uri = {
+  def convertToRemoteUri(requestUri: Uri, localBasePath: Uri.Path, remoteBaseUri: Uri, modifiedRemotePath: Option[String] = None): Uri = {
     // Ensure the incoming request starts with the localBasePath. Abort if it doesn't.
     // This condition should only be caused by developer error in which the streamingPassthrough
     // directive is incorrectly configured inside a route.

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/utils/StreamingPassthrough.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/utils/StreamingPassthrough.scala
@@ -89,7 +89,7 @@ trait StreamingPassthrough
     * @param req the request inbound to Orchestration
     * @return the outbound request to be sent to another service
     */
-  def transformToPassthroughRequest(localBasePath: Uri.Path, remoteBaseUri: Uri, remotePath: Option[String])(req: HttpRequest): HttpRequest = {
+  def transformToPassthroughRequest(localBasePath: Uri.Path, remoteBaseUri: Uri, remotePath: Option[String] = None)(req: HttpRequest): HttpRequest = {
     // Convert the URI to the one suitable for the remote system
     val targetUri = convertToRemoteUri(req.uri, localBasePath, remoteBaseUri, remotePath)
     // Remove unwanted headers:

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/utils/StreamingPassthrough.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/utils/StreamingPassthrough.scala
@@ -60,13 +60,28 @@ trait StreamingPassthrough
   }
 
   /**
+   * Passes through, to a remote server, all requests that match or start with the
+   * supplied local path with a supplied remotePath for remote Uri construction
+   *
+   * @param passthroughMapping in the form `localBasePath -> remoteBaseUri`, where
+   *                           the localBasePath is the Orchestration-local path
+   *                           which must be matched for passthroughs, and remoteBaseUri
+   *                           is the fully-qualified URL to a remote system
+   *                           to use as target for passthrough requests.
+   *  @param pathOverride as the pre-defined path to use when constructing the remote path value
+   */
+  def streamingPassthroughWithPathRedirect(passthroughMapping: (Uri.Path, Uri), pathOverride: String): Route = {
+    passthroughImpl(passthroughMapping._1, passthroughMapping._2, Option(pathOverride))
+  }
+
+  /**
     * The passthrough implementation:
     *   - `mapRequest` to transform the incoming request to what we want to send to the remote system
     *   - `extractRequest` so we have the transformed request as an object
    *    - `remotePathOverride` to provide a pre-configured path if remote path structure is different from local
     *   - call the remote system and reply to the user via `routeResponse` streaming
    */
-  def passthroughImpl(localBasePath: Uri.Path, remoteBaseUri: Uri, remotePathOverride: Option[String] = None): Route = {
+  private def passthroughImpl(localBasePath: Uri.Path, remoteBaseUri: Uri, remotePathOverride: Option[String] = None): Route = {
     mapRequest(transformToPassthroughRequest(localBasePath, remoteBaseUri, remotePathOverride)) {
       extractRequest { req =>
         complete {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/utils/StreamingPassthrough.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/utils/StreamingPassthrough.scala
@@ -56,7 +56,7 @@ trait StreamingPassthrough
     *                           to use as target for passthrough requests.
     */
   def streamingPassthrough(passthroughMapping: (Uri.Path, Uri)): Route = {
-    passthroughImpl(passthroughMapping._1, passthroughMapping._2, None)
+    passthroughImpl(passthroughMapping._1, passthroughMapping._2)
   }
 
   /**

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/CromIamApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/CromIamApiService.scala
@@ -14,15 +14,20 @@ trait CromIamApiService extends FireCloudRequestBuilding
   lazy val workflowRoot: String = FireCloudConfig.CromIAM.authUrl + "/workflows/v1"
   lazy val womtoolRoute: String = FireCloudConfig.CromIAM.authUrl + "/womtool/v1"
   lazy val engineRoot: String = FireCloudConfig.CromIAM.baseUrl + "/engine/v1"
-//  lazy val rawlsWorkflowRoot: String = FireCloudConfig.Rawls.authUrl + "/workflows"
+  lazy val rawlsWorkflowRoot: String = FireCloudConfig.Rawls.authUrl + "/workflows"
 
   // This is the subset of CromIAM endpoints required for Job Manager. Orchestration is acting as a proxy between
   // CromIAM and Job Manager as of February 2019.
   // Adam Nichols, 2019-02-04
 
-  val cromIamApiServiceRoutes: Route =
-    pathPrefix( "workflows" / Segment ) { _ =>
-      streamingPassthrough(Uri.Path(s"/api/workflows/v1") -> Uri(workflowRoot))
+  val cromIamApiServiceRoutes: Route = {
+    pathPrefix( "workflows" / Segments ) { segmentsArr =>
+      // TODO: get feedback on this method
+      // There is one endpoint that is meant to be redirected to rawls and not cromIAM ("/backend/metadata/" substring present)
+      // Root assignment can be handled here, curious if there's any way to handle req.path modifications here as well
+      val suffix = segmentsArr.mkString("/")
+      val root = if (suffix.contains("/backend/metadata/")) rawlsWorkflowRoot else workflowRoot
+      streamingPassthrough(Uri.Path(s"/api/workflows/v1") -> Uri(root))
     } ~
     pathPrefix( "womtool" / Segment ) { _ =>
       path( "describe" ) {
@@ -33,10 +38,10 @@ trait CromIamApiService extends FireCloudRequestBuilding
         }
       }
     }
+  }
 
   val cromIamEngineRoutes: Route =
     pathPrefix( "engine" / Segment ) { _ =>
       streamingPassthrough(Uri.Path("/engine/v1") -> Uri(engineRoot))
     }
-
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/CromIamApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/CromIamApiService.scala
@@ -23,7 +23,7 @@ trait CromIamApiService extends FireCloudRequestBuilding
     val localBase = s"/api/workflows/v1"
     pathPrefix("workflows" / Segment / Segment / "backend" / "metadata" / Segments) {(version, workflowId, operationSegments) =>
       val suffix = operationSegments.mkString("/")
-      rawlsPassthrough(Uri.Path(localBase), Uri(rawlsWorkflowRoot), s"/${workflowId}/genomics/${suffix}")
+      passthroughImpl(Uri.Path(localBase), Uri(rawlsWorkflowRoot), Option(s"/${workflowId}/genomics/${suffix}"))
     } ~
     pathPrefix( "workflows" / Segments ) { segmentsArr =>
       streamingPassthrough(Uri.Path(localBase) -> Uri(workflowRoot))

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/CromIamApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/CromIamApiServiceSpec.scala
@@ -130,6 +130,7 @@ class CromIamApiServiceSpec extends BaseServiceSpec with CromIamApiService with 
 
       val endpointPapiV1 = workflowRoot + "/my-bogus-workflow-id-565656/backend/metadata/operations/foobar"
       val endpointPapiV2 = workflowRoot + "/my-bogus-workflow-id-565656/backend/metadata/projects/proj/operations/foobar"
+      val endpointGoogleLifeSciencesBeta = workflowRoot + "/my-bogus-workflow-id-565656/backend/metadata/projects/proj/projId/locations/us-somewhere/operations/opId"
       val myMethods = List(HttpMethods.GET)
 
       "should pass through my methods PAPIv1" in {
@@ -141,6 +142,12 @@ class CromIamApiServiceSpec extends BaseServiceSpec with CromIamApiService with 
       "should pass through my methods PAPIv2" in {
         myMethods foreach { method =>
           checkIfPassedThrough(testableRoutes, method, endpointPapiV2, toBeHandled = true)
+        }
+      }
+
+      "should pass through my methods Google Life Sciences Beta" in {
+        myMethods foreach { method =>
+          checkIfPassedThrough(testableRoutes, method, endpointGoogleLifeSciencesBeta, toBeHandled = true)
         }
       }
 


### PR DESCRIPTION
Partially addresses [SUP-757](https://broadworkbench.atlassian.net/browse/SUP-757)

The initial ticket describes a UI bug where the "Compute Details" button in Job Manager's UI did nothing. Looking into the bug, I noticed that the button did make the expected outbound request only to receive a 404 response.

Further exploration lead me here to where I think the JM requests eventually land, where all of the workflow endpoint routes are redirected with a CromIAM based URI assigned and the request path appended to the constructed remote request. 

The sole Rawls based endpoint is different not just because it requires a Rawls based url, but the path itself needs to be reconstructed to match the expected pattern on Rawls.

I'm new to Scala and Akka, so I'd appreciate any feedback given (especially for the path construction part).

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment


[SUP-757]: https://broadworkbench.atlassian.net/browse/SUP-757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ