### PR TITLE
Fix for Dockerfile smell DL3025

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,4 @@ EXPOSE 8080
 RUN mkdir /orch
 COPY ./FireCloud-Orchestration*.jar /orch
 
-CMD java $JAVA_OPTS -jar $(find /orch -name 'FireCloud-Orchestration*.jar')
+CMD ["java", "$JAVA_OPTS", "-jar", "$(find", "/orch", "-name", "FireCloud-Orchestration*.jar)"]


### PR DESCRIPTION
Hi!
The Dockerfile placed at "Dockerfile" contains the best practice violation [DL3025](https://github.com/hadolint/hadolint/wiki/DL3025) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL3025 occurs if the JSON notation is not used for the arguments of CMD and ENTRYPOINT instructions.
This pull request proposes a fix for that smell generated by my fixing tool. The patch was manually verified before opening the pull request. To fix this smell, specifically, the command arguments are refactored in the JSON notation format.

This change is only aimed at fixing that specific smell. If the fix is not valid or useful, please briefly indicate the reason and suggestions for possible improvements.

Thanks in advance


Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
