### PR TITLE
AJ-1154: update io.grpc:grpc-xds

### DIFF
--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -27,7 +27,8 @@ object Dependencies {
   val transitiveDependencyOverrides: Seq[ModuleID] = Seq(
     "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonV,
     "com.fasterxml.jackson.core" % "jackson-databind" % jacksonHotfixV,
-    "com.fasterxml.jackson.core" % "jackson-core" % jacksonV
+    "com.fasterxml.jackson.core" % "jackson-core" % jacksonV,
+    "io.grpc" % "grpc-xds" % "1.56.1"
   )
 
   val rootDependencies: Seq[ModuleID] = Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -24,7 +24,8 @@ object Dependencies {
     "com.fasterxml.jackson.core" % "jackson-core" % jacksonV,
     "org.yaml" % "snakeyaml" % "1.33",
     // workbench-google2 has jose4j as a dependency; directly updating to a non-vulnerable version until workbench-google2 updates
-    "org.bitbucket.b_c" % "jose4j" % "0.9.3"
+    "org.bitbucket.b_c" % "jose4j" % "0.9.3",
+    "io.grpc" % "grpc-xds" % "1.56.1"
   )
 
   val rootDependencies: Seq[ModuleID] = Seq(


### PR DESCRIPTION
Updates `io.grpc:grpc-xds` to latest to address proactive security warnings.

Verified via `sbt dependencyTree`.

---

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
