### PR TITLE
AJ-912: remove compile-time warnings

### DIFF
--- a/automation/project/Settings.scala
+++ b/automation/project/Settings.scala
@@ -21,7 +21,7 @@ object Settings {
     "-unchecked",
     "-deprecation",
     "-feature",
-    "-target:jvm-1.8",
+    "-release:8",
     "-encoding", "utf8", "100"
   )
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -27,7 +27,7 @@ object Settings {
     "-deprecation",
     "-feature",
     "-encoding", "utf8",
-    "-target:jvm-1.8"
+    "-release:8"
   )
 
   //sbt assembly settings

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/Boot.scala
@@ -3,7 +3,6 @@ package org.broadinstitute.dsde.firecloud
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.server.Directives._
-import akka.stream.ActorMaterializer
 import cats.effect.IO
 import cats.effect.unsafe.IORuntime
 import com.typesafe.scalalogging.LazyLogging
@@ -22,8 +21,7 @@ object Boot extends App with LazyLogging {
 
   private def startup(): Unit = {
     // we need an ActorSystem to host our application in
-    implicit val system = ActorSystem("FireCloud-Orchestration-API")
-    implicit val materializer = ActorMaterializer()
+    implicit val system: ActorSystem = ActorSystem("FireCloud-Orchestration-API")
 
     val elasticSearchClient: TransportClient = ElasticUtils.buildClient(FireCloudConfig.ElasticSearch.servers, FireCloudConfig.ElasticSearch.clusterName)
 
@@ -43,7 +41,7 @@ object Boot extends App with LazyLogging {
     val app:Application = Application(agoraDAO, googleServicesDAO, ontologyDAO, consentDAO, rawlsDAO, samDAO, searchDAO, researchPurposeSupport, thurloeDAO, shareLogDAO, importServiceDAO, shibbolethDAO);
 
     val agoraPermissionServiceConstructor: (UserInfo) => AgoraPermissionService = AgoraPermissionService.constructor(app)
-    val exportEntitiesByTypeActorConstructor: (ExportEntitiesByTypeArguments) => ExportEntitiesByTypeActor = ExportEntitiesByTypeActor.constructor(app, materializer)
+    val exportEntitiesByTypeActorConstructor: (ExportEntitiesByTypeArguments) => ExportEntitiesByTypeActor = ExportEntitiesByTypeActor.constructor(app, system)
     val entityServiceConstructor: (ModelSchema) => EntityService = EntityService.constructor(app)
     val libraryServiceConstructor: (UserInfo) => LibraryService = LibraryService.constructor(app)
     val ontologyServiceConstructor: () => OntologyService = OntologyService.constructor(app)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/Boot.scala
@@ -59,7 +59,7 @@ object Boot extends App with LazyLogging {
     val healthChecks = new HealthChecks(app)
     val healthMonitorChecks = healthChecks.healthMonitorChecks
     val healthMonitor = system.actorOf(HealthMonitor.props(healthMonitorChecks().keySet)( healthMonitorChecks ), "health-monitor")
-    system.scheduler.schedule(3.seconds, 1.minute, healthMonitor, HealthMonitor.CheckAll)
+    system.scheduler.scheduleWithFixedDelay(3.seconds, 1.minute, healthMonitor, HealthMonitor.CheckAll)
 
     val statusServiceConstructor: () => StatusService = StatusService.constructor(healthMonitor)
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/ExportEntitiesByTypeActor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/ExportEntitiesByTypeActor.scala
@@ -146,7 +146,7 @@ class ExportEntitiesByTypeActor(rawlsDAO: RawlsDAO,
     // Result of this will be a tuple of Future[IOResult] that represents the success or failure of
     // streaming content to the file sinks.
     val fileStreamIOResults: Future[IOResult] = {
-      RunnableGraph.fromGraph(GraphDSL.create(entitySink) { implicit builder =>
+      RunnableGraph.fromGraph(GraphDSL.createGraph(entitySink) { implicit builder =>
         (eSink) =>
           import GraphDSL.Implicits._
 
@@ -202,7 +202,7 @@ class ExportEntitiesByTypeActor(rawlsDAO: RawlsDAO,
     // Result of this will be a tuple of Future[IOResult] that represents the success or failure of
     // streaming content to the file sinks.
     val fileStreamIOResults: (Future[IOResult], Future[IOResult]) = {
-      RunnableGraph.fromGraph(GraphDSL.create(entitySink, membershipSink)((_, _)) { implicit builder =>
+      RunnableGraph.fromGraph(GraphDSL.createGraph(entitySink, membershipSink)((_, _)) { implicit builder =>
         (eSink, mSink) =>
           import GraphDSL.Implicits._
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/ExportEntitiesByTypeServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/ExportEntitiesByTypeServiceSpec.scala
@@ -27,7 +27,7 @@ class ExportEntitiesByTypeServiceSpec extends BaseServiceSpec with ExportEntitie
 
   def actorRefFactory: ActorSystem = system
 
-  val exportEntitiesByTypeConstructor: ExportEntitiesByTypeArguments => ExportEntitiesByTypeActor = ExportEntitiesByTypeActor.constructor(app, ActorMaterializer())
+  val exportEntitiesByTypeConstructor: ExportEntitiesByTypeArguments => ExportEntitiesByTypeActor = ExportEntitiesByTypeActor.constructor(app, actorRefFactory)
   val storageServiceConstructor: (UserInfo) => StorageService = StorageService.constructor(app)
 
   val largeFireCloudEntitiesSampleTSVPath = "/api/workspaces/broad-dsde-dev/large/entities/sample/tsv"

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/utils/ConsentStatusSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/utils/ConsentStatusSpec.scala
@@ -2,7 +2,6 @@ package org.broadinstitute.dsde.firecloud.utils
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model._
-import akka.stream.ActorMaterializer
 import org.broadinstitute.dsde.firecloud.dataaccess.ReportsSubsystemStatus
 import org.broadinstitute.dsde.workbench.util.health.SubsystemStatus
 import org.scalatest.concurrent.ScalaFutures
@@ -21,7 +20,6 @@ class ConsentStatusSpec extends AnyFreeSpec with ScalaFutures with ReportsSubsys
 
   implicit val system: ActorSystem = ActorSystem("ConsentStatusSpec")
   implicit val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
-  implicit val materializer: ActorMaterializer = ActorMaterializer()
   implicit val defaultPatience: PatienceConfig = PatienceConfig(timeout = Span(30, Seconds), interval = Span(5, Millis))
 
   "ReportsSubsystemStatus" - {

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/StatusApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/StatusApiServiceSpec.scala
@@ -25,7 +25,7 @@ class StatusApiServiceSpec extends BaseServiceSpec with StatusApiService with Sp
 
   val healthMonitorChecks = new HealthChecks(app).healthMonitorChecks
   val healthMonitor = system.actorOf(HealthMonitor.props(healthMonitorChecks().keySet)( healthMonitorChecks ), "health-monitor")
-  val monitorSchedule = system.scheduler.schedule(Duration.Zero, 1.second, healthMonitor, HealthMonitor.CheckAll)
+  val monitorSchedule = system.scheduler.scheduleWithFixedDelay(Duration.Zero, 1.second, healthMonitor, HealthMonitor.CheckAll)
 
   override def beforeAll() = {
     // wait for the healthMonitor to start up ...


### PR DESCRIPTION
This PR, as part of ongoing maintenance, removes  all the warnings emitted by `sbt`/`scalac` at compile time. We had accumulated warnings over time as sbt, scala, and frameworks were updated.

---

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
