### PR TITLE
WOR-1215: revert removal of v1 billing endpoints

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/UserApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/UserApiService.scala
@@ -94,6 +94,18 @@ trait UserApiService
         }
       }
     } ~
+    pathPrefix("profile" / "billing") {
+      pathEnd {
+        get {
+          passthrough(UserApiService.billingUrl, HttpMethods.GET)
+        }
+      } ~
+      path(Segment) { projectName =>
+        get {
+          passthrough(UserApiService.billingProjectUrl(projectName), HttpMethods.GET)
+        }
+      }
+    } ~
     pathPrefix("api") {
       path("profile" / "billingAccounts") {
         get {


### PR DESCRIPTION
Put back profile to v1 billing proxy
All other endpoints should still be covered by the streaming passthrough.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
