### PR TITLE
AJ-1076 check for strings that look like number literals

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/TSVFileSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/TSVFileSupport.scala
@@ -155,7 +155,8 @@ trait TSVFileSupport {
         // to AttributeString.
         case Success(doubleValue) if !Double.NegativeInfinity.equals(doubleValue)
           && !Double.PositiveInfinity.equals(doubleValue)
-          && !Double.NaN.equals(doubleValue) =>
+          && !Double.NaN.equals(doubleValue)
+        && !matchesLiteral(value) =>
           AttributeNumber(doubleValue)
         case _ => Try(BooleanUtils.toBoolean(value.toLowerCase, "true", "false")) match {
           case Success(booleanValue) => AttributeBoolean(booleanValue)
@@ -168,6 +169,10 @@ trait TSVFileSupport {
         }
       }
     }
+  }
+
+  def matchesLiteral(value: String): Boolean = {
+    value.toLowerCase().endsWith("d") || value.toLowerCase().endsWith("f")
   }
 
   /**

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/TSVFileSupportSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/TSVFileSupportSpec.scala
@@ -154,6 +154,12 @@ class TSVFileSupportSpec extends AnyFreeSpec with TSVFileSupport {
     }
   }
 
+  List("1234d", "-5678D", "9012f", "3456F") foreach { str =>
+    s"should handle a string '$str' that looks like a number literal" in {
+      stringToTypedAttribute(str) shouldBe AttributeString(str)
+    }
+  }
+
   List("NaN") foreach { str =>
     s"should handle a string '$str' that looks like not-a-number" in {
       stringToTypedAttribute(str) shouldBe AttributeString(str)


### PR DESCRIPTION
[AJ-1076](https://broadworkbench.atlassian.net/browse/AJ-1076)
If a string attribute consists of a number ending in 'd' or 'f', then scala will read that as indicating 'double' or 'float', coerce it to a number, and drop the 'd' or 'f'.  This PR assumes that such attributes will always be intended to be strings and specifically checks for these cases.

[AJ-1076]: https://broadworkbench.atlassian.net/browse/AJ-1076?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ