### PR TITLE
Add deprecation note for workspaceSubmissionStats (WOR-1568).

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -8980,7 +8980,8 @@ components:
         workspace:
           $ref: '#/components/schemas/WorkspaceDetails'
         workspaceSubmissionStats:
-          $ref: '#/components/schemas/WorkspaceSubmissionStats'
+          description: GCP workspace submission statistics, deprecated as part of the list response due to slow performance. This field will continue to be supported on individual workspace details.
+          deprecated: true
       description: ""
     WorkspaceRequest:
       required:
@@ -9085,7 +9086,7 @@ components:
         runningSubmissionsCount:
           type: integer
           description: Count of all the running submissions
-      description: Statistics about submissions in a workspace
+      description: Statistics about submissions in a workspace (only supported for GCP workspaces)
     WorkspaceTag:
       required:
         - count


### PR DESCRIPTION
Related to https://github.com/broadinstitute/rawls/pull/2791

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
