### PR TITLE
disable anonymized email when google is disabled

### DIFF
--- a/.github/workflows/orch-build-tag-publish-and-run-tests.yml
+++ b/.github/workflows/orch-build-tag-publish-and-run-tests.yml
@@ -23,6 +23,7 @@ jobs:
       id-token: 'write'
     outputs:
       tag: ${{ steps.tag.outputs.tag }}
+      custom-version-json: ${{ steps.publish-orch.outputs.custom-version-json }}
     steps:
       - uses: 'actions/checkout@v4'
 

--- a/.github/workflows/orch-build-tag-publish-and-run-tests.yml
+++ b/.github/workflows/orch-build-tag-publish-and-run-tests.yml
@@ -168,7 +168,8 @@ jobs:
           inputs: '{
               "bee-name": "orch-${{ github.run_id }}-${{ matrix.terra-env }}",
               "ENV": "${{ matrix.testing-env }}",
-              "test-context": "${{ needs.prepare-configs.outputs.test-context }}"
+              "test-context": "${{ needs.prepare-configs.outputs.test-context }}",
+              "ref": "${{ github.ref_name }}"
             }'
 
   destroy-bee-workflow:

--- a/.github/workflows/orch-build-tag-publish-and-run-tests.yml
+++ b/.github/workflows/orch-build-tag-publish-and-run-tests.yml
@@ -73,7 +73,8 @@ jobs:
           docker build -t ${{ github.event.repository.full_name }}:${DOCKER_TAG} --pull .
           docker tag ${{ github.event.repository.full_name }}:${DOCKER_TAG} ${{ env.GCR_REGISTRY }}:${DOCKER_TAG}
           gcloud docker -- push $GCR_REGISTRY:${DOCKER_TAG}
-    
+          echo 'custom-version-json={\"firecloudorch\":{\"appVersion\":\"${{ env.DOCKER_TAG }}\"}}' >> $GITHUB_OUTPUT
+
   prepare-configs:
     runs-on: ubuntu-latest
     outputs:
@@ -168,8 +169,7 @@ jobs:
           inputs: '{
               "bee-name": "orch-${{ github.run_id }}-${{ matrix.terra-env }}",
               "ENV": "${{ matrix.testing-env }}",
-              "test-context": "${{ needs.prepare-configs.outputs.test-context }}",
-              "ref": "${{ github.ref_name }}"
+              "test-context": "${{ needs.prepare-configs.outputs.test-context }}"
             }'
 
   destroy-bee-workflow:

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
@@ -129,13 +129,12 @@ object FireCloudConfig {
 
   object FireCloud {
     private val firecloud = config.getConfig("firecloud")
-    val baseUrl = firecloud.getString("baseUrl")
     val fireCloudId = firecloud.getString("fireCloudId")
+
     // lazy - only required when google is enabled
     lazy val serviceProject = firecloud.getString("serviceProject")
-    val supportDomain = firecloud.getString("supportDomain")
-    val supportPrefix = firecloud.getString("supportPrefix")
-    // lazy - only required when google is enabled
+    lazy val supportDomain = firecloud.getString("supportDomain")
+    lazy val supportPrefix = firecloud.getString("supportPrefix")
     lazy val userAdminAccount = firecloud.getString("userAdminAccount")
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/GoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/GoogleServicesDAO.scala
@@ -11,7 +11,7 @@ import java.io.InputStream
 import scala.concurrent.{ExecutionContext, Future}
 
 object GoogleServicesDAO {
-  lazy val serviceName = "Google"
+  lazy val serviceName = "GoogleBuckets"
 }
 
 trait GoogleServicesDAO extends ReportsSubsystemStatus {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/OntologyDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/OntologyDAO.scala
@@ -7,7 +7,7 @@ import org.broadinstitute.dsde.rawls.model.ErrorReportSource
 import scala.concurrent.{ExecutionContext, Future}
 
 object OntologyDAO {
-  lazy val serviceName = "Ontology"
+  lazy val serviceName = "OntologyIndex"
 }
 
 trait OntologyDAO extends ReportsSubsystemStatus {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/SearchDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/SearchDAO.scala
@@ -8,7 +8,7 @@ import org.broadinstitute.dsde.rawls.model.ErrorReportSource
 import scala.concurrent.Future
 
 object SearchDAO {
-  lazy val serviceName = "Search"
+  lazy val serviceName = "LibraryIndex"
 }
 
 trait SearchDAO extends LazyLogging with ReportsSubsystemStatus {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/UserService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/UserService.scala
@@ -189,10 +189,10 @@ class UserService(rawlsDAO: RawlsDAO, thurloeDAO: ThurloeDAO, googleServicesDAO:
     val futureKeys:Future[ProfileWrapper] = getAllKeysFromThurloe(userToken)
     futureKeys flatMap { keys: ProfileWrapper =>
       getProfileValue(keys, UserService.AnonymousGroupKey) match { // getProfileValue returns Option[String]
-        case None | Some("") => {
+        case None | Some("") if FireCloudConfig.GoogleCloud.enabled => {
           setupAnonymizedGoogleGroup(keys, getNewAnonymousGroupName)
         }
-        case Some(_) => {
+        case _ => {
           Future(RequestComplete(keys))
         }
       }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/StatusApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/StatusApiServiceSpec.scala
@@ -5,10 +5,9 @@ import org.broadinstitute.dsde.firecloud.HealthChecks
 import org.broadinstitute.dsde.firecloud.service.{BaseServiceSpec, StatusService}
 import org.broadinstitute.dsde.workbench.util.health.StatusJsonSupport.StatusCheckResponseFormat
 import org.broadinstitute.dsde.workbench.util.health.Subsystems._
-import org.broadinstitute.dsde.workbench.util.health.{HealthMonitor, StatusCheckResponse, Subsystems}
+import org.broadinstitute.dsde.workbench.util.health.{HealthMonitor, StatusCheckResponse}
 import akka.http.scaladsl.model.HttpMethods.GET
 import akka.http.scaladsl.model.StatusCodes.OK
-import org.broadinstitute.dsde.firecloud.dataaccess.{AgoraDAO, GoogleServicesDAO, OntologyDAO, SearchDAO}
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
@@ -62,15 +61,8 @@ class StatusApiServiceSpec extends BaseServiceSpec with StatusApiService with Sp
     "should contain all the subsystems we care about" in {
       Get(statusPath) ~> statusRoutes ~> check {
         val statusCheckResponse = responseAs[StatusCheckResponse]
-        val expectedSystems = Set(
-          Agora, Rawls, Sam, Thurloe,
-          Subsystems.withName(GoogleServicesDAO.serviceName),
-          Subsystems.withName(SearchDAO.serviceName),
-          Subsystems.withName(OntologyDAO.serviceName))
-
-        assertResult(expectedSystems) {
-          statusCheckResponse.systems.keySet
-        }
+        val expectedSystems = Set(Agora, GoogleBuckets, LibraryIndex, OntologyIndex, Rawls, Sam, Thurloe)
+        assertResult(expectedSystems) { statusCheckResponse.systems.keySet }
       }
     }
   }


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/TOAZ-345

missed this in the first PR, only generate an anonymous email group when google is enabled

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
