### PR TITLE
only b2c in swagger

### DIFF
--- a/local-dev/templates/firecloud-orchestration.conf.ctmpl
+++ b/local-dev/templates/firecloud-orchestration.conf.ctmpl
@@ -64,7 +64,7 @@ akka {
 auth {
 	authorityEndpoint = "https://terra{{ $b2cTenant }}b2c.b2clogin.com/terra{{ $b2cTenant }}b2c.onmicrosoft.com/v2.0?p=b2c_1a_signup_signin_{{ $b2cEnv }}"
 	oidcClientId = "{{ $b2cAppId }}"
-	b2cProfileWithGoogleBillingScope = "b2c_1a_signup_signin_billing_{{ $b2cEnv }}"
+	authorityEndpointWithGoogleBillingScope = "https://terra{{ $b2cTenant }}b2c.b2clogin.com/terra{{ $b2cTenant }}b2c.onmicrosoft.com/v2.0?p=b2c_1a_signup_signin_billing_{{ $b2cEnv }}"
 
 	pemFile = "/etc/firecloud-account.pem"
 	pemFileClientId = "{{ $firecloudSaKey.client_email }}"

--- a/local-dev/templates/firecloud-orchestration.conf.ctmpl
+++ b/local-dev/templates/firecloud-orchestration.conf.ctmpl
@@ -64,7 +64,7 @@ akka {
 auth {
 	authorityEndpoint = "https://terra{{ $b2cTenant }}b2c.b2clogin.com/terra{{ $b2cTenant }}b2c.onmicrosoft.com/v2.0?p=b2c_1a_signup_signin_{{ $b2cEnv }}"
 	oidcClientId = "{{ $b2cAppId }}"
-	legacyGoogleClientId = "{{ $refreshTokenCredential.web.client_id }}"
+	b2cProfileWithGoogleBillingScope = "b2c_1a_signup_signin_billing_{{ $b2cEnv }}"
 
 	pemFile = "/etc/firecloud-account.pem"
 	pemFileClientId = "{{ $firecloudSaKey.client_email }}"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
   val jacksonV = "2.13.5"
   val jacksonHotfixV = "2.13.5" // for when only some of the Jackson libs have hotfix releases
   val nettyV = "4.1.108.Final"
-  val workbenchLibsHash = "d314413" // see https://github.com/broadinstitute/workbench-libs readme for hash values
+  val workbenchLibsHash = "5762674" // see https://github.com/broadinstitute/workbench-libs readme for hash values
 
   def excludeGuava(m: ModuleID): ModuleID = m.exclude("com.google.guava", "guava")
   val excludeAkkaActor =        ExclusionRule(organization = "com.typesafe.akka", name = "akka-actor_2.13")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -52,7 +52,7 @@ object Dependencies {
       excludeAll(excludeAkkaHttp, excludeSprayJson),
     excludeGuava("org.broadinstitute.dsde.workbench" %% "workbench-util"  % s"0.10-$workbenchLibsHash"),
     "org.broadinstitute.dsde.workbench" %% "workbench-google2" % s"0.36-$workbenchLibsHash",
-    "org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % s"0.6-$workbenchLibsHash",
+    "org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % s"0.7-$workbenchLibsHash",
     "org.broadinstitute.dsde.workbench" %% "sam-client"       % "0.1-ef83073",
     "org.broadinstitute.dsde.workbench" %% "workbench-notifications" %s"0.6-$workbenchLibsHash",
     "org.databiosphere" % "workspacedataservice-client-okhttp-jakarta" % "0.2.118-SNAPSHOT",

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -9771,22 +9771,10 @@ components:
             $ref: '#/components/schemas/ErrorReport'
   securitySchemes:
     oidc:
-      type: oauth2
-      flows:
-        authorizationCode:
-          authorizationUrl: /oauth2/authorize
-          tokenUrl: /oauth2/token
-          scopes:
-            openid: open id authorization
-            email: email authorization
-            profile: profile authorization
+      type: openIdConnect
+      openIdConnectUrl: OPEN_ID_CONNECT_URL
+      x-tokenName: id_token
     oidc_google_billing_scope:
-      type: oauth2
-      flows:
-        authorizationCode:
-          authorizationUrl: /oauth2/authorize?p=B2C_PROFILE_WITH_GOOGLE_BILLING_SCOPE
-          tokenUrl: /oauth2/token?p=B2C_PROFILE_WITH_GOOGLE_BILLING_SCOPE
-          scopes:
-            openid: open id authorization
-            email: email authorization
-            profile: profile authorization
+      type: openIdConnect
+      openIdConnectUrl: OPEN_ID_CONNECT_URL_WITH_GOOGLE_BILLING_SCOPE
+      x-tokenName: id_token

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -35,10 +35,6 @@ tags:
   - name: Womtool
   - name: Workspaces
 security:
-  - googleoauth:
-      - openid
-      - email
-      - profile
   - oidc:
       - openid
       - email
@@ -207,11 +203,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorReport'
       security:
-        - googleoauth:
+        - oidc_google_billing_scope:
             - openid
             - email
             - profile
-            - https://www.googleapis.com/auth/cloud-billing
       x-codegen-request-body-name: createProjectRequest
   /api/billing/v2/{projectId}:
     get:
@@ -301,6 +296,11 @@ paths:
             'application/json':
               schema:
                 $ref: '#/components/schemas/ErrorReport'
+      security:
+        - oidc_google_billing_scope:
+            - openid
+            - email
+            - profile
       x-passthrough: true
       x-passthrough-target: rawls
     delete:
@@ -2579,11 +2579,10 @@ paths:
           description: Internal Server Error
           content: {}
       security:
-        - googleoauth:
+        - oidc_google_billing_scope:
             - openid
             - email
             - profile
-            - https://www.googleapis.com/auth/cloud-billing
       x-passthrough: true
       x-passthrough-target: rawls
   /api/profile/importstatus:
@@ -9771,22 +9770,22 @@ components:
           schema:
             $ref: '#/components/schemas/ErrorReport'
   securitySchemes:
-    googleoauth:
-      type: oauth2
-      flows:
-        implicit:
-          authorizationUrl: https://accounts.google.com/o/oauth2/auth
-          scopes:
-            openid: open id authorization
-            email: email authorization
-            profile: profile authorization
-            https://www.googleapis.com/auth/cloud-billing: GCS billing
     oidc:
       type: oauth2
       flows:
         authorizationCode:
           authorizationUrl: /oauth2/authorize
           tokenUrl: /oauth2/token
+          scopes:
+            openid: open id authorization
+            email: email authorization
+            profile: profile authorization
+    oidc_google_billing_scope:
+      type: oauth2
+      flows:
+        authorizationCode:
+          authorizationUrl: /oauth2/authorize?p=B2C_PROFILE_WITH_GOOGLE_BILLING_SCOPE
+          tokenUrl: /oauth2/token?p=B2C_PROFILE_WITH_GOOGLE_BILLING_SCOPE
           scopes:
             openid: open id authorization
             email: email authorization

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/Boot.scala
@@ -54,7 +54,7 @@ object Boot extends App with LazyLogging {
         FireCloudConfig.Auth.authorityEndpoint,
         ClientId(FireCloudConfig.Auth.oidcClientId),
         extraAuthParams = Some("prompt=login"),
-        b2cProfileWithGoogleBillingScope = FireCloudConfig.Auth.b2cProfileWithGoogleBillingScope
+        authorityEndpointWithGoogleBillingScope = FireCloudConfig.Auth.authorityEndpointWithGoogleBillingScope
       ).unsafeToFuture()(IORuntime.global)
 
       service <- Future {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/Boot.scala
@@ -10,7 +10,7 @@ import org.broadinstitute.dsde.firecloud.elastic.ElasticUtils
 import org.broadinstitute.dsde.firecloud.model.{ModelSchema, UserInfo, WithAccessToken}
 import org.broadinstitute.dsde.firecloud.service._
 import org.broadinstitute.dsde.firecloud.utils.DisabledServiceFactory
-import org.broadinstitute.dsde.workbench.oauth2.{ClientId, ClientSecret, OpenIDConnectConfiguration}
+import org.broadinstitute.dsde.workbench.oauth2.{ClientId, OpenIDConnectConfiguration}
 import org.broadinstitute.dsde.workbench.util.health.HealthMonitor
 import org.elasticsearch.client.transport.TransportClient
 
@@ -53,9 +53,8 @@ object Boot extends App with LazyLogging {
       oauth2Config <- OpenIDConnectConfiguration[IO](
         FireCloudConfig.Auth.authorityEndpoint,
         ClientId(FireCloudConfig.Auth.oidcClientId),
-        oidcClientSecret = FireCloudConfig.Auth.oidcClientSecret.map(ClientSecret),
-        extraGoogleClientId = FireCloudConfig.Auth.legacyGoogleClientId.map(ClientId),
-        extraAuthParams = Some("prompt=login")
+        extraAuthParams = Some("prompt=login"),
+        b2cProfileWithGoogleBillingScope = FireCloudConfig.Auth.b2cProfileWithGoogleBillingScope
       ).unsafeToFuture()(IORuntime.global)
 
       service <- Future {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
@@ -18,7 +18,7 @@ object FireCloudConfig {
     // OIDC configuration using PKCE flow
     val authorityEndpoint = auth.getString("authorityEndpoint")
     val oidcClientId = auth.getString("oidcClientId")
-    val b2cProfileWithGoogleBillingScope = auth.optionalString("b2cProfileWithGoogleBillingScope")
+    val authorityEndpointWithGoogleBillingScope = auth.optionalString("authorityEndpointWithGoogleBillingScope")
 
     // credentials for orchestration's "firecloud" service account, used for admin duties
     // lazy - only required when google is enabled

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
@@ -18,10 +18,8 @@ object FireCloudConfig {
     // OIDC configuration using PKCE flow
     val authorityEndpoint = auth.getString("authorityEndpoint")
     val oidcClientId = auth.getString("oidcClientId")
-    val oidcClientSecret = auth.optionalString("oidcClientSecret")
-    // legacyGoogleClientId is displayed as a separate option in Swagger UI using
-    // implicit flow. Remove once we fully migrate to B2C.
-    val legacyGoogleClientId = auth.optionalString("legacyGoogleClientId")
+    val b2cProfileWithGoogleBillingScope = auth.optionalString("b2cProfileWithGoogleBillingScope")
+
     // credentials for orchestration's "firecloud" service account, used for admin duties
     // lazy - only required when google is enabled
     lazy val firecloudAdminSAJsonFile = auth.getString("firecloudAdminSA")


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/TOAZ-349

update to latest version of workbench-libs oauth2 and adopt open api `securitySchemes`:
```
    oidc:
      type: openIdConnect
      openIdConnectUrl: OPEN_ID_CONNECT_URL
      x-tokenName: id_token
    oidc_google_billing_scope:
      type: openIdConnect
      openIdConnectUrl: OPEN_ID_CONNECT_URL_WITH_GOOGLE_BILLING_SCOPE
      x-tokenName: id_token
```

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
