### PR TITLE
AJ-1743: delete billing-passthrough swat tests

### DIFF
--- a/.github/workflows/orch-build-tag-publish-and-run-tests.yml
+++ b/.github/workflows/orch-build-tag-publish-and-run-tests.yml
@@ -169,7 +169,7 @@ jobs:
               "bee-name": "orch-${{ github.run_id }}-${{ matrix.terra-env }}",
               "ENV": "${{ matrix.testing-env }}",
               "test-context": "${{ needs.prepare-configs.outputs.test-context }}",
-              "ref": "${{ github.head_ref }}"
+              "ref": ""
             }'
 
   destroy-bee-workflow:

--- a/.github/workflows/orch-build-tag-publish-and-run-tests.yml
+++ b/.github/workflows/orch-build-tag-publish-and-run-tests.yml
@@ -168,7 +168,8 @@ jobs:
           inputs: '{
               "bee-name": "orch-${{ github.run_id }}-${{ matrix.terra-env }}",
               "ENV": "${{ matrix.testing-env }}",
-              "test-context": "${{ needs.prepare-configs.outputs.test-context }}"
+              "test-context": "${{ needs.prepare-configs.outputs.test-context }}",
+              "ref": "${{ github.head_ref }}"
             }'
 
   destroy-bee-workflow:

--- a/.github/workflows/orch-build-tag-publish-and-run-tests.yml
+++ b/.github/workflows/orch-build-tag-publish-and-run-tests.yml
@@ -169,7 +169,7 @@ jobs:
               "bee-name": "orch-${{ github.run_id }}-${{ matrix.terra-env }}",
               "ENV": "${{ matrix.testing-env }}",
               "test-context": "${{ needs.prepare-configs.outputs.test-context }}",
-              "ref": ""
+              "ref": "${{ github.head_ref }}"
             }'
 
   destroy-bee-workflow:

--- a/.github/workflows/orch-build-tag-publish-and-run-tests.yml
+++ b/.github/workflows/orch-build-tag-publish-and-run-tests.yml
@@ -171,6 +171,8 @@ jobs:
               "test-context": "${{ needs.prepare-configs.outputs.test-context }}",
               "ref": "${{ github.head_ref }}"
             }'
+          # github.head_ref, used above, is only populated for PRs and will be blank when merging to develop.
+          # This is ok; the orch-swat-tests workflow uses "develop" as a default when receiving a blank value.
 
   destroy-bee-workflow:
     strategy:

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/OrchestrationApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/OrchestrationApiSpec.scala
@@ -72,7 +72,8 @@ class OrchestrationApiSpec
       } finally resetNihLinkToInactive()
     }
 
-    "should get the user's billing projects" in {
+    // this tests a passthrough; no need for it
+    "should get the user's billing projects" ignore {
       val ownerUser: Credentials = UserPool.chooseProjectOwner
       val ownerToken: AuthToken = ownerUser.makeAuthToken()
       withTemporaryBillingProject(billingAccountId) { projectName =>
@@ -88,7 +89,7 @@ class OrchestrationApiSpec
 
     "querying for an individual billing project status" - {
 
-      "should get the user's billing project" in {
+      "should get the user's billing project" ignore {
         val ownerUser: Credentials = UserPool.chooseProjectOwner
         val ownerToken: AuthToken = ownerUser.makeAuthToken()
         withTemporaryBillingProject(billingAccountId) { projectName =>
@@ -103,7 +104,7 @@ class OrchestrationApiSpec
         }(ownerUser.makeAuthToken(billingScopes))
       }
 
-      "should not find a non-existent billing project" in {
+      "should not find a non-existent billing project" ignore {
         val ownerUser: Credentials = UserPool.chooseProjectOwner
         val ownerToken: AuthToken = ownerUser.makeAuthToken()
 
@@ -115,7 +116,7 @@ class OrchestrationApiSpec
         getException.message should include(StatusCodes.NotFound.defaultMessage)
       }
 
-      "should not find a billing project for user without billing project access" in {
+      "should not find a billing project for user without billing project access" ignore {
         val ownerUser: Credentials = UserPool.chooseProjectOwner
         val user: Credentials = UserPool.chooseStudent
         val userToken: AuthToken = user.makeAuthToken()


### PR DESCRIPTION
AJ-1743

Two changes in this PR:
1. Delete 4 swat tests which were just testing behavior of an underlying system, since the Orch API is just a passthrough.
2. Tweak how swat tests run. Swat tests should run the test code in your PR, so as a developer you can make changes to swat test code and see those changes in action. Before this PR, we would always run swat tests from the `develop` branch.