### PR TITLE
AJ-1485: remove compile-time warnings

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/RegisterService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/RegisterService.scala
@@ -37,7 +37,7 @@ class RegisterService(val rawlsDao: RawlsDAO, val samDao: SamDAO, val thurloeDao
       _ <- thurloeDao.saveKeyValues(registrationResultUserInfo, Map("isRegistrationComplete" -> Profile.currentVersion.toString))
       _ <- if (!registerResult.allowed) {
         thurloeDao.saveKeyValues(registrationResultUserInfo, Map("email" -> userInfo.userEmail))
-      } else Future.successful()
+      } else Future.successful(())
     } yield RequestComplete(StatusCodes.OK, registerResult)
 
   def createUpdateProfile(userInfo: UserInfo, basicProfile: BasicProfile): Future[PerRequestMessage] = {

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAOSpec.scala
@@ -35,7 +35,7 @@ class HttpGoogleServicesDAOSpec extends AnyFlatSpec with Matchers with PrivateMe
   val testProject = "broad-dsde-dev"
   val priceListUrl = ConfigFactory.load().getString("googlecloud.priceListUrl")
   val defaultPriceList = GooglePriceList(GooglePrices(Map("us" -> BigDecimal(-0.11)), UsTieredPriceItem(Map(1L -> BigDecimal(-0.22)))), "v1", "1")
-  implicit val system = ActorSystem("HttpGoogleCloudStorageDAOSpec")
+  implicit val system: ActorSystem = ActorSystem("HttpGoogleCloudStorageDAOSpec")
   import system.dispatcher
   val gcsDAO = new HttpGoogleServicesDAO(priceListUrl, defaultPriceList)
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpImportServiceDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpImportServiceDAOSpec.scala
@@ -19,7 +19,7 @@ import java.util.UUID
 
 class HttpImportServiceDAOSpec extends AsyncFlatSpec with Matchers with SprayJsonSupport {
 
-  implicit val system = ActorSystem("HttpGoogleCloudStorageDAOSpec")
+  implicit val system: ActorSystem = ActorSystem("HttpGoogleCloudStorageDAOSpec")
   import system.dispatcher
 
   behavior of "HttpImportServiceDAO"

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/BaseServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/BaseServiceSpec.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.firecloud.service
 
+import akka.http.scaladsl.server.ExceptionHandler
 import org.broadinstitute.dsde.firecloud.dataaccess._
 import org.broadinstitute.dsde.firecloud.mock.MockGoogleServicesDAO
 import org.broadinstitute.dsde.firecloud.{Application, FireCloudApiService}
@@ -8,7 +9,7 @@ import org.scalatest.BeforeAndAfter
 class BaseServiceSpec extends ServiceSpec with BeforeAndAfter {
 
   // this gets fed into sealRoute so that exceptions are handled the same in tests as in real life
-  implicit val exceptionHandler = FireCloudApiService.exceptionHandler
+  implicit val exceptionHandler: ExceptionHandler = FireCloudApiService.exceptionHandler
 
   val agoraDao:MockAgoraDAO = new MockAgoraDAO
   val googleServicesDao:MockGoogleServicesDAO = new MockGoogleServicesDAO

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/ExportEntitiesByTypeServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/ExportEntitiesByTypeServiceSpec.scala
@@ -23,7 +23,7 @@ class ExportEntitiesByTypeServiceSpec extends BaseServiceSpec with ExportEntitie
   override val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
 
   // On travis, slow processing causes the route to timeout and complete too quickly for the large content checks.
-  override implicit val routeTestTimeout = RouteTestTimeout(30.seconds)
+  override implicit val routeTestTimeout: RouteTestTimeout = RouteTestTimeout(30.seconds)
 
   def actorRefFactory: ActorSystem = system
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/PassthroughDirectivesSpecSupport.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/PassthroughDirectivesSpecSupport.scala
@@ -9,6 +9,7 @@ import akka.http.scaladsl.model.StatusCodes.OK
 import akka.http.scaladsl.model.Uri
 import akka.http.scaladsl.model.Uri.{Path, Query}
 import spray.json.DefaultJsonProtocol._
+import spray.json.RootJsonFormat
 
 import scala.jdk.CollectionConverters._
 
@@ -45,5 +46,5 @@ case class RequestInfo(
   url: String)
 
 object PassthroughDirectivesSpecSupport {
-  implicit val requestInfoFormat = jsonFormat4(RequestInfo)
+  implicit val requestInfoFormat: RootJsonFormat[RequestInfo] = jsonFormat4(RequestInfo)
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/ServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/ServiceSpec.scala
@@ -23,7 +23,7 @@ import scala.concurrent.duration._
 // common Service Spec to be inherited by service tests
 trait ServiceSpec extends AnyFreeSpec with ScalaFutures with ScalatestRouteTest with Matchers with TestRequestBuilding with TestKitBase {
 
-  implicit val routeTestTimeout = RouteTestTimeout(5.seconds)
+  implicit val routeTestTimeout: RouteTestTimeout = RouteTestTimeout(5.seconds)
 
   val allHttpMethods = Seq(CONNECT, DELETE, GET, HEAD, PATCH, POST, PUT, TRACE)
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/ApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/ApiServiceSpec.scala
@@ -20,7 +20,7 @@ import scala.concurrent.duration._
 trait ApiServiceSpec extends AnyFlatSpec with Matchers with ScalatestRouteTest with SprayJsonSupport with TestRequestBuilding {
   // increase the timeout for ScalatestRouteTest from the default of 1 second, otherwise
   // intermittent failures occur on requests not completing in time
-  implicit val routeTestTimeout = RouteTestTimeout(5.seconds)
+  implicit val routeTestTimeout: RouteTestTimeout = RouteTestTimeout(5.seconds)
 
   def actorRefFactory = system
 


### PR DESCRIPTION
On my laptop, before this PR, `sbt clean test` reported 7 compile warnings. After this PR, it reports 0. This PR should not change any functionality, it just cleans up code.


----



Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
