### PR TITLE
AJ-1330: fix .scala-steward.conf

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -51,7 +51,7 @@ pullRequests.frequency = "0 0 ? * MON" # every monday at midnight
 updates.ignore = [
   { groupId = "org.elasticsearch.client", artifactId = "transport" },   # AJ-266
   { groupId = "org.apache.lucene", artifactId = "lucene-queryparser" }, # AJ-266
-  { groupId = "org.mock-server", artifactId = "mockserver-netty" },     # AJ-423
+  { groupId = "org.mock-server", artifactId = "mockserver-netty" }      # AJ-423
 ]
 
 # If set, Scala Steward will only create or update `n` PRs each time it runs (see `pullRequests.frequency` above).

--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -48,8 +48,11 @@ pullRequests.frequency = "0 0 ? * MON" # every monday at midnight
 
 # Elasticsearch and its Lucene dependency should not be automatically updated;
 # these require nontrivial changes to calling code and business logic. See AJ-266.
-updates.ignore = [ { groupId = "org.elasticsearch.client", artifactId = "transport" } ]
-updates.ignore = [ { groupId = "org.apache.lucene", artifactId = "lucene-queryparser" } ]
+updates.ignore = [
+  { groupId = "org.elasticsearch.client", artifactId = "transport" },   # AJ-266
+  { groupId = "org.apache.lucene", artifactId = "lucene-queryparser" }, # AJ-266
+  { groupId = "org.mock-server", artifactId = "mockserver-netty" },     # AJ-423
+]
 
 # If set, Scala Steward will only create or update `n` PRs each time it runs (see `pullRequests.frequency` above).
 # Useful if running frequently and/or CI build are costly


### PR DESCRIPTION
our `.scala-steward.conf` was incorrect w/r/t ignored updates.

It set `updates.ignore` twice; the second invocation overwrote the first, and that's why Scala Steward generated #1212 even though we didn't want it to.

I've also added `mockserver-netty` to the ignore list, and tagged each ignore with its associated Jira ticket.