### PR TITLE
AJ-1571: re-enable one AsyncImportSpec test

### DIFF
--- a/.github/workflows/orch-build-tag-publish-and-run-tests.yml
+++ b/.github/workflows/orch-build-tag-publish-and-run-tests.yml
@@ -157,6 +157,9 @@ jobs:
       contents: 'read'
       id-token: 'write'
     steps:
+      - name: Determine Branch Name
+        id: branch-names
+        uses: tj-actions/branch-names@v8
       - name: dispatch to terra-github-workflows
         uses: broadinstitute/workflow-dispatch@v4
         with:
@@ -167,6 +170,7 @@ jobs:
           # manually recalculate b/c env context is broken https://github.com/actions/runner/issues/480
           inputs: '{
               "bee-name": "orch-${{ github.run_id }}-${{ matrix.terra-env }}",
+              "ref": "${{ steps.branch-names.current_branch }}",
               "ENV": "${{ matrix.testing-env }}",
               "test-context": "${{ needs.prepare-configs.outputs.test-context }}"
             }'

--- a/.github/workflows/orch-build-tag-publish-and-run-tests.yml
+++ b/.github/workflows/orch-build-tag-publish-and-run-tests.yml
@@ -170,7 +170,7 @@ jobs:
           # manually recalculate b/c env context is broken https://github.com/actions/runner/issues/480
           inputs: '{
               "bee-name": "orch-${{ github.run_id }}-${{ matrix.terra-env }}",
-              "ref": "${{ steps.branch-names.current_branch }}",
+              "ref": "${{ steps.branch-names.outputs.current_branch }}",
               "ENV": "${{ matrix.testing-env }}",
               "test-context": "${{ needs.prepare-configs.outputs.test-context }}"
             }'

--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   val jacksonHotfixV = "2.13.5" // for when only some of the Jackson libs have hotfix releases
   val akkaV = "2.6.19"
   val akkaHttpV = "10.2.10"
-  val workbenchLibsHash = "8ccaa6d"
+  val workbenchLibsHash = "1c0cf92"
 
   val workbenchModelV  = s"0.19-$workbenchLibsHash"
   val workbenchModel: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-model" % workbenchModelV
@@ -17,7 +17,7 @@ object Dependencies {
   val workbenchGoogle: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-google" % workbenchGoogleV excludeAll excludeWorkbenchModel
   val excludeWorkbenchGoogle = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-google_" + scalaV)
 
-  val workbenchServiceTestV = s"4.2-$workbenchLibsHash"
+  val workbenchServiceTestV = s"4.3-$workbenchLibsHash"
   val workbenchServiceTest: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-service-test" % workbenchServiceTestV % "test" classifier "tests" excludeAll (excludeWorkbenchGoogle, excludeWorkbenchModel)
 
   // Overrides for transitive dependencies. These apply - via Settings.scala - to all projects in this codebase.

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/AsyncImportSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/AsyncImportSpec.scala
@@ -52,7 +52,7 @@ class AsyncImportSpec
   "Orchestration" - {
 
     "should import a PFB file via import service" - {
-      "for the owner of a workspace" ignore {
+      "for the owner of a workspace" in {
         implicit val token: AuthToken = ownerAuthToken
 
         withTemporaryBillingProject(billingAccountId) { projectName =>


### PR DESCRIPTION
AJ-1571

Re-enables one of the `AsyncImportSpec` swat tests which were previously ignored. This is a precursor to running this test against cWDS.

---

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [x] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
