### PR TITLE
switch to only push to dev when merging to dev, update workflow-dispa…

### DIFF
--- a/.github/workflows/orch-build-tag-publish-and-run-tests.yml
+++ b/.github/workflows/orch-build-tag-publish-and-run-tests.yml
@@ -194,3 +194,4 @@ jobs:
               "bee-name": "orch-${{ github.run_id }}-${{ matrix.terra-env }}",
               "caller_run_id": "${{ github.run_id }}"
             }'
+          wait-for-completion: false

--- a/.github/workflows/orch-build-tag-publish-and-run-tests.yml
+++ b/.github/workflows/orch-build-tag-publish-and-run-tests.yml
@@ -73,6 +73,20 @@ jobs:
           docker tag ${{ github.event.repository.full_name }}:${DOCKER_TAG} ${{ env.GCR_REGISTRY }}:${DOCKER_TAG}
           gcloud docker -- push $GCR_REGISTRY:${DOCKER_TAG}
     
+  prepare-configs:
+    runs-on: ubuntu-latest
+    outputs:
+      log-results: ${{ steps.prepare-outputs.outputs.log-results }}
+      test-context: ${{ steps.prepare-outputs.outputs.test-context }}
+    steps:
+      - id: prepare-outputs
+        run: |-
+          echo 'log-results=true' >> $GITHUB_OUTPUT
+          if ${{ github.ref_name == 'develop' }}; then
+            echo 'test-context=dev-merge' >> $GITHUB_OUTPUT
+          else
+            echo 'test-context=pr-test' >> $GITHUB_OUTPUT
+          fi
  
   report-to-sherlock:
     # Report new firecloudorch version to Broad DevOps
@@ -89,6 +103,7 @@ jobs:
     # Put new firecloudorch version in Broad dev environment
     uses: broadinstitute/sherlock/.github/workflows/client-set-environment-app-version.yaml@main
     needs: [orch-build-tag-publish-job, report-to-sherlock]
+    if: ${{ github.ref_name == 'develop' }}
     with:
       new-version: ${{ needs.orch-build-tag-publish-job.outputs.tag }}
       chart-name: 'firecloudorch'
@@ -114,7 +129,7 @@ jobs:
           echo '${{ needs.orch-build-tag-publish-job.outputs.custom-version-json }}'
 
       - name: dispatch to terra-github-workflows
-        uses: aurelien-baudet/workflow-dispatch@93e95b157d791ae7f42aef8f8a0d3d723eba1c31 #commit sha for v2.1.1
+        uses: broadinstitute/workflow-dispatch@v4
         with:
           workflow: bee-create
           repo: broadinstitute/terra-github-workflows
@@ -122,7 +137,12 @@ jobs:
           token: ${{ secrets.BROADBOT_TOKEN}} # github token for access to kick off a job in the private repo
           # manually recalculate b/c env context is broken https://github.com/actions/runner/issues/480
           # Note: There is a hard limit of bee-name not exceeding 32 characters
-          inputs: '{ "bee-name": "orch-${{ github.run_id }}-${{ matrix.terra-env }}", "version-template": "${{ matrix.terra-env }}", "custom-version-json": "${{ needs.orch-build-tag-publish-job.outputs.custom-version-json }}" }'
+          inputs: '{
+              "bee-name": "orch-${{ github.run_id }}-${{ matrix.terra-env }}",
+              "version-template": "${{ matrix.terra-env }}",
+              "custom-version-json": "${{ needs.orch-build-tag-publish-job.outputs.custom-version-json }}",
+              "caller_run_id": "${{ github.run_id }}"
+            }'
 
   orch-swat-test-job:
     strategy:
@@ -136,14 +156,20 @@ jobs:
       id-token: 'write'
     steps:
       - name: dispatch to terra-github-workflows
-        uses: aurelien-baudet/workflow-dispatch@93e95b157d791ae7f42aef8f8a0d3d723eba1c31 #commit sha for v2.1.1
+        uses: broadinstitute/workflow-dispatch@v4
         with:
           workflow: orch-swat-tests
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/main
           token: ${{ secrets.BROADBOT_TOKEN}} # github token for access to kick off a job in the private repo
           # manually recalculate b/c env context is broken https://github.com/actions/runner/issues/480
-          inputs: '{ "bee-name": "orch-${{ github.run_id }}-${{ matrix.terra-env }}", "ENV": "${{ matrix.testing-env }}" }'
+          inputs: '{
+              "bee-name": "orch-${{ github.run_id }}-${{ matrix.terra-env }}",
+              "ENV": "${{ matrix.testing-env }}",
+              "log-results": "${{ needs.prepare-configs.outputs.log-results }}",
+              "test-context": "${{ needs.prepare-configs.outputs.test-context }}",
+              "caller_run_id": "${{ github.run_id }}"
+            }'
 
   destroy-bee-workflow:
     strategy:
@@ -157,11 +183,14 @@ jobs:
       id-token: 'write'
     steps:
       - name: dispatch to terra-github-workflows
-        uses: aurelien-baudet/workflow-dispatch@93e95b157d791ae7f42aef8f8a0d3d723eba1c31 #commit sha for v2.1.1
+        uses: broadinstitute/workflow-dispatch@v4
         with:
           workflow: bee-destroy
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/main
           token: ${{ secrets.BROADBOT_TOKEN}} # github token for access to kick off a job in the private repo
           # manually recalculate b/c env context is broken https://github.com/actions/runner/issues/480
-          inputs: '{ "bee-name": "orch-${{ github.run_id }}-${{ matrix.terra-env }}" }'
+          inputs: '{
+              "bee-name": "orch-${{ github.run_id }}-${{ matrix.terra-env }}",
+              "caller_run_id": "${{ github.run_id }}"
+            }'

--- a/.github/workflows/orch-build-tag-publish-and-run-tests.yml
+++ b/.github/workflows/orch-build-tag-publish-and-run-tests.yml
@@ -13,6 +13,7 @@ env:
   GCR_REGISTRY: gcr.io/broad-dsp-gcr-public/firecloud-orchestration
   # Region-specific Google Docker repository where GOOGLE_PROJECT/REPOSITORY_NAME can be found
   GOOGLE_DOCKER_REPOSITORY: us-central1-docker.pkg.dev
+  RUN_NAME: '${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}'
 
 jobs:
   orch-build-tag-publish-job:
@@ -132,6 +133,7 @@ jobs:
         uses: broadinstitute/workflow-dispatch@v4
         with:
           workflow: bee-create
+          run-name: "bee-create-${{ env.RUN_NAME }}"
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/main
           token: ${{ secrets.BROADBOT_TOKEN}} # github token for access to kick off a job in the private repo
@@ -140,8 +142,7 @@ jobs:
           inputs: '{
               "bee-name": "orch-${{ github.run_id }}-${{ matrix.terra-env }}",
               "version-template": "${{ matrix.terra-env }}",
-              "custom-version-json": "${{ needs.orch-build-tag-publish-job.outputs.custom-version-json }}",
-              "caller_run_id": "${{ github.run_id }}"
+              "custom-version-json": "${{ needs.orch-build-tag-publish-job.outputs.custom-version-json }}"
             }'
 
   orch-swat-test-job:
@@ -159,6 +160,7 @@ jobs:
         uses: broadinstitute/workflow-dispatch@v4
         with:
           workflow: orch-swat-tests
+          run-name: "orch-test-${{ env.RUN_NAME }}"
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/main
           token: ${{ secrets.BROADBOT_TOKEN}} # github token for access to kick off a job in the private repo
@@ -167,8 +169,7 @@ jobs:
               "bee-name": "orch-${{ github.run_id }}-${{ matrix.terra-env }}",
               "ENV": "${{ matrix.testing-env }}",
               "log-results": "${{ needs.prepare-configs.outputs.log-results }}",
-              "test-context": "${{ needs.prepare-configs.outputs.test-context }}",
-              "caller_run_id": "${{ github.run_id }}"
+              "test-context": "${{ needs.prepare-configs.outputs.test-context }}"
             }'
 
   destroy-bee-workflow:
@@ -186,12 +187,12 @@ jobs:
         uses: broadinstitute/workflow-dispatch@v4
         with:
           workflow: bee-destroy
+          run-name: "bee-destroy-${{ env.RUN_NAME }}"
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/main
           token: ${{ secrets.BROADBOT_TOKEN}} # github token for access to kick off a job in the private repo
           # manually recalculate b/c env context is broken https://github.com/actions/runner/issues/480
           inputs: '{
-              "bee-name": "orch-${{ github.run_id }}-${{ matrix.terra-env }}",
-              "caller_run_id": "${{ github.run_id }}"
+              "bee-name": "orch-${{ github.run_id }}-${{ matrix.terra-env }}"
             }'
           wait-for-completion: false

--- a/.github/workflows/orch-build-tag-publish-and-run-tests.yml
+++ b/.github/workflows/orch-build-tag-publish-and-run-tests.yml
@@ -168,7 +168,6 @@ jobs:
           inputs: '{
               "bee-name": "orch-${{ github.run_id }}-${{ matrix.terra-env }}",
               "ENV": "${{ matrix.testing-env }}",
-              "log-results": "${{ needs.prepare-configs.outputs.log-results }}",
               "test-context": "${{ needs.prepare-configs.outputs.test-context }}"
             }'
 

--- a/.github/workflows/orch-build-tag-publish-and-run-tests.yml
+++ b/.github/workflows/orch-build-tag-publish-and-run-tests.yml
@@ -142,7 +142,8 @@ jobs:
           inputs: '{
               "bee-name": "orch-${{ github.run_id }}-${{ matrix.terra-env }}",
               "version-template": "${{ matrix.terra-env }}",
-              "custom-version-json": "${{ needs.orch-build-tag-publish-job.outputs.custom-version-json }}"
+              "custom-version-json": "${{ needs.orch-build-tag-publish-job.outputs.custom-version-json }}",
+              "run-name": "bee-create-${{ env.RUN_NAME }}"
             }'
 
   orch-swat-test-job:
@@ -160,7 +161,6 @@ jobs:
         uses: broadinstitute/workflow-dispatch@v4
         with:
           workflow: orch-swat-tests
-          run-name: "orch-test-${{ env.RUN_NAME }}"
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/main
           token: ${{ secrets.BROADBOT_TOKEN}} # github token for access to kick off a job in the private repo
@@ -193,6 +193,7 @@ jobs:
           token: ${{ secrets.BROADBOT_TOKEN}} # github token for access to kick off a job in the private repo
           # manually recalculate b/c env context is broken https://github.com/actions/runner/issues/480
           inputs: '{
-              "bee-name": "orch-${{ github.run_id }}-${{ matrix.terra-env }}"
+              "bee-name": "orch-${{ github.run_id }}-${{ matrix.terra-env }}",
+              "run-name": "bee-destroy-${{ env.RUN_NAME }}"
             }'
           wait-for-completion: false


### PR DESCRIPTION
switch to only push to dev when merging to dev, update workflow-dispatch to report test results

\<your comments for this PR go here\>

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
