### PR TITLE
[AJ-1130] Remove akka's server header

### DIFF
--- a/local-dev/templates/firecloud-orchestration.conf.ctmpl
+++ b/local-dev/templates/firecloud-orchestration.conf.ctmpl
@@ -32,6 +32,7 @@ akka {
     server {
       idle-timeout = 210 s
       request-timeout = infinite
+      server-header = ""
       parsing {
         max-content-length = 50m
       }


### PR DESCRIPTION
Currently, responses from Orchestration include a "Server" header that identifies the version of the server. This has been identified as a security issue.

This removes the `Server` header set by the Akka server in the local dev config, which results in getting the more generic `Server` header from the Apache proxy, which does not include a version.

Before
```
$ curl -I https://local.broadinstitute.org:10443/
...
Server: akka-http/10.2.10
...
```

After
```
$ curl -I https://local.broadinstitute.org:10443/
...
Server: Apache
...
```


Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
