### PR TITLE
AJ-1602: list-jobs API should aggregate Import Service and cWDS

### DIFF
--- a/local-dev/templates/firecloud-orchestration.conf.ctmpl
+++ b/local-dev/templates/firecloud-orchestration.conf.ctmpl
@@ -99,6 +99,7 @@ thurloe {
 
 cwds {
     baseUrl = "https://cwds.dsde-dev.broadinstitute.org"
+    enabled = true
 }
 
 firecloud {

--- a/local-dev/templates/firecloud-orchestration.conf.ctmpl
+++ b/local-dev/templates/firecloud-orchestration.conf.ctmpl
@@ -97,6 +97,10 @@ thurloe {
 	baseUrl = "https://thurloe.dsde-dev.broadinstitute.org"
 }
 
+cwds {
+    baseUrl = "https://cwds.dsde-dev.broadinstitute.org"
+}
+
 firecloud {
 	baseUrl = "https://firecloud-orchestration.dsde-dev.broadinstitute.org"
 	portalUrl = "https://firecloud.dsde-dev.broadinstitute.org"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -55,6 +55,7 @@ object Dependencies {
     "org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % s"0.5-$workbenchLibsHash",
     "org.broadinstitute.dsde.workbench" %% "sam-client"       % "0.1-ef83073",
     "org.broadinstitute.dsde.workbench" %% "workbench-notifications" %s"0.6-$workbenchLibsHash",
+    "org.databiosphere" % "workspacedataservice-client-okhttp-jakarta" % "0.2.117-SNAPSHOT",
 
     "com.typesafe.akka"   %%  "akka-actor"           % akkaV,
     "com.typesafe.akka"   %%  "akka-slf4j"           % akkaV,

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/Application.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/Application.scala
@@ -16,4 +16,5 @@ case class Application(agoraDAO: AgoraDAO,
                        thurloeDAO: ThurloeDAO,
                        shareLogDAO: ShareLogDAO,
                        importServiceDAO: ImportServiceDAO,
-                       shibbolethDAO: ShibbolethDAO)
+                       shibbolethDAO: ShibbolethDAO,
+                       cwdsDAO: CwdsDAO)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/Boot.scala
@@ -36,8 +36,9 @@ object Boot extends App with LazyLogging {
     val shareLogDAO:ShareLogDAO = new ElasticSearchShareLogDAO(elasticSearchClient, FireCloudConfig.ElasticSearch.shareLogIndexName)
     val importServiceDAO:ImportServiceDAO = new HttpImportServiceDAO
     val shibbolethDAO:ShibbolethDAO = new HttpShibbolethDAO
+    val cwdsDAO:CwdsDAO = new HttpCwdsDAO
 
-    val app:Application = Application(agoraDAO, googleServicesDAO, ontologyDAO, rawlsDAO, samDAO, searchDAO, researchPurposeSupport, thurloeDAO, shareLogDAO, importServiceDAO, shibbolethDAO);
+    val app:Application = Application(agoraDAO, googleServicesDAO, ontologyDAO, rawlsDAO, samDAO, searchDAO, researchPurposeSupport, thurloeDAO, shareLogDAO, importServiceDAO, shibbolethDAO, cwdsDAO);
 
     val agoraPermissionServiceConstructor: (UserInfo) => AgoraPermissionService = AgoraPermissionService.constructor(app)
     val exportEntitiesByTypeActorConstructor: (ExportEntitiesByTypeArguments) => ExportEntitiesByTypeActor = ExportEntitiesByTypeActor.constructor(app, system)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/Boot.scala
@@ -36,7 +36,7 @@ object Boot extends App with LazyLogging {
     val shareLogDAO:ShareLogDAO = new ElasticSearchShareLogDAO(elasticSearchClient, FireCloudConfig.ElasticSearch.shareLogIndexName)
     val importServiceDAO:ImportServiceDAO = new HttpImportServiceDAO
     val shibbolethDAO:ShibbolethDAO = new HttpShibbolethDAO
-    val cwdsDAO:CwdsDAO = new HttpCwdsDAO
+    val cwdsDAO:CwdsDAO = new HttpCwdsDAO(FireCloudConfig.Cwds.enabled)
 
     val app:Application = Application(agoraDAO, googleServicesDAO, ontologyDAO, rawlsDAO, samDAO, searchDAO, researchPurposeSupport, thurloeDAO, shareLogDAO, importServiceDAO, shibbolethDAO, cwdsDAO);
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/EntityService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/EntityService.scala
@@ -381,7 +381,11 @@ class EntityService(rawlsDAO: RawlsDAO, importServiceDAO: ImportServiceDAO, cwds
       // get jobs from Import Service
       importServiceJobs <- importServiceDAO.listJobs(workspaceNamespace, workspaceName, runningOnly)(userInfo)
       // get jobs from cWDS
-      cwdsJobs = cwdsDAO.listJobsV1(workspace.workspace.workspaceId, runningOnly)(userInfo)
+      cwdsJobs = if (cwdsDAO.isEnabled) {
+        cwdsDAO.listJobsV1(workspace.workspace.workspaceId, runningOnly)(userInfo)
+      } else {
+        List.empty
+      }
     } yield {
       // merge Import Service and cWDS results
       importServiceJobs.concat(cwdsJobs)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/EntityService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/EntityService.scala
@@ -10,7 +10,7 @@ import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.EntityService._
 import org.broadinstitute.dsde.firecloud.FireCloudConfig.Rawls
 import org.broadinstitute.dsde.firecloud.dataaccess.ImportServiceFiletypes.{FILETYPE_PFB, FILETYPE_RAWLS}
-import org.broadinstitute.dsde.firecloud.dataaccess.{GoogleServicesDAO, ImportServiceDAO, RawlsDAO}
+import org.broadinstitute.dsde.firecloud.dataaccess.{CwdsDAO, GoogleServicesDAO, ImportServiceDAO, RawlsDAO}
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
 import org.broadinstitute.dsde.firecloud.model.{ModelSchema, _}
 import org.broadinstitute.dsde.firecloud.service.PerRequest.{PerRequestMessage, RequestComplete}
@@ -34,7 +34,7 @@ import scala.util.{Failure, Success, Try}
 object EntityService {
 
   def constructor(app: Application)(modelSchema: ModelSchema)(implicit executionContext: ExecutionContext) =
-    new EntityService(app.rawlsDAO, app.importServiceDAO, app.googleServicesDAO, modelSchema)
+    new EntityService(app.rawlsDAO, app.importServiceDAO, app.cwdsDAO, app.googleServicesDAO, modelSchema)
 
   def colNamesToAttributeNames(headers: Seq[String], requiredAttributes: Map[String, String]): Seq[(String, Option[String])] = {
     headers.tail map { colName => (colName, requiredAttributes.get(colName))}
@@ -102,7 +102,7 @@ object EntityService {
 
 }
 
-class EntityService(rawlsDAO: RawlsDAO, importServiceDAO: ImportServiceDAO, googleServicesDAO: GoogleServicesDAO, modelSchema: ModelSchema)(implicit val executionContext: ExecutionContext)
+class EntityService(rawlsDAO: RawlsDAO, importServiceDAO: ImportServiceDAO, cwdsDAO: CwdsDAO, googleServicesDAO: GoogleServicesDAO, modelSchema: ModelSchema)(implicit val executionContext: ExecutionContext)
   extends TSVFileSupport with LazyLogging {
 
   val format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZZ")
@@ -374,11 +374,18 @@ class EntityService(rawlsDAO: RawlsDAO, importServiceDAO: ImportServiceDAO, goog
   }
 
   def listJobs(workspaceNamespace: String, workspaceName: String, runningOnly: Boolean, userInfo: UserInfo): Future[List[ImportServiceListResponse]] = {
-    // get jobs from Import Service
-    val importServiceJobs = importServiceDAO.listJobs(workspaceNamespace, workspaceName, runningOnly)(userInfo)
-    // TODO AJ-1602: get jobs from cWDS
-    // TODO AJ-1602: merge lists before replying
-    importServiceJobs
+
+    for {
+      // translate workspace namespace/name to workspaceid
+      workspace <- rawlsDAO.getWorkspace(workspaceNamespace, workspaceName)(userInfo)
+      // get jobs from Import Service
+      importServiceJobs <- importServiceDAO.listJobs(workspaceNamespace, workspaceName, runningOnly)(userInfo)
+      // get jobs from cWDS
+      cwdsJobs = cwdsDAO.listJobsV1(workspace.workspace.workspaceId, runningOnly)(userInfo)
+    } yield {
+      // merge Import Service and cWDS results
+      importServiceJobs.concat(cwdsJobs)
+    }
   }
 
   def getEntitiesWithType(workspaceNamespace: String, workspaceName: String, userInfo: UserInfo): Future[PerRequestMessage] = {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
@@ -123,6 +123,7 @@ object FireCloudConfig {
   object Cwds {
     private val cwds = config.getConfig("cwds")
     val baseUrl = cwds.getString("baseUrl")
+    val enabled = cwds.getBoolean("enabled")
   }
 
   object FireCloud {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
@@ -120,6 +120,11 @@ object FireCloudConfig {
     val validPreferenceKeys = profile.getStringList("validPreferenceKeys").asScala.toSet
   }
 
+  object Cwds {
+    private val cwds = config.getConfig("cwds")
+    val baseUrl = cwds.getString("baseUrl")
+  }
+
   object FireCloud {
     private val firecloud = config.getConfig("firecloud")
     val baseUrl = firecloud.getString("baseUrl")

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/CwdsDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/CwdsDAO.scala
@@ -7,6 +7,8 @@ import scala.concurrent.Future
 
 trait CwdsDAO {
 
+  def isEnabled: Boolean
+
   def listJobsV1(workspaceId: String,
                  runningOnly: Boolean
                 )(implicit userInfo: UserInfo): List[ImportServiceListResponse]

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/CwdsDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/CwdsDAO.scala
@@ -7,7 +7,7 @@ import scala.concurrent.Future
 
 trait CwdsDAO {
 
-  def listJobsV1(workspaceId: UUID,
+  def listJobsV1(workspaceId: String,
                  runningOnly: Boolean
                 )(implicit userInfo: UserInfo): List[ImportServiceListResponse]
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/CwdsDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/CwdsDAO.scala
@@ -1,0 +1,13 @@
+package org.broadinstitute.dsde.firecloud.dataaccess
+
+import org.broadinstitute.dsde.firecloud.model.{ImportServiceListResponse, UserInfo}
+
+import java.util.UUID
+import scala.concurrent.Future
+
+trait CwdsDAO {
+
+  def listJobsV1(workspaceId: UUID,
+                 runningOnly: Boolean
+                )(implicit userInfo: UserInfo): List[ImportServiceListResponse]
+}

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpCwdsDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpCwdsDAO.scala
@@ -1,0 +1,61 @@
+package org.broadinstitute.dsde.firecloud.dataaccess
+
+import org.broadinstitute.dsde.firecloud.FireCloudConfig
+import org.broadinstitute.dsde.firecloud.model.{ImportServiceListResponse, UserInfo}
+import org.databiosphere.workspacedata.api.JobApi
+import org.databiosphere.workspacedata.client.ApiClient
+import org.databiosphere.workspacedata.model.GenericJob
+import org.databiosphere.workspacedata.model.GenericJob.StatusEnum._
+
+import scala.jdk.CollectionConverters._
+import java.util.UUID
+
+class HttpCwdsDAO extends CwdsDAO {
+
+  private final val RUNNING_STATUSES: java.util.List[String] = List("CREATED", "QUEUED", "RUNNING").asJava
+  private final val ALL_STATUSES: java.util.List[String] = List.empty[String].asJava
+
+  private final val STATUS_TRANSLATION: Map[GenericJob.StatusEnum,String] = Map(
+    // there is no effective difference between Translating and ReadyForUpsert for our purposes
+    CREATED -> "Translating",
+    QUEUED -> "Translating",
+    RUNNING -> "ReadyForUpsert",
+    SUCCEEDED -> "Done",
+    ERROR -> "Error",
+    CANCELLED -> "Error",
+    UNKNOWN -> "Error"
+  )
+
+  override def listJobsV1(workspaceId: UUID, runningOnly: Boolean)(implicit userInfo: UserInfo)
+  : List[ImportServiceListResponse] = {
+    // determine the proper cWDS statuses based on the runningOnly argument
+    val statuses = if (runningOnly) RUNNING_STATUSES else ALL_STATUSES
+
+    // prepare the cWDS client
+    // TODO AJ-1602: reuse api client?
+    val apiClient: ApiClient = new ApiClient()
+    apiClient.setBasePath(FireCloudConfig.Cwds.baseUrl)
+    apiClient.setAccessToken(userInfo.accessToken.token)
+    val jobApi: JobApi = new JobApi()
+    jobApi.setApiClient(apiClient)
+
+    // query cWDS for its jobs, and translate the response to ImportServiceListResponse format
+    jobApi.jobsInInstanceV1(workspaceId, statuses)
+      .asScala
+      .map(toImportServiceListResponse)
+      .toList
+  }
+
+  private def toImportServiceListResponse(cwdsJob: GenericJob) = {
+    ImportServiceListResponse(jobId = cwdsJob.getJobId.toString,
+      status = toImportServiceStatus(cwdsJob.getStatus),
+      filetype = cwdsJob.getJobType.getValue,
+      message = Option(cwdsJob.getErrorMessage))
+  }
+
+  private def toImportServiceStatus(cwdsStatus: GenericJob.StatusEnum): String = {
+    STATUS_TRANSLATION.getOrElse(cwdsStatus, "blah")
+  }
+
+
+}

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpCwdsDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpCwdsDAO.scala
@@ -10,7 +10,7 @@ import org.databiosphere.workspacedata.model.GenericJob.StatusEnum._
 import scala.jdk.CollectionConverters._
 import java.util.UUID
 
-class HttpCwdsDAO extends CwdsDAO {
+class HttpCwdsDAO(enabled: Boolean) extends CwdsDAO {
 
   private final val RUNNING_STATUSES: java.util.List[String] = List("CREATED", "QUEUED", "RUNNING").asJava
   private final val ALL_STATUSES: java.util.List[String] = List.empty[String].asJava
@@ -25,6 +25,8 @@ class HttpCwdsDAO extends CwdsDAO {
     CANCELLED -> "Error",
     UNKNOWN -> "Error"
   )
+
+  override def isEnabled: Boolean = enabled
 
   override def listJobsV1(workspaceId: String, runningOnly: Boolean)(implicit userInfo: UserInfo)
   : List[ImportServiceListResponse] = {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpCwdsDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpCwdsDAO.scala
@@ -1,6 +1,8 @@
 package org.broadinstitute.dsde.firecloud.dataaccess
 
+import okhttp3.Protocol
 import org.broadinstitute.dsde.firecloud.FireCloudConfig
+import org.broadinstitute.dsde.firecloud.dataaccess.HttpCwdsDAO.commonHttpClient
 import org.broadinstitute.dsde.firecloud.model.{ImportServiceListResponse, UserInfo}
 import org.databiosphere.workspacedata.api.JobApi
 import org.databiosphere.workspacedata.client.ApiClient
@@ -10,10 +12,16 @@ import org.databiosphere.workspacedata.model.GenericJob.StatusEnum._
 import scala.jdk.CollectionConverters._
 import java.util.UUID
 
+object HttpCwdsDAO {
+  // singleton common http client to prevent object thrashing
+  private val commonHttpClient = new ApiClient().getHttpClient.newBuilder
+    .protocols(List(Protocol.HTTP_1_1).asJava)
+    .build
+}
+
 class HttpCwdsDAO(enabled: Boolean) extends CwdsDAO {
 
   private final val RUNNING_STATUSES: java.util.List[String] = List("CREATED", "QUEUED", "RUNNING").asJava
-  private final val ALL_STATUSES: java.util.List[String] = List.empty[String].asJava
 
   private final val STATUS_TRANSLATION: Map[GenericJob.StatusEnum,String] = Map(
     // there is no effective difference between Translating and ReadyForUpsert for our purposes
@@ -29,13 +37,14 @@ class HttpCwdsDAO(enabled: Boolean) extends CwdsDAO {
   override def isEnabled: Boolean = enabled
 
   override def listJobsV1(workspaceId: String, runningOnly: Boolean)(implicit userInfo: UserInfo)
-  : List[ImportServiceListResponse] = {
+  : scala.collection.immutable.List[ImportServiceListResponse] = {
     // determine the proper cWDS statuses based on the runningOnly argument
-    val statuses = if (runningOnly) RUNNING_STATUSES else ALL_STATUSES
+    // the Java API expects null when not specifying statuses
+    val statuses = if (runningOnly) RUNNING_STATUSES else null
 
     // prepare the cWDS client
-    // TODO AJ-1602: reuse api client?
     val apiClient: ApiClient = new ApiClient()
+    apiClient.setHttpClient(commonHttpClient)
     apiClient.setBasePath(FireCloudConfig.Cwds.baseUrl)
     apiClient.setAccessToken(userInfo.accessToken.token)
     val jobApi: JobApi = new JobApi()
@@ -48,15 +57,15 @@ class HttpCwdsDAO(enabled: Boolean) extends CwdsDAO {
       .toList
   }
 
-  private def toImportServiceListResponse(cwdsJob: GenericJob) = {
+  protected[dataaccess] def toImportServiceListResponse(cwdsJob: GenericJob): ImportServiceListResponse = {
     ImportServiceListResponse(jobId = cwdsJob.getJobId.toString,
       status = toImportServiceStatus(cwdsJob.getStatus),
       filetype = cwdsJob.getJobType.getValue,
       message = Option(cwdsJob.getErrorMessage))
   }
 
-  private def toImportServiceStatus(cwdsStatus: GenericJob.StatusEnum): String = {
-    STATUS_TRANSLATION.getOrElse(cwdsStatus, "blah")
+  protected[dataaccess] def toImportServiceStatus(cwdsStatus: GenericJob.StatusEnum): String = {
+    STATUS_TRANSLATION.getOrElse(cwdsStatus, "Unknown")
   }
 
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpCwdsDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpCwdsDAO.scala
@@ -26,7 +26,7 @@ class HttpCwdsDAO extends CwdsDAO {
     UNKNOWN -> "Error"
   )
 
-  override def listJobsV1(workspaceId: UUID, runningOnly: Boolean)(implicit userInfo: UserInfo)
+  override def listJobsV1(workspaceId: String, runningOnly: Boolean)(implicit userInfo: UserInfo)
   : List[ImportServiceListResponse] = {
     // determine the proper cWDS statuses based on the runningOnly argument
     val statuses = if (runningOnly) RUNNING_STATUSES else ALL_STATUSES
@@ -40,7 +40,7 @@ class HttpCwdsDAO extends CwdsDAO {
     jobApi.setApiClient(apiClient)
 
     // query cWDS for its jobs, and translate the response to ImportServiceListResponse format
-    jobApi.jobsInInstanceV1(workspaceId, statuses)
+    jobApi.jobsInInstanceV1(UUID.fromString(workspaceId), statuses)
       .asScala
       .map(toImportServiceListResponse)
       .toList

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpCwdsDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpCwdsDAO.scala
@@ -65,6 +65,7 @@ class HttpCwdsDAO(enabled: Boolean) extends CwdsDAO {
   }
 
   protected[dataaccess] def toImportServiceStatus(cwdsStatus: GenericJob.StatusEnum): String = {
+    // don't fail status translation if status somehow could not be found
     STATUS_TRANSLATION.getOrElse(cwdsStatus, "Unknown")
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/EntityServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/EntityServiceSpec.scala
@@ -264,7 +264,7 @@ class EntityServiceSpec extends BaseServiceSpec with BeforeAndAfterEach {
       val cwdsDAO = mockito[MockCwdsDAO]
 
       when(importServiceDAO.listJobs(any[String], any[String], any[Boolean])(any[UserInfo])).thenReturn(Future.successful(importServiceResponse))
-      when(cwdsDAO.listJobsV1(any[UUID], any[Boolean])(any[UserInfo])).thenReturn(cwdsResponse)
+      when(cwdsDAO.listJobsV1(any[String], any[Boolean])(any[UserInfo])).thenReturn(cwdsResponse)
 
       // inject mocks to entity service
       val entityService = getEntityService(mockImportServiceDAO = importServiceDAO, cwdsDAO = cwdsDAO)

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/EntityServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/EntityServiceSpec.scala
@@ -4,10 +4,10 @@ import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import akka.http.scaladsl.model.{HttpResponse, StatusCode, StatusCodes}
 import com.google.cloud.storage.StorageException
 import org.broadinstitute.dsde.firecloud.dataaccess.ImportServiceFiletypes.FILETYPE_RAWLS
-import org.broadinstitute.dsde.firecloud.dataaccess.{MockImportServiceDAO, MockRawlsDAO}
+import org.broadinstitute.dsde.firecloud.dataaccess.{MockCwdsDAO, MockImportServiceDAO, MockRawlsDAO}
 import org.broadinstitute.dsde.firecloud.mock.MockGoogleServicesDAO
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
-import org.broadinstitute.dsde.firecloud.model.{AsyncImportRequest, EntityUpdateDefinition, FirecloudModelSchema, ImportServiceResponse, ModelSchema, RequestCompleteWithErrorReport, UserInfo}
+import org.broadinstitute.dsde.firecloud.model.{AsyncImportRequest, EntityUpdateDefinition, FirecloudModelSchema, ImportServiceListResponse, ImportServiceResponse, ModelSchema, RequestCompleteWithErrorReport, UserInfo}
 import org.broadinstitute.dsde.firecloud.service.PerRequest.RequestComplete
 import org.broadinstitute.dsde.firecloud.service.{BaseServiceSpec, PerRequest}
 import org.broadinstitute.dsde.rawls.model.{ErrorReport, ErrorReportSource}
@@ -19,6 +19,7 @@ import org.parboiled.common.FileUtils
 import org.scalatest.BeforeAndAfterEach
 import org.scalatestplus.mockito.MockitoSugar.{mock => mockito}
 
+import java.util.UUID
 import java.util.zip.ZipFile
 import scala.concurrent.ExecutionContext.Implicits._
 import scala.concurrent.Future
@@ -31,6 +32,8 @@ class EntityServiceSpec extends BaseServiceSpec with BeforeAndAfterEach {
   override def afterEach(): Unit = {
     searchDao.reset()
   }
+
+  private def dummyUserInfo(tokenStr: String) = UserInfo("dummy", OAuth2BearerToken(tokenStr), -1, "dummy")
 
   "EntityClient should extract TSV files out of bagit zips" - {
     "with neither participants nor samples in the zip" in {
@@ -214,10 +217,72 @@ class EntityServiceSpec extends BaseServiceSpec with BeforeAndAfterEach {
     }
   }
 
+  "EntityService.listJobs" - {
+    "should concatenate results from cWDS and Import Service" in {
+      val importServiceResponse = List(
+        ImportServiceListResponse("jobId1", "status1", "filetype1", None),
+        ImportServiceListResponse("jobId2", "status2", "filetype2", None)
+      )
+      val cwdsResponse = List(
+        ImportServiceListResponse("jobId1", "status1", "filetype1", None),
+        ImportServiceListResponse("jobId2", "status2", "filetype2", None)
+      )
+
+      listJobsTestImpl(importServiceResponse, cwdsResponse)
+    }
+
+    "should return empty list if both cWDS and Import Service return empty lists" in {
+      val importServiceResponse = List()
+      val cwdsResponse = List()
+
+      listJobsTestImpl(importServiceResponse, cwdsResponse)
+    }
+
+    "should return results if Import Service has results but cWDS is empty" in {
+      val importServiceResponse = List(
+        ImportServiceListResponse("jobId1", "status1", "filetype1", None),
+        ImportServiceListResponse("jobId2", "status2", "filetype2", None)
+      )
+      val cwdsResponse = List()
+
+      listJobsTestImpl(importServiceResponse, cwdsResponse)
+    }
+
+    "should return results if cWDS has results but Import Service is empty" in {
+      val importServiceResponse = List()
+      val cwdsResponse = List(
+        ImportServiceListResponse("jobId1", "status1", "filetype1", None),
+        ImportServiceListResponse("jobId2", "status2", "filetype2", None)
+      )
+
+      listJobsTestImpl(importServiceResponse, cwdsResponse)
+    }
+
+    def listJobsTestImpl(importServiceResponse: List[ImportServiceListResponse], cwdsResponse: List[ImportServiceListResponse]) = {
+      // set up mocks
+      val importServiceDAO = mockito[MockImportServiceDAO]
+      val cwdsDAO = mockito[MockCwdsDAO]
+
+      when(importServiceDAO.listJobs(any[String], any[String], any[Boolean])(any[UserInfo])).thenReturn(Future.successful(importServiceResponse))
+      when(cwdsDAO.listJobsV1(any[UUID], any[Boolean])(any[UserInfo])).thenReturn(cwdsResponse)
+
+      // inject mocks to entity service
+      val entityService = getEntityService(mockImportServiceDAO = importServiceDAO, cwdsDAO = cwdsDAO)
+
+      // list jobs via entity service
+      val actual = entityService.listJobs("workspaceNamespace", "workspaceName", runningOnly = true, dummyUserInfo("mytoken")).futureValue
+
+      actual should contain theSameElementsAs (importServiceResponse ++ cwdsResponse)
+    }
+
+
+  }
+
   private def getEntityService(mockGoogleServicesDAO: MockGoogleServicesDAO = new MockGoogleServicesDAO,
                                mockImportServiceDAO: MockImportServiceDAO = new MockImportServiceDAO,
-                               rawlsDAO: MockRawlsDAO = new MockRawlsDAO) = {
-    val application = app.copy(googleServicesDAO = mockGoogleServicesDAO, rawlsDAO = rawlsDAO, importServiceDAO = mockImportServiceDAO)
+                               rawlsDAO: MockRawlsDAO = new MockRawlsDAO,
+                               cwdsDAO: MockCwdsDAO = new MockCwdsDAO) = {
+    val application = app.copy(googleServicesDAO = mockGoogleServicesDAO, rawlsDAO = rawlsDAO, importServiceDAO = mockImportServiceDAO, cwdsDAO = cwdsDAO)
 
     // instantiate an EntityService, specify importServiceDAO and googleServicesDAO
     implicit val modelSchema: ModelSchema = FirecloudModelSchema

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/EntityServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/EntityServiceSpec.scala
@@ -7,7 +7,7 @@ import org.broadinstitute.dsde.firecloud.dataaccess.ImportServiceFiletypes.FILET
 import org.broadinstitute.dsde.firecloud.dataaccess.{MockCwdsDAO, MockImportServiceDAO, MockRawlsDAO}
 import org.broadinstitute.dsde.firecloud.mock.MockGoogleServicesDAO
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
-import org.broadinstitute.dsde.firecloud.model.{AsyncImportRequest, EntityUpdateDefinition, FirecloudModelSchema, ImportServiceListResponse, ImportServiceResponse, ModelSchema, RequestCompleteWithErrorReport, UserInfo}
+import org.broadinstitute.dsde.firecloud.model.{AsyncImportRequest, EntityUpdateDefinition, FirecloudModelSchema, ImportServiceListResponse, ImportServiceResponse, ModelSchema, RequestCompleteWithErrorReport, UserInfo, WithAccessToken}
 import org.broadinstitute.dsde.firecloud.service.PerRequest.RequestComplete
 import org.broadinstitute.dsde.firecloud.service.{BaseServiceSpec, PerRequest}
 import org.broadinstitute.dsde.rawls.model.ErrorReport
@@ -262,6 +262,7 @@ class EntityServiceSpec extends BaseServiceSpec with BeforeAndAfterEach {
       // set up mocks
       val importServiceDAO = mockito[MockImportServiceDAO]
       val cwdsDAO = mockito[MockCwdsDAO]
+      val rawlsDAO = mockito[MockRawlsDAO]
 
       val importServiceResponse = List(
         ImportServiceListResponse("jobId1", "status1", "filetype1", None),
@@ -282,6 +283,8 @@ class EntityServiceSpec extends BaseServiceSpec with BeforeAndAfterEach {
       // list jobs via entity service
       val actual = entityService.listJobs("workspaceNamespace", "workspaceName", runningOnly = true, dummyUserInfo("mytoken")).futureValue
 
+      // verify Rawls get-workspace was NOT called
+      verify(rawlsDAO, never).getWorkspace(any[String], any[String])(any[WithAccessToken])
       // verify cwds list-jobs was NOT called
       verify(cwdsDAO, never).listJobsV1(any[String], any[Boolean])(any[UserInfo])
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpCwdsDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpCwdsDAOSpec.scala
@@ -1,0 +1,105 @@
+package org.broadinstitute.dsde.firecloud.dataaccess
+
+import org.broadinstitute.dsde.firecloud.model.ImportServiceListResponse
+import org.databiosphere.workspacedata.model.GenericJob
+import org.databiosphere.workspacedata.model.GenericJob.{JobTypeEnum, StatusEnum}
+import org.databiosphere.workspacedata.model.GenericJob.StatusEnum._
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class HttpCwdsDAOSpec extends AnyFreeSpec with Matchers {
+
+  // a dao that can be reused in multiple tests below
+  private val cwdsDao: HttpCwdsDAO = new HttpCwdsDAO(true)
+
+  "HttpCwdsDAOSpec" - {
+
+    "isEnabled" - {
+      "when (true)" in {
+        new HttpCwdsDAO(true).isEnabled shouldBe true
+      }
+      "when (false)" in {
+        new HttpCwdsDAO(false).isEnabled shouldBe false
+      }
+    }
+
+    "toImportServiceStatus" - {
+      val statusTranslations = Map(
+        // there is no effective difference between Translating and ReadyForUpsert for our purposes
+        CREATED -> "Translating",
+        QUEUED -> "Translating",
+        RUNNING -> "ReadyForUpsert",
+        SUCCEEDED -> "Done",
+        ERROR -> "Error",
+        CANCELLED -> "Error",
+        UNKNOWN -> "Error"
+      )
+
+      statusTranslations.foreach { case (input, expected) =>
+        s"input ($input) should translate to $expected" in {
+          cwdsDao.toImportServiceStatus(input) shouldBe expected
+        }
+      }
+
+      "should cover all possible statuses" in {
+        GenericJob.StatusEnum.values().foreach { enumValue =>
+          cwdsDao.toImportServiceStatus(enumValue) should not be "Unknown" // and should not throw
+        }
+      }
+    }
+
+    "toImportServiceListResponse" - {
+
+      "should translate a job without an error message" in {
+        val jobId: UUID = UUID.randomUUID()
+
+        val input = new GenericJob()
+        input.setJobId(jobId)
+        input.setStatus(StatusEnum.RUNNING)
+        input.setJobType(JobTypeEnum.DATA_IMPORT)
+        input.setInstanceId(UUID.randomUUID())
+        input.setCreated(OffsetDateTime.now())
+        input.setUpdated(OffsetDateTime.now())
+
+        val expected = ImportServiceListResponse(
+          jobId = jobId.toString,
+          status = "ReadyForUpsert",
+          filetype = "DATA_IMPORT",
+          message = None
+        )
+
+        cwdsDao.toImportServiceListResponse(input) shouldBe expected
+      }
+
+      "should translate a job with an error message" in {
+        val jobId: UUID = UUID.randomUUID()
+        val errMsg: String = "My error message for this unit test"
+
+        val input = new GenericJob()
+        input.setJobId(jobId)
+        input.setStatus(StatusEnum.ERROR)
+        input.setJobType(JobTypeEnum.DATA_IMPORT)
+        input.setInstanceId(UUID.randomUUID())
+        input.setCreated(OffsetDateTime.now())
+        input.setUpdated(OffsetDateTime.now())
+        input.setErrorMessage(errMsg)
+
+        val expected = ImportServiceListResponse(
+          jobId = jobId.toString,
+          status = "Error",
+          filetype = "DATA_IMPORT",
+          message = Some(errMsg)
+        )
+
+        cwdsDao.toImportServiceListResponse(input) shouldBe expected
+      }
+
+    }
+
+  }
+
+
+}

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockCwdsDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockCwdsDAO.scala
@@ -5,6 +5,8 @@ import org.broadinstitute.dsde.firecloud.model.{ImportServiceListResponse, UserI
 import java.util.UUID
 
 class MockCwdsDAO extends CwdsDAO {
+
+  override def isEnabled: Boolean = true
   override def listJobsV1(workspaceId: String, runningOnly: Boolean)(implicit userInfo: UserInfo)
   : List[ImportServiceListResponse] = List()
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockCwdsDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockCwdsDAO.scala
@@ -1,0 +1,10 @@
+package org.broadinstitute.dsde.firecloud.dataaccess
+
+import org.broadinstitute.dsde.firecloud.model.{ImportServiceListResponse, UserInfo}
+
+import java.util.UUID
+
+class MockCwdsDAO extends CwdsDAO {
+  override def listJobsV1(workspaceId: UUID, runningOnly: Boolean)(implicit userInfo: UserInfo)
+  : List[ImportServiceListResponse] = List()
+}

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockCwdsDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockCwdsDAO.scala
@@ -5,6 +5,6 @@ import org.broadinstitute.dsde.firecloud.model.{ImportServiceListResponse, UserI
 import java.util.UUID
 
 class MockCwdsDAO extends CwdsDAO {
-  override def listJobsV1(workspaceId: UUID, runningOnly: Boolean)(implicit userInfo: UserInfo)
+  override def listJobsV1(workspaceId: String, runningOnly: Boolean)(implicit userInfo: UserInfo)
   : List[ImportServiceListResponse] = List()
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/BaseServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/BaseServiceSpec.scala
@@ -22,8 +22,9 @@ class BaseServiceSpec extends ServiceSpec with BeforeAndAfter {
   val shareLogDao:MockShareLogDAO = new MockShareLogDAO
   val importServiceDao:MockImportServiceDAO = new MockImportServiceDAO
   val shibbolethDao:MockShibbolethDAO = new MockShibbolethDAO
+  val cwdsDao:CwdsDAO = new MockCwdsDAO
 
   val app:Application =
-    new Application(agoraDao, googleServicesDao, ontologyDao, rawlsDao, samDao, searchDao, researchPurposeSupport, thurloeDao, shareLogDao, importServiceDao, shibbolethDao)
+    new Application(agoraDao, googleServicesDao, ontologyDao, rawlsDao, samDao, searchDao, researchPurposeSupport, thurloeDao, shareLogDao, importServiceDao, shibbolethDao, cwdsDao)
 
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/UserServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/UserServiceSpec.scala
@@ -3,7 +3,7 @@ package org.broadinstitute.dsde.firecloud.service
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import akka.testkit.TestActorRef
 import org.broadinstitute.dsde.firecloud.{Application, FireCloudConfig}
-import org.broadinstitute.dsde.firecloud.dataaccess.{MockImportServiceDAO, MockResearchPurposeSupport, MockShareLogDAO}
+import org.broadinstitute.dsde.firecloud.dataaccess.{MockCwdsDAO, MockImportServiceDAO, MockResearchPurposeSupport, MockShareLogDAO}
 import org.broadinstitute.dsde.firecloud.mock.MockGoogleServicesDAO
 import org.broadinstitute.dsde.firecloud.model.{ProfileWrapper, UserInfo}
 import org.broadinstitute.dsde.firecloud.service.PerRequest.RequestComplete
@@ -15,7 +15,7 @@ import scala.concurrent.duration._
 
 class UserServiceSpec  extends BaseServiceSpec with BeforeAndAfterEach {
 
-  val customApp = Application(agoraDao, new MockGoogleServicesFailedGroupsDAO(), ontologyDao, new MockRawlsDeleteWSDAO(), samDao, new MockSearchDeleteWSDAO(), new MockResearchPurposeSupport, thurloeDao, new MockShareLogDAO, new MockImportServiceDAO, shibbolethDao)
+  val customApp = Application(agoraDao, new MockGoogleServicesFailedGroupsDAO(), ontologyDao, new MockRawlsDeleteWSDAO(), samDao, new MockSearchDeleteWSDAO(), new MockResearchPurposeSupport, thurloeDao, new MockShareLogDAO, new MockImportServiceDAO, shibbolethDao, new MockCwdsDAO)
 
   val userServiceConstructor: (UserInfo) => UserService = UserService.constructor(customApp)
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceServiceSpec.scala
@@ -16,7 +16,7 @@ import scala.concurrent.{Await, ExecutionContext, Future}
 
 class WorkspaceServiceSpec extends BaseServiceSpec with BeforeAndAfterEach {
 
-  val customApp = Application(agoraDao, googleServicesDao, ontologyDao, new MockRawlsDeleteWSDAO(), samDao, new MockSearchDeleteWSDAO(), new MockResearchPurposeSupport, thurloeDao, new MockShareLogDAO, new MockImportServiceDAO, shibbolethDao)
+  val customApp = Application(agoraDao, googleServicesDao, ontologyDao, new MockRawlsDeleteWSDAO(), samDao, new MockSearchDeleteWSDAO(), new MockResearchPurposeSupport, thurloeDao, new MockShareLogDAO, new MockImportServiceDAO, shibbolethDao, new MockCwdsDAO)
 
   val workspaceServiceConstructor: (WithAccessToken) => WorkspaceService = WorkspaceService.constructor(customApp)
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/ApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/ApiServiceSpec.scala
@@ -36,11 +36,12 @@ trait ApiServiceSpec extends AnyFlatSpec with Matchers with ScalatestRouteTest w
     val shareLogDao: MockShareLogDAO
     val importServiceDao: ImportServiceDAO
     val shibbolethDao: ShibbolethDAO
+    val cwdsDao: CwdsDAO
 
     def actorRefFactory = system
 
     val nihServiceConstructor = NihService.constructor(
-      new Application(agoraDao, googleDao, ontologyDao, rawlsDao, samDao, searchDao, researchPurposeSupport, thurloeDao, shareLogDao, importServiceDao, shibbolethDao)
+      new Application(agoraDao, googleDao, ontologyDao, rawlsDao, samDao, searchDao, researchPurposeSupport, thurloeDao, shareLogDao, importServiceDao, shibbolethDao, cwdsDao)
     ) _
 
   }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/NihApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/NihApiServiceSpec.scala
@@ -45,10 +45,10 @@ class NihApiServiceSpec extends ApiServiceSpec with BeforeAndAfterAll with SamMo
   //JWT for NIH username "not-on-whitelist" (don't ever add this to the mock whitelists in MockGoogleServicesDAO.scala)
   val validJwtNotOnWhitelist = JWTWrapper("eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJlcmFDb21tb25zVXNlcm5hbWUiOiJub3Qtb24td2hpdGVsaXN0IiwiaWF0IjoxNjE0ODc3NTc4MDB9.WpDrgtui5mOgDc5WvdWYC-l6vljGVyRI7DbBnpRYm7QOq00VLU6FI5YzVFe1eyjnHIqdz_KkkQD604Bi3G1qdyzhk_KKFCSeT4k5in-zS4Em_I2rcyUFs9DeHyFqVrBMZK8eZM_oKtSs23AtwGJASQ-sMvfXeXLcjTFuLWUdeiQEYedj9oOOA93ne-5Kaw9V7sR1foX-ybLDDHfHuAwTN2Vnvpmz0Qlk5osvvv-NunCo4M6A4fQ2FQWjrCwXk8-1N4Wf06dgDJ7ymsw9HtwHhzctVDzodaVlVU_RaC2gtSOWeD5nPaAJ7h6aNmNeLRmNwzCBm3TyPDY-qznPVM0DRg")
 
-  case class TestApiService(agoraDao: MockAgoraDAO, googleDao: MockGoogleServicesDAO, ontologyDao: MockOntologyDAO, rawlsDao: MockRawlsDAO, samDao: MockSamDAO, searchDao: MockSearchDAO, researchPurposeSupport: MockResearchPurposeSupport, thurloeDao: MockThurloeDAO, shareLogDao: MockShareLogDAO, importServiceDao: MockImportServiceDAO, shibbolethDao: MockShibbolethDAO)(implicit val executionContext: ExecutionContext, implicit val materializer: Materializer) extends ApiServices
+  case class TestApiService(agoraDao: MockAgoraDAO, googleDao: MockGoogleServicesDAO, ontologyDao: MockOntologyDAO, rawlsDao: MockRawlsDAO, samDao: MockSamDAO, searchDao: MockSearchDAO, researchPurposeSupport: MockResearchPurposeSupport, thurloeDao: MockThurloeDAO, shareLogDao: MockShareLogDAO, importServiceDao: MockImportServiceDAO, shibbolethDao: MockShibbolethDAO, cwdsDao: CwdsDAO)(implicit val executionContext: ExecutionContext, implicit val materializer: Materializer) extends ApiServices
 
   def withDefaultApiServices[T](testCode: TestApiService => T): T = {
-    val apiService = TestApiService(new MockAgoraDAO, new MockGoogleServicesDAO, new MockOntologyDAO, new MockRawlsDAO, new MockSamDAO, new MockSearchDAO, new MockResearchPurposeSupport, new MockThurloeDAO, new MockShareLogDAO, new MockImportServiceDAO, new MockShibbolethDAO)
+    val apiService = TestApiService(new MockAgoraDAO, new MockGoogleServicesDAO, new MockOntologyDAO, new MockRawlsDAO, new MockSamDAO, new MockSearchDAO, new MockResearchPurposeSupport, new MockThurloeDAO, new MockShareLogDAO, new MockImportServiceDAO, new MockShibbolethDAO, new MockCwdsDAO)
     testCode(apiService)
   }
 


### PR DESCRIPTION
AJ-1602

High-level changes:
* add the cWDS client library
* create a new `CwdsDAO` trait, with `Http*` and `Mock*` implementations
* when listing jobs:
    * call Import Service to list its jobs
    * if `cwds.enabled` (see https://github.com/broadinstitute/terra-helmfile/pull/5261):
        * call Rawls to translate the workspace namespace/name into a workspace id
        * call cWDS, using the workspace id, to list its jobs
    * else:
        *  skip Rawls and cWDS and return an empty list of jobs
    * concat the Import Service and cWDS results
* unit tests

open questions:
- [ ] do we need more error trapping/retries?
- [ ] do we need cWDS in swatomation?

for a future PR:
- [ ] similar Import Service/cWDS support for the create-job APIs

---

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
