### PR TITLE
AJ-1141 debugging README

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,14 +101,34 @@ To build the orch jar with docker, and then build the orch docker image, run:
 ## Debugging
 
 Remote debugging is enabled for firecloud-orchestration on port 5051.
-//Revolver.enableDebugging(port = 5051, suspend = false)
+In order to debug in Intellij:
+1. first modify the `build.sbt` file as follows:
+   1. Comment out the `Revolver.enableDebugging` [line](https://github.com/broadinstitute/firecloud-orchestration/blob/f0873d444114013ec9612d28c2ccb17bc85f05d2/build.sbt#L11)
+   2. Replace the `reStart / javaOptions` [line](https://github.com/broadinstitute/firecloud-orchestration/blob/f0873d444114013ec9612d28c2ccb17bc85f05d2/build.sbt#L17) with `reStart / javaOptions ++= sys.env.getOrElse("JAVA_OPTS", "")
+      .concat(" -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5051")
+      .split(" ")
+      .toList`
 
-// When JAVA_OPTS are specified in the environment, they are usually meant for the application
-// itself rather than sbt, but they are not passed by default to the application, which is a forked
-// process. This passes them through to the "re-start" command, which is probably what a developer
-// would normally expect.
-//reStart / javaOptions ++= sys.env("JAVA_OPTS").split(" ").toSeq
-reStart / javaOptions ++= sys.env.getOrElse("JAVA_OPTS", "")
-.concat(" -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5051")
-.split(" ")
-.toList
+    That section of the `build.sbt` file should now look like this:
+    ```aidl
+    //Revolver.enableDebugging(port = 5051, suspend = false)
+    
+    // When JAVA_OPTS are specified in the environment, they are usually meant for the application
+    // itself rather than sbt, but they are not passed by default to the application, which is a forked
+    // process. This passes them through to the "re-start" command, which is probably what a developer
+    // would normally expect.
+    reStart / javaOptions ++= sys.env.getOrElse("JAVA_OPTS", "")
+    .concat(" -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5051")
+    .split(" ")
+    .toList
+    ```
+2. In Intellij, go to Run -> Edit Configurations
+3. Choose "Add new Configuration" (the + sign)
+4. Select "Remote JVM Debug" and set the following configuration:
+   1. Debugger mode: Attach to remote JVM
+   2. Host: localhost
+   3. Port: 5051
+   4. Use module classpath: Select Firecloud-Orchestration
+5. Run the local firecloud docker with `./config/docker-rsync-local-orch.sh` from the root directory
+6. In Intellij, choose your debug configuration and run 'debug'.
+

--- a/README.md
+++ b/README.md
@@ -101,3 +101,14 @@ To build the orch jar with docker, and then build the orch docker image, run:
 ## Debugging
 
 Remote debugging is enabled for firecloud-orchestration on port 5051.
+//Revolver.enableDebugging(port = 5051, suspend = false)
+
+// When JAVA_OPTS are specified in the environment, they are usually meant for the application
+// itself rather than sbt, but they are not passed by default to the application, which is a forked
+// process. This passes them through to the "re-start" command, which is probably what a developer
+// would normally expect.
+//reStart / javaOptions ++= sys.env("JAVA_OPTS").split(" ").toSeq
+reStart / javaOptions ++= sys.env.getOrElse("JAVA_OPTS", "")
+.concat(" -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5051")
+.split(" ")
+.toList

--- a/README.md
+++ b/README.md
@@ -128,7 +128,6 @@ In order to debug in Intellij:
    1. Debugger mode: Attach to remote JVM
    2. Host: localhost
    3. Port: 5051
-   4. Use module classpath: Select Firecloud-Orchestration
 5. Run the local firecloud docker with `./config/docker-rsync-local-orch.sh` from the root directory
 6. In Intellij, choose your debug configuration and run 'debug'.
 


### PR DESCRIPTION
It was not easy to figure out how to debug firecloud-orchestration, which in the end requires a completely unexpected change to `build.sbt`.  To save others from this struggle, I have added the steps I went through to the README.