### PR TITLE
ID-1219 Add nih sync logging and extend max uri length for local dev.

### DIFF
--- a/local-dev/templates/firecloud-orchestration.conf.ctmpl
+++ b/local-dev/templates/firecloud-orchestration.conf.ctmpl
@@ -34,6 +34,7 @@ akka {
       request-timeout = infinite
       server-header = ""
       parsing {
+        max-uri-length = 16k
         max-content-length = 50m
       }
     }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/NihService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/NihService.scala
@@ -117,7 +117,7 @@ class NihService(val samDao: SamDAO, val thurloeDao: ThurloeDAO, val googleDao: 
       // The request to rawls to completely overwrite the group
       // with the list of actively linked users on the whitelist
       _ <- samDao.overwriteGroupMembers(nihWhitelist.groupToSync, ManagedGroupRoles.Member, members)(getAdminAccessToken) recoverWith {
-        case _: Exception => throw new FireCloudException("Error synchronizing NIH whitelist")
+        case e: Exception => throw new FireCloudException(s"Error synchronizing NIH whitelist: ${e.getMessage}")
       }
     } yield ()
   }


### PR DESCRIPTION
Adds logging of an error we would have found useful when debugging ncbiaccess syncing stuff. Also a follow up to https://github.com/broadinstitute/terra-helmfile/pull/5432 to just keep the local setup in line with live envs. 

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [x] Get two thumbsworth of review and PO signoff if necessary
- [x] Verify all tests go green
- [x] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [x] Test this change deployed correctly and works on dev environment after deployment
