### PR TITLE
AJ-901: remove unused storage-related methods

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/GoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/GoogleServicesDAO.scala
@@ -1,14 +1,13 @@
 package org.broadinstitute.dsde.firecloud.dataaccess
 
-import java.io.InputStream
 import akka.http.scaladsl.model.HttpResponse
 import com.google.api.services.storage.model.Bucket
 import org.broadinstitute.dsde.firecloud.model.WithAccessToken
-import org.broadinstitute.dsde.firecloud.service.PerRequest.PerRequestMessage
 import org.broadinstitute.dsde.rawls.model.ErrorReportSource
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GcsObjectName, GcsPath}
 import org.broadinstitute.dsde.workbench.util.health.SubsystemStatus
 
+import java.io.InputStream
 import scala.concurrent.{ExecutionContext, Future}
 
 object GoogleServicesDAO {
@@ -24,9 +23,6 @@ trait GoogleServicesDAO extends ReportsSubsystemStatus {
   def getObjectResourceUrl(bucketName: String, objectKey: String): String
   def getUserProfile(accessToken: WithAccessToken)
                     (implicit executionContext: ExecutionContext): Future[HttpResponse]
-
-  def listObjectsAsRawlsSA(bucketName: String, prefix: String): List[String]
-  def getObjectContentsAsRawlsSA(bucketName: String, objectKey: String): String
 
   val fetchPriceList: Future[GooglePriceList]
   

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
@@ -108,10 +108,6 @@ class HttpGoogleServicesDAO(priceListUrl: String, defaultPriceList: GooglePriceL
   val httpTransport = GoogleNetHttpTransport.newTrustedTransport
   val jsonFactory = GsonFactory.getDefaultInstance
 
-  // credentials for the rawls service account, used for signing GCS urls
-  lazy private val rawlsSACreds = ServiceAccountCredentials
-    .fromStream(new FileInputStream(FireCloudConfig.Auth.rawlsSAJsonFile))
-
   // credential for creating anonymized Google groups
   val userAdminAccount = FireCloudConfig.FireCloud.userAdminAccount
   // settings for users in anonymized Google groups
@@ -142,9 +138,6 @@ class HttpGoogleServicesDAO(priceListUrl: String, defaultPriceList: GooglePriceL
     getScopedServiceAccountCredentials(firecloudAdminSACreds, Seq(PubsubScopes.PUBSUB))
   }
 
-  def getRawlsServiceAccountCredential = {
-    getScopedServiceAccountCredentials(rawlsSACreds, storageReadOnly)
-  }
 
   /**
     * Uploads the supplied data to GCS, using the Rawls service account credentials

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
@@ -16,7 +16,7 @@ import com.google.api.services.directory.model.{Group, Member}
 import com.google.api.services.directory.{Directory, DirectoryScopes}
 import com.google.api.services.pubsub.model.{PublishRequest, PubsubMessage}
 import com.google.api.services.pubsub.{Pubsub, PubsubScopes}
-import com.google.api.services.storage.model.{Bucket, Objects}
+import com.google.api.services.storage.model.Bucket
 import com.google.api.services.storage.{Storage, StorageScopes}
 import com.google.auth.http.HttpCredentialsAdapter
 import com.google.auth.oauth2.{GoogleCredentials, ServiceAccountCredentials}
@@ -144,32 +144,6 @@ class HttpGoogleServicesDAO(priceListUrl: String, defaultPriceList: GooglePriceL
 
   def getRawlsServiceAccountCredential = {
     getScopedServiceAccountCredentials(rawlsSACreds, storageReadOnly)
-  }
-
-  override def listObjectsAsRawlsSA(bucketName: String, prefix: String): List[String] = {
-    val storage = new Storage.Builder(httpTransport, jsonFactory, new HttpCredentialsAdapter(getRawlsServiceAccountCredential)).setApplicationName(appName).build()
-    val listRequest = storage.objects().list(bucketName).setPrefix(prefix)
-    Try(executeGoogleRequest[Objects](listRequest)) match {
-      case Failure(ex) =>
-        // handle this case so we can give a good log message. In the future we may handle this
-        // differently, such as returning an empty list.
-        logger.warn(s"could not list objects in bucket/prefix gs://$bucketName/$prefix", ex)
-        throw ex
-      case Success(obs) =>
-        Option(obs.getItems) match {
-          case None => List.empty[String]
-          case Some(items) => items.asScala.toList.map { ob =>
-            ob.getName
-          }
-        }
-    }
-  }
-
-  // WARNING: only call on smallish objects!
-  override def getObjectContentsAsRawlsSA(bucketName: String, objectKey: String): String = {
-    val storage = new Storage.Builder(httpTransport, jsonFactory, new HttpCredentialsAdapter(getRawlsServiceAccountCredential)).setApplicationName(appName).build()
-    val is = storage.objects().get(bucketName, objectKey).executeMediaAsInputStream
-    scala.io.Source.fromInputStream(is).mkString
   }
 
   /**

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockGoogleServicesDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockGoogleServicesDAO.scala
@@ -1,20 +1,15 @@
 package org.broadinstitute.dsde.firecloud.mock
 
-import java.io.{ByteArrayInputStream, InputStream}
-import java.util.concurrent.LinkedBlockingQueue
-
-import akka.actor.ActorRefFactory
-import akka.http.scaladsl.model.{HttpResponse, StatusCodes}
-import org.broadinstitute.dsde.firecloud.FireCloudException
+import akka.http.scaladsl.model.HttpResponse
 import com.google.api.services.storage.model.Bucket
 import org.broadinstitute.dsde.firecloud.dataaccess._
-import org.broadinstitute.dsde.firecloud.model.{ProfileWrapper, WithAccessToken}
-import org.broadinstitute.dsde.firecloud.service.PerRequest.{PerRequestMessage, RequestComplete}
+import org.broadinstitute.dsde.firecloud.model.WithAccessToken
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GcsObjectName, GcsPath}
 import org.broadinstitute.dsde.workbench.util.health.SubsystemStatus
-import spray.json.JsObject
 import spray.json._
 
+import java.io.{ByteArrayInputStream, InputStream}
+import java.util.concurrent.LinkedBlockingQueue
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -82,9 +77,6 @@ class MockGoogleServicesDAO extends GoogleServicesDAO {
     }
   }
   override def getObjectResourceUrl(bucketName: String, objectKey: String): String = ""
-
-  override def listObjectsAsRawlsSA(bucketName: String, prefix: String): List[String] = List("foo", "bar")
-  override def getObjectContentsAsRawlsSA(bucketName: String, objectKey: String): String = "my object contents"
 
   override def writeObjectAsRawlsSA(bucketName: GcsBucketName, objectKey: GcsObjectName, objectContents: Array[Byte]): GcsPath = GcsPath(bucketName, objectKey)
 


### PR DESCRIPTION
While investigating uses of the rawls SA inside orch, I found two methods that used the SA but are unused. This PR deletes those methods. These may have become unused in #1122 .

---

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [x] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
