### PR TITLE
[WOR-1581] Add organization to Rawls billing project response

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -6823,6 +6823,15 @@ components:
         managedResourceGroupId:
           type: string
           description: ID of the Azure managed resource group for this managed application deployment.
+    RawlsBillingProjectOrganization:
+      required:
+        - enterprise
+      type: object
+      description: Details about billing project's organization. Only present if billing project is backed by a billing profile.
+      properties:
+        enterprise:
+          type: boolean
+          description: whether this billing project is part of an enterprise organization i.e. they have a signed business associate agreement (BAA)
     CuratorStatus:
       required:
         - curator
@@ -7843,6 +7852,8 @@ components:
           type: string
           format: uuid
           description: the UUID of the landing zone associated with the project (cloudPlatform AZURE only)
+        organization:
+          $ref: '#/components/schemas/RawlsBillingProjectOrganization'
     RawlsGroupRef:
       type: object
       properties:


### PR DESCRIPTION
Ticket: [WOR-1581](https://broadworkbench.atlassian.net/browse/WOR-1581)
* Update Swagger to include organization in `RawlsBillingProjectResponse`. See https://github.com/broadinstitute/rawls/pull/2840 for details

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment


[WOR-1581]: https://broadworkbench.atlassian.net/browse/WOR-1581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ