### PR TITLE
AJ-1428: exclude netty3

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -25,14 +25,15 @@ object Dependencies {
     "org.yaml" % "snakeyaml" % "1.33",
     // workbench-google2 has jose4j as a dependency; directly updating to a non-vulnerable version until workbench-google2 updates
     "org.bitbucket.b_c" % "jose4j" % "0.9.3",
-    "io.grpc" % "grpc-xds" % "1.56.1"
+    "io.grpc" % "grpc-xds" % "1.56.1",
+    // netty is needed by the Elasticsearch client at runtime
+    "io.netty" % "netty-handler" % nettyV
   )
 
   val rootDependencies: Seq[ModuleID] = Seq(
     // proactively pull in latest versions of these libraries, instead of relying on the versions
     // specified as transitive dependencies, due to OWASP DependencyCheck warnings for earlier versions.
     // TODO: can these move to sbt's dependencyOverrides?
-    "io.netty"                       % "netty-handler"       % nettyV, // netty is needed by the Elasticsearch client at runtime
     "org.apache.lucene"              % "lucene-queryparser"  % "6.6.6", // pin to this version; it's the latest compatible with our elasticsearch client
     "com.google.guava"               % "guava"               % "32.1.3-jre",
     // END transitive dependency overrides
@@ -67,6 +68,7 @@ object Dependencies {
     "net.virtual-void"              %% "json-lenses"               % "0.6.2"  % "test",
 
     "org.elasticsearch.client"       % "transport"           % "5.6.16" // pin to this version; it's the latest compatible with our elasticsearch server
+      exclude("org.elasticsearch.plugin", "transport-netty3-client")
       exclude("io.netty", "netty-codec")
       exclude("io.netty", "netty-transport")
       exclude("io.netty", "netty-resolver")

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/elastic/ElasticUtils.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/elastic/ElasticUtils.scala
@@ -1,21 +1,40 @@
 package org.broadinstitute.dsde.firecloud.elastic
 
 import java.net.InetAddress
-
 import org.elasticsearch.client.transport.TransportClient
 import org.elasticsearch.common.settings.Settings
 import org.elasticsearch.common.transport.InetSocketTransportAddress
 import org.elasticsearch.transport.client.PreBuiltTransportClient
 import akka.http.scaladsl.model.Uri.Authority
+import org.elasticsearch.index.reindex.ReindexPlugin
+import org.elasticsearch.join.ParentJoinPlugin
+import org.elasticsearch.percolator.PercolatorPlugin
+import org.elasticsearch.plugins.Plugin
+import org.elasticsearch.script.mustache.MustachePlugin
+import org.elasticsearch.transport.Netty4Plugin
+
+import java.util
+import java.util.Collections
 
 object ElasticUtils {
-  def buildClient(servers:Seq[Authority], clusterName: String): TransportClient = {
+
+  // copied from PreBuiltTransportClient, but removed Netty3Plugin
+  val pluginList: util.Collection[Class[_ <: Plugin]] = Collections.unmodifiableList(util.Arrays.asList(
+    // classOf[Netty3Plugin],
+    classOf[Netty4Plugin],
+    classOf[ReindexPlugin],
+    classOf[PercolatorPlugin],
+    classOf[MustachePlugin],
+    classOf[ParentJoinPlugin]))
+
+  def buildClient(servers: Seq[Authority], clusterName: String): TransportClient = {
     val settings = Settings.builder
       .put("cluster.name", clusterName)
       .build
     val addresses = servers map { server =>
       new InetSocketTransportAddress(InetAddress.getByName(server.host.address), server.port)
     }
-    new PreBuiltTransportClient(settings).addTransportAddresses(addresses: _*)
+
+    new PreBuiltTransportClient(settings, pluginList).addTransportAddresses(addresses: _*)
   }
 }


### PR DESCRIPTION
Cleans up our dependencies a little bit.
1. Move our version override for `io.netty:netty-handler` away from being a direct dependency and into sbt's `dependencyOverrides`.
2. Exclude `org.elasticsearch.plugin:transport-netty3-client` from `org.elasticsearch.client:transport`. `transport-netty3-client` is the library that was pulling in netty3, which triggered a bunch of dependabot alerts.



---

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
