### PR TITLE
isEnabled in disabled service returns false

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/utils/DisabledServiceFactory.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/utils/DisabledServiceFactory.scala
@@ -6,7 +6,8 @@ import scala.reflect.{ClassTag, classTag}
 object DisabledServiceFactory {
 
   /**
-   * Create a new instance of a service that throws UnsupportedOperationException for all methods.
+   * Create a new instance of a service that throws UnsupportedOperationException for all methods
+   * unless the method is boolean isEnabled(), in which case return false.
    * Implemented using a dynamic proxy.
    * @tparam T the type of the service, must be a trait
    * @return a new instance of the service that throws UnsupportedOperationException for all methods
@@ -17,7 +18,10 @@ object DisabledServiceFactory {
         classTag[T].runtimeClass.getClassLoader,
         Array(classTag[T].runtimeClass),
         (_, method, _) =>
-          throw new UnsupportedOperationException(s"${method.toGenericString} is disabled.")
+          if (method.getName.equals("isEnabled") && method.getParameterCount == 0 && method.getReturnType == classOf[Boolean])
+            false
+          else
+            throw new UnsupportedOperationException(s"${method.toGenericString} is disabled.")
       )
       .asInstanceOf[T]
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/utils/DisabledServiceFactoryTest.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/utils/DisabledServiceFactoryTest.scala
@@ -1,0 +1,35 @@
+package org.broadinstitute.dsde.firecloud.utils
+
+import org.broadinstitute.dsde.firecloud.dataaccess.CwdsDAO
+import org.broadinstitute.dsde.firecloud.model.UserInfo
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+class DisabledServiceFactoryTest extends AnyFreeSpec with Matchers {
+  "DisabledServiceFactory" - {
+    "newDisabledService" - {
+      "should return a new instance of the service that throws UnsupportedOperationException for all methods except isEnabled" in {
+        implicit val userInfo: UserInfo = null
+
+        val disabledService = DisabledServiceFactory.newDisabledService[CwdsDAO]
+        assertThrows[UnsupportedOperationException] {
+          disabledService.getSupportedFormats
+        }
+        assertThrows[UnsupportedOperationException] {
+          disabledService.listJobsV1("workspaceId", runningOnly = true)
+        }
+        assertThrows[UnsupportedOperationException] {
+          disabledService.getJobV1("workspaceId", "jobId")
+        }
+        assertThrows[UnsupportedOperationException] {
+          disabledService.importV1("workspaceId", null)
+        }
+      }
+
+      "should return a new instance of the service that returns false for isEnabled" in {
+        val disabledService = DisabledServiceFactory.newDisabledService[CwdsDAO]
+        disabledService.isEnabled shouldBe false
+      }
+    }
+  }
+}


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/PROD-945

add special handling for isEnabled in disabled service proxy

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
