### PR TITLE
WOR-659 remove v1 billing endpoints

### DIFF
--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -17,7 +17,7 @@ object Dependencies {
   val workbenchGoogle: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-google" % workbenchGoogleV excludeAll excludeWorkbenchModel
   val excludeWorkbenchGoogle = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-google_" + scalaV)
 
-  val workbenchServiceTestV = s"2.0-$workbenchLibsHash"
+  val workbenchServiceTestV = s"4.0-e42c23c"
   val workbenchServiceTest: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-service-test" % workbenchServiceTestV % "test" classifier "tests" excludeAll (excludeWorkbenchGoogle, excludeWorkbenchModel)
 
   // Overrides for transitive dependencies. These apply - via Settings.scala - to all projects in this codebase.

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -28,7 +28,9 @@ object Dependencies {
     "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonV,
     "com.fasterxml.jackson.core" % "jackson-databind" % jacksonHotfixV,
     "com.fasterxml.jackson.core" % "jackson-core" % jacksonV,
-    "io.grpc" % "grpc-xds" % "1.56.1"
+    "io.grpc" % "grpc-xds" % "1.56.1",
+    "org.typelevel" %% "cats-effect" % "3.4.11",
+    "org.typelevel" %% "cats-core" % "2.10.0"
   )
 
   val rootDependencies: Seq[ModuleID] = Seq(

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/OrchestrationApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/OrchestrationApiSpec.scala
@@ -93,12 +93,12 @@ class OrchestrationApiSpec
         val ownerToken: AuthToken = ownerUser.makeAuthToken()
         withTemporaryBillingProject(billingAccountId) { projectName =>
           nowPrint(s"Querying for (owner) user profile billing project status: $projectName")
-          // Returns a map of projectName and creationStatus for the project specified
+          // Returns a map of projectName and status for the project specified
           implicit val patienceConfig = PatienceConfig(Span(2, Minutes), Span(10, Seconds))
           eventually {
             val statusMap: Map[String, String] = Orchestration.billingV2.getBillingProject(projectName)(ownerToken)
             statusMap should contain("projectName" -> projectName)
-            statusMap should contain("creationStatus" -> BillingProjectStatus.Ready.toString)
+            statusMap should contain("status" -> BillingProjectStatus.Ready.toString)
           }
         }(ownerUser.makeAuthToken(billingScopes))
       }

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/OrchestrationApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/OrchestrationApiSpec.scala
@@ -76,10 +76,11 @@ class OrchestrationApiSpec
       val ownerUser: Credentials = UserPool.chooseProjectOwner
       val ownerToken: AuthToken = ownerUser.makeAuthToken()
       withTemporaryBillingProject(billingAccountId) { projectName =>
-        nowPrint(s"Querying for (owner) user profile billing projects, with project: $projectName")
+        nowPrint(s"Querying for (owner) user billing projects, with project: $projectName")
         // Returns a list of maps, one map per billing project the user has access to.
         // Each map has a key for the projectName, role, status, and an optional message
-        val projectList: List[Map[String, String]] = Orchestration.profile.getUserBillingProjects()(ownerToken)
+        val projectList: List[Map[String, String]] = Orchestration.billingV2.listUserBillingProjects()(ownerToken)
+
         val projectNames: List[String] = projectList.map(_.getOrElse("projectName", ""))
         projectNames should (contain(projectName) and not contain "")
       }(ownerUser.makeAuthToken(billingScopes))
@@ -95,7 +96,7 @@ class OrchestrationApiSpec
           // Returns a map of projectName and creationStatus for the project specified
           implicit val patienceConfig = PatienceConfig(Span(2, Minutes), Span(10, Seconds))
           eventually {
-            val statusMap: Map[String, String] = Orchestration.profile.getUserBillingProjectStatus(projectName)(ownerToken)
+            val statusMap: Map[String, String] = Orchestration.billingV2.getBillingProject(projectName)(ownerToken)
             statusMap should contain("projectName" -> projectName)
             statusMap should contain("creationStatus" -> BillingProjectStatus.Ready.toString)
           }
@@ -109,7 +110,7 @@ class OrchestrationApiSpec
         val random: String = UUID.randomUUID().toString
         nowPrint(s"Querying for (owner) user profile billing project status: $random")
         val getException = intercept[RestException] {
-          Orchestration.profile.getUserBillingProjectStatus(random)(ownerToken)
+          Orchestration.billingV2.getBillingProject(random)(ownerToken)
         }
         getException.message should include(StatusCodes.NotFound.defaultMessage)
       }
@@ -119,9 +120,9 @@ class OrchestrationApiSpec
         val user: Credentials = UserPool.chooseStudent
         val userToken: AuthToken = user.makeAuthToken()
         withTemporaryBillingProject(billingAccountId) { projectName =>
-          nowPrint(s"Querying for (student) user profile billing project status: $projectName")
+          nowPrint(s"Querying for (student) user billing project status: $projectName")
           val getException = intercept[RestException] {
-            Orchestration.profile.getUserBillingProjectStatus(projectName)(userToken)
+            Orchestration.billingV2.getBillingProject(projectName)(userToken)
           }
           getException.message should include(StatusCodes.NotFound.defaultMessage)
         }(ownerUser.makeAuthToken(billingScopes))

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -11,7 +11,6 @@ info:
 servers:
   - url: /
 tags:
-  - name: Billing
   - name: BillingV2
   - name: CromIAM Engine (for Job Manager)
   - name: CromIAM Workflows (for Admin)
@@ -45,38 +44,6 @@ security:
       - email
       - profile
 paths:
-  /api/billing/{projectId}/members:
-    get:
-      tags:
-        - Billing
-      summary: List members of billing project the caller owns. Deprecated, use v2 version.
-      deprecated: true
-      operationId: listBillingProjectMembers
-      parameters:
-        - $ref: '#/components/parameters/billingProjectPathParam'
-      responses:
-        200:
-          description: Success
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/BillingProjectMember'
-        403:
-          description: You must be a project owner to view the members of a project
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
-        500:
-          description: FireCloud Internal Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
-      x-passthrough: true
-      x-passthrough-target: rawls
   /api/billing/v2/{projectId}/spendReportConfiguration:
     get:
       tags:
@@ -179,101 +146,6 @@ paths:
           description: Rawls Internal Error
           content:
             'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
-      x-passthrough: true
-      x-passthrough-target: rawls
-  /api/billing/{projectId}/{workbenchRole}/{email}:
-    put:
-      tags:
-        - Billing
-      summary: Add user to billing project the caller owns. Deprecated, use v2 version.
-      deprecated: true
-      operationId: addUserToBillingProject
-      parameters:
-        - $ref: '#/components/parameters/billingProjectPathParam'
-        - name: workbenchRole
-          in: path
-          description: role of user for project
-          required: true
-          schema:
-            type: string
-            enum:
-              - user
-              - owner
-        - name: email
-          in: path
-          description: email of user or group to add
-          required: true
-          schema:
-            type: string
-      responses:
-        200:
-          description: Successfully Added User To Billing Project
-          content: {}
-        403:
-          description: You must be a project owner to add a user to a billing project
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
-        404:
-          description: User not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
-        500:
-          description: FireCloud Internal Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
-      x-passthrough: true
-      x-passthrough-target: rawls
-    delete:
-      tags:
-        - Billing
-      summary: Remove user from billing project the caller owns. Deprecated, use v2 version.
-      deprecated: true
-      operationId: removeUserFromBillingProject
-      parameters:
-        - $ref: '#/components/parameters/billingProjectPathParam'
-        - name: workbenchRole
-          in: path
-          description: role of user for project
-          required: true
-          schema:
-            type: string
-            enum:
-              - user
-              - owner
-        - name: email
-          in: path
-          description: email of user or group to remove
-          required: true
-          schema:
-            type: string
-      responses:
-        200:
-          description: Successfully Removed User From Billing Project
-          content: {}
-        403:
-          description: You must be a project owner to add a user to a billing project
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
-        404:
-          description: User not found
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
-        500:
-          description: FireCloud Internal Error
-          content:
-            application/json:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
       x-passthrough: true
@@ -571,43 +443,6 @@ paths:
                 $ref: '#/components/schemas/ErrorReport'
         500:
           description: FireCloud Internal Error
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
-  /api/user/billing/{projectName}:
-    delete:
-      tags:
-        - Billing
-      summary: Delete billing project. Deprecated, use v2 version.
-      deprecated: true
-      description: delete billing project
-      operationId: deleteBillingProjectV2
-      parameters:
-        - name: projectName
-          in: path
-          description: Name of the billing project
-          required: true
-          schema:
-            type: string
-      responses:
-        200:
-          description: Successfully delete billing project
-          content: {}
-        400:
-          description: Project cannot be deleted because it contains workspaces.
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
-        403:
-          description: You must be a project owner to delete billing project
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/ErrorReport'
-        500:
-          description: Rawls Internal Error
           content:
             'application/json':
               schema:
@@ -2708,60 +2543,6 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/NotificationType'
-      x-passthrough: true
-      x-passthrough-target: rawls
-  /api/profile/billing:
-    get:
-      tags:
-        - Profile
-      summary: List billing projects for a user. Deprecated, use v2 billing API.
-      deprecated: true
-      operationId: billing
-      responses:
-        200:
-          description: OK
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/BillingProjectMembership'
-        404:
-          description: User Not Found
-          content: {}
-        500:
-          description: Internal Server Error
-          content: {}
-      x-passthrough: true
-      x-passthrough-target: rawls
-  /api/profile/billing/{projectName}:
-    get:
-      tags:
-        - Profile
-      summary: Billing project status. Deprecated, use v2 billing API.
-      deprecated: true
-      description: billing project status
-      operationId: billingProjectStatus
-      parameters:
-        - name: projectName
-          in: path
-          description: Name of the billing project
-          required: true
-          schema:
-            type: string
-      responses:
-        200:
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/BillingProjectStatus'
-        404:
-          description: Project Not Found
-          content: {}
-        500:
-          description: Internal Server Error
-          content: {}
       x-passthrough: true
       x-passthrough-target: rawls
   /api/profile/billingAccounts:

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/Profile.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/Profile.scala
@@ -1,9 +1,5 @@
 package org.broadinstitute.dsde.firecloud.model
 
-import org.broadinstitute.dsde.firecloud.service.NihDatasetPermission
-import org.broadinstitute.dsde.firecloud.utils.DateUtils
-import spray.json.DefaultJsonProtocol._
-
 import scala.language.postfixOps
 import scala.util.Try
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/BillingApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/BillingApiService.scala
@@ -14,10 +14,6 @@ trait BillingApiService extends FireCloudDirectives with StreamingPassthrough {
     pathPrefix("billing") {
       // all paths under /api/billing pass through to the same path in Rawls
       streamingPassthrough(Uri.Path("/api/billing") -> Uri(FireCloudConfig.Rawls.authUrl + "/billing"))
-    } ~
-    path("user" / "billing" / Segment) { projectId =>
-      delete {
-        passthrough(s"$userBillingUrl/$projectId", DELETE)
-      }
     }
+
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/UserApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/UserApiService.scala
@@ -95,18 +95,6 @@ trait UserApiService
       }
     } ~
     pathPrefix("api") {
-      pathPrefix("profile" / "billing") {
-        pathEnd {
-          get {
-            passthrough(UserApiService.billingUrl, HttpMethods.GET)
-          }
-        } ~
-        path(Segment) { projectName =>
-          get {
-            passthrough(UserApiService.billingProjectUrl(projectName), HttpMethods.GET)
-          }
-        }
-      } ~
       path("profile" / "billingAccounts") {
         get {
           passthrough(UserApiService.billingAccountsUrl, HttpMethods.GET)

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/UserApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/UserApiServiceSpec.scala
@@ -176,23 +176,6 @@ class UserApiServiceSpec extends BaseServiceSpec with SamMockserverUtils
       }
     }
 
-    "when calling GET for user billing service" - {
-      "MethodNotAllowed response is not returned" in {
-        Get("/api/profile/billing") ~> dummyUserIdHeaders(uniqueId) ~> sealRoute(userServiceRoutes) ~> check {
-          log.debug("/api/profile/billing: " + status)
-          status shouldNot equal(MethodNotAllowed)
-        }
-      }
-    }
-
-    "When calling GET for a valid user billing project" - {
-      "MethodNotAllowed response is not returned" in {
-        Get("/api/profile/billing/random-project-name") ~> dummyUserIdHeaders(uniqueId) ~> sealRoute(userServiceRoutes) ~> check {
-          status shouldNot equal(MethodNotAllowed)
-        }
-      }
-    }
-
     "when calling GET for user refresh token date service" - {
       "MethodNotAllowed response is not returned" in {
         Get("/api/profile/refreshTokenDate") ~> dummyUserIdHeaders(uniqueId) ~> sealRoute(userServiceRoutes) ~> check {


### PR DESCRIPTION
Removes v1 billing project endpoints from api-docs and tests.
V2 endpoints should be unaffected, since they fall within the existing rawls-passthrough endpoints.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
