### PR TITLE
Azure control plane

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/Boot.scala
@@ -2,7 +2,6 @@ package org.broadinstitute.dsde.firecloud
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
-import akka.http.scaladsl.server.Directives._
 import cats.effect.IO
 import cats.effect.unsafe.IORuntime
 import com.typesafe.scalalogging.LazyLogging
@@ -10,12 +9,14 @@ import org.broadinstitute.dsde.firecloud.dataaccess._
 import org.broadinstitute.dsde.firecloud.elastic.ElasticUtils
 import org.broadinstitute.dsde.firecloud.model.{ModelSchema, UserInfo, WithAccessToken}
 import org.broadinstitute.dsde.firecloud.service._
+import org.broadinstitute.dsde.firecloud.utils.DisabledServiceFactory
 import org.broadinstitute.dsde.workbench.oauth2.{ClientId, ClientSecret, OpenIDConnectConfiguration}
 import org.broadinstitute.dsde.workbench.util.health.HealthMonitor
 import org.elasticsearch.client.transport.TransportClient
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
+import scala.reflect.ClassTag
 
 object Boot extends App with LazyLogging {
 
@@ -23,22 +24,7 @@ object Boot extends App with LazyLogging {
     // we need an ActorSystem to host our application in
     implicit val system: ActorSystem = ActorSystem("FireCloud-Orchestration-API")
 
-    val elasticSearchClient: TransportClient = ElasticUtils.buildClient(FireCloudConfig.ElasticSearch.servers, FireCloudConfig.ElasticSearch.clusterName)
-
-    val agoraDAO:AgoraDAO = new HttpAgoraDAO(FireCloudConfig.Agora)
-    val rawlsDAO:RawlsDAO = new HttpRawlsDAO
-    val samDAO:SamDAO = new HttpSamDAO
-    val thurloeDAO:ThurloeDAO = new HttpThurloeDAO
-    val googleServicesDAO:GoogleServicesDAO = new HttpGoogleServicesDAO(FireCloudConfig.GoogleCloud.priceListUrl, GooglePriceList(GooglePrices(FireCloudConfig.GoogleCloud.defaultStoragePriceList, UsTieredPriceItem(FireCloudConfig.GoogleCloud.defaultEgressPriceList)), "v1", "1"))
-    val ontologyDAO:OntologyDAO = new ElasticSearchOntologyDAO(elasticSearchClient, FireCloudConfig.ElasticSearch.ontologyIndexName)
-    val researchPurposeSupport:ResearchPurposeSupport = new ESResearchPurposeSupport(ontologyDAO)
-    val searchDAO:SearchDAO = new ElasticSearchDAO(elasticSearchClient, FireCloudConfig.ElasticSearch.indexName, researchPurposeSupport)
-    val shareLogDAO:ShareLogDAO = new ElasticSearchShareLogDAO(elasticSearchClient, FireCloudConfig.ElasticSearch.shareLogIndexName)
-    val importServiceDAO:ImportServiceDAO = new HttpImportServiceDAO
-    val shibbolethDAO:ShibbolethDAO = new HttpShibbolethDAO
-    val cwdsDAO:CwdsDAO = new HttpCwdsDAO(FireCloudConfig.Cwds.enabled, FireCloudConfig.Cwds.supportedFormats)
-
-    val app:Application = Application(agoraDAO, googleServicesDAO, ontologyDAO, rawlsDAO, samDAO, searchDAO, researchPurposeSupport, thurloeDAO, shareLogDAO, importServiceDAO, shibbolethDAO, cwdsDAO);
+    val app: Application = buildApplication
 
     val agoraPermissionServiceConstructor: (UserInfo) => AgoraPermissionService = AgoraPermissionService.constructor(app)
     val exportEntitiesByTypeActorConstructor: (ExportEntitiesByTypeArguments) => ExportEntitiesByTypeActor = ExportEntitiesByTypeActor.constructor(app, system)
@@ -99,6 +85,39 @@ object Boot extends App with LazyLogging {
 
     } yield {
 
+    }
+  }
+
+  private def buildApplication(implicit system: ActorSystem) = {
+    // can't be disabled
+    val rawlsDAO: RawlsDAO = new HttpRawlsDAO
+    val samDAO: SamDAO = new HttpSamDAO
+    val thurloeDAO: ThurloeDAO = new HttpThurloeDAO
+
+    // can be disabled
+    val agoraDAO: AgoraDAO = whenEnabled(FireCloudConfig.Agora.enabled, new HttpAgoraDAO(FireCloudConfig.Agora))
+    val googleServicesDAO: GoogleServicesDAO = whenEnabled(FireCloudConfig.GoogleCloud.enabled, new HttpGoogleServicesDAO(FireCloudConfig.GoogleCloud.priceListUrl, GooglePriceList(GooglePrices(FireCloudConfig.GoogleCloud.defaultStoragePriceList, UsTieredPriceItem(FireCloudConfig.GoogleCloud.defaultEgressPriceList)), "v1", "1")))
+    val importServiceDAO: ImportServiceDAO = whenEnabled(FireCloudConfig.ImportService.enabled, new HttpImportServiceDAO)
+    val shibbolethDAO: ShibbolethDAO = whenEnabled(FireCloudConfig.Shibboleth.enabled, new HttpShibbolethDAO)
+    val cwdsDAO: CwdsDAO = whenEnabled(FireCloudConfig.Cwds.enabled, new HttpCwdsDAO(FireCloudConfig.Cwds.enabled, FireCloudConfig.Cwds.supportedFormats))
+
+    val elasticSearchClient: Option[TransportClient] = Option.when(FireCloudConfig.ElasticSearch.enabled) {
+      ElasticUtils.buildClient(FireCloudConfig.ElasticSearch.servers, FireCloudConfig.ElasticSearch.clusterName)
+    }
+
+    val ontologyDAO: OntologyDAO = elasticSearchClient.map(new ElasticSearchOntologyDAO(_, FireCloudConfig.ElasticSearch.ontologyIndexName)).getOrElse(DisabledServiceFactory.newDisabledService)
+    val researchPurposeSupport: ResearchPurposeSupport = new ESResearchPurposeSupport(ontologyDAO)
+    val searchDAO: SearchDAO = elasticSearchClient.map(new ElasticSearchDAO(_, FireCloudConfig.ElasticSearch.indexName, researchPurposeSupport)).getOrElse(DisabledServiceFactory.newDisabledService)
+    val shareLogDAO: ShareLogDAO = elasticSearchClient.map(new ElasticSearchShareLogDAO(_, FireCloudConfig.ElasticSearch.shareLogIndexName)).getOrElse(DisabledServiceFactory.newDisabledService)
+
+    Application(agoraDAO, googleServicesDAO, ontologyDAO, rawlsDAO, samDAO, searchDAO, researchPurposeSupport, thurloeDAO, shareLogDAO, importServiceDAO, shibbolethDAO, cwdsDAO)
+  }
+
+  private def whenEnabled[T : ClassTag](enabled: Boolean, realService: => T): T = {
+    if (enabled) {
+      realService
+    } else {
+      DisabledServiceFactory.newDisabledService
     }
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
@@ -23,17 +23,18 @@ object FireCloudConfig {
     // implicit flow. Remove once we fully migrate to B2C.
     val legacyGoogleClientId = auth.optionalString("legacyGoogleClientId")
     // credentials for orchestration's "firecloud" service account, used for admin duties
-    val firecloudAdminSAJsonFile = auth.getString("firecloudAdminSA")
+    lazy val firecloudAdminSAJsonFile = auth.getString("firecloudAdminSA")
     // credentials for the rawls service account, used for signing GCS urls
-    val rawlsSAJsonFile = auth.getString("rawlsSA")
+    lazy val rawlsSAJsonFile = auth.getString("rawlsSA")
   }
 
   object Agora {
-    private val methods = config.getConfig("methods")
-    private val agora = config.getConfig("agora")
-    val baseUrl = agora.getString("baseUrl")
-    val authPrefix = methods.getString("authPrefix")
-    val authUrl = baseUrl + authPrefix
+    private lazy val methods = config.getConfig("methods")
+    private lazy val agora = config.getConfig("agora")
+    lazy val baseUrl = agora.getString("baseUrl")
+    lazy val authPrefix = methods.getString("authPrefix")
+    lazy val authUrl = baseUrl + authPrefix
+    val enabled = agora.optionalBoolean("enabled").getOrElse(true)
   }
 
   object Rawls {
@@ -48,17 +49,13 @@ object FireCloudConfig {
     val entitiesPath = workspace.getString("entitiesPath")
     val entityQueryPath = workspace.getString("entityQueryPath")
     val entityBagitMaximumSize = workspace.getInt("entityBagitMaximumSize")
-    val importEntitiesPath = workspace.getString("importEntitiesPath")
     val workspacesEntitiesCopyPath = workspace.getString("workspacesEntitiesCopyPath")
     def workspacesEntitiesCopyUrl(linkExistingEntities: Boolean) = authUrl + workspacesEntitiesCopyPath + "?linkExistingEntities=%s".format(linkExistingEntities)
     val submissionsCountPath = workspace.getString("submissionsCountPath")
     val submissionsPath = workspace.getString("submissionsPath")
-    val submissionsUrl = authUrl + submissionsPath
     val submissionsIdPath = workspace.getString("submissionsIdPath")
     val submissionsWorkflowIdPath = workspace.getString("submissionsWorkflowIdPath")
     val submissionsWorkflowIdOutputsPath = workspace.getString("submissionsWorkflowIdOutputsPath")
-    val overwriteGroupMembershipPath = workspace.getString("overwriteGroupMembershipPath")
-    val alterGroupMembershipPath = workspace.getString("alterGroupMembershipPath")
     val createGroupPath = workspace.getString("createGroup")
     val submissionQueueStatusPath = workspace.getString("submissionQueueStatusPath")
     val submissionQueueStatusUrl = authUrl + submissionQueueStatusPath
@@ -70,9 +67,6 @@ object FireCloudConfig {
 
     def entityPathFromWorkspace(namespace: String, name: String) = authUrl + entitiesPath.format(namespace, name)
     def entityQueryPathFromWorkspace(namespace: String, name: String) = authUrl + entityQueryPath.format(namespace, name)
-    def importEntitiesPathFromWorkspace(namespace: String, name: String) = authUrl + importEntitiesPath.format(namespace, name)
-    def overwriteGroupMembershipUrlFromGroupName(groupName: String, role: String) = authUrl + overwriteGroupMembershipPath.format(groupName, role)
-    def alterGroupMembershipUrlFromGroupName(groupName: String, role: String, email: String) = authUrl + alterGroupMembershipPath.format(groupName, role, email)
     def createGroup(groupName: String) = authUrl + createGroupPath.format(groupName)
     def entityQueryUriFromWorkspaceAndQuery(workspaceNamespace: String, workspaceName: String, entityType: String, query: Option[EntityQuery] = None): Uri = {
       val baseEntityQueryUri = Uri(FireCloudDirectiveUtils.encodeUri(s"${entityQueryPathFromWorkspace(workspaceNamespace, workspaceName)}/$entityType"))
@@ -99,10 +93,11 @@ object FireCloudConfig {
   }
 
   object CromIAM {
-    private val cromIam = config.getConfig("cromiam")
-    val baseUrl = cromIam.getString("baseUrl")
-    val authPrefix = cromIam.getString("authPrefix")
-    val authUrl = baseUrl + authPrefix
+    private lazy val cromIam = config.getConfig("cromiam")
+    lazy val baseUrl = cromIam.getString("baseUrl")
+    lazy val authPrefix = cromIam.getString("authPrefix")
+    lazy val authUrl = baseUrl + authPrefix
+    val enabled = cromIam.optionalBoolean("enabled").getOrElse(true)
   }
 
   object Thurloe {
@@ -121,32 +116,32 @@ object FireCloudConfig {
   }
 
   object Cwds {
-    private val cwds = config.getConfig("cwds")
-    val baseUrl: String = cwds.getString("baseUrl")
-    val enabled: Boolean = cwds.getBoolean("enabled")
-    val supportedFormats: List[String] = cwds.getStringList("supportedFormats").asScala.toList
+    private lazy val cwds = config.getConfig("cwds")
+    lazy val baseUrl: String = cwds.getString("baseUrl")
+    lazy val enabled: Boolean = cwds.getBoolean("enabled")
+    lazy val supportedFormats: List[String] = cwds.getStringList("supportedFormats").asScala.toList
   }
 
   object FireCloud {
     private val firecloud = config.getConfig("firecloud")
     val baseUrl = firecloud.getString("baseUrl")
     val fireCloudId = firecloud.getString("fireCloudId")
-    val fireCloudPortalUrl = firecloud.getString("portalUrl")
-    val serviceProject = firecloud.getString("serviceProject")
+    lazy val serviceProject = firecloud.getString("serviceProject")
     val supportDomain = firecloud.getString("supportDomain")
     val supportPrefix = firecloud.getString("supportPrefix")
-    val userAdminAccount = firecloud.getString("userAdminAccount")
+    lazy val userAdminAccount = firecloud.getString("userAdminAccount")
   }
 
   object Shibboleth {
-    private val shibboleth = config.getConfig("shibboleth")
-    val publicKeyUrl = shibboleth.getString("publicKeyUrl")
+    private lazy val shibboleth = config.getConfig("shibboleth")
+    lazy val publicKeyUrl = shibboleth.getString("publicKeyUrl")
+    val enabled = shibboleth.optionalBoolean("enabled").getOrElse(true)
   }
 
   object Nih {
-    private val nih = config.getConfig("nih")
-    val whitelistBucket = nih.getString("whitelistBucket")
-    val whitelists: Set[NihWhitelist] = {
+    private lazy val nih = config.getConfig("nih")
+    lazy val whitelistBucket = nih.getString("whitelistBucket")
+    lazy val whitelists: Set[NihWhitelist] = {
       val whitelistConfigs = nih.getConfig("whitelists")
 
       whitelistConfigs.root.asScala.collect { case (name, configObject:ConfigObject) =>
@@ -157,17 +152,19 @@ object FireCloudConfig {
         NihWhitelist(name, WorkbenchGroupName(rawlsGroup), fileName)
       }
     }.toSet
+    val enabled = nih.optionalBoolean("enabled").getOrElse(true)
   }
 
   object ElasticSearch {
-    private val elasticsearch = config.getConfig("elasticsearch")
-    val servers: Seq[Authority] = parseESServers(elasticsearch.getString("urls"))
-    val clusterName = elasticsearch.getString("clusterName")
-    val indexName = elasticsearch.getString("index") // for library
-    val ontologyIndexName = elasticsearch.getString("ontologyIndex")
-    val discoverGroupNames = elasticsearch.getStringList("discoverGroupNames")
-    val shareLogIndexName: String = elasticsearch.getString("shareLogIndex")
-    val maxAggregations: Int = Try(elasticsearch.getInt("maxAggregations")).getOrElse(1000)
+    private lazy val elasticsearch = config.getConfig("elasticsearch")
+    lazy val servers: Seq[Authority] = parseESServers(elasticsearch.getString("urls"))
+    lazy val clusterName = elasticsearch.getString("clusterName")
+    lazy val indexName = elasticsearch.getString("index") // for library
+    lazy val ontologyIndexName = elasticsearch.getString("ontologyIndex")
+    lazy val discoverGroupNames = elasticsearch.getStringList("discoverGroupNames")
+    lazy val shareLogIndexName: String = elasticsearch.getString("shareLogIndex")
+    lazy val maxAggregations: Int = Try(elasticsearch.getInt("maxAggregations")).getOrElse(1000)
+    val enabled = elasticsearch.optionalBoolean("enabled").getOrElse(true)
   }
 
   def parseESServers(confString: String): Seq[Authority] = {
@@ -178,31 +175,28 @@ object FireCloudConfig {
   }
 
   object GoogleCloud {
-    private val googlecloud = config.getConfig("googlecloud")
-    val priceListUrl = googlecloud.getString("priceListUrl")
-    val priceListEgressKey = googlecloud.getString("priceListEgressKey")
-    val priceListStorageKey = googlecloud.getString("priceListStorageKey")
-    val defaultStoragePriceListConf = googlecloud.getConfig("defaultStoragePriceList")
-    val defaultStoragePriceList = defaultStoragePriceListConf.root().keySet().asScala.map(key => key -> BigDecimal(defaultStoragePriceListConf.getDouble(key))).toMap
-    val defaultEgressPriceListConf = googlecloud.getConfig("defaultEgressPriceList")
-    val defaultEgressPriceList = defaultEgressPriceListConf.root().keySet().asScala.map(key => key.toLong -> BigDecimal(defaultEgressPriceListConf.getDouble(key))).toMap
+    private lazy val googlecloud = config.getConfig("googlecloud")
+    lazy val priceListUrl = googlecloud.getString("priceListUrl")
+    lazy val priceListEgressKey = googlecloud.getString("priceListEgressKey")
+    lazy val priceListStorageKey = googlecloud.getString("priceListStorageKey")
+    lazy val defaultStoragePriceListConf = googlecloud.getConfig("defaultStoragePriceList")
+    lazy val defaultStoragePriceList = defaultStoragePriceListConf.root().keySet().asScala.map(key => key -> BigDecimal(defaultStoragePriceListConf.getDouble(key))).toMap
+    lazy val defaultEgressPriceListConf = googlecloud.getConfig("defaultEgressPriceList")
+    lazy val defaultEgressPriceList = defaultEgressPriceListConf.root().keySet().asScala.map(key => key.toLong -> BigDecimal(defaultEgressPriceListConf.getDouble(key))).toMap
+    val enabled = googlecloud.optionalBoolean("enabled").getOrElse(true)
   }
 
   object Duos {
-    private val duos = config.getConfig("duos")
-    val baseOntologyUrl = duos.getString("baseOntologyUrl")
-    val dulvn = duos.getInt("dulvn")
-  }
-
-  object Spray {
-    private val spray = config.getConfig("spray")
-    // grab a copy of this Spray setting to use when displaying an error message
-    lazy val chunkLimit = spray.getString("can.client.response-chunk-aggregation-limit")
+    private lazy val duos = config.getConfig("duos")
+    lazy val baseOntologyUrl = duos.getString("baseOntologyUrl")
+    lazy val dulvn = duos.getInt("dulvn")
+    val enabled = duos.optionalBoolean("enabled").getOrElse(true)
   }
 
   object Notification {
-    private val notification = config.getConfig("notification")
-    val fullyQualifiedNotificationTopic: String = notification.getString("fullyQualifiedNotificationTopic")
+    private lazy val notification = config.getConfig("notification")
+    lazy val fullyQualifiedNotificationTopic: String = notification.getString("fullyQualifiedNotificationTopic")
+    val enabled = notification.optionalBoolean("enabled").getOrElse(true)
   }
 
   object StaticNotebooks {
@@ -213,7 +207,7 @@ object FireCloudConfig {
   object ImportService {
     lazy val server: String = config.getString("importService.server")
     lazy val bucket: String = config.getString("importService.bucketName")
-    lazy val enabled: Boolean = config.optionalBoolean("importService.enabled").getOrElse(true)
+    val enabled: Boolean = config.optionalBoolean("importService.enabled").getOrElse(true)
   }
 
   implicit class RichConfig(val config: Config) {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
@@ -23,12 +23,15 @@ object FireCloudConfig {
     // implicit flow. Remove once we fully migrate to B2C.
     val legacyGoogleClientId = auth.optionalString("legacyGoogleClientId")
     // credentials for orchestration's "firecloud" service account, used for admin duties
+    // lazy - only required when google is enabled
     lazy val firecloudAdminSAJsonFile = auth.getString("firecloudAdminSA")
-    // credentials for the rawls service account, used for signing GCS urls
+    // credentials for the rawls service account, used for writing files to buckets for import
+    // lazy - only required when import service is enabled
     lazy val rawlsSAJsonFile = auth.getString("rawlsSA")
   }
 
   object Agora {
+    // lazy - only required when agora is enabled
     private lazy val methods = config.getConfig("methods")
     private lazy val agora = config.getConfig("agora")
     lazy val baseUrl = agora.getString("baseUrl")
@@ -93,6 +96,7 @@ object FireCloudConfig {
   }
 
   object CromIAM {
+    // lazy - only required when cromiam is enabled
     private lazy val cromIam = config.getConfig("cromiam")
     lazy val baseUrl = cromIam.getString("baseUrl")
     lazy val authPrefix = cromIam.getString("authPrefix")
@@ -116,6 +120,7 @@ object FireCloudConfig {
   }
 
   object Cwds {
+    // lazy - only required when cwds is enabled
     private lazy val cwds = config.getConfig("cwds")
     lazy val baseUrl: String = cwds.getString("baseUrl")
     lazy val enabled: Boolean = cwds.getBoolean("enabled")
@@ -126,19 +131,23 @@ object FireCloudConfig {
     private val firecloud = config.getConfig("firecloud")
     val baseUrl = firecloud.getString("baseUrl")
     val fireCloudId = firecloud.getString("fireCloudId")
+    // lazy - only required when google is enabled
     lazy val serviceProject = firecloud.getString("serviceProject")
     val supportDomain = firecloud.getString("supportDomain")
     val supportPrefix = firecloud.getString("supportPrefix")
+    // lazy - only required when google is enabled
     lazy val userAdminAccount = firecloud.getString("userAdminAccount")
   }
 
   object Shibboleth {
+    // lazy - only required when shibboleth is enabled
     private lazy val shibboleth = config.getConfig("shibboleth")
     lazy val publicKeyUrl = shibboleth.getString("publicKeyUrl")
     val enabled = shibboleth.optionalBoolean("enabled").getOrElse(true)
   }
 
   object Nih {
+    // lazy - only required when nih is enabled
     private lazy val nih = config.getConfig("nih")
     lazy val whitelistBucket = nih.getString("whitelistBucket")
     lazy val whitelists: Set[NihWhitelist] = {
@@ -156,6 +165,7 @@ object FireCloudConfig {
   }
 
   object ElasticSearch {
+    // lazy - only required when elasticsearch is enabled
     private lazy val elasticsearch = config.getConfig("elasticsearch")
     lazy val servers: Seq[Authority] = parseESServers(elasticsearch.getString("urls"))
     lazy val clusterName = elasticsearch.getString("clusterName")
@@ -175,6 +185,7 @@ object FireCloudConfig {
   }
 
   object GoogleCloud {
+    // lazy - only required when google is enabled
     private lazy val googlecloud = config.getConfig("googlecloud")
     lazy val priceListUrl = googlecloud.getString("priceListUrl")
     lazy val priceListEgressKey = googlecloud.getString("priceListEgressKey")
@@ -187,6 +198,7 @@ object FireCloudConfig {
   }
 
   object Duos {
+    // lazy - only required when duos is enabled
     private lazy val duos = config.getConfig("duos")
     lazy val baseOntologyUrl = duos.getString("baseOntologyUrl")
     lazy val dulvn = duos.getInt("dulvn")
@@ -194,6 +206,7 @@ object FireCloudConfig {
   }
 
   object Notification {
+    // lazy - only required when notification is enabled
     private lazy val notification = config.getConfig("notification")
     lazy val fullyQualifiedNotificationTopic: String = notification.getString("fullyQualifiedNotificationTopic")
     val enabled = notification.optionalBoolean("enabled").getOrElse(true)
@@ -205,6 +218,7 @@ object FireCloudConfig {
   }
 
   object ImportService {
+    // lazy - only required when import service is enabled
     lazy val server: String = config.getString("importService.server")
     lazy val bucket: String = config.getString("importService.bucketName")
     val enabled: Boolean = config.optionalBoolean("importService.enabled").getOrElse(true)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/utils/DisabledServiceFactory.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/utils/DisabledServiceFactory.scala
@@ -1,0 +1,23 @@
+package org.broadinstitute.dsde.firecloud.utils
+
+import java.lang.reflect.Proxy
+import scala.reflect.{ClassTag, classTag}
+
+object DisabledServiceFactory {
+
+  /**
+   * Create a new instance of a service that throws UnsupportedOperationException for all methods.
+   * Implemented using a dynamic proxy.
+   * @tparam T the type of the service, must be a trait
+   * @return a new instance of the service that throws UnsupportedOperationException for all methods
+   */
+  def newDisabledService[T: ClassTag]: T =
+    Proxy
+      .newProxyInstance(
+        classTag[T].runtimeClass.getClassLoader,
+        Array(classTag[T].runtimeClass),
+        (_, method, _) =>
+          throw new UnsupportedOperationException(s"${method.toGenericString} is disabled.")
+      )
+      .asInstanceOf[T]
+}

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/Ga4ghApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/Ga4ghApiService.scala
@@ -12,7 +12,7 @@ trait Ga4ghApiService extends FireCloudDirectives {
 
   implicit val executionContext: ExecutionContext
 
-  private val agoraGA4GH = s"${FireCloudConfig.Agora.baseUrl}/ga4gh/v1"
+  private lazy val agoraGA4GH = s"${FireCloudConfig.Agora.baseUrl}/ga4gh/v1"
 
   val ga4ghRoutes: Route =
     pathPrefix("ga4gh") {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/MethodsApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/MethodsApiService.scala
@@ -13,11 +13,11 @@ import spray.json.DefaultJsonProtocol._
 import scala.concurrent.ExecutionContext
 
 trait MethodsApiServiceUrls {
-  val remoteMethodsPath = FireCloudConfig.Agora.authPrefix + "/methods"
-  val remoteMethodsUrl = FireCloudConfig.Agora.baseUrl + remoteMethodsPath
-  val remoteConfigurationsPath = FireCloudConfig.Agora.authPrefix + "/configurations"
-  val remoteConfigurationsUrl = FireCloudConfig.Agora.baseUrl + remoteConfigurationsPath
-  val remoteMultiPermissionsUrl = remoteMethodsUrl + "/permissions"
+  lazy val remoteMethodsPath = FireCloudConfig.Agora.authPrefix + "/methods"
+  lazy val remoteMethodsUrl = FireCloudConfig.Agora.baseUrl + remoteMethodsPath
+  lazy val remoteConfigurationsPath = FireCloudConfig.Agora.authPrefix + "/configurations"
+  lazy val remoteConfigurationsUrl = FireCloudConfig.Agora.baseUrl + remoteConfigurationsPath
+  lazy val remoteMultiPermissionsUrl = remoteMethodsUrl + "/permissions"
 
   val localMethodsPath = "methods"
   val localConfigsPath = "configurations"

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/StatusApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/StatusApiServiceSpec.scala
@@ -5,9 +5,10 @@ import org.broadinstitute.dsde.firecloud.HealthChecks
 import org.broadinstitute.dsde.firecloud.service.{BaseServiceSpec, StatusService}
 import org.broadinstitute.dsde.workbench.util.health.StatusJsonSupport.StatusCheckResponseFormat
 import org.broadinstitute.dsde.workbench.util.health.Subsystems._
-import org.broadinstitute.dsde.workbench.util.health.{HealthMonitor, StatusCheckResponse}
+import org.broadinstitute.dsde.workbench.util.health.{HealthMonitor, StatusCheckResponse, Subsystems}
 import akka.http.scaladsl.model.HttpMethods.GET
 import akka.http.scaladsl.model.StatusCodes.OK
+import org.broadinstitute.dsde.firecloud.dataaccess.{AgoraDAO, GoogleServicesDAO, OntologyDAO, SearchDAO}
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
@@ -61,8 +62,12 @@ class StatusApiServiceSpec extends BaseServiceSpec with StatusApiService with Sp
     "should contain all the subsystems we care about" in {
       Get(statusPath) ~> statusRoutes ~> check {
         val statusCheckResponse = responseAs[StatusCheckResponse]
-        val expectedSystems = Set(Agora, GoogleBuckets, LibraryIndex, OntologyIndex, Rawls, Sam, Thurloe)
-        assertResult(expectedSystems) { statusCheckResponse.systems.keySet }
+        val expectedSystems = Set(
+          Agora, Rawls, Sam, Thurloe,
+          Subsystems.withName(GoogleServicesDAO.serviceName),
+          Subsystems.withName(SearchDAO.serviceName),
+          Subsystems.withName(OntologyDAO.serviceName))
+          assertResult(expectedSystems) { statusCheckResponse.systems.keySet }
       }
     }
   }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/StatusApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/StatusApiServiceSpec.scala
@@ -67,7 +67,10 @@ class StatusApiServiceSpec extends BaseServiceSpec with StatusApiService with Sp
           Subsystems.withName(GoogleServicesDAO.serviceName),
           Subsystems.withName(SearchDAO.serviceName),
           Subsystems.withName(OntologyDAO.serviceName))
-          assertResult(expectedSystems) { statusCheckResponse.systems.keySet }
+
+        assertResult(expectedSystems) {
+          statusCheckResponse.systems.keySet
+        }
       }
     }
   }


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/TOAZ-345

When orch needs to run without various services, e.g. Agora, the associated config is replaced with `enabled=false` and the associated DAO, e.g. `AgoraDAO`, is replaced with a dummy implementation (a proxy) that throws an error for every method call (similar to rawls). See the ticket for list of services that can be disabled. Disabled services should not be checked by the health check.

Much of orch's config was loaded at startup time into `val`s. Any non-optional config for disableable services were switched to `lazy`.

In doing this I discovered that the error handling on startup was faulty, exceptions did not cause the JVM to terminate and were lost unless explicitly handled. Fixed.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
