### PR TITLE
AJ-1602: getJob checks both cWDS and Import Service

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/EntityService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/EntityService.scala
@@ -426,7 +426,7 @@ class EntityService(rawlsDAO: RawlsDAO, importServiceDAO: ImportServiceDAO, cwds
       logger.info(s"Found job $jobId in Import Service")
       importServiceResponse
     } recover { importServiceError =>
-      logger.info(s"Job $jobId not found in either cWDS or Import Service: " + importServiceError.getClass.getName)
+      logger.info(s"Job $jobId not returned successfully by either cWDS or Import Service")
       importServiceError match {
         case fex: FireCloudExceptionWithErrorReport => throw fex
         case   t => throw new FireCloudExceptionWithErrorReport(ErrorReport(StatusCodes.InternalServerError, t))

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/CwdsDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/CwdsDAO.scala
@@ -1,6 +1,7 @@
 package org.broadinstitute.dsde.firecloud.dataaccess
 
 import org.broadinstitute.dsde.firecloud.model.{AsyncImportRequest, AsyncImportResponse, ImportServiceListResponse, UserInfo}
+import org.databiosphere.workspacedata.client.ApiException
 import org.databiosphere.workspacedata.model.GenericJob
 
 trait CwdsDAO {
@@ -9,14 +10,17 @@ trait CwdsDAO {
 
   def getSupportedFormats: List[String]
 
+  @throws(classOf[ApiException])
   def listJobsV1(workspaceId: String,
                  runningOnly: Boolean
                 )(implicit userInfo: UserInfo): List[ImportServiceListResponse]
 
+  @throws(classOf[ApiException])
   def getJobV1(workspaceId: String,
                jobId: String
               )(implicit userInfo: UserInfo): ImportServiceListResponse
 
+  @throws(classOf[ApiException])
   def importV1(workspaceId: String,
                asyncImportRequest: AsyncImportRequest
               )(implicit userInfo: UserInfo): GenericJob

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/CwdsDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/CwdsDAO.scala
@@ -13,6 +13,10 @@ trait CwdsDAO {
                  runningOnly: Boolean
                 )(implicit userInfo: UserInfo): List[ImportServiceListResponse]
 
+  def getJobV1(workspaceId: String,
+               jobId: String
+              )(implicit userInfo: UserInfo): ImportServiceListResponse
+
   def importV1(workspaceId: String,
                asyncImportRequest: AsyncImportRequest
               )(implicit userInfo: UserInfo): GenericJob

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpCwdsDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpCwdsDAO.scala
@@ -60,6 +60,13 @@ class HttpCwdsDAO(enabled: Boolean, supportedFormats: List[String]) extends Cwds
       .toList
   }
 
+  override def getJobV1(workspaceId: String, jobId: String)(implicit userInfo: UserInfo): ImportServiceListResponse = {
+    val jobApi: JobApi = new JobApi()
+    jobApi.setApiClient(getApiClient(userInfo.accessToken.token))
+
+    toImportServiceListResponse(jobApi.jobStatusV1(UUID.fromString(jobId)))
+  }
+
   override def importV1(workspaceId: String,
                         asyncImportRequest: AsyncImportRequest
                        )(implicit userInfo: UserInfo): GenericJob = {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ImportServiceDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ImportServiceDAO.scala
@@ -24,4 +24,9 @@ trait ImportServiceDAO {
                runningOnly: Boolean
               )(implicit userInfo: UserInfo): Future[List[ImportServiceListResponse]]
 
+  def getJob(workspaceNamespace: String,
+             workspaceName: String,
+             jobId: String,
+            )(implicit userInfo: UserInfo): Future[ImportServiceListResponse]
+
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiService.scala
@@ -194,7 +194,11 @@ trait WorkspaceApiService extends FireCloudRequestBuilding with FireCloudDirecti
                 path(("importPFB" | "importJob") / Segment) { jobId =>
                   get {
                     requireUserInfo() { userInfo =>
-                      passthrough(Uri(encodeUri(s"${FireCloudConfig.ImportService.server}/$workspaceNamespace/$workspaceName/imports/$jobId")), HttpMethods.GET)
+                      complete {
+                        entityServiceConstructor(FlexibleModelSchema).getJob(workspaceNamespace, workspaceName, jobId, userInfo) map { respBody =>
+                          RequestComplete(OK, respBody)
+                        }
+                      }
                     }
                   }
                 } ~

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/EntityServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/EntityServiceSpec.scala
@@ -10,14 +10,17 @@ import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
 import org.broadinstitute.dsde.firecloud.model.{AsyncImportRequest, EntityUpdateDefinition, FirecloudModelSchema, ImportServiceListResponse, ImportServiceResponse, ModelSchema, RequestCompleteWithErrorReport, UserInfo, WithAccessToken}
 import org.broadinstitute.dsde.firecloud.service.PerRequest.RequestComplete
 import org.broadinstitute.dsde.firecloud.service.{BaseServiceSpec, PerRequest}
-import org.broadinstitute.dsde.rawls.model.{ErrorReport, WorkspaceAccessLevels, WorkspaceBucketOptions, WorkspaceResponse, WorkspaceSubmissionStats}
+import org.broadinstitute.dsde.rawls.model.{ErrorReport, ErrorReportSource}
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GcsObjectName, GcsPath}
+import org.databiosphere.workspacedata.client.ApiException
 import org.databiosphere.workspacedata.model.GenericJob
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.{never, times, verify, when}
+import org.mockito.Mockito.{doThrow, never, times, verify, when}
 import org.parboiled.common.FileUtils
 import org.scalatest.BeforeAndAfterEach
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.time.{Millis, Span}
 import org.scalatestplus.mockito.MockitoSugar.{mock => mockito}
 
 import java.util.UUID
@@ -26,6 +29,9 @@ import scala.concurrent.ExecutionContext.Implicits._
 import scala.concurrent.Future
 
 class EntityServiceSpec extends BaseServiceSpec with BeforeAndAfterEach {
+
+  implicit val errorReportSource: ErrorReportSource = ErrorReportSource("EntityServiceSpec")
+
   override def beforeEach(): Unit = {
     searchDao.reset()
   }
@@ -388,12 +394,193 @@ class EntityServiceSpec extends BaseServiceSpec with BeforeAndAfterEach {
   }
 
   "EntityService.getJob" - {
-    "should return correctly if job found in cWDS" is pending
-    "should return correctly if job not found in cWDS, but is found in Import Service" is pending
-    "should return correctly if cWDS errors, but is found in Import Service" is pending
-    "should return 404 if job not found in either cWDS or Import Service" is pending
-    "should return Import Service's error if job not found in cWDS and Import Service errors" is pending
-    "should return Import Service's error if cWDS errors and Import Service errors" is pending
+
+    val importServiceNotFound = new FireCloudExceptionWithErrorReport(
+      ErrorReport(
+        StatusCodes.NotFound,
+        "Import Service unit test intentional error"))
+
+    "should return correctly if job found in cWDS and not call Import Service" in {
+      val jobId = UUID.randomUUID().toString
+
+      val cwdsResponse = ImportServiceListResponse(jobId, "status1", "filename1", None)
+
+      // set up mocks
+      val cwdsDAO = mockito[MockCwdsDAO]
+      val importServiceDAO = mockito[MockImportServiceDAO]
+
+      when(cwdsDAO.isEnabled).thenReturn(true)
+      when(cwdsDAO.getJobV1(any[String], ArgumentMatchers.eq(jobId))(any[UserInfo]))
+        .thenReturn(cwdsResponse)
+      when(importServiceDAO.getJob(any[String], any[String], ArgumentMatchers.eq(jobId))(any[UserInfo]))
+        .thenReturn(Future.failed(importServiceNotFound))
+
+      // inject mocks to entity service
+      val entityService = getEntityService(mockImportServiceDAO = importServiceDAO, cwdsDAO = cwdsDAO)
+
+      // get job via entity service
+      val actual = entityService.getJob("workspaceNamespace", "workspaceName", jobId, dummyUserInfo("mytoken")).futureValue
+
+      actual shouldBe cwdsResponse
+      verify(importServiceDAO, never).getJob(any[String], any[String], any[String])(any[UserInfo])
+    }
+    "should return correctly if job not found in cWDS, but is found in Import Service" in {
+      val jobId = UUID.randomUUID().toString
+
+      val importServiceResponse = ImportServiceListResponse(jobId, "status1", "filename1", None)
+
+      // set up mocks
+      val cwdsDAO = mockito[MockCwdsDAO]
+      val importServiceDAO = mockito[MockImportServiceDAO]
+
+      when(cwdsDAO.isEnabled).thenReturn(true)
+      doThrow(new ApiException(404, "unit test intentional error"))
+        .when(cwdsDAO).getJobV1(any[String], ArgumentMatchers.eq(jobId))(any[UserInfo])
+      when(importServiceDAO.getJob(any[String], any[String], ArgumentMatchers.eq(jobId))(any[UserInfo]))
+        .thenReturn(Future.successful(importServiceResponse))
+
+      // inject mocks to entity service
+      val entityService = getEntityService(mockImportServiceDAO = importServiceDAO, cwdsDAO = cwdsDAO)
+
+      // get job via entity service
+      val actual = entityService.getJob("workspaceNamespace", "workspaceName", jobId, dummyUserInfo("mytoken")).futureValue
+
+      actual shouldBe importServiceResponse
+    }
+    "should return correctly if cWDS errors, but is found in Import Service" in {
+      val jobId = UUID.randomUUID().toString
+
+      val importServiceResponse = ImportServiceListResponse(jobId, "status1", "filename1", None)
+
+      // set up mocks
+      val cwdsDAO = mockito[MockCwdsDAO]
+      val importServiceDAO = mockito[MockImportServiceDAO]
+
+      when(cwdsDAO.isEnabled).thenReturn(true)
+      doThrow(new ApiException(500, "unit test intentional error"))
+        .when(cwdsDAO).getJobV1(any[String], ArgumentMatchers.eq(jobId))(any[UserInfo])
+      when(importServiceDAO.getJob(any[String], any[String], ArgumentMatchers.eq(jobId))(any[UserInfo]))
+        .thenReturn(Future.successful(importServiceResponse))
+
+      // inject mocks to entity service
+      val entityService = getEntityService(mockImportServiceDAO = importServiceDAO, cwdsDAO = cwdsDAO)
+
+      // get job via entity service
+      val actual = entityService.getJob("workspaceNamespace", "workspaceName", jobId, dummyUserInfo("mytoken")).futureValue
+
+      actual shouldBe importServiceResponse
+    }
+    "should return 404 if job not found in either cWDS or Import Service" in {
+      val jobId = UUID.randomUUID().toString
+
+      // set up mocks
+      val cwdsDAO = mockito[MockCwdsDAO]
+      val importServiceDAO = mockito[MockImportServiceDAO]
+
+      when(cwdsDAO.isEnabled).thenReturn(true)
+      doThrow(new ApiException(404, "cWDS unit test intentional error"))
+        .when(cwdsDAO).getJobV1(any[String], ArgumentMatchers.eq(jobId))(any[UserInfo])
+      when(importServiceDAO.getJob(any[String], any[String], ArgumentMatchers.eq(jobId))(any[UserInfo]))
+        .thenReturn(Future.failed(importServiceNotFound))
+
+      // inject mocks to entity service
+      val entityService = getEntityService(mockImportServiceDAO = importServiceDAO, cwdsDAO = cwdsDAO)
+
+      // get job via entity service
+      val getJobFuture = entityService.getJob("workspaceNamespace", "workspaceName", jobId, dummyUserInfo("mytoken"))
+
+      ScalaFutures.whenReady(getJobFuture.failed) { actual =>
+        actual shouldBe a [FireCloudExceptionWithErrorReport]
+        val fex = actual.asInstanceOf[FireCloudExceptionWithErrorReport]
+        fex.errorReport.statusCode should contain (StatusCodes.NotFound)
+      }
+    }
+    "should return Import Service's error if job not found in cWDS and Import Service errors" in {
+      val jobId = UUID.randomUUID().toString
+
+      // set up mocks
+      val cwdsDAO = mockito[MockCwdsDAO]
+      val importServiceDAO = mockito[MockImportServiceDAO]
+
+      when(cwdsDAO.isEnabled).thenReturn(true)
+      doThrow(new ApiException(404, "cWDS unit test intentional error"))
+        .when(cwdsDAO).getJobV1(any[String], ArgumentMatchers.eq(jobId))(any[UserInfo])
+      when(importServiceDAO.getJob(any[String], any[String], ArgumentMatchers.eq(jobId))(any[UserInfo]))
+        .thenReturn(Future.failed(
+          new FireCloudExceptionWithErrorReport(
+            ErrorReport(
+              StatusCodes.ImATeapot,
+              "Import Service unit test intentional error"))
+        ))
+
+      // inject mocks to entity service
+      val entityService = getEntityService(mockImportServiceDAO = importServiceDAO, cwdsDAO = cwdsDAO)
+
+      // get job via entity service
+      val getJobFuture = entityService.getJob("workspaceNamespace", "workspaceName", jobId, dummyUserInfo("mytoken"))
+
+      ScalaFutures.whenReady(getJobFuture.failed) { actual =>
+        actual shouldBe a [FireCloudExceptionWithErrorReport]
+        val fex = actual.asInstanceOf[FireCloudExceptionWithErrorReport]
+        fex.errorReport.statusCode should contain (StatusCodes.ImATeapot)
+        fex.errorReport.message shouldBe "Import Service unit test intentional error"
+      }
+    }
+    "should return Import Service's error if cWDS errors and Import Service errors" in {
+      val jobId = UUID.randomUUID().toString
+
+      // set up mocks
+      val cwdsDAO = mockito[MockCwdsDAO]
+      val importServiceDAO = mockito[MockImportServiceDAO]
+
+      when(cwdsDAO.isEnabled).thenReturn(true)
+      doThrow(new ApiException(500, "cWDS unit test intentional error"))
+        .when(cwdsDAO).getJobV1(any[String], ArgumentMatchers.eq(jobId))(any[UserInfo])
+      when(importServiceDAO.getJob(any[String], any[String], ArgumentMatchers.eq(jobId))(any[UserInfo]))
+        .thenReturn(Future.failed(
+          new FireCloudExceptionWithErrorReport(
+            ErrorReport(
+              StatusCodes.ImATeapot,
+              "Import Service unit test intentional error"))
+        ))
+
+      // inject mocks to entity service
+      val entityService = getEntityService(mockImportServiceDAO = importServiceDAO, cwdsDAO = cwdsDAO)
+
+      // get job via entity service
+      val getJobFuture = entityService.getJob("workspaceNamespace", "workspaceName", jobId, dummyUserInfo("mytoken"))
+
+      ScalaFutures.whenReady(getJobFuture.failed) { actual =>
+        actual shouldBe a [FireCloudExceptionWithErrorReport]
+        val fex = actual.asInstanceOf[FireCloudExceptionWithErrorReport]
+        fex.errorReport.statusCode should contain (StatusCodes.ImATeapot)
+        fex.errorReport.message shouldBe "Import Service unit test intentional error"
+      }
+    }
+    "should not call cWDS or Rawls if cWDS is not enabled" in {
+      val jobId = UUID.randomUUID().toString
+
+      val importServiceResponse = ImportServiceListResponse(jobId, "status1", "filename1", None)
+
+      // set up mocks
+      val cwdsDAO = mockito[MockCwdsDAO]
+      val importServiceDAO = mockito[MockImportServiceDAO]
+      val mockRawlsDAO = mockito[MockRawlsDAO]
+
+      when(cwdsDAO.isEnabled).thenReturn(false)
+      when(importServiceDAO.getJob(any[String], any[String], ArgumentMatchers.eq(jobId))(any[UserInfo]))
+        .thenReturn(Future.successful(importServiceResponse))
+
+      // inject mocks to entity service
+      val entityService = getEntityService(mockImportServiceDAO = importServiceDAO, cwdsDAO = cwdsDAO, rawlsDAO = mockRawlsDAO)
+
+      // get job via entity service
+      val actual = entityService.getJob("workspaceNamespace", "workspaceName", jobId, dummyUserInfo("mytoken")).futureValue
+
+      actual shouldBe importServiceResponse
+      verify(cwdsDAO, never).getJobV1(any[String], any[String])(any[UserInfo])
+      verify(mockRawlsDAO, never).getWorkspace(any[String], any[String])(any[UserInfo])
+    }
   }
 
   private def getEntityService(mockGoogleServicesDAO: MockGoogleServicesDAO = new MockGoogleServicesDAO,

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/EntityServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/EntityServiceSpec.scala
@@ -387,6 +387,15 @@ class EntityServiceSpec extends BaseServiceSpec with BeforeAndAfterEach {
 
   }
 
+  "EntityService.getJob" - {
+    "should return correctly if job found in cWDS" is pending
+    "should return correctly if job not found in cWDS, but is found in Import Service" is pending
+    "should return correctly if cWDS errors, but is found in Import Service" is pending
+    "should return 404 if job not found in either cWDS or Import Service" is pending
+    "should return Import Service's error if job not found in cWDS and Import Service errors" is pending
+    "should return Import Service's error if cWDS errors and Import Service errors" is pending
+  }
+
   private def getEntityService(mockGoogleServicesDAO: MockGoogleServicesDAO = new MockGoogleServicesDAO,
                                mockImportServiceDAO: MockImportServiceDAO = new MockImportServiceDAO,
                                rawlsDAO: MockRawlsDAO = new MockRawlsDAO,

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockCwdsDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockCwdsDAO.scala
@@ -15,6 +15,9 @@ class MockCwdsDAO(enabled: Boolean = true) extends CwdsDAO {
   override def listJobsV1(workspaceId: String, runningOnly: Boolean)(implicit userInfo: UserInfo)
   : List[ImportServiceListResponse] = List()
 
+  override def getJobV1(workspaceId: String, jobId: String)(implicit userInfo: UserInfo): ImportServiceListResponse =
+    ImportServiceListResponse(jobId, "ReadyForUpsert", "pfb", None)
+
   override def importV1(workspaceId: String,
                         asyncImportRequest: AsyncImportRequest
                        )(implicit userInfo: UserInfo): GenericJob = {

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockImportServiceDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockImportServiceDAO.scala
@@ -44,4 +44,9 @@ class MockImportServiceDAO extends ImportServiceDAO {
   : Future[List[ImportServiceListResponse]] = {
     Future.successful(List.empty[ImportServiceListResponse])
   }
+
+  override def getJob(workspaceNamespace: String, workspaceName: String, jobId: String)(implicit userInfo: UserInfo)
+  : Future[ImportServiceListResponse] = {
+    Future.successful(ImportServiceListResponse(jobId, "status", "filetype", None))
+  }
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiServiceSpec.scala
@@ -1159,45 +1159,6 @@ class WorkspaceApiServiceSpec extends BaseServiceSpec with WorkspaceApiService w
 
     }
 
-    "WorkspaceService importPFB job-status Tests" - {
-
-      List(importJobStatusPath, pfbImportPath) foreach { pathUnderTest =>
-        s"Successful passthrough should return OK with payload for $pathUnderTest" in {
-
-          val jobId = UUID.randomUUID().toString
-
-          val responsePayload = JsObject(
-            ("id", JsString(jobId)),
-            ("status", JsString("Running"))
-          )
-
-          importServiceServer
-            .when(request()
-              .withMethod("GET")
-              .withPath(s"/${workspace.namespace}/${workspace.name}/imports/$jobId"))
-            .respond(org.mockserver.model.HttpResponse.response()
-              .withStatusCode(OK.intValue)
-              .withBody(responsePayload.compactPrint)
-              .withHeader("Content-Type", "application/json"))
-
-          (Get(s"$pathUnderTest/$jobId")
-            ~> dummyUserIdHeaders(dummyUserId)
-            ~> sealRoute(workspaceRoutes)) ~> check {
-            status should equal(OK)
-            responseAs[String].parseJson should be (responsePayload) // to address string-formatting issues
-          }
-        }
-
-        s"Passthrough should not pass unrecognized HTTP verbs for $pathUnderTest" in {
-          (Delete(s"$pathUnderTest/dummyJobId")
-            ~> dummyUserIdHeaders(dummyUserId)
-            ~> sealRoute(workspaceRoutes)) ~> check {
-            status should equal(MethodNotAllowed)
-          }
-        }
-      }
-    }
-
     "WorkspaceService POST importJob Tests" - {
 
       List(FILETYPE_PFB, FILETYPE_TDR) foreach { filetype =>


### PR DESCRIPTION
AJ-1602

When asking for the status of a given import job:
* if cWDS is enabled, ask cWDS for that job
* if found in cWDS, return the job
* if cWDS failed to return the job, or was disabled, ask Import Service for that job and return whatever Import Service returns, even if it's an error/not found

At the implementation level, this required changing the get-job API from a pure passthrough to a full implementation. This is similar to what we did in #1305.

---

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [x] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
