### PR TITLE
AJ-1508: integration tests to GHA

### DIFF
--- a/.github/workflows/es-int-tests.yml
+++ b/.github/workflows/es-int-tests.yml
@@ -6,7 +6,7 @@ on:
       - 'README.md'
   pull_request:
     branches: [ develop ]
-  workflow_call:
+  workflow_dispatch:
 
 jobs:
   es-integration-tests:

--- a/.github/workflows/es-int-tests.yml
+++ b/.github/workflows/es-int-tests.yml
@@ -1,0 +1,32 @@
+name: Elasticsearch Integration Tests
+
+on:
+  push:
+    paths-ignore:
+      - 'README.md'
+  pull_request:
+    branches: [ develop ]
+  workflow_call:
+
+jobs:
+  es-integration-tests:
+    name: Elasticsearch Integration Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'sbt'
+
+      - name: Start Elasticsearch
+        run: ./docker/run-es.sh start
+
+      - name: Execute Tests
+        run: sbt it:test
+

--- a/.github/workflows/es-int-tests.yml
+++ b/.github/workflows/es-int-tests.yml
@@ -28,5 +28,5 @@ jobs:
         run: ./docker/run-es.sh start
 
       - name: Execute Tests
-        run: sbt it:test
+        run: sbt clean "IntegrationTest / test"
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/AutoSuggestSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/AutoSuggestSpec.scala
@@ -37,7 +37,7 @@ class AutoSuggestSpec extends AnyFreeSpec with Matchers with BeforeAndAfterAll w
     "Text search autocomplete suggestions correctness" - {
 
       val testCases: Seq[(String, Seq[String])] = Seq(
-        ("brca open",    Seq("~~~intentional fail for verifying test behavior~~~")),
+        ("brca open",    Seq("TCGA_BRCA_OpenAccess")),
         ("brca o",       Seq("TCGA_BRCA_OpenAccess")),
         ("BRCA_Cont",    Seq("TCGA_BRCA_ControlledAccess")),
         ("glio",         Seq("Glioblastoma multiforme")),

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/AutoSuggestSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/integrationtest/AutoSuggestSpec.scala
@@ -37,7 +37,7 @@ class AutoSuggestSpec extends AnyFreeSpec with Matchers with BeforeAndAfterAll w
     "Text search autocomplete suggestions correctness" - {
 
       val testCases: Seq[(String, Seq[String])] = Seq(
-        ("brca open",    Seq("TCGA_BRCA_OpenAccess")),
+        ("brca open",    Seq("~~~intentional fail for verifying test behavior~~~")),
         ("brca o",       Seq("TCGA_BRCA_OpenAccess")),
         ("BRCA_Cont",    Seq("TCGA_BRCA_ControlledAccess")),
         ("glio",         Seq("Glioblastoma multiforme")),


### PR DESCRIPTION
This moves the Elasticsearch integration tests to Github Actions. Once this merges, we can disable the corresponding tests in Jenkins, and we can mark these integration tests as required to merge PRs.

Note this is the Orchestration-specific integration tests; this is not the BEE-based swatomation tests.

See commit 696962a for an example of a failing test marking the GHA as failed.

-----


Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
