### PR TITLE
AJ-1602: use setBearerToken instead of setAccessToken for cWDS

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpCwdsDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpCwdsDAO.scala
@@ -46,7 +46,7 @@ class HttpCwdsDAO(enabled: Boolean) extends CwdsDAO {
     val apiClient: ApiClient = new ApiClient()
     apiClient.setHttpClient(commonHttpClient)
     apiClient.setBasePath(FireCloudConfig.Cwds.baseUrl)
-    apiClient.setAccessToken(userInfo.accessToken.token)
+    apiClient.setBearerToken(userInfo.accessToken.token)
     val jobApi: JobApi = new JobApi()
     jobApi.setApiClient(apiClient)
 


### PR DESCRIPTION
cWDS client needs to use `setBearerToken` instead of `setAccessToken`.

See also:
https://github.com/DataBiosphere/terra-workspace-data-service/pull/389
https://github.com/DataBiosphere/terra-workspace-data-service/pull/335

---

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
