### PR TITLE
[DDO-2787] Allow Orch to be passed environment variables with periods in them

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,14 @@ EXPOSE 8080
 RUN mkdir /orch
 COPY ./FireCloud-Orchestration*.jar /orch
 
-CMD java $JAVA_OPTS -jar $(find /orch -name 'FireCloud-Orchestration*.jar')
+# 1. “Exec” form of CMD necessary to avoid “shell” form’s `sh` stripping 
+#    environment variables with periods in them, often used in DSP for Lightbend 
+#    config.
+# 2. Handling $JAVA_OPTS is necessary as long as firecloud-develop or the app’s 
+#    chart tries to set it. Apps that use devops’s foundation subchart don’t need 
+#    to handle this.
+# 3. The jar’s location and naming scheme in the filesystem is required by preflight 
+#    liquibase migrations in some app charts. Apps that expose liveness endpoints 
+#    may not need preflight liquibase migrations.
+# We use the “exec” form with `bash` to accomplish all of the above.
+CMD ["/bin/bash", "-c", "java $JAVA_OPTS -jar $(find /orch -name 'FireCloud-Orchestration*.jar')"]


### PR DESCRIPTION
Ticket: [broadworkbench.atlassian.net/browse/DDO-2787](https://broadworkbench.atlassian.net/browse/DDO-2787)

What:

Allows Orch to be passed environment variables with periods in them.

Why:

Lightbend config expects folks to configure array fields by passing environment variables with periods in them. I'm standardizing this as much as I can, regardless of whether the app actually needs to use this. I just don't think we should have arbitrary differences between Dockerfiles, it'll just trip someone up at some point.

How:

Use bash instead of the implicit sh for the Dockerfile's CMD.

Like https://github.com/DataBiosphere/leonardo/pull/3291, https://github.com/broadinstitute/sam/pull/1060, https://github.com/broadinstitute/rawls/pull/2328

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes

> No API changes!

- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change

> Nothing special to do

- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

> No changes! Discussed with appsec, see ticket

In all cases:

- [x] Get two thumbsworth of review and PO signoff if necessary
- [x] Verify all tests go green
- [x] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [x] Test this change deployed correctly and works on dev environment after deployment
