### PR TITLE
AJ-969: prefer artifactory caching proxy

### DIFF
--- a/automation/project/Settings.scala
+++ b/automation/project/Settings.scala
@@ -10,6 +10,9 @@ object Settings {
     "artifactory-releases" at artifactory + "libs-release",
     "artifactory-snapshots" at artifactory + "libs-snapshot"
   )
+  val proxyResolvers = List(
+    "internal-maven-proxy" at artifactory + "maven-central"
+  )
 
   //coreDefaultSettings + defaultConfigs = the now deprecated defaultSettings
   val commonBuildSettings = Defaults.coreDefaultSettings ++ Defaults.defaultConfigs ++ Seq(
@@ -40,7 +43,7 @@ object Settings {
     commonBuildSettings ++ testSettings ++ List(
     organization  := "org.broadinstitute.dsde.firecloud",
     scalaVersion  := "2.13.10",
-    resolvers ++= commonResolvers,
+    resolvers := proxyResolvers ++: resolvers.value ++: commonResolvers,
     scalacOptions ++= commonCompilerSettings,
     dependencyOverrides ++= transitiveDependencyOverrides
   )

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -16,6 +16,10 @@ object Settings {
     "jitpack.io" at "https://jitpack.io"
   )
 
+  val proxyResolvers = List(
+    "internal-maven-proxy" at artifactory + "maven-central"
+  )
+
   //coreDefaultSettings + defaultConfigs = the now deprecated defaultSettings
   val commonBuildSettings = Defaults.coreDefaultSettings ++ Defaults.defaultConfigs ++ Seq(
     javaOptions += "-Xmx2G",
@@ -41,7 +45,7 @@ object Settings {
     commonBuildSettings ++ commonAssemblySettings ++ commonTestSettings ++ List(
     organization  := "org.broadinstitute.dsde.firecloud",
     scalaVersion  := "2.13.10",
-    resolvers ++= commonResolvers,
+    resolvers := proxyResolvers ++: resolvers.value ++: commonResolvers,
     scalacOptions ++= commonCompilerSettings,
     dependencyOverrides ++= transitiveDependencyOverrides
   )


### PR DESCRIPTION
See https://github.com/broadinstitute/sam/pull/1052 as prior art for this PR.

This adds the Broad Artifactory caching proxy as the first repository to check. This should help with any transient Maven Central outages.
