### PR TITLE
AJ-1128 check for json in tsv attribute upload

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/TSVFileSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/TSVFileSupport.scala
@@ -126,7 +126,9 @@ trait TSVFileSupport {
       if (value.equals("__DELETE__"))
         RemoveAttribute(AttributeName.fromDelimitedName(name))
       else {
-        AddUpdateAttribute(AttributeName.fromDelimitedName(name), AttributeString(StringContext.processEscapes(value)))
+        //stringToTypedAttribute
+        AddUpdateAttribute(AttributeName.fromDelimitedName(name), stringToTypedAttribute(StringContext.processEscapes(value)))
+//        AddUpdateAttribute(AttributeName.fromDelimitedName(name), AttributeString(StringContext.processEscapes(value)))
       }
     }
   }
@@ -161,8 +163,12 @@ trait TSVFileSupport {
         case _ => Try(BooleanUtils.toBoolean(value.toLowerCase, "true", "false")) match {
           case Success(booleanValue) => AttributeBoolean(booleanValue)
           case Failure(_) =>
-            Try(value.parseJson.convertTo[AttributeEntityReference]) match {
-              case Success(ref) => ref
+            Try(value.parseJson) match {
+              case Success(jsVal) =>
+                  Try(jsVal.convertTo[AttributeEntityReference]) match {
+                    case Success(ref) => ref
+                    case Failure(_) => AttributeValueRawJson(value)
+                  }
               case Failure(_) => AttributeString(value)
             }
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/TSVFileSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/TSVFileSupport.scala
@@ -172,8 +172,8 @@ trait TSVFileSupport {
 
   def checkForJson(value: String): Attribute = {
     Try(value.parseJson) match {
-        case Success(jsVal) => AttributeValueRawJson(value)
-        case Failure(_) => AttributeString(value)
+        case Success(_: JsObject) => AttributeValueRawJson(value)
+        case _ => AttributeString(value)
       }
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockTSV.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockTSV.scala
@@ -3,6 +3,7 @@ package org.broadinstitute.dsde.firecloud.mock
 import akka.http.scaladsl.model.Multipart
 import akka.http.scaladsl.model.Multipart.FormData.BodyPart
 import org.broadinstitute.dsde.firecloud.utils.TSVLoadFile
+import org.broadinstitute.dsde.rawls.model.AttributeValueRawJson
 
 object MockTSVStrings {
 
@@ -309,7 +310,7 @@ object MockTSVLoadFiles {
     Seq("foo", "bar", "baz"),
     Seq(Seq("woop", "", "doo")))
 
-  val validWorkspaceAttributes = TSVLoadFile("workspace", Seq("a1", "a2", "a3"), Seq(Seq("v1", "2", "[1,2,3]")))
+  val validWorkspaceAttributes = TSVLoadFile("workspace", Seq("a1", "a2", "a3", "a4"), Seq(Seq("v1", "2", "[1,2,3]","""{"tables":{"sample":{"save":["participant",false,"sample",true]}}}""")))
   val validOneWorkspaceAttribute = TSVLoadFile("workspace", Seq("a1"), Seq(Seq("v1")))
   val validEmptyStrWSAttribute = TSVLoadFile("workspace", Seq("a1"), Seq(Seq("")))
   val validRemoveWSAttribute = TSVLoadFile("workspace", Seq("a1"), Seq(Seq("__DELETE__")))

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockTSV.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockTSV.scala
@@ -3,8 +3,6 @@ package org.broadinstitute.dsde.firecloud.mock
 import akka.http.scaladsl.model.Multipart
 import akka.http.scaladsl.model.Multipart.FormData.BodyPart
 import org.broadinstitute.dsde.firecloud.utils.TSVLoadFile
-import org.broadinstitute.dsde.rawls.model.AttributeValueRawJson
-
 object MockTSVStrings {
 
   /*

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/TSVFileSupportSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/TSVFileSupportSpec.scala
@@ -23,8 +23,10 @@ class TSVFileSupportSpec extends AnyFreeSpec with TSVFileSupport {
       val attributes = getWorkspaceAttributeCalls(MockTSVLoadFiles.validWorkspaceAttributes)
       assertResult(attributes) {
         List(AddUpdateAttribute(AttributeName("default", "a1"), AttributeString("v1")),
-          AddUpdateAttribute(AttributeName("default", "a2"), AttributeString("2")),
-          AddUpdateAttribute(AttributeName("default", "a3"), AttributeValueRawJson("[1,2,3]")))
+          AddUpdateAttribute(AttributeName("default", "a2"), AttributeValueRawJson("2")),
+          AddUpdateAttribute(AttributeName("default", "a3"), AttributeValueRawJson("[1,2,3]")),
+        AddUpdateAttribute(AttributeName("default", "a4"), AttributeValueRawJson("""{"tables":{"sample":{"save":["participant",false,"sample",true]}}}""")
+        ))
       }
     }
 
@@ -142,13 +144,13 @@ class TSVFileSupportSpec extends AnyFreeSpec with TSVFileSupport {
       }
     }
 
-    "should detect json values when applicable" in {
-      jsonTestCases foreach {
-        case (input, expected) => withClue(s"should handle potential reference: $input") {
-          stringToTypedAttribute(input) shouldBe expected
-        }
-      }
-    }
+//    "should detect json values when applicable" in {
+//      jsonTestCases foreach {
+//        case (input, expected) => withClue(s"should handle potential reference: $input") {
+//          stringToTypedAttribute(input) shouldBe expected
+//        }
+//      }
+//    }
 
     "should detect string values when applicable" in {
       stringTestCases foreach {

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/TSVFileSupportSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/TSVFileSupportSpec.scala
@@ -23,8 +23,8 @@ class TSVFileSupportSpec extends AnyFreeSpec with TSVFileSupport {
       val attributes = getWorkspaceAttributeCalls(MockTSVLoadFiles.validWorkspaceAttributes)
       assertResult(attributes) {
         List(AddUpdateAttribute(AttributeName("default", "a1"), AttributeString("v1")),
-          AddUpdateAttribute(AttributeName("default", "a2"), AttributeValueRawJson("2")),
-          AddUpdateAttribute(AttributeName("default", "a3"), AttributeValueRawJson("[1,2,3]")),
+          AddUpdateAttribute(AttributeName("default", "a2"), AttributeString("2")),
+          AddUpdateAttribute(AttributeName("default", "a3"), AttributeString("[1,2,3]")),
         AddUpdateAttribute(AttributeName("default", "a4"), AttributeValueRawJson("""{"tables":{"sample":{"save":["participant",false,"sample",true]}}}""")
         ))
       }
@@ -108,9 +108,6 @@ class TSVFileSupportSpec extends AnyFreeSpec with TSVFileSupport {
     val referenceTestCases = Map(
       """{"entityType":"targetType","entityName":"targetName"}""" -> AttributeEntityReference("targetType", "targetName")
     )
-    val jsonTestCases = Map(
-      """{"tables":{"sample":{"save":["bai",true,"bam",true,"participant",false,"sample",true]}}}""" -> AttributeValueRawJson("""{"tables":{"sample":{"save":["bai",true,"bam",true,"participant",false,"sample",true]}}}""")
-    )
 
     "should detect boolean values when applicable" in {
       booleanTestCases foreach {
@@ -143,14 +140,6 @@ class TSVFileSupportSpec extends AnyFreeSpec with TSVFileSupport {
         }
       }
     }
-
-//    "should detect json values when applicable" in {
-//      jsonTestCases foreach {
-//        case (input, expected) => withClue(s"should handle potential reference: $input") {
-//          stringToTypedAttribute(input) shouldBe expected
-//        }
-//      }
-//    }
 
     "should detect string values when applicable" in {
       stringTestCases foreach {

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/TSVFileSupportSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/TSVFileSupportSpec.scala
@@ -24,7 +24,7 @@ class TSVFileSupportSpec extends AnyFreeSpec with TSVFileSupport {
       assertResult(attributes) {
         List(AddUpdateAttribute(AttributeName("default", "a1"), AttributeString("v1")),
           AddUpdateAttribute(AttributeName("default", "a2"), AttributeString("2")),
-          AddUpdateAttribute(AttributeName("default", "a3"), AttributeString("[1,2,3]")))
+          AddUpdateAttribute(AttributeName("default", "a3"), AttributeValueRawJson("[1,2,3]")))
       }
     }
 
@@ -106,6 +106,9 @@ class TSVFileSupportSpec extends AnyFreeSpec with TSVFileSupport {
     val referenceTestCases = Map(
       """{"entityType":"targetType","entityName":"targetName"}""" -> AttributeEntityReference("targetType", "targetName")
     )
+    val jsonTestCases = Map(
+      """{"tables":{"sample":{"save":["bai",true,"bam",true,"participant",false,"sample",true]}}}""" -> AttributeValueRawJson("""{"tables":{"sample":{"save":["bai",true,"bam",true,"participant",false,"sample",true]}}}""")
+    )
 
     "should detect boolean values when applicable" in {
       booleanTestCases foreach {
@@ -133,6 +136,14 @@ class TSVFileSupportSpec extends AnyFreeSpec with TSVFileSupport {
 
     "should detect entity references when applicable" in {
       referenceTestCases foreach {
+        case (input, expected) => withClue(s"should handle potential reference: $input") {
+          stringToTypedAttribute(input) shouldBe expected
+        }
+      }
+    }
+
+    "should detect json values when applicable" in {
+      jsonTestCases foreach {
         case (input, expected) => withClue(s"should handle potential reference: $input") {
           stringToTypedAttribute(input) shouldBe expected
         }


### PR DESCRIPTION
[AJ-1128](https://broadworkbench.atlassian.net/browse/AJ-1128)
Workspace attributes are all automatically typed as strings.  This led to a problem with attributes that were large/long json objects - too large to be strings.  If we check for json compatibility and assign these attributes to json if possible, the problem is solved.


Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment


[AJ-1128]: https://broadworkbench.atlassian.net/browse/AJ-1128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ