### PR TITLE
AJ-1805: update bcprov-jdk18on

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -25,7 +25,7 @@ object Dependencies {
     "org.yaml" % "snakeyaml" % "1.33",
     "io.grpc" % "grpc-xds" % "1.56.1",
     // workbench-google2 has bouncycastle as a dependency; directly updating to a non-vulnerable version until workbench-google2 updates
-    "org.bouncycastle" % "bcprov-jdk18on" % "1.74"
+    "org.bouncycastle" % "bcprov-jdk18on" % "1.78.1"
   )
 
   val rootDependencies: Seq[ModuleID] = Seq(


### PR DESCRIPTION
AJ-1805

updates `bcprov-jdk18on` to latest version.

---

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [x] Get two thumbsworth of review and PO signoff if necessary
- [x] Verify all tests go green
- [x] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [x] Test this change deployed correctly and works on dev environment after deployment
