### PR TITLE
AJ-1721: deprecate bagit import

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -3780,6 +3780,7 @@ paths:
     post:
       tags:
         - Entities
+      deprecated: true
       summary: Import entity TSVs from a zipped [BagIt](https://tools.ietf.org/html/draft-kunze-bagit-14)
         directory, whose payload contains two files - participants.tsv and samples.tsv
       operationId: importBagit


### PR DESCRIPTION
AJ-1721

The `POST /api/workspaces/{workspaceNamespace}/{workspaceName}/importBagit` API is now deprecated and will be fully deleted on or after May 16, 2024.

This API supports import into data tables from the [Bagit](https://en.wikipedia.org/wiki/BagIt) file format, aka [BDBag](https://bd2k.ini.usc.edu/tools/bdbag/). This file format is no longer used by Terra or Terra's partners.

Developer's note: this API has seen zero traffic in the last 90 days according to Logit, and zero traffic _through the UI_ for 1 year according to Mixpanel. Beth has checked with partners in DataBiosphere and none of our integrations has a desire to use this file format.

-----

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
