### PR TITLE
ID-816 ID-817 New User Registration Endpoint

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -5807,6 +5807,34 @@ paths:
           description: OK
           content: {}
       x-passthrough: false
+  /api/users/v1/registerWithProfile:
+    post:
+      tags:
+        - Users
+      summary: Registers the user in Sam and saves the user profile in Thurloe
+      operationId: registerUserWithProfile
+      requestBody:
+        description: A registration request
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/RegisterRequest'
+        required: false
+      responses:
+        200:
+          description: OK
+          content: {}
+        400:
+          description: Bad request
+          content: {}
+        403:
+          description: Forbidden
+          content: {}
+        500:
+          description: Internal server error
+          content: {}
+      x-passthrough: false
+      x-codegen-request-body-name: profile
   /tos/text:
     get:
       tags:
@@ -7880,6 +7908,14 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/KeyValuePair'
+    RegisterRequest:
+      type: object
+      properties:
+        acceptsTermsOfService:
+          type: boolean
+          description: Does the user accept the Terra Terms of Service?
+        profile:
+          $ref: '#/components/schemas/Profile'
     ResearchPurpose:
       required:
         - DS

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudApiService.scala
@@ -184,7 +184,8 @@ trait FireCloudApiService extends CookieAuthedApiService
           billingServiceRoutes ~
           shareLogServiceRoutes ~
           staticNotebooksRoutes ~
-          perimeterServiceRoutes
+          perimeterServiceRoutes ~
+          newRegisterRoutes
       }
 
   val routeWrappers: Directive[Unit] =

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudApiService.scala
@@ -175,6 +175,7 @@ trait FireCloudApiService extends CookieAuthedApiService
   def apiRoutes: server.Route =
     options { complete(StatusCodes.OK) } ~
       withExecutionContext(ExecutionContext.global) {
+        v1RegisterRoutes ~
         methodsApiServiceRoutes ~
           profileRoutes ~
           cromIamApiServiceRoutes ~
@@ -184,8 +185,7 @@ trait FireCloudApiService extends CookieAuthedApiService
           billingServiceRoutes ~
           shareLogServiceRoutes ~
           staticNotebooksRoutes ~
-          perimeterServiceRoutes ~
-          v1RegisterRoutes
+          perimeterServiceRoutes
       }
 
   val routeWrappers: Directive[Unit] =

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudApiService.scala
@@ -185,7 +185,7 @@ trait FireCloudApiService extends CookieAuthedApiService
           shareLogServiceRoutes ~
           staticNotebooksRoutes ~
           perimeterServiceRoutes ~
-          newRegisterRoutes
+          v1RegisterRoutes
       }
 
   val routeWrappers: Directive[Unit] =

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpSamDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpSamDAO.scala
@@ -38,8 +38,8 @@ class HttpSamDAO( implicit val system: ActorSystem, val materializer: Materializ
     authedRequestToObject[RegistrationInfo](Post(samUserRegistrationUrl, termsOfService), label=Some("HttpSamDAO.registerUser"))
   }
 
-  override def registerUserSelf(termsOfService: Boolean)(implicit userInfo: WithAccessToken): Future[SamUserResponse] = {
-    authedRequestToObject[SamUserResponse](Post(samUserRegisterSelfUrl, SamUserRegistrationRequest(termsOfService, SamUserAttributesRequest(marketingConsent = Some(false)))), label = Some("HttpSamDAO.registerUserSelf"))
+  override def registerUserSelf(acceptsTermsOfService: Boolean)(implicit userInfo: WithAccessToken): Future[SamUserResponse] = {
+    authedRequestToObject[SamUserResponse](Post(samUserRegisterSelfUrl, SamUserRegistrationRequest(acceptsTermsOfService, SamUserAttributesRequest(marketingConsent = Some(false)))), label = Some("HttpSamDAO.registerUserSelf"))
   }
 
   override def getRegistrationStatus(implicit userInfo: WithAccessToken): Future[RegistrationInfo] = {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpSamDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpSamDAO.scala
@@ -12,7 +12,7 @@ import org.broadinstitute.dsde.firecloud.model.ErrorReportExtensions.FCErrorRepo
 import org.broadinstitute.dsde.firecloud.model.ManagedGroupRoles.ManagedGroupRole
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
 import org.broadinstitute.dsde.firecloud.model.SamResource.UserPolicy
-import org.broadinstitute.dsde.firecloud.model.{AccessToken, FireCloudManagedGroupMembership, ManagedGroupRoles, RegistrationInfo, RegistrationInfoV2, UserIdInfo, UserInfo, WithAccessToken}
+import org.broadinstitute.dsde.firecloud.model.{AccessToken, FireCloudManagedGroupMembership, ManagedGroupRoles, RegistrationInfo, RegistrationInfoV2, SamUserAttributesRequest, SamUserRegistrationRequest, SamUserResponse, UserIdInfo, UserInfo, WithAccessToken}
 import org.broadinstitute.dsde.firecloud.utils.RestJsonClient
 import org.broadinstitute.dsde.rawls.model.RawlsUserEmail
 import org.broadinstitute.dsde.workbench.model.WorkbenchIdentityJsonSupport._
@@ -36,6 +36,10 @@ class HttpSamDAO( implicit val system: ActorSystem, val materializer: Materializ
 
   override def registerUser(termsOfService: Option[String])(implicit userInfo: WithAccessToken): Future[RegistrationInfo] = {
     authedRequestToObject[RegistrationInfo](Post(samUserRegistrationUrl, termsOfService), label=Some("HttpSamDAO.registerUser"))
+  }
+
+  override def registerUserSelf(termsOfService: Boolean)(implicit userInfo: WithAccessToken): Future[SamUserResponse] = {
+    authedRequestToObject[SamUserResponse](Post(samUserRegisterSelfUrl, SamUserRegistrationRequest(termsOfService, SamUserAttributesRequest(marketingConsent = Some(false)))), label = Some("HttpSamDAO.registerUserSelf"))
   }
 
   override def getRegistrationStatus(implicit userInfo: WithAccessToken): Future[RegistrationInfo] = {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/SamDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/SamDAO.scala
@@ -6,7 +6,7 @@ import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.FireCloudConfig
 import org.broadinstitute.dsde.firecloud.model.ManagedGroupRoles.ManagedGroupRole
 import org.broadinstitute.dsde.firecloud.model.SamResource.UserPolicy
-import org.broadinstitute.dsde.firecloud.model.{AccessToken, FireCloudManagedGroupMembership, RegistrationInfo, RegistrationInfoV2, UserIdInfo, UserInfo, WithAccessToken}
+import org.broadinstitute.dsde.firecloud.model.{AccessToken, FireCloudManagedGroupMembership, RegistrationInfo, RegistrationInfoV2, SamUserResponse, UserIdInfo, UserInfo, WithAccessToken}
 import org.broadinstitute.dsde.rawls.model.{ErrorReportSource, RawlsUserEmail}
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.model.{WorkbenchEmail, WorkbenchGroupName}
@@ -29,6 +29,7 @@ trait SamDAO extends LazyLogging with ReportsSubsystemStatus {
   val managedGroupResourceTypeName = "managed-group"
 
   val samUserRegistrationUrl = FireCloudConfig.Sam.baseUrl + "/register/user"
+  val samUserRegisterSelfUrl = FireCloudConfig.Sam.baseUrl + "/api/users/v2/self/register"
   val samStatusUrl = FireCloudConfig.Sam.baseUrl + "/status"
   val samGetUserIdsUrl = FireCloudConfig.Sam.baseUrl + "/api/users/v1/%s"
   val samArbitraryPetTokenUrl = FireCloudConfig.Sam.baseUrl + "/api/google/v1/user/petServiceAccount/token"
@@ -53,6 +54,8 @@ trait SamDAO extends LazyLogging with ReportsSubsystemStatus {
   def samListResources(resourceTypeName: String): String = samResourcesBase + s"/$resourceTypeName"
 
   def registerUser(termsOfService: Option[String])(implicit userInfo: WithAccessToken): Future[RegistrationInfo]
+
+  def registerUserSelf(acceptsTermsOfService: Boolean)(implicit userInfo: WithAccessToken): Future[SamUserResponse]
   def getRegistrationStatus(implicit userInfo: WithAccessToken): Future[RegistrationInfo]
 
   def getUserIds(email: RawlsUserEmail)(implicit userInfo: WithAccessToken): Future[UserIdInfo]

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
@@ -220,6 +220,10 @@ object ModelJsonProtocol extends WorkspaceJsonSupport with SprayJsonSupport {
   implicit val impTerraPreference: RootJsonFormat[TerraPreference] = jsonFormat2(TerraPreference)
   implicit val impShibbolethToken: RootJsonFormat[ShibbolethToken] = jsonFormat2(ShibbolethToken)
 
+  implicit val impRegisterRequest: RootJsonFormat[RegisterRequest] = jsonFormat2(RegisterRequest)
+  implicit val impSamUserRegistrationRequest: RootJsonFormat[SamUserRegistrationRequest] = jsonFormat2(SamUserRegistrationRequest)
+  implicit val impSamUserAttributesRequest: RootJsonFormat[SamUserAttributesRequest] = jsonFormat1(SamUserAttributesRequest)
+
   implicit val impJWTWrapper: RootJsonFormat[JWTWrapper] = jsonFormat1(JWTWrapper)
 
   implicit val impOAuthUser: RootJsonFormat[OAuthUser] = jsonFormat2(OAuthUser)
@@ -229,6 +233,7 @@ object ModelJsonProtocol extends WorkspaceJsonSupport with SprayJsonSupport {
   implicit val impWorkbenchEnabledV2: RootJsonFormat[WorkbenchEnabledV2] = jsonFormat3(WorkbenchEnabledV2)
   implicit val impRegistrationInfo: RootJsonFormat[RegistrationInfo] = jsonFormat3(RegistrationInfo)
   implicit val impRegistrationInfoV2: RootJsonFormat[RegistrationInfoV2] = jsonFormat3(RegistrationInfoV2)
+  implicit val impSamUserResponse: RootJsonFormat[SamUserResponse] = jsonFormat8(SamUserResponse)
   implicit val impUserIdInfo: RootJsonFormat[UserIdInfo] = jsonFormat3(UserIdInfo)
   implicit val impCurator: RootJsonFormat[Curator] = jsonFormat1(Curator)
   implicit val impUserImportPermission: RootJsonFormat[UserImportPermission] = jsonFormat2(UserImportPermission)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
@@ -221,8 +221,8 @@ object ModelJsonProtocol extends WorkspaceJsonSupport with SprayJsonSupport {
   implicit val impShibbolethToken: RootJsonFormat[ShibbolethToken] = jsonFormat2(ShibbolethToken)
 
   implicit val impRegisterRequest: RootJsonFormat[RegisterRequest] = jsonFormat2(RegisterRequest)
-  implicit val impSamUserRegistrationRequest: RootJsonFormat[SamUserRegistrationRequest] = jsonFormat2(SamUserRegistrationRequest)
   implicit val impSamUserAttributesRequest: RootJsonFormat[SamUserAttributesRequest] = jsonFormat1(SamUserAttributesRequest)
+  implicit val impSamUserRegistrationRequest: RootJsonFormat[SamUserRegistrationRequest] = jsonFormat2(SamUserRegistrationRequest)
 
   implicit val impJWTWrapper: RootJsonFormat[JWTWrapper] = jsonFormat1(JWTWrapper)
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/RegisterRequest.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/RegisterRequest.scala
@@ -1,0 +1,3 @@
+package org.broadinstitute.dsde.firecloud.model
+
+case class RegisterRequest(acceptsTermsOfService: Boolean, profile: BasicProfile)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/SamUserAttributesRequest.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/SamUserAttributesRequest.scala
@@ -1,0 +1,3 @@
+package org.broadinstitute.dsde.firecloud.model
+
+case class SamUserAttributesRequest(marketingConsent: Option[Boolean])

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/SamUserRegistrationRequest.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/SamUserRegistrationRequest.scala
@@ -1,0 +1,8 @@
+package org.broadinstitute.dsde.firecloud.model
+
+import org.broadinstitute.dsde.workbench.model.ErrorReport
+
+case class SamUserRegistrationRequest(
+                                       acceptsTermsOfService: Boolean,
+                                       userAttributes: SamUserAttributesRequest
+                                     )

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/SamUserResponse.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/SamUserResponse.scala
@@ -1,0 +1,16 @@
+package org.broadinstitute.dsde.firecloud.model
+
+import org.broadinstitute.dsde.workbench.model.{AzureB2CId, GoogleSubjectId, WorkbenchEmail, WorkbenchUserId}
+
+import java.time.Instant
+
+final case class SamUserResponse(
+                                  id: WorkbenchUserId,
+                                  googleSubjectId: Option[GoogleSubjectId],
+                                  email: WorkbenchEmail,
+                                  azureB2CId: Option[AzureB2CId],
+                                  allowed: Boolean,
+                                  createdAt: Instant,
+                                  registeredAt: Option[Instant],
+                                  updatedAt: Instant
+                                ) {}

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/RegisterApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/RegisterApiService.scala
@@ -18,7 +18,7 @@ trait RegisterApiService extends FireCloudDirectives with EnabledUserDirectives 
 
   val registerServiceConstructor: () => RegisterService
 
-  val newRegisterRoutes: Route =
+  val v1RegisterRoutes: Route =
     pathPrefix("users" / "v1" / "registerWithProfile") {
         post {
           requireUserInfo() { userInfo =>

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/RegisterApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/RegisterApiService.scala
@@ -18,6 +18,19 @@ trait RegisterApiService extends FireCloudDirectives with EnabledUserDirectives 
 
   val registerServiceConstructor: () => RegisterService
 
+  val newRegisterRoutes: Route =
+    pathPrefix("users" / "v1" / "registerWithProfile") {
+        post {
+          requireUserInfo() { userInfo =>
+            entity(as[RegisterRequest]) { registerRequest =>
+              complete {
+                registerServiceConstructor().createUserWithProfile(userInfo, registerRequest)
+              }
+            }
+          }
+        }
+    }
+
   val registerRoutes: Route =
     pathPrefix("register") {
       path("profile") {

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/RegisterApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/RegisterApiServiceSpec.scala
@@ -175,14 +175,14 @@ final class RegisterApiServiceSpec extends BaseServiceSpec with RegisterApiServi
     "register-with-profile API POST" - {
       "should fail if Sam does not register the user" in {
         val payload = makeBasicProfile(false)
-        Post("/users/v1/registerWithProfile", RegisterRequest(acceptsTermsOfService = false, profile = payload)) ~> dummyUserIdHeaders("RegisterApiServiceSpec", "new") ~> sealRoute(newRegisterRoutes) ~> check {
+        Post("/users/v1/registerWithProfile", RegisterRequest(acceptsTermsOfService = false, profile = payload)) ~> dummyUserIdHeaders("RegisterApiServiceSpec", "new") ~> sealRoute(v1RegisterRoutes) ~> check {
           status should be(BadRequest)
         }
       }
 
       "should succeed if Sam does register the user" in {
         val payload = makeBasicProfile(true)
-        Post("/users/v1/registerWithProfile", RegisterRequest(acceptsTermsOfService = true, profile = payload)) ~> dummyUserIdHeaders("RegisterApiServiceSpec", "new") ~> sealRoute(newRegisterRoutes) ~> check {
+        Post("/users/v1/registerWithProfile", RegisterRequest(acceptsTermsOfService = true, profile = payload)) ~> dummyUserIdHeaders("RegisterApiServiceSpec", "new") ~> sealRoute(v1RegisterRoutes) ~> check {
           status should be(OK)
         }
       }


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/ID-816

This needs to wait until [ID-812](https://broadworkbench.atlassian.net/browse/ID-812) has merged and deployed in Sam

Implements a new `/api/users/v1/registerWithProfile` endpoint, which replaces `/register/profile`. Orch now reaches out to Sam first to register the user, and only actually saves values in Thurloe if the user  was successfully registered.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment


[ID-812]: https://broadworkbench.atlassian.net/browse/ID-812?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ