### PR TITLE
AJ-862, AJ-864: add columnFilter param to entityQuery API swagger def

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -4002,7 +4002,7 @@ paths:
               - desc
         - name: filterTerms
           in: query
-          description: terms to search for, using substring matching, in all attributes of an entity. Mutually exclusive with the entityNameFilter and columnFilter parameters.
+          description: terms to search for, using substring matching, in all attributes of an entity. Mutually exclusive with the columnFilter parameter.
           schema:
             type: string
         - name: filterOperator
@@ -4014,14 +4014,9 @@ paths:
             enum:
               - and
               - or
-        - name: entityNameFilter
-          in: query
-          description: exact-match name of entity to return. Mutually exclusive with the filterTerms and columnFilter parameters.
-          schema:
-            type: string
         - name: columnFilter
           in: query
-          description: exact-match filter for a value in a single column, in the form columnName=string-to-match. Mutually exclusive with the filterTerms and entityNameFilter parameters.
+          description: exact-match filter for a value in a single column, in the form columnName=string-to-match. Mutually exclusive with the filterTerms parameter.
           schema:
             type: string
         - name: fields

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -4002,7 +4002,7 @@ paths:
               - desc
         - name: filterTerms
           in: query
-          description: Terms to search for inside entity attributes
+          description: terms to search for, using substring matching, in all attributes of an entity. Mutually exclusive with the entityNameFilter and columnFilter parameters.
           schema:
             type: string
         - name: filterOperator
@@ -4014,6 +4014,16 @@ paths:
             enum:
               - and
               - or
+        - name: entityNameFilter
+          in: query
+          description: exact-match name of entity to return. Mutually exclusive with the filterTerms and columnFilter parameters.
+          schema:
+            type: string
+        - name: columnFilter
+          in: query
+          description: exact-match filter for a value in a single column, in the form columnName=string-to-match. Mutually exclusive with the filterTerms and entityNameFilter parameters.
+          schema:
+            type: string
         - name: fields
           in: query
           description: |


### PR DESCRIPTION
This adds the `columnFilter` query params to the entityQuery API, as implemented by Rawls in:
* https://github.com/broadinstitute/rawls/pull/2239 (merged)
* https://github.com/broadinstitute/rawls/pull/2240 (merged)
* https://github.com/broadinstitute/rawls/pull/2249 (merged)

No changes necessary at the Scala level, since we already use `streamingPassthrough` to handle this API and `streamingPassthrough` automatically passes all query params.