### PR TITLE
SUP-819: handle infinite and NaN numbers in TSV cells

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/TSVFileSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/TSVFileSupport.scala
@@ -150,8 +150,14 @@ trait TSVFileSupport {
     Try (java.lang.Integer.parseInt(value)) match {
       case Success(intValue) => AttributeNumber(intValue)
       case Failure(_) => Try (java.lang.Double.parseDouble(value)) match {
-        case Success(doubleValue) => AttributeNumber(doubleValue)
-        case Failure(_) => Try(BooleanUtils.toBoolean(value.toLowerCase, "true", "false")) match {
+        // because we represent AttributeNumber as a BigDecimal, and BigDecimal has no concept of infinity or NaN,
+        // if we find infinite/NaN numbers here, don't save them as AttributeNumber; instead let them fall through
+        // to AttributeString.
+        case Success(doubleValue) if !Double.NegativeInfinity.equals(doubleValue)
+          && !Double.PositiveInfinity.equals(doubleValue)
+          && !Double.NaN.equals(doubleValue) =>
+          AttributeNumber(doubleValue)
+        case _ => Try(BooleanUtils.toBoolean(value.toLowerCase, "true", "false")) match {
           case Success(booleanValue) => AttributeBoolean(booleanValue)
           case Failure(_) =>
             Try(value.parseJson.convertTo[AttributeEntityReference]) match {

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/TSVFileSupportSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/TSVFileSupportSpec.scala
@@ -148,6 +148,18 @@ class TSVFileSupportSpec extends AnyFreeSpec with TSVFileSupport {
     }
   }
 
+  List("6e260905", "-5e345678") foreach { str =>
+    s"should handle a string '$str' that looks like scientific notation but translates to Infinity (positive or negative)" in {
+      stringToTypedAttribute(str) shouldBe AttributeString(str)
+    }
+  }
+
+  List("NaN") foreach { str =>
+    s"should handle a string '$str' that looks like not-a-number" in {
+      stringToTypedAttribute(str) shouldBe AttributeString(str)
+    }
+  }
+
   "setAttributesOnEntity" - {
 
     case class TsvArrayTestCase(loadFile: TSVLoadFile,


### PR DESCRIPTION
SUP-819 - and https://github.com/DataBiosphere/azul/issues/5045 - discuss problems with both PFB and BDBag import.

The issues with PFB import were solved in https://github.com/broadinstitute/import-service/pull/125.

The issue with BDBag is fixed in this PR. This issue is dataset-dependent. What I'm seeing is that in certain datasets, some rows in the TSVs inside the BDBag contain values that trip up the import. In the "1.3 Million Brain Cells from E18 Mice" dataset, for instance, the row with id c928080f-7953-4cdb-8ef9-853212825b29.2019-05-16T211813.091000Z has a value of 6e260905 in the column __fastq_read1__file_crc32c. The value of 6e260905 is being interpreted as scientific notation; within Java this becomes a Double of Infinity, and later in Terra's processing we attempt to convert this to a BigDecimal which doesn't support Infinity.

I've proactively addressed `NaN` values in this PR as well, since I can see from code inspection they would also cause a problem.



