### PR TITLE
AJ-1428: address compile warnings

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudApiService.scala
@@ -31,7 +31,7 @@ object FireCloudApiService extends LazyLogging {
 
     import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport._
 
-    implicit val errorReportSource = ErrorReportSource("FireCloud") //TODO make sure this doesn't clobber source names globally
+    implicit val errorReportSource: ErrorReportSource = ErrorReportSource("FireCloud") //TODO make sure this doesn't clobber source names globally
 
     ExceptionHandler {
       case withErrorReport: FireCloudExceptionWithErrorReport =>

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/AgoraDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/AgoraDAO.scala
@@ -12,7 +12,7 @@ object AgoraDAO {
 
 trait AgoraDAO extends ReportsSubsystemStatus {
 
-  implicit val errorReportSource = ErrorReportSource(AgoraDAO.serviceName)
+  implicit val errorReportSource: ErrorReportSource = ErrorReportSource(AgoraDAO.serviceName)
 
   def getNamespacePermissions(ns: String, entity: String)(implicit userInfo: UserInfo): Future[List[AgoraPermission]]
   def postNamespacePermissions(ns: String, entity: String, perms: List[AgoraPermission])(implicit userInfo: UserInfo): Future[List[AgoraPermission]]

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ConsentDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ConsentDAO.scala
@@ -12,7 +12,7 @@ object ConsentDAO {
 
 trait ConsentDAO extends ReportsSubsystemStatus {
 
-  implicit val errorReportSource = ErrorReportSource(ConsentDAO.serviceName)
+  implicit val errorReportSource: ErrorReportSource = ErrorReportSource(ConsentDAO.serviceName)
 
   override def serviceName:String = ConsentDAO.serviceName
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/GoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/GoogleServicesDAO.scala
@@ -16,7 +16,7 @@ object GoogleServicesDAO {
 
 trait GoogleServicesDAO extends ReportsSubsystemStatus {
 
-  implicit val errorReportSource = ErrorReportSource(GoogleServicesDAO.serviceName)
+  implicit val errorReportSource: ErrorReportSource = ErrorReportSource(GoogleServicesDAO.serviceName)
 
   def getAdminUserAccessToken: String
   def getBucketObjectAsInputStream(bucketName: String, objectKey: String): InputStream

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
@@ -64,8 +64,8 @@ object GooglePriceListJsonProtocol extends DefaultJsonProtocol with SprayJsonSup
       case x => throw new DeserializationException("invalid value: " + x)
     }
   }
-  implicit val GooglePricesFormat = jsonFormat(GooglePrices, FireCloudConfig.GoogleCloud.priceListStorageKey, FireCloudConfig.GoogleCloud.priceListEgressKey)
-  implicit val GooglePriceListFormat = jsonFormat(GooglePriceList, "gcp_price_list", "version", "updated")
+  implicit val GooglePricesFormat: RootJsonFormat[GooglePrices] = jsonFormat(GooglePrices, FireCloudConfig.GoogleCloud.priceListStorageKey, FireCloudConfig.GoogleCloud.priceListEgressKey)
+  implicit val GooglePriceListFormat: RootJsonFormat[GooglePriceList] = jsonFormat(GooglePriceList, "gcp_price_list", "version", "updated")
 }
 import org.broadinstitute.dsde.firecloud.dataaccess.GooglePriceListJsonProtocol._
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpImportServiceDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpImportServiceDAO.scala
@@ -20,7 +20,7 @@ import scala.concurrent.duration._
 class HttpImportServiceDAO(implicit val system: ActorSystem, implicit val materializer: Materializer, implicit val executionContext: ExecutionContext)
   extends ImportServiceDAO with RestJsonClient with SprayJsonSupport {
 
-  implicit val errorReportSource = ErrorReportSource("FireCloud")
+  implicit val errorReportSource: ErrorReportSource = ErrorReportSource("FireCloud")
 
   override def importJob(workspaceNamespace: String, workspaceName: String, importRequest: AsyncImportRequest, isUpsert: Boolean)(implicit userInfo: UserInfo): Future[PerRequestMessage] = {
     doImport(workspaceNamespace, workspaceName, isUpsert, importRequest)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/OntologyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/OntologyDAO.scala
@@ -14,7 +14,7 @@ trait OntologyDAO extends ReportsSubsystemStatus {
 
   lazy val ontologySearchUrl = FireCloudConfig.Duos.baseOntologyUrl + "/search"
 
-  implicit val errorReportSource = ErrorReportSource(OntologyDAO.serviceName)
+  implicit val errorReportSource: ErrorReportSource = ErrorReportSource(OntologyDAO.serviceName)
 
   def search(term: String): List[TermResource]
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/RawlsDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/RawlsDAO.scala
@@ -30,7 +30,7 @@ trait RawlsDAO extends LazyLogging with ReportsSubsystemStatus {
 
   def encodeUri(path: String): String = FireCloudDirectiveUtils.encodeUri(path)
 
-  implicit val errorReportSource = ErrorReportSource(RawlsDAO.serviceName)
+  implicit val errorReportSource: ErrorReportSource = ErrorReportSource(RawlsDAO.serviceName)
 
   lazy val rawlsWorkspacesRoot = FireCloudConfig.Rawls.workspacesUrl
   lazy val rawlsAdminUrl = FireCloudConfig.Rawls.authUrl + "/user/role/admin"

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/SamDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/SamDAO.scala
@@ -24,7 +24,7 @@ object SamDAO {
 
 trait SamDAO extends LazyLogging with ReportsSubsystemStatus {
 
-  implicit val errorReportSource = ErrorReportSource(SamDAO.serviceName)
+  implicit val errorReportSource: ErrorReportSource = ErrorReportSource(SamDAO.serviceName)
 
   val managedGroupResourceTypeName = "managed-group"
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/SearchDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/SearchDAO.scala
@@ -13,7 +13,7 @@ object SearchDAO {
 
 trait SearchDAO extends LazyLogging with ReportsSubsystemStatus {
 
-  implicit val errorReportSource = ErrorReportSource(RawlsDAO.serviceName)
+  implicit val errorReportSource: ErrorReportSource = ErrorReportSource(RawlsDAO.serviceName)
 
   def initIndex(): Unit
   def recreateIndex(): Unit

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ShareLogDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ShareLogDAO.scala
@@ -9,7 +9,7 @@ object ShareLogDAO {
 
 trait ShareLogDAO extends ReportsSubsystemStatus with ElasticSearchDAOSupport {
 
-  implicit val errorReportSource = ErrorReportSource(ShareLogDAO.serviceName)
+  implicit val errorReportSource: ErrorReportSource = ErrorReportSource(ShareLogDAO.serviceName)
 
   override def serviceName: String = ShareLogDAO.serviceName
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ThurloeDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ThurloeDAO.scala
@@ -16,7 +16,7 @@ object ThurloeDAO {
 
 trait ThurloeDAO extends LazyLogging with ReportsSubsystemStatus {
 
-  implicit val errorReportSource = ErrorReportSource(ThurloeDAO.serviceName)
+  implicit val errorReportSource: ErrorReportSource = ErrorReportSource(ThurloeDAO.serviceName)
 
   def getAllKVPs(forUserId: String, callerToken: WithAccessToken): Future[Option[ProfileWrapper]]
   def getAllUserValuesForKey(key: String): Future[Map[String, String]]

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/GoogleStorage.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/GoogleStorage.scala
@@ -1,7 +1,0 @@
-package org.broadinstitute.dsde.firecloud.model
-
-/**
-  * Created by davidan on 9/30/16.
-  */
-
-

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
@@ -70,8 +70,8 @@ object ModelJsonProtocol extends WorkspaceJsonSupport with SprayJsonSupport {
       case _ => throw DeserializationException(s"cannot deserialize DiseaseOntologyNodeId from [$json]")
     }
   }
-  implicit val impResearchPurpose = jsonFormat6(ResearchPurpose.apply)
-  implicit val impResearchPurposeRequest = jsonFormat7(ResearchPurposeRequest.apply)
+  implicit val impResearchPurpose: RootJsonFormat[ResearchPurpose] = jsonFormat6(ResearchPurpose.apply)
+  implicit val impResearchPurposeRequest: RootJsonFormat[ResearchPurposeRequest] = jsonFormat7(ResearchPurposeRequest.apply)
 
   implicit object impLibrarySearchParams extends RootJsonFormat[LibrarySearchParams] {
     val SEARCH_STRING = "searchString"
@@ -129,10 +129,10 @@ object ModelJsonProtocol extends WorkspaceJsonSupport with SprayJsonSupport {
     }
   }
 
-  implicit val ESInnerFieldFormat = jsonFormat7(ESInnerField)
-  implicit val ESInternalTypeFormat = jsonFormat3(ESInternalType)
-  implicit val ESNestedTypeFormat = jsonFormat2(ESNestedType)
-  implicit val ESTypeFormat = jsonFormat3(ESType.apply)
+  implicit val ESInnerFieldFormat: RootJsonFormat[ESInnerField] = jsonFormat7(ESInnerField)
+  implicit val ESInternalTypeFormat: RootJsonFormat[ESInternalType] = jsonFormat3(ESInternalType)
+  implicit val ESNestedTypeFormat: RootJsonFormat[ESNestedType] = jsonFormat2(ESNestedType)
+  implicit val ESTypeFormat: RootJsonFormat[ESType] = jsonFormat3(ESType.apply)
 
   implicit object impESPropertyFields extends JsonFormat[ESPropertyFields] {
     override def write(input: ESPropertyFields): JsValue = input match {
@@ -153,7 +153,7 @@ object ModelJsonProtocol extends WorkspaceJsonSupport with SprayJsonSupport {
     }
   }
 
-  implicit val ESDatasetPropertiesFormat = jsonFormat1(ESDatasetProperty)
+  implicit val ESDatasetPropertiesFormat: RootJsonFormat[ESDatasetProperty] = jsonFormat1(ESDatasetProperty)
 
   implicit object impStackTraceElement extends RootJsonFormat[StackTraceElement] {
     val CLASS_NAME = "className"
@@ -176,72 +176,72 @@ object ModelJsonProtocol extends WorkspaceJsonSupport with SprayJsonSupport {
   }
 
   // Build error about missing implicit for Spray parameter unmarshaller? Add an entry here.
-  implicit val impMethod = jsonFormat11(OrchMethodRepository.Method.apply)
-  implicit val impConfiguration = jsonFormat10(OrchMethodRepository.Configuration)
-  implicit val impAgoraConfigurationShort = jsonFormat4(OrchMethodRepository.AgoraConfigurationShort)
+  implicit val impMethod: RootJsonFormat[Method] = jsonFormat11(OrchMethodRepository.Method.apply)
+  implicit val impConfiguration: RootJsonFormat[Configuration] = jsonFormat10(OrchMethodRepository.Configuration)
+  implicit val impAgoraConfigurationShort: RootJsonFormat[AgoraConfigurationShort] = jsonFormat4(OrchMethodRepository.AgoraConfigurationShort)
 
-  implicit val impUIWorkspaceResponse = jsonFormat6(UIWorkspaceResponse)
+  implicit val impUIWorkspaceResponse: RootJsonFormat[UIWorkspaceResponse] = jsonFormat6(UIWorkspaceResponse)
 
   //implicit val impEntity = jsonFormat5(Entity)
-  implicit val impEntityCreateResult = jsonFormat4(EntityCreateResult)
-  implicit val impEntityCopyWithoutDestinationDefinition = jsonFormat3(EntityCopyWithoutDestinationDefinition)
-  implicit val impEntityId = jsonFormat2(EntityId)
+  implicit val impEntityCreateResult: RootJsonFormat[EntityCreateResult] = jsonFormat4(EntityCreateResult)
+  implicit val impEntityCopyWithoutDestinationDefinition: RootJsonFormat[EntityCopyWithoutDestinationDefinition] = jsonFormat3(EntityCopyWithoutDestinationDefinition)
+  implicit val impEntityId: RootJsonFormat[EntityId] = jsonFormat2(EntityId)
 
-  implicit val impDestination = jsonFormat3(MethodConfigurationId)
-  implicit val impMethodConfigurationCopy = jsonFormat4(MethodConfigurationCopy)
-  implicit val impConfigurationCopyIngest = jsonFormat5(CopyConfigurationIngest)
-  implicit val impMethodConfigurationPublish = jsonFormat3(MethodConfigurationPublish)
-  implicit val impPublishConfigurationIngest = jsonFormat4(PublishConfigurationIngest)
-  implicit val impMethodConfigurationName = jsonFormat2(OrchMethodConfigurationName.apply)
+  implicit val impDestination: RootJsonFormat[MethodConfigurationId] = jsonFormat3(MethodConfigurationId)
+  implicit val impMethodConfigurationCopy: RootJsonFormat[MethodConfigurationCopy] = jsonFormat4(MethodConfigurationCopy)
+  implicit val impConfigurationCopyIngest: RootJsonFormat[CopyConfigurationIngest] = jsonFormat5(CopyConfigurationIngest)
+  implicit val impMethodConfigurationPublish: RootJsonFormat[MethodConfigurationPublish] = jsonFormat3(MethodConfigurationPublish)
+  implicit val impPublishConfigurationIngest: RootJsonFormat[PublishConfigurationIngest] = jsonFormat4(PublishConfigurationIngest)
+  implicit val impMethodConfigurationName: RootJsonFormat[OrchMethodConfigurationName] = jsonFormat2(OrchMethodConfigurationName.apply)
 
-  implicit val impFireCloudPermission = jsonFormat2(FireCloudPermission)
-  implicit val impAgoraPermission = jsonFormat2(AgoraPermission)
+  implicit val impFireCloudPermission: RootJsonFormat[FireCloudPermission] = jsonFormat2(FireCloudPermission)
+  implicit val impAgoraPermission: RootJsonFormat[AgoraPermission] = jsonFormat2(AgoraPermission)
 
-  implicit val impEntityAccessControl = jsonFormat4(EntityAccessControl)
-  implicit val impEntityAccessControlAgora = jsonFormat3(EntityAccessControlAgora)
-  implicit val impAccessEntry = jsonFormat4(AccessEntry)
-  implicit val impPermissionReport = jsonFormat2(PermissionReport)
-  implicit val impPermissionReportRequest = jsonFormat2(PermissionReportRequest)
-  implicit val impMethodAclPair = jsonFormat3(MethodAclPair)
+  implicit val impEntityAccessControl: RootJsonFormat[EntityAccessControl] = jsonFormat4(EntityAccessControl)
+  implicit val impEntityAccessControlAgora: RootJsonFormat[EntityAccessControlAgora] = jsonFormat3(EntityAccessControlAgora)
+  implicit val impAccessEntry: RootJsonFormat[AccessEntry] = jsonFormat4(AccessEntry)
+  implicit val impPermissionReport: RootJsonFormat[PermissionReport] = jsonFormat2(PermissionReport)
+  implicit val impPermissionReportRequest: RootJsonFormat[PermissionReportRequest] = jsonFormat2(PermissionReportRequest)
+  implicit val impMethodAclPair: RootJsonFormat[MethodAclPair] = jsonFormat3(MethodAclPair)
 
-  implicit val impEntityMetadata = jsonFormat3(EntityMetadata)
-  implicit val impModelSchema = jsonFormat1(EntityModel)
-  implicit val impOrchSubmissionRequest = jsonFormat11(OrchSubmissionRequest)
+  implicit val impEntityMetadata: RootJsonFormat[EntityMetadata] = jsonFormat3(EntityMetadata)
+  implicit val impModelSchema: RootJsonFormat[EntityModel] = jsonFormat1(EntityModel)
+  implicit val impOrchSubmissionRequest: RootJsonFormat[OrchSubmissionRequest] = jsonFormat11(OrchSubmissionRequest)
 
-  implicit val impEntityUpdateDefinition = jsonFormat3(EntityUpdateDefinition)
+  implicit val impEntityUpdateDefinition: RootJsonFormat[EntityUpdateDefinition] = jsonFormat3(EntityUpdateDefinition)
 
-  implicit val impFireCloudKeyValue = jsonFormat2(FireCloudKeyValue)
-  implicit val impThurloeKeyValue = jsonFormat2(ThurloeKeyValue)
-  implicit val impThurloeKeyValues = jsonFormat2(ThurloeKeyValues)
-  implicit val impBasicProfile = jsonFormat12(BasicProfile)
-  implicit val impProfile = jsonFormat13(Profile.apply)
-  implicit val impProfileWrapper = jsonFormat2(ProfileWrapper)
-  implicit val impProfileKVP = jsonFormat2(ProfileKVP)
-  implicit val impTerraPreference = jsonFormat2(TerraPreference)
-  implicit val impShibbolethToken = jsonFormat2(ShibbolethToken)
+  implicit val impFireCloudKeyValue: RootJsonFormat[FireCloudKeyValue] = jsonFormat2(FireCloudKeyValue)
+  implicit val impThurloeKeyValue: RootJsonFormat[ThurloeKeyValue] = jsonFormat2(ThurloeKeyValue)
+  implicit val impThurloeKeyValues: RootJsonFormat[ThurloeKeyValues] = jsonFormat2(ThurloeKeyValues)
+  implicit val impBasicProfile: RootJsonFormat[BasicProfile] = jsonFormat12(BasicProfile)
+  implicit val impProfile: RootJsonFormat[Profile] = jsonFormat13(Profile.apply)
+  implicit val impProfileWrapper: RootJsonFormat[ProfileWrapper] = jsonFormat2(ProfileWrapper)
+  implicit val impProfileKVP: RootJsonFormat[ProfileKVP] = jsonFormat2(ProfileKVP)
+  implicit val impTerraPreference: RootJsonFormat[TerraPreference] = jsonFormat2(TerraPreference)
+  implicit val impShibbolethToken: RootJsonFormat[ShibbolethToken] = jsonFormat2(ShibbolethToken)
 
-  implicit val impJWTWrapper = jsonFormat1(JWTWrapper)
+  implicit val impJWTWrapper: RootJsonFormat[JWTWrapper] = jsonFormat1(JWTWrapper)
 
-  implicit val impOAuthUser = jsonFormat2(OAuthUser)
+  implicit val impOAuthUser: RootJsonFormat[OAuthUser] = jsonFormat2(OAuthUser)
 
-  implicit val impWorkbenchUserInfo = jsonFormat2(WorkbenchUserInfo)
-  implicit val impWorkbenchEnabled = jsonFormat3(WorkbenchEnabled)
-  implicit val impWorkbenchEnabledV2 = jsonFormat3(WorkbenchEnabledV2)
-  implicit val impRegistrationInfo = jsonFormat3(RegistrationInfo)
-  implicit val impRegistrationInfoV2 = jsonFormat3(RegistrationInfoV2)
-  implicit val impUserIdInfo = jsonFormat3(UserIdInfo)
-  implicit val impCurator = jsonFormat1(Curator)
-  implicit val impUserImportPermission = jsonFormat2(UserImportPermission)
+  implicit val impWorkbenchUserInfo: RootJsonFormat[WorkbenchUserInfo] = jsonFormat2(WorkbenchUserInfo)
+  implicit val impWorkbenchEnabled: RootJsonFormat[WorkbenchEnabled] = jsonFormat3(WorkbenchEnabled)
+  implicit val impWorkbenchEnabledV2: RootJsonFormat[WorkbenchEnabledV2] = jsonFormat3(WorkbenchEnabledV2)
+  implicit val impRegistrationInfo: RootJsonFormat[RegistrationInfo] = jsonFormat3(RegistrationInfo)
+  implicit val impRegistrationInfoV2: RootJsonFormat[RegistrationInfoV2] = jsonFormat3(RegistrationInfoV2)
+  implicit val impUserIdInfo: RootJsonFormat[UserIdInfo] = jsonFormat3(UserIdInfo)
+  implicit val impCurator: RootJsonFormat[Curator] = jsonFormat1(Curator)
+  implicit val impUserImportPermission: RootJsonFormat[UserImportPermission] = jsonFormat2(UserImportPermission)
 
-  implicit val impBagitImportRequest = jsonFormat2(BagitImportRequest)
-  implicit val impPFBImportRequest = jsonFormat1(PFBImportRequest)
-  implicit val impOptions = jsonFormat1(ImportOptions)
-  implicit val impAsyncImportRequest = jsonFormat3(AsyncImportRequest)
-  implicit val impAsyncImportResponse = jsonFormat3(AsyncImportResponse)
-  implicit val impImportServiceRequest = jsonFormat4(ImportServiceRequest)
-  implicit val impImportServiceResponse = jsonFormat3(ImportServiceResponse)
+  implicit val impBagitImportRequest: RootJsonFormat[BagitImportRequest] = jsonFormat2(BagitImportRequest)
+  implicit val impPFBImportRequest: RootJsonFormat[PFBImportRequest] = jsonFormat1(PFBImportRequest)
+  implicit val impOptions: RootJsonFormat[ImportOptions] = jsonFormat1(ImportOptions)
+  implicit val impAsyncImportRequest: RootJsonFormat[AsyncImportRequest] = jsonFormat3(AsyncImportRequest)
+  implicit val impAsyncImportResponse: RootJsonFormat[AsyncImportResponse] = jsonFormat3(AsyncImportResponse)
+  implicit val impImportServiceRequest: RootJsonFormat[ImportServiceRequest] = jsonFormat4(ImportServiceRequest)
+  implicit val impImportServiceResponse: RootJsonFormat[ImportServiceResponse] = jsonFormat3(ImportServiceResponse)
 
-  implicit val impWorkspaceStorageCostEstimate = jsonFormat2(WorkspaceStorageCostEstimate)
+  implicit val impWorkspaceStorageCostEstimate: RootJsonFormat[WorkspaceStorageCostEstimate] = jsonFormat2(WorkspaceStorageCostEstimate)
 
   implicit object impManagedGroupRoleFormat extends RootJsonFormat[ManagedGroupRole] {
     override def write(obj: ManagedGroupRole): JsValue = JsString(obj.toString)
@@ -252,27 +252,27 @@ object ModelJsonProtocol extends WorkspaceJsonSupport with SprayJsonSupport {
     }
   }
 
-  implicit val impFireCloudManagedGroup = jsonFormat3(FireCloudManagedGroup)
-  implicit val impFireCloudManagedGroupMembership = jsonFormat3(FireCloudManagedGroupMembership)
+  implicit val impFireCloudManagedGroup: RootJsonFormat[FireCloudManagedGroup] = jsonFormat3(FireCloudManagedGroup)
+  implicit val impFireCloudManagedGroupMembership: RootJsonFormat[FireCloudManagedGroupMembership] = jsonFormat3(FireCloudManagedGroupMembership)
 
-  implicit val impResourceId = ValueObjectFormat(ResourceId)
-  implicit val impAccessPolicyName = ValueObjectFormat(AccessPolicyName)
-  implicit val impUserPolicy = jsonFormat5(UserPolicy)
+  implicit val impResourceId: ValueObjectFormat[ResourceId] = ValueObjectFormat(ResourceId)
+  implicit val impAccessPolicyName: ValueObjectFormat[AccessPolicyName] = ValueObjectFormat(AccessPolicyName)
+  implicit val impUserPolicy: RootJsonFormat[UserPolicy] = jsonFormat5(UserPolicy)
 
 
 
   implicit val AttributeDetailFormat: RootJsonFormat[AttributeDetail] = rootFormat(lazyFormat(jsonFormat5(AttributeDetail)))
-  implicit val AttributeDefinitionFormat = jsonFormat1(AttributeDefinition)
+  implicit val AttributeDefinitionFormat: RootJsonFormat[AttributeDefinition] = jsonFormat1(AttributeDefinition)
 
 
-  implicit val impAggregationTermResult = jsonFormat2(AggregationTermResult)
-  implicit val impAggregationFieldResults = jsonFormat2(AggregationFieldResults)
-  implicit val impLibraryAggregationResponse = jsonFormat2(LibraryAggregationResponse)
-  implicit val impLibrarySearchResponse = jsonFormat4(LibrarySearchResponse)
-  implicit val impLibraryBulkIndexResponse = jsonFormat3(LibraryBulkIndexResponse)
+  implicit val impAggregationTermResult: RootJsonFormat[AggregationTermResult] = jsonFormat2(AggregationTermResult)
+  implicit val impAggregationFieldResults: RootJsonFormat[AggregationFieldResults] = jsonFormat2(AggregationFieldResults)
+  implicit val impLibraryAggregationResponse: RootJsonFormat[LibraryAggregationResponse] = jsonFormat2(LibraryAggregationResponse)
+  implicit val impLibrarySearchResponse: RootJsonFormat[LibrarySearchResponse] = jsonFormat4(LibrarySearchResponse)
+  implicit val impLibraryBulkIndexResponse: RootJsonFormat[LibraryBulkIndexResponse] = jsonFormat3(LibraryBulkIndexResponse)
 
-  implicit val impStructuredDataRequest = jsonFormat12(StructuredDataRequest)
-  implicit val impStructuredDataResponse = jsonFormat4(StructuredDataResponse)
+  implicit val impStructuredDataRequest: RootJsonFormat[StructuredDataRequest] = jsonFormat12(StructuredDataRequest)
+  implicit val impStructuredDataResponse: RootJsonFormat[StructuredDataResponse] = jsonFormat4(StructuredDataResponse)
 
   implicit object impDuosDataUse extends RootJsonFormat[DuosDataUse] {
     override def write(ddu: DuosDataUse): JsValue = {
@@ -297,15 +297,15 @@ object ModelJsonProtocol extends WorkspaceJsonSupport with SprayJsonSupport {
       }
     }
   }
-  implicit val impDuosConsent = jsonFormat11(Consent)
-  implicit val impDuosConsentError = jsonFormat2(ConsentError)
-  implicit val impOntologyTermParent = jsonFormat5(TermParent)
-  implicit val impOntologyTermResource = jsonFormat7(TermResource)
-  implicit val impOntologyESTermParent = jsonFormat2(ESTermParent)
+  implicit val impDuosConsent: RootJsonFormat[Consent] = jsonFormat11(Consent)
+  implicit val impDuosConsentError: RootJsonFormat[ConsentError] = jsonFormat2(ConsentError)
+  implicit val impOntologyTermParent: RootJsonFormat[TermParent] = jsonFormat5(TermParent)
+  implicit val impOntologyTermResource: RootJsonFormat[TermResource] = jsonFormat7(TermResource)
+  implicit val impOntologyESTermParent: RootJsonFormat[ESTermParent] = jsonFormat2(ESTermParent)
 
-  implicit val impThurloeStatus = jsonFormat2(ThurloeStatus)
-  implicit val impDropwizardHealth = jsonFormat2(DropwizardHealth)
-  implicit val impDuosConsentStatus = jsonFormat3(ConsentStatus)
+  implicit val impThurloeStatus: RootJsonFormat[ThurloeStatus] = jsonFormat2(ThurloeStatus)
+  implicit val impDropwizardHealth: RootJsonFormat[DropwizardHealth] = jsonFormat2(DropwizardHealth)
+  implicit val impDuosConsentStatus: RootJsonFormat[ConsentStatus] = jsonFormat3(ConsentStatus)
 
   // don't make this implicit! It would be pulled in by anything including ModelJsonProtocol._
   val entityExtractionRejectionHandler = RejectionHandler.newBuilder().handle {
@@ -315,7 +315,7 @@ object ModelJsonProtocol extends WorkspaceJsonSupport with SprayJsonSupport {
 
   // See http://stackoverflow.com/questions/24526103/generic-spray-client and
   // https://gist.github.com/mikemckibben/fad4328de85a79a06bf3
-  implicit def rootEitherFormat[A : RootJsonFormat, B : RootJsonFormat] = new RootJsonFormat[Either[A, B]] {
+  implicit def rootEitherFormat[A : RootJsonFormat, B : RootJsonFormat]: RootJsonFormat[Either[A, B]] = new RootJsonFormat[Either[A, B]] {
     val format = DefaultJsonProtocol.eitherFormat[A, B]
     def write(either: Either[A, B]) = format.write(either)
     def read(value: JsValue) = format.read(value)
@@ -342,13 +342,13 @@ object ModelJsonProtocol extends WorkspaceJsonSupport with SprayJsonSupport {
     }
   }
 
-  implicit val impRawlsBillingProjectMember = jsonFormat2(RawlsBillingProjectMember)
+  implicit val impRawlsBillingProjectMember: RootJsonFormat[RawlsBillingProjectMember] = jsonFormat2(RawlsBillingProjectMember)
 
   // END copy/paste from rawls
 
-  implicit val impRawlsBillingProjectMembership = jsonFormat4(RawlsBillingProjectMembership)
+  implicit val impRawlsBillingProjectMembership: RootJsonFormat[RawlsBillingProjectMembership] = jsonFormat4(RawlsBillingProjectMembership)
 
-  implicit val impCreateRawlsBillingProjectFullRequestFormat = jsonFormat2(CreateRawlsBillingProjectFullRequest)
+  implicit val impCreateRawlsBillingProjectFullRequestFormat: RootJsonFormat[CreateRawlsBillingProjectFullRequest] = jsonFormat2(CreateRawlsBillingProjectFullRequest)
 
   implicit object ShareTypeFormat extends RootJsonFormat[ShareType.Value] {
     override def write(obj: ShareType.Value): JsValue = JsString(obj.toString)
@@ -359,5 +359,5 @@ object ModelJsonProtocol extends WorkspaceJsonSupport with SprayJsonSupport {
     }
   }
 
-  implicit val impShareFormat = jsonFormat4(Share)
+  implicit val impShareFormat: RootJsonFormat[Share] = jsonFormat4(Share)
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/package.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/package.scala
@@ -8,7 +8,7 @@ import scala.language.implicitConversions
 import scala.util.{Failure, Success, Try}
 
 package object model {
-  implicit val errorReportSource = ErrorReportSource("FireCloud")
+  implicit val errorReportSource: ErrorReportSource = ErrorReportSource("FireCloud")
 
   import org.broadinstitute.dsde.rawls.model.WorkspaceJsonSupport._
   import spray.json._

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/package.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/package.scala
@@ -16,7 +16,7 @@ package object model {
   /*
     Rejection handler: if the response from the rejection is not already json, make it json.
    */
-  implicit val defaultErrorReportRejectionHandler = RejectionHandler.default.mapRejectionResponse {
+  implicit val defaultErrorReportRejectionHandler: RejectionHandler = RejectionHandler.default.mapRejectionResponse {
     case resp@HttpResponse(statusCode, _, ent: HttpEntity.Strict, _) => {
 
       // since all Akka default rejection responses are Strict this will handle all rejections

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/LibraryService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/LibraryService.scala
@@ -45,7 +45,7 @@ class LibraryService (protected val argUserInfo: UserInfo,
 
   lazy val log = LoggerFactory.getLogger(getClass)
 
-  implicit val userToken = argUserInfo
+  implicit val userToken: UserInfo = argUserInfo
 
   // attributes come in as standard json so we can use json schema for validation. Thus,
   // we need to use the plain-array deserialization.

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/NamespaceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/NamespaceService.scala
@@ -20,7 +20,7 @@ object NamespaceService {
 class NamespaceService (protected val argUserInfo: UserInfo, val agoraDAO: AgoraDAO)(implicit protected val executionContext: ExecutionContext)
   extends SprayJsonSupport {
 
-  implicit val userInfo = argUserInfo
+  implicit val userInfo: UserInfo = argUserInfo
 
   def getFireCloudPermissions(ns: String, entity: String): Future[PerRequestMessage] = {
     val agoraPermissions = agoraDAO.getNamespacePermissions(ns, entity)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/NihService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/NihService.scala
@@ -36,8 +36,8 @@ case class NihWhitelist(
 case class NihDatasetPermission(name: String, authorized: Boolean)
 
 object NihStatus {
-  implicit val impNihDatasetPermission = jsonFormat2(NihDatasetPermission)
-  implicit val impNihStatus = jsonFormat3(NihStatus.apply)
+  implicit val impNihDatasetPermission: RootJsonFormat[NihDatasetPermission] = jsonFormat2(NihDatasetPermission)
+  implicit val impNihStatus: RootJsonFormat[NihStatus] = jsonFormat3(NihStatus.apply)
 }
 
 object NihService {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/PermissionReportService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/PermissionReportService.scala
@@ -26,7 +26,7 @@ class PermissionReportService (protected val argUserInfo: UserInfo, val rawlsDAO
 
   import PermissionReportService._
 
-  implicit val userInfo = argUserInfo
+  implicit val userInfo: UserInfo = argUserInfo
   
   def getPermissionReport(workspaceNamespace: String, workspaceName: String, reportInput: PermissionReportRequest) = {
     // start the requests to get workspace users and workspace configs in parallel

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/StatusService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/StatusService.scala
@@ -24,7 +24,7 @@ object StatusService {
 
 class StatusService (val healthMonitor: ActorRef)
                     (implicit protected val executionContext: ExecutionContext) extends SprayJsonSupport {
-  implicit val timeout = Timeout(1.minute) // timeout for the ask to healthMonitor for GetCurrentStatus
+  implicit val timeout: Timeout = Timeout(1.minute) // timeout for the ask to healthMonitor for GetCurrentStatus
 
   def collectStatusInfo(): Future[PerRequestMessage] = {
     (healthMonitor ? GetCurrentStatus).mapTo[StatusCheckResponse].map { statusCheckResponse =>

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceService.scala
@@ -32,7 +32,7 @@ object WorkspaceService {
 class WorkspaceService(protected val argUserToken: WithAccessToken, val rawlsDAO: RawlsDAO, val samDao: SamDAO, val thurloeDAO: ThurloeDAO, val googleServicesDAO: GoogleServicesDAO, val ontologyDAO: OntologyDAO, val searchDAO: SearchDAO, val consentDAO: ConsentDAO, val shareLogDAO: ShareLogDAO)
                       (implicit protected val executionContext: ExecutionContext) extends AttributeSupport with TSVFileSupport with PermissionsSupport with WorkspacePublishingSupport with SprayJsonSupport with LazyLogging {
 
-  implicit val userToken = argUserToken
+  implicit val userToken: WithAccessToken = argUserToken
 
   def getStorageCostEstimate(workspaceNamespace: String, workspaceName: String): Future[RequestComplete[WorkspaceStorageCostEstimate]] = {
     rawlsDAO.getWorkspace(workspaceNamespace, workspaceName) flatMap { workspaceResponse =>


### PR DESCRIPTION
I haven't been in Orchestration for a while. I noticed that when compiling Orch, sbt threw a whole bunch of warnings. This PR addresses those.

As of this PR, compile has no warnings:
```
➜  firecloud-orchestration git:(da_AJ-1428_compileWarnings) sbt clean compile                       
[info] welcome to sbt 1.9.7 (Eclipse Adoptium Java 17.0.2)
[info] loading global plugins from /Users/davidan/.sbt/1.0/plugins
[info] loading settings for project firecloud-orchestration-build from plugins.sbt ...
[info] loading project definition from /Users/davidan/work/src/firecloud-orchestration/project
[info] loading settings for project root from build.sbt ...
[info] set current project to FireCloud-Orchestration (in build file:/Users/davidan/work/src/firecloud-orchestration/)
[info] Executing in batch mode. For better performance use sbt's shell
[success] Total time: 0 s, completed Nov 6, 2023, 11:51:10 AM
[info] compiling 111 Scala sources to /Users/davidan/work/src/firecloud-orchestration/target/scala-2.13/classes ...
[success] Total time: 23 s, completed Nov 6, 2023, 11:51:33 AM
➜  firecloud-orchestration git
```

whereas on the `develop` branch, compilation spews out a lot of "[warn]" log lines, and compilation ends with:
```
[warn] 95 warnings found
[success] Total time: 22 s, completed Nov 6, 2023, 11:53:53 AM
➜  firecloud-orchestration git:(develop) 
```
turns out it's 304 lines of "[warn]":
```
➜  firecloud-orchestration git:(develop) sbt clean compile | grep -c "[warn]"
304
```

---

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [x] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
