### PR TITLE
AJ-1485: de-flake unit test by removing random collisions

### DIFF
--- a/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockWorkspaceServer.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockWorkspaceServer.scala
@@ -69,9 +69,9 @@ object MockWorkspaceServer {
     WorkspaceState.Ready
   )
 
-  val mockValidId = randomPositiveInt()
-  val mockInvalidId = randomPositiveInt()
-  val alternativeMockValidId = randomPositiveInt()
+  val mockValidId = 3
+  val mockInvalidId = 6
+  val alternativeMockValidId = 9
 
   val mockValidSubmission = OrchSubmissionRequest(
     methodConfigurationNamespace = Option(randomAlpha()),


### PR DESCRIPTION
The `SubmissionApiServiceSpec` unit test has been flaky. See, for instance: https://github.com/broadinstitute/firecloud-orchestration/actions/runs/7145799461/job/19462223538?pr=1256

This PR hopefully fixes the flakiness. See my comments inline for why.



Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [x] Get two thumbsworth of review and PO signoff if necessary
- [x] Verify all tests go green
- [x] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [x] Test this change deployed correctly and works on dev environment after deployment
