### PR TITLE
AJ-1790 cwds async

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -55,7 +55,7 @@ object Dependencies {
     "org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % s"0.6-$workbenchLibsHash",
     "org.broadinstitute.dsde.workbench" %% "sam-client"       % "0.1-ef83073",
     "org.broadinstitute.dsde.workbench" %% "workbench-notifications" %s"0.6-$workbenchLibsHash",
-    "org.databiosphere" % "workspacedataservice-client-okhttp-jakarta" % "0.2.119-SNAPSHOT",
+    "org.databiosphere" % "workspacedataservice-client-okhttp-jakarta" % "0.2.140-SNAPSHOT",
 
     "com.typesafe.akka"   %%  "akka-actor"           % akkaV,
     "com.typesafe.akka"   %%  "akka-slf4j"           % akkaV,

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/EntityService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/EntityService.scala
@@ -227,8 +227,7 @@ class EntityService(rawlsDAO: RawlsDAO, importServiceDAO: ImportServiceDAO, cwds
     val insertedObject = googleServicesDAO.writeObjectAsRawlsSA(bucketToWrite, fileToWrite, dataBytes)
     val gcsPath = s"gs://${insertedObject.bucketName.value}/${insertedObject.objectName.value}"
 
-    val importRequest = AsyncImportRequest(gcsPath, FILETYPE_RAWLS)
-//    val importRequest = AsyncImportRequest(gcsPath, FILETYPE_RAWLS, Some(ImportOptions(None, Some(isUpsert))))
+    val importRequest = AsyncImportRequest(gcsPath, FILETYPE_RAWLS, Some(ImportOptions(None, Some(isUpsert))))
 
     if (cwdsDAO.isEnabled && cwdsDAO.getSupportedFormats.contains(importRequest.filetype.toLowerCase)) {
       // translate the workspace namespace/name into an id

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/EntityService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/EntityService.scala
@@ -228,7 +228,22 @@ class EntityService(rawlsDAO: RawlsDAO, importServiceDAO: ImportServiceDAO, cwds
     val gcsPath = s"gs://${insertedObject.bucketName.value}/${insertedObject.objectName.value}"
 
     val importRequest = AsyncImportRequest(gcsPath, FILETYPE_RAWLS)
-    importServiceDAO.importJob(workspaceNamespace, workspaceName, importRequest, isUpsert)(userInfo)
+//    val importRequest = AsyncImportRequest(gcsPath, FILETYPE_RAWLS, Some(ImportOptions(None, Some(isUpsert))))
+
+    if (cwdsDAO.isEnabled && cwdsDAO.getSupportedFormats.contains(importRequest.filetype.toLowerCase)) {
+      // translate the workspace namespace/name into an id
+      rawlsDAO.getWorkspace(workspaceNamespace, workspaceName)(userInfo) map { workspace =>
+        // create the job in cWDS
+      val cwdsJob = cwdsDAO.importV1(workspace.workspace.workspaceId, importRequest)(userInfo)
+        // massage the cWDS job into the response format Orch requires
+        val asyncImportResponse = AsyncImportResponse(url = importRequest.url,
+          jobId = cwdsJob.getJobId.toString,
+          workspace = WorkspaceName(workspaceNamespace, workspaceName))
+        RequestComplete(Accepted, asyncImportResponse)
+    }
+    } else {
+      importServiceDAO.importJob(workspaceNamespace, workspaceName, importRequest, isUpsert)(userInfo)
+    }
   }
 
   private def handleBatchRawlsResponse(entityType: String, response: Future[HttpResponse]): Future[PerRequestMessage] = {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpCwdsDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpCwdsDAO.scala
@@ -37,7 +37,8 @@ class HttpCwdsDAO(enabled: Boolean, supportedFormats: List[String]) extends Cwds
 
   private final val TYPE_TRANSLATION: Map[String, ImportRequest.TypeEnum] = Map(
     "pfb" -> ImportRequest.TypeEnum.PFB,
-    "tdrexport" -> ImportRequest.TypeEnum.TDRMANIFEST
+    "tdrexport" -> ImportRequest.TypeEnum.TDRMANIFEST,
+    "rawlsjson" -> ImportRequest.TypeEnum.RAWLSJSON
   )
 
   override def isEnabled: Boolean = enabled
@@ -85,6 +86,10 @@ class HttpCwdsDAO(enabled: Boolean, supportedFormats: List[String]) extends Cwds
     asyncImportRequest.options.map { opts =>
       opts.tdrSyncPermissions.map { tdrSyncPermissions =>
         importRequest.setOptions(Map[String, Object]("tdrSyncPermissions" -> tdrSyncPermissions.asInstanceOf[Object]).asJava)
+      }
+      opts.isUpsert.map { isUpsert =>
+        importRequest.setOptions(Map[String, Object]("isUpsert" -> isUpsert.asInstanceOf[Object]).asJava)
+
       }
     }
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
@@ -239,7 +239,7 @@ object ModelJsonProtocol extends WorkspaceJsonSupport with SprayJsonSupport {
 
   implicit val impBagitImportRequest: RootJsonFormat[BagitImportRequest] = jsonFormat2(BagitImportRequest)
   implicit val impPFBImportRequest: RootJsonFormat[PFBImportRequest] = jsonFormat1(PFBImportRequest)
-  implicit val impOptions: RootJsonFormat[ImportOptions] = jsonFormat1(ImportOptions)
+  implicit val impOptions: RootJsonFormat[ImportOptions] = jsonFormat2(ImportOptions)
   implicit val impAsyncImportRequest: RootJsonFormat[AsyncImportRequest] = jsonFormat3(AsyncImportRequest)
   implicit val impAsyncImportResponse: RootJsonFormat[AsyncImportResponse] = jsonFormat3(AsyncImportResponse)
   implicit val impImportServiceRequest: RootJsonFormat[ImportServiceRequest] = jsonFormat4(ImportServiceRequest)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/Workspace.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/Workspace.scala
@@ -28,7 +28,7 @@ case class BagitImportRequest(bagitURL: String, format: String)
 case class PFBImportRequest(url: String)
 
 // additional import options
-case class ImportOptions(tdrSyncPermissions: Option[Boolean] = None)
+case class ImportOptions(tdrSyncPermissions: Option[Boolean] = None, isUpsert: Option[Boolean] = None)
 // the request payload sent by users to Orchestration for async PFB and TDR snapshot imports
 case class AsyncImportRequest(url: String, filetype: String, options: Option[ImportOptions] = None)
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/EntityServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/EntityServiceSpec.scala
@@ -228,49 +228,6 @@ class EntityServiceSpec extends BaseServiceSpec with BeforeAndAfterEach {
           }
     }
 
-//    "should send sample tsv to cWDS with appropriate options when cWDS is enabled and supports rawlsjson" in {
-//      // set up mocks
-//      val importServiceDAO = mockito[MockImportServiceDAO]
-//      val cwdsDAO = mockito[MockCwdsDAO]
-//      val rawlsDAO = mockito[MockRawlsDAO]
-//
-//      // inject mocks to entity service
-//      val entityService = getEntityService(mockImportServiceDAO = importServiceDAO, cwdsDAO = cwdsDAO, rawlsDAO = rawlsDAO)
-//
-//      // set up behaviors
-//      val genericJob: GenericJob = new GenericJob
-//      genericJob.setJobId(UUID.randomUUID())
-//      // the "new MockRawlsDAO()" here is only to get access to a pre-canned WorkspaceResponse object
-//      val workspaceResponse = new MockRawlsDAO().rawlsWorkspaceResponseWithAttributes
-//
-//      when(cwdsDAO.isEnabled).thenReturn(true)
-//      when(cwdsDAO.getSupportedFormats).thenReturn(List("pfb","tdrexport", "rawlsjson"))
-//      when(importServiceDAO.importJob(any[String], any[String], any[AsyncImportRequest], any[Boolean])(any[UserInfo]))
-//        .thenReturn(Future.successful(RequestComplete(StatusCodes.Accepted, "")))
-//      when(rawlsDAO.getWorkspace(any[String], any[String])(any[UserInfo]))
-//        .thenReturn(Future.successful(workspaceResponse))
-//
-//      entityService.importEntitiesFromTSV("workspaceNamespace", "workspaceName", tsvParticipants, dummyUserInfo("token"), true).futureValue
-//
-//      val argumentCaptor = ArgumentCaptor.forClass(classTag[AsyncImportRequest].runtimeClass).asInstanceOf[ArgumentCaptor[AsyncImportRequest]]
-//
-//      //            verify(mockedRawlsDAO, times(1)).batchUpdateEntities(
-//      //              ArgumentMatchers.eq("workspaceNamespace"), ArgumentMatchers.eq("workspaceName"),
-//      //              ArgumentMatchers.eq(expectedEntityType), any[Seq[EntityUpdateDefinition]])(any[UserInfo])
-//
-//      //            verify(cwdsDAO, cwdsCallCount)
-//      //              .importV1(any[String], any[AsyncImportRequest])(any[UserInfo])
-//      verify(cwdsDAO, times(1))
-//        .importV1(any[String], argumentCaptor.capture())(any[UserInfo])
-//      val capturedRequest = argumentCaptor.getValue
-//      capturedRequest.options should be(Some(ImportOptions(None, Some(tsvType != "update"))))
-//      verify(importServiceDAO, never)
-//        .importJob(any[String], any[String], any[AsyncImportRequest], any[Boolean])(any[UserInfo])
-//      verify(rawlsDAO, times(1))
-//        .getWorkspace(any[String], any[String])(any[UserInfo])
-//
-//    }
-
     "should return error for (async=true) when failed to write to GCS" in {
       val testGoogleDAO = new ErroringGoogleServicesDAO
       val entityService = getEntityService(mockGoogleServicesDAO = testGoogleDAO)

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/EntityServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/EntityServiceSpec.scala
@@ -7,26 +7,26 @@ import org.broadinstitute.dsde.firecloud.dataaccess.ImportServiceFiletypes.FILET
 import org.broadinstitute.dsde.firecloud.dataaccess.{MockCwdsDAO, MockImportServiceDAO, MockRawlsDAO}
 import org.broadinstitute.dsde.firecloud.mock.MockGoogleServicesDAO
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
-import org.broadinstitute.dsde.firecloud.model.{AsyncImportRequest, EntityUpdateDefinition, FirecloudModelSchema, ImportServiceListResponse, ImportServiceResponse, ModelSchema, RequestCompleteWithErrorReport, UserInfo, WithAccessToken}
+import org.broadinstitute.dsde.firecloud.model.{AsyncImportRequest, EntityUpdateDefinition, FirecloudModelSchema, ImportOptions, ImportServiceListResponse, ImportServiceResponse, ModelSchema, RequestCompleteWithErrorReport, UserInfo, WithAccessToken}
 import org.broadinstitute.dsde.firecloud.service.PerRequest.RequestComplete
 import org.broadinstitute.dsde.firecloud.service.{BaseServiceSpec, PerRequest}
 import org.broadinstitute.dsde.rawls.model.{ErrorReport, ErrorReportSource}
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GcsObjectName, GcsPath}
 import org.databiosphere.workspacedata.client.ApiException
 import org.databiosphere.workspacedata.model.GenericJob
-import org.mockito.ArgumentMatchers
+import org.mockito.{ArgumentCaptor, ArgumentMatchers}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{doThrow, never, times, verify, when}
 import org.parboiled.common.FileUtils
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.time.{Millis, Span}
 import org.scalatestplus.mockito.MockitoSugar.{mock => mockito}
 
 import java.util.UUID
 import java.util.zip.ZipFile
 import scala.concurrent.ExecutionContext.Implicits._
 import scala.concurrent.Future
+import scala.reflect.classTag
 
 class EntityServiceSpec extends BaseServiceSpec with BeforeAndAfterEach {
 
@@ -190,7 +190,86 @@ class EntityServiceSpec extends BaseServiceSpec with BeforeAndAfterEach {
 
         }
 
+        s"should send $expectedEntityType tsv to cWDS with appropriate options when cWDS is enabled and supports rawlsjson" in {
+            // set up mocks
+            val importServiceDAO = mockito[MockImportServiceDAO]
+            val cwdsDAO = mockito[MockCwdsDAO]
+            val rawlsDAO = mockito[MockRawlsDAO]
+
+            // inject mocks to entity service
+            val entityService = getEntityService(mockImportServiceDAO = importServiceDAO, cwdsDAO = cwdsDAO, rawlsDAO = rawlsDAO)
+
+            // set up behaviors
+            val genericJob: GenericJob = new GenericJob
+            genericJob.setJobId(UUID.randomUUID())
+            // the "new MockRawlsDAO()" here is only to get access to a pre-canned WorkspaceResponse object
+            val workspaceResponse = new MockRawlsDAO().rawlsWorkspaceResponseWithAttributes
+
+            when(cwdsDAO.isEnabled).thenReturn(true)
+            when(cwdsDAO.getSupportedFormats).thenReturn(List("pfb","tdrexport", "rawlsjson"))
+            when(importServiceDAO.importJob(any[String], any[String], any[AsyncImportRequest], any[Boolean])(any[UserInfo]))
+              .thenReturn(Future.successful(RequestComplete(StatusCodes.Accepted, "")))
+            when(rawlsDAO.getWorkspace(any[String], any[String])(any[UserInfo]))
+              .thenReturn(Future.successful(workspaceResponse))
+
+            entityService.importEntitiesFromTSV("workspaceNamespace", "workspaceName", tsvData, dummyUserInfo("token"), true).futureValue
+
+          val argumentCaptor = ArgumentCaptor.forClass(classTag[AsyncImportRequest].runtimeClass).asInstanceOf[ArgumentCaptor[AsyncImportRequest]]
+
+          verify(cwdsDAO, times(1))
+            .importV1(any[String], argumentCaptor.capture())(any[UserInfo])
+          val capturedRequest = argumentCaptor.getValue
+          capturedRequest.options should be(Some(ImportOptions(None, Some(tsvType != "update"))))
+          verify(importServiceDAO, never)
+              .importJob(any[String], any[String], any[AsyncImportRequest], any[Boolean])(any[UserInfo])
+          verify(rawlsDAO, times(1))
+              .getWorkspace(any[String], any[String])(any[UserInfo])
+
+          }
     }
+
+//    "should send sample tsv to cWDS with appropriate options when cWDS is enabled and supports rawlsjson" in {
+//      // set up mocks
+//      val importServiceDAO = mockito[MockImportServiceDAO]
+//      val cwdsDAO = mockito[MockCwdsDAO]
+//      val rawlsDAO = mockito[MockRawlsDAO]
+//
+//      // inject mocks to entity service
+//      val entityService = getEntityService(mockImportServiceDAO = importServiceDAO, cwdsDAO = cwdsDAO, rawlsDAO = rawlsDAO)
+//
+//      // set up behaviors
+//      val genericJob: GenericJob = new GenericJob
+//      genericJob.setJobId(UUID.randomUUID())
+//      // the "new MockRawlsDAO()" here is only to get access to a pre-canned WorkspaceResponse object
+//      val workspaceResponse = new MockRawlsDAO().rawlsWorkspaceResponseWithAttributes
+//
+//      when(cwdsDAO.isEnabled).thenReturn(true)
+//      when(cwdsDAO.getSupportedFormats).thenReturn(List("pfb","tdrexport", "rawlsjson"))
+//      when(importServiceDAO.importJob(any[String], any[String], any[AsyncImportRequest], any[Boolean])(any[UserInfo]))
+//        .thenReturn(Future.successful(RequestComplete(StatusCodes.Accepted, "")))
+//      when(rawlsDAO.getWorkspace(any[String], any[String])(any[UserInfo]))
+//        .thenReturn(Future.successful(workspaceResponse))
+//
+//      entityService.importEntitiesFromTSV("workspaceNamespace", "workspaceName", tsvParticipants, dummyUserInfo("token"), true).futureValue
+//
+//      val argumentCaptor = ArgumentCaptor.forClass(classTag[AsyncImportRequest].runtimeClass).asInstanceOf[ArgumentCaptor[AsyncImportRequest]]
+//
+//      //            verify(mockedRawlsDAO, times(1)).batchUpdateEntities(
+//      //              ArgumentMatchers.eq("workspaceNamespace"), ArgumentMatchers.eq("workspaceName"),
+//      //              ArgumentMatchers.eq(expectedEntityType), any[Seq[EntityUpdateDefinition]])(any[UserInfo])
+//
+//      //            verify(cwdsDAO, cwdsCallCount)
+//      //              .importV1(any[String], any[AsyncImportRequest])(any[UserInfo])
+//      verify(cwdsDAO, times(1))
+//        .importV1(any[String], argumentCaptor.capture())(any[UserInfo])
+//      val capturedRequest = argumentCaptor.getValue
+//      capturedRequest.options should be(Some(ImportOptions(None, Some(tsvType != "update"))))
+//      verify(importServiceDAO, never)
+//        .importJob(any[String], any[String], any[AsyncImportRequest], any[Boolean])(any[UserInfo])
+//      verify(rawlsDAO, times(1))
+//        .getWorkspace(any[String], any[String])(any[UserInfo])
+//
+//    }
 
     "should return error for (async=true) when failed to write to GCS" in {
       val testGoogleDAO = new ErroringGoogleServicesDAO
@@ -586,7 +665,7 @@ class EntityServiceSpec extends BaseServiceSpec with BeforeAndAfterEach {
   private def getEntityService(mockGoogleServicesDAO: MockGoogleServicesDAO = new MockGoogleServicesDAO,
                                mockImportServiceDAO: MockImportServiceDAO = new MockImportServiceDAO,
                                rawlsDAO: MockRawlsDAO = new MockRawlsDAO,
-                               cwdsDAO: MockCwdsDAO = new MockCwdsDAO) = {
+                               cwdsDAO: MockCwdsDAO = new MockCwdsDAO(false)) = {
     val application = app.copy(googleServicesDAO = mockGoogleServicesDAO, rawlsDAO = rawlsDAO, importServiceDAO = mockImportServiceDAO, cwdsDAO = cwdsDAO)
 
     // instantiate an EntityService, specify importServiceDAO and googleServicesDAO

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpCwdsDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpCwdsDAOSpec.scala
@@ -15,7 +15,7 @@ import scala.jdk.CollectionConverters._
 
 class HttpCwdsDAOSpec extends AnyFreeSpec with Matchers {
 
-  private val supportedFormats: List[String] = List("pfb", "tdrexport")
+  private val supportedFormats: List[String] = List("pfb", "tdrexport", "rawlsjson")
 
   // a dao that can be reused in multiple tests below
   private val cwdsDao: HttpCwdsDAO = new HttpCwdsDAO(true, supportedFormats)
@@ -111,6 +111,9 @@ class HttpCwdsDAOSpec extends AnyFreeSpec with Matchers {
       "input (tdrexport) should translate to TDRMANIFEST" in {
         cwdsDao.toCwdsImportType("tdrexport") shouldBe ImportRequest.TypeEnum.TDRMANIFEST
       }
+      "input (rawlsjson) should translate to RAWLSJSON" in {
+        cwdsDao.toCwdsImportType("rawlsjson") shouldBe ImportRequest.TypeEnum.RAWLSJSON
+      }
       "other input should throw" in {
         a [FireCloudException] should be thrownBy cwdsDao.toCwdsImportType("something-else")
       }
@@ -173,6 +176,21 @@ class HttpCwdsDAOSpec extends AnyFreeSpec with Matchers {
         expected.setUrl(testURI)
         expected.setType(ImportRequest.TypeEnum.PFB)
         expected.setOptions(Map[String,Object]("tdrSyncPermissions" -> false.asInstanceOf[Object]).asJava)
+
+        cwdsDao.toCwdsImportRequest(input) shouldBe expected
+      }
+
+      "should translate an import request with isUpsert=true" in {
+        val testURI: URI = URI.create("https://example.com/")
+
+        val input = AsyncImportRequest(url = testURI.toString,
+          filetype = "rawlsjson",
+          options = Some(ImportOptions(isUpsert = Some(true))))
+
+        val expected = new ImportRequest()
+        expected.setUrl(testURI)
+        expected.setType(ImportRequest.TypeEnum.RAWLSJSON)
+        expected.setOptions(Map[String,Object]("isUpsert" -> true.asInstanceOf[Object]).asJava)
 
         cwdsDao.toCwdsImportRequest(input) shouldBe expected
       }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockCwdsDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockCwdsDAO.scala
@@ -11,7 +11,7 @@ class MockCwdsDAO(enabled: Boolean = true) extends CwdsDAO {
 
   override def isEnabled: Boolean = enabled
 
-  override def getSupportedFormats: List[String] = List("pfb", "tdrexport")
+  override def getSupportedFormats: List[String] = List("pfb", "tdrexport", "rawlsjson")
   override def listJobsV1(workspaceId: String, runningOnly: Boolean)(implicit userInfo: UserInfo)
   : List[ImportServiceListResponse] = List()
 


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1790

Orch should now route async tsv uploads to cWDS, if cWDS is enabled and supports the `rawlsjson` file type.  
Adds an `isUpsert` flag to the import request options to distinguish `update` type uploads. Although these are not available from the UI, it is apparently possible through the API and we need to maintain parity with import service, which respects these differences.

Requires https://github.com/broadinstitute/terra-helmfile/pull/5467 to come into effect.

\<your comments for this PR go here\>

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
