### PR TITLE
[SU-281] Azure preview welcome email

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,10 @@ object Dependencies {
   val excludeAkkaStream =       ExclusionRule(organization = "com.typesafe.akka", name = "akka-stream_2.13")
   val excludeAkkaHttp = ExclusionRule(organization = "com.typesafe.akka", name = "akka-http_2.13")
   val excludeSprayJson = ExclusionRule(organization = "com.typesafe.akka", name = "akka-http-spray-json_2.13")
-  val excludeBouncyCastle =     ExclusionRule(organization = "org.bouncycastle", name = s"bcprov-jdk15on")
+  val excludeBouncyCastle = ExclusionRule(organization = "org.bouncycastle", name = s"bcprov-jdk15on")
+  val excludeBouncyCastleExt = ExclusionRule(organization = "org.bouncycastle", name = s"bcprov-ext-jdk15on")
+  val excludeBouncyCastleUtil = ExclusionRule(organization = "org.bouncycastle", name = s"bcutil-jdk15on")
+  val excludeBouncyCastlePkix = ExclusionRule(organization = "org.bouncycastle", name = s"bcpkix-jdk15on")
 
   // Overrides for transitive dependencies. These apply - via Settings.scala - to all projects in this codebase.
   // These are overrides only; if the direct dependencies stop including any of these, they will not be included
@@ -49,7 +52,7 @@ object Dependencies {
       exclude("bio.terra", "workspace-manager-client")
       excludeAll(excludeAkkaHttp, excludeSprayJson),
     excludeGuava("org.broadinstitute.dsde.workbench" %% "workbench-util"  % "0.6-bc324ba"), // TODO: upgrading to latest workbench-libs hash causes failures
-    "org.broadinstitute.dsde.workbench" %% "workbench-google2" % s"0.25-$workbenchLibsHash" excludeAll(excludeBouncyCastle),
+    "org.broadinstitute.dsde.workbench" %% "workbench-google2" % s"0.25-$workbenchLibsHash" excludeAll(excludeBouncyCastle, excludeBouncyCastleExt, excludeBouncyCastlePkix, excludeBouncyCastleUtil),
     "org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % s"0.2-$workbenchLibsHash",
     "org.broadinstitute.dsde.workbench" %% "sam-client"       % "0.1-ef83073",
     "org.broadinstitute.dsde.workbench" %% "workbench-notifications" %s"0.3-$workbenchLibsHash",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,10 +13,6 @@ object Dependencies {
   val excludeAkkaStream =       ExclusionRule(organization = "com.typesafe.akka", name = "akka-stream_2.13")
   val excludeAkkaHttp = ExclusionRule(organization = "com.typesafe.akka", name = "akka-http_2.13")
   val excludeSprayJson = ExclusionRule(organization = "com.typesafe.akka", name = "akka-http-spray-json_2.13")
-  val excludeBouncyCastle = ExclusionRule(organization = "org.bouncycastle", name = s"bcprov-jdk15on")
-  val excludeBouncyCastleExt = ExclusionRule(organization = "org.bouncycastle", name = s"bcprov-ext-jdk15on")
-  val excludeBouncyCastleUtil = ExclusionRule(organization = "org.bouncycastle", name = s"bcutil-jdk15on")
-  val excludeBouncyCastlePkix = ExclusionRule(organization = "org.bouncycastle", name = s"bcpkix-jdk15on")
 
   // Overrides for transitive dependencies. These apply - via Settings.scala - to all projects in this codebase.
   // These are overrides only; if the direct dependencies stop including any of these, they will not be included
@@ -52,7 +48,7 @@ object Dependencies {
       exclude("bio.terra", "workspace-manager-client")
       excludeAll(excludeAkkaHttp, excludeSprayJson),
     excludeGuava("org.broadinstitute.dsde.workbench" %% "workbench-util"  % "0.6-bc324ba"), // TODO: upgrading to latest workbench-libs hash causes failures
-    "org.broadinstitute.dsde.workbench" %% "workbench-google2" % s"0.25-$workbenchLibsHash" excludeAll(excludeBouncyCastle, excludeBouncyCastleExt, excludeBouncyCastlePkix, excludeBouncyCastleUtil),
+    "org.broadinstitute.dsde.workbench" %% "workbench-google2" % s"0.25-$workbenchLibsHash",
     "org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % s"0.2-$workbenchLibsHash",
     "org.broadinstitute.dsde.workbench" %% "sam-client"       % "0.1-ef83073",
     "org.broadinstitute.dsde.workbench" %% "workbench-notifications" %s"0.3-$workbenchLibsHash",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,6 +13,7 @@ object Dependencies {
   val excludeAkkaStream =       ExclusionRule(organization = "com.typesafe.akka", name = "akka-stream_2.13")
   val excludeAkkaHttp = ExclusionRule(organization = "com.typesafe.akka", name = "akka-http_2.13")
   val excludeSprayJson = ExclusionRule(organization = "com.typesafe.akka", name = "akka-http-spray-json_2.13")
+  val excludeBouncyCastle =     ExclusionRule(organization = "org.bouncycastle", name = s"bcprov-jdk15on")
 
   // Overrides for transitive dependencies. These apply - via Settings.scala - to all projects in this codebase.
   // These are overrides only; if the direct dependencies stop including any of these, they will not be included
@@ -51,7 +52,7 @@ object Dependencies {
     "org.broadinstitute.dsde.workbench" %% "workbench-google2" % s"0.25-$workbenchLibsHash",
     "org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % s"0.2-$workbenchLibsHash",
     "org.broadinstitute.dsde.workbench" %% "sam-client"       % "0.1-ef83073",
-    "org.broadinstitute.dsde.workbench" %% "workbench-notifications" %s"0.3-$workbenchLibsHash",
+    "org.broadinstitute.dsde.workbench" %% "workbench-notifications" %s"0.3-$workbenchLibsHash" excludeAll(excludeBouncyCastle),
 
     "com.typesafe.akka"   %%  "akka-actor"           % akkaV,
     "com.typesafe.akka"   %%  "akka-slf4j"           % akkaV,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -49,10 +49,10 @@ object Dependencies {
       exclude("bio.terra", "workspace-manager-client")
       excludeAll(excludeAkkaHttp, excludeSprayJson),
     excludeGuava("org.broadinstitute.dsde.workbench" %% "workbench-util"  % "0.6-bc324ba"), // TODO: upgrading to latest workbench-libs hash causes failures
-    "org.broadinstitute.dsde.workbench" %% "workbench-google2" % s"0.25-$workbenchLibsHash",
+    "org.broadinstitute.dsde.workbench" %% "workbench-google2" % s"0.25-$workbenchLibsHash" excludeAll(excludeBouncyCastle),
     "org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % s"0.2-$workbenchLibsHash",
     "org.broadinstitute.dsde.workbench" %% "sam-client"       % "0.1-ef83073",
-    "org.broadinstitute.dsde.workbench" %% "workbench-notifications" %s"0.3-$workbenchLibsHash" excludeAll(excludeBouncyCastle),
+    "org.broadinstitute.dsde.workbench" %% "workbench-notifications" %s"0.3-$workbenchLibsHash",
 
     "com.typesafe.akka"   %%  "akka-actor"           % akkaV,
     "com.typesafe.akka"   %%  "akka-slf4j"           % akkaV,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
   val jacksonV = "2.13.4"
   val jacksonHotfixV = "2.13.4.2" // for when only some of the Jackson libs have hotfix releases
   val nettyV = "4.1.86.Final"
-  val workbenchLibsHash = "20f9225"
+  val workbenchLibsHash = "084d25b"
 
   def excludeGuava(m: ModuleID): ModuleID = m.exclude("com.google.guava", "guava")
   val excludeAkkaActor =        ExclusionRule(organization = "com.typesafe.akka", name = "akka-actor_2.13")
@@ -48,7 +48,7 @@ object Dependencies {
       exclude("bio.terra", "workspace-manager-client")
       excludeAll(excludeAkkaHttp, excludeSprayJson),
     excludeGuava("org.broadinstitute.dsde.workbench" %% "workbench-util"  % "0.6-bc324ba"), // TODO: upgrading to latest workbench-libs hash causes failures
-    "org.broadinstitute.dsde.workbench" %% "workbench-google2" % s"0.24-$workbenchLibsHash",
+    "org.broadinstitute.dsde.workbench" %% "workbench-google2" % s"0.25-$workbenchLibsHash",
     "org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % s"0.2-$workbenchLibsHash",
     "org.broadinstitute.dsde.workbench" %% "sam-client"       % "0.1-ef83073",
     "org.broadinstitute.dsde.workbench" %% "workbench-notifications" %s"0.3-$workbenchLibsHash",

--- a/project/Merging.scala
+++ b/project/Merging.scala
@@ -13,6 +13,7 @@ object Merging {
     case x if x.contains("javax/annotation") => MergeStrategy.first
 
     case x if x.endsWith("kotlin-stdlib.kotlin_module") => MergeStrategy.first
+    case x if x.contains("bouncycastle") => MergeStrategy.first
     case x if x.endsWith("kotlin-stdlib-common.kotlin_module") => MergeStrategy.first
     case x if x.endsWith("arrow-git.properties") => MergeStrategy.concat
 

--- a/project/Merging.scala
+++ b/project/Merging.scala
@@ -12,6 +12,10 @@ object Merging {
     case x if x.contains("javax/activation") => MergeStrategy.first
     case x if x.contains("javax/annotation") => MergeStrategy.first
 
+    case x if x.endsWith("kotlin-stdlib.kotlin_module") => MergeStrategy.first
+    case x if x.endsWith("kotlin-stdlib-common.kotlin_module") => MergeStrategy.first
+    case x if x.endsWith("arrow-git.properties") => MergeStrategy.concat
+
     // For the following error:
     // Error: (assembly) deduplicate: different file contents found in the following:
     // Error: /home/sbtuser/.cache/coursier/v1/https/repo1.maven.org/maven2/com/google/protobuf/protobuf-java/3.19.4/protobuf-java-3.19.4.jar:google/protobuf/struct.proto

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
@@ -15,8 +15,8 @@ import com.google.api.client.googleapis.json.GoogleJsonResponseException
 import com.google.api.client.googleapis.services.AbstractGoogleClientRequest
 import com.google.api.client.http.HttpResponseException
 import com.google.api.client.json.jackson2.JacksonFactory
-import com.google.api.services.admin.directory.model.{Group, Member}
-import com.google.api.services.admin.directory.{Directory, DirectoryScopes}
+import com.google.api.services.directory.model.{Group, Member}
+import com.google.api.services.directory.{Directory, DirectoryScopes}
 import com.google.api.services.pubsub.model.{PublishRequest, PubsubMessage}
 import com.google.api.services.pubsub.{Pubsub, PubsubScopes}
 import com.google.api.services.storage.model.Bucket

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/UserInfo.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/UserInfo.scala
@@ -27,13 +27,11 @@ trait WithAccessToken { val accessToken : OAuth2BearerToken }
   * @param userEmail the user's email address. Resolved to the owner if the request is from a pet.
   * @param accessToken the user's access token. Either a B2C JWT or a Google opaque token.
   * @param accessTokenExpiresIn number of seconds until the access token expires.
-  * @param userSubjectId the user id. Either a Google id (numeric) or a B2C id (uuid).
+  * @param id the user id. Either a Google id (numeric) or a B2C id (uuid).
   * @param googleAccessTokenThroughB2C if this is a Google login through B2C, contains the opaque
   *                                    Google access token. Empty otherwise.
   */
 case class UserInfo(userEmail: String, accessToken: OAuth2BearerToken, accessTokenExpiresIn: Long, id: String, googleAccessTokenThroughB2C: Option[OAuth2BearerToken] = None) extends WithAccessToken {
-  def getUniqueId = id
-
   def isB2C: Boolean =
   // B2C ids are uuids, while google ids are numeric
     Try(BigInt(id)).isFailure

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/UserInfo.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/UserInfo.scala
@@ -1,6 +1,9 @@
 package org.broadinstitute.dsde.firecloud.model
 
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
+
+import scala.util.Try
+
 /**
  * Created by dvoet on 7/21/15.
  *
@@ -16,10 +19,24 @@ import akka.http.scaladsl.model.headers.OAuth2BearerToken
   *  This is so that we can use AccessToken for cookies we get from the browser, which do not come with the fields in
   *  UserInfo.
  */
+
 trait WithAccessToken { val accessToken : OAuth2BearerToken }
 
-case class UserInfo(userEmail: String, accessToken: OAuth2BearerToken, accessTokenExpiresIn: Long, id: String) extends WithAccessToken {
+/**
+  * Represents an authenticated user.
+  * @param userEmail the user's email address. Resolved to the owner if the request is from a pet.
+  * @param accessToken the user's access token. Either a B2C JWT or a Google opaque token.
+  * @param accessTokenExpiresIn number of seconds until the access token expires.
+  * @param userSubjectId the user id. Either a Google id (numeric) or a B2C id (uuid).
+  * @param googleAccessTokenThroughB2C if this is a Google login through B2C, contains the opaque
+  *                                    Google access token. Empty otherwise.
+  */
+case class UserInfo(userEmail: String, accessToken: OAuth2BearerToken, accessTokenExpiresIn: Long, id: String, googleAccessTokenThroughB2C: Option[OAuth2BearerToken] = None) extends WithAccessToken {
   def getUniqueId = id
+
+  def isB2C: Boolean =
+  // B2C ids are uuids, while google ids are numeric
+    Try(BigInt(id)).isFailure
 }
 
 object UserInfo {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/RegisterService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/RegisterService.scala
@@ -54,6 +54,7 @@ class RegisterService(val rawlsDao: RawlsDAO, val samDao: SamDAO, val thurloeDao
   }
 
   def generateWelcomeEmail(userInfo: UserInfo): Notification = {
+    //If the user is a B2C user and does not have a Google access token, we can safely assume that they're an Azure user
     userInfo.googleAccessTokenThroughB2C match {
       case None if userInfo.isB2C => AzurePreviewActivationNotification(WorkbenchUserId(userInfo.id))
       case _ => ActivationNotification(WorkbenchUserId(userInfo.id))

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/RegisterService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/RegisterService.scala
@@ -54,8 +54,8 @@ class RegisterService(val rawlsDao: RawlsDAO, val samDao: SamDAO, val thurloeDao
   }
 
   def generateWelcomeEmail(userInfo: UserInfo): Notification = {
-    userInfo match {
-      case UserInfo(_, _, _, _, None) if userInfo.isB2C => AzurePreviewActivationNotification(WorkbenchUserId(userInfo.id))
+    userInfo.googleAccessTokenThroughB2C match {
+      case None if userInfo.isB2C => AzurePreviewActivationNotification(WorkbenchUserId(userInfo.id))
       case _ => ActivationNotification(WorkbenchUserId(userInfo.id))
     }
   }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/utils/StandardUserInfoDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/utils/StandardUserInfoDirectives.scala
@@ -14,10 +14,11 @@ trait StandardUserInfoDirectives extends UserInfoDirectives {
       headerValueByName("OIDC_CLAIM_user_id") &
       headerValueByName("OIDC_CLAIM_expires_in") &
       headerValueByName("OIDC_CLAIM_email") &
-      optionalHeaderValueByName("OAUTH2_CLAIM_google_id")
+      optionalHeaderValueByName("OAUTH2_CLAIM_google_id") &
+      optionalHeaderValueByName("OAUTH2_CLAIM_idp_access_token")
     ) tmap {
-      case (token, userId, expiresIn, email, googleIdOpt) => {
-        UserInfo(email, OAuth2BearerToken(token), expiresIn.toLong, googleIdOpt.getOrElse(userId))
+      case (token, userId, expiresIn, email, googleIdOpt, googleTokenOpt) => {
+        UserInfo(email, OAuth2BearerToken(token), expiresIn.toLong, googleIdOpt.getOrElse(userId), googleTokenOpt.map(OAuth2BearerToken))
       }
     }
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/RegisterServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/RegisterServiceSpec.scala
@@ -1,0 +1,41 @@
+package org.broadinstitute.dsde.firecloud.service
+
+import akka.http.scaladsl.model.headers.OAuth2BearerToken
+import org.broadinstitute.dsde.firecloud.dataaccess.{GoogleServicesDAO, RawlsDAO, SamDAO, ThurloeDAO}
+import org.broadinstitute.dsde.firecloud.model.UserInfo
+import org.broadinstitute.dsde.workbench.model.Notifications.{ActivationNotification, ActivationNotificationType, AzurePreviewActivationNotification, AzurePreviewActivationNotificationType}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar.mock
+
+class RegisterServiceSpec extends AnyFlatSpec with Matchers {
+
+  import scala.concurrent.ExecutionContext.Implicits.global
+
+  val rawlsDAO = mock[RawlsDAO]
+  val samDAO = mock[SamDAO]
+  val thurloeDAO = mock[ThurloeDAO]
+  val googleServicesDAO = mock[GoogleServicesDAO]
+
+  val registerService = new RegisterService(rawlsDAO, samDAO, thurloeDAO, googleServicesDAO)
+
+  val azureB2CUserInfo = UserInfo("azure-b2c@example.com", OAuth2BearerToken("token"), 1, "0f3cd8e4-59c2-4bce-9c24-98c5a0c308c1", None)
+  val googleB2CUserInfo = UserInfo("google-b2c@example.com", OAuth2BearerToken("token"), 1, "0617047d-a81f-4724-b783-b5af51af9a70", Some(OAuth2BearerToken("some-google-token")))
+  val googleLegacyUserInfo = UserInfo("google-legacy@example.com", OAuth2BearerToken("token"), 1, "111111111111", None)
+
+  "generateWelcomeEmail" should "generate an Azure welcome email for Azure B2C users" in {
+    val notification = registerService.generateWelcomeEmail(azureB2CUserInfo)
+    notification.getClass.getName shouldBe AzurePreviewActivationNotification.getClass.getName.stripSuffix("$")
+  }
+
+  it should "generate a standard welcome email for Google B2C users" in {
+    val notification = registerService.generateWelcomeEmail(googleB2CUserInfo)
+    notification.getClass.getName shouldBe ActivationNotification.getClass.getName.stripSuffix("$")
+  }
+
+  it should "generate a standard welcome email for legacy Google users" in {
+    val notification = registerService.generateWelcomeEmail(googleLegacyUserInfo)
+    notification.getClass.getName shouldBe ActivationNotification.getClass.getName.stripSuffix("$")
+  }
+
+}


### PR DESCRIPTION
I tested that the existing email flow still works and also sort of pseudo-tested that the new Azure account flow works by changing around some of the pattern matching logic to fire off an Azure email if the user logs in as a legacy GCP user. So we know the Orch->Thurloe->SendGrid flow works fine for the new Azure email and as long as the pattern matching logic in `generateWelcomeEmail` is correct, then all should be well.

Other relevant PRs for context:

https://github.com/broadinstitute/workbench-libs/pull/1229
https://github.com/broadinstitute/thurloe/pull/131
https://github.com/broadinstitute/firecloud-develop/pull/3224

\<your comments for this PR go here\>

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
