### PR TITLE
AJ-803: mark storage apis as deprecated

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -3016,8 +3016,8 @@ paths:
     get:
       tags:
         - Storage
-      summary: |
-        Get metadata about an object stored in GCS.
+      deprecated: true
+      summary: This API will be deleted on April 1, 2023.
       description: |
         Returns a subset of the metadata available from Google's Cloud Storage JSON API, as well as the estimated egress
         charge to North America. If you need the full metadata, we recommend you use Google's API directly; see
@@ -5560,8 +5560,8 @@ paths:
     get:
       tags:
         - Storage
-      summary: |
-        Download GCS object using a cookie token
+      deprecated: true
+      summary: This API will be deleted on April 1, 2023.
       description: |
         Download GCS object using a cookie token
       operationId: getStorageDownload


### PR DESCRIPTION
* comms will be publishing an article under the Service Notifications page announcing the deprecation. See Slack thread https://broadinstitute.slack.com/archives/C33EBDEAX/p1674660231069389
* logs show neither of these APIs have been called in the last 90 days
* we have scheduled full deletion for April 1 2023, 66 days away at the time of this PR
* close to the actual deletion date, we will check again to look for any traffic to these APIs
  * this will be tricky - I bet somebody out there will read the deprecation announcement and try out the APIs just to see what they do
* I have made AJ-818 to track the actual deletion of these APIs on 4/1/23

![Screenshot 1-25-2023 at 10 47 AM](https://user-images.githubusercontent.com/6041577/214612621-ecc760e1-cb3b-442f-9847-e221ea2f5fc8.png)


