### PR TITLE
AJ-1812 Improve bucket security for handoff to cwds

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/EntityService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/EntityService.scala
@@ -227,14 +227,14 @@ class EntityService(rawlsDAO: RawlsDAO, importServiceDAO: ImportServiceDAO, cwds
         val bucketToWrite = GcsBucketName(FireCloudConfig.Cwds.bucket)
         val fileToWrite = GcsObjectName(s"to-cwds/${workspaceId}/${java.util.UUID.randomUUID()}.json")
         val gcsPath = writeDataToGcs(bucketToWrite, fileToWrite, dataBytes)
-        val importRequest = getImportRequest(gcsPath, isUpsert)
+        val importRequest = getRawlsJsonImportRequest(gcsPath, isUpsert)
         importToCWDS(workspaceNamespace, workspaceName, workspaceId, userInfo, importRequest)
       }
     } else {
       val bucketToWrite = GcsBucketName(FireCloudConfig.ImportService.bucket)
       val fileToWrite = GcsObjectName(s"incoming/${java.util.UUID.randomUUID()}.json")
       val gcsPath = writeDataToGcs(bucketToWrite, fileToWrite, dataBytes)
-      val importRequest = getImportRequest(gcsPath, isUpsert)
+      val importRequest = getRawlsJsonImportRequest(gcsPath, isUpsert)
       importServiceDAO.importJob(workspaceNamespace, workspaceName, importRequest, isUpsert)(userInfo)
     }
   }
@@ -244,7 +244,7 @@ class EntityService(rawlsDAO: RawlsDAO, importServiceDAO: ImportServiceDAO, cwds
     s"gs://${insertedObject.bucketName.value}/${insertedObject.objectName.value}"
   }
 
-  private def getImportRequest(gcsPath: String, isUpsert: Boolean): AsyncImportRequest = {
+  private def getRawlsJsonImportRequest(gcsPath: String, isUpsert: Boolean): AsyncImportRequest = {
     AsyncImportRequest(gcsPath, FILETYPE_RAWLS, Some(ImportOptions(None, Some(isUpsert))))
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/EntityService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/EntityService.scala
@@ -220,36 +220,48 @@ class EntityService(rawlsDAO: RawlsDAO, importServiceDAO: ImportServiceDAO, cwds
 
     val useCWDS = cwdsDAO.isEnabled && cwdsDAO.getSupportedFormats.contains(FILETYPE_RAWLS)
 
-    // generate unique name for the file-to-upload
-    val fileToWrite = GcsObjectName(s"incoming/${java.util.UUID.randomUUID()}.json")
-    val bucketToWrite = if (useCWDS) GcsBucketName(FireCloudConfig.Cwds.bucket) else GcsBucketName(FireCloudConfig.ImportService.bucket)
-
-    // write rawlsCalls to import service's bucket
     val dataBytes = rawlsCalls.toJson.prettyPrint.getBytes(StandardCharsets.UTF_8)
-    val insertedObject = googleServicesDAO.writeObjectAsRawlsSA(bucketToWrite, fileToWrite, dataBytes)
-    val gcsPath = s"gs://${insertedObject.bucketName.value}/${insertedObject.objectName.value}"
-
-    val importRequest = AsyncImportRequest(gcsPath, FILETYPE_RAWLS, Some(ImportOptions(None, Some(isUpsert))))
 
     if (useCWDS) {
-      importToCWDS(workspaceNamespace, workspaceName, userInfo, importRequest)
+      getWorkspaceId(workspaceNamespace, workspaceName, userInfo) flatMap { workspaceId =>
+        val bucketToWrite = GcsBucketName(FireCloudConfig.Cwds.bucket)
+        val fileToWrite = GcsObjectName(s"to-cwds/${workspaceId}/${java.util.UUID.randomUUID()}.json")
+        val gcsPath = writeDataToGcs(bucketToWrite, fileToWrite, dataBytes)
+        val importRequest = getImportRequest(gcsPath, isUpsert)
+        importToCWDS(workspaceNamespace, workspaceName, workspaceId, userInfo, importRequest)
+      }
     } else {
+      val bucketToWrite = GcsBucketName(FireCloudConfig.ImportService.bucket)
+      val fileToWrite = GcsObjectName(s"incoming/${java.util.UUID.randomUUID()}.json")
+      val gcsPath = writeDataToGcs(bucketToWrite, fileToWrite, dataBytes)
+      val importRequest = getImportRequest(gcsPath, isUpsert)
       importServiceDAO.importJob(workspaceNamespace, workspaceName, importRequest, isUpsert)(userInfo)
     }
   }
 
-  private def importToCWDS(workspaceNamespace: String, workspaceName: String, userInfo: UserInfo, importRequest: AsyncImportRequest
+  private def writeDataToGcs(bucket: GcsBucketName, objectName: GcsObjectName, data: Array[Byte]): String = {
+    val insertedObject = googleServicesDAO.writeObjectAsRawlsSA(bucket, objectName, data)
+    s"gs://${insertedObject.bucketName.value}/${insertedObject.objectName.value}"
+  }
+
+  private def getImportRequest(gcsPath: String, isUpsert: Boolean): AsyncImportRequest = {
+    AsyncImportRequest(gcsPath, FILETYPE_RAWLS, Some(ImportOptions(None, Some(isUpsert))))
+  }
+
+  private def getWorkspaceId(workspaceNamespace: String, workspaceName: String, userInfo: UserInfo): Future[String] = {
+    rawlsDAO.getWorkspace(workspaceNamespace, workspaceName)(userInfo).map(_.workspace.workspaceId)
+  }
+
+  private def importToCWDS(workspaceNamespace: String, workspaceName: String, workspaceId: String, userInfo: UserInfo, importRequest: AsyncImportRequest
                           ): Future[PerRequestMessage] = {
-      // translate the workspace namespace/name into an id
-      rawlsDAO.getWorkspace(workspaceNamespace, workspaceName)(userInfo) map { workspace =>
-      // create the job in cWDS
-      val cwdsJob = cwdsDAO.importV1(workspace.workspace.workspaceId, importRequest)(userInfo)
-      // massage the cWDS job into the response format Orch requires
-      val asyncImportResponse = AsyncImportResponse(url = importRequest.url,
+    // create the job in cWDS
+    val cwdsJob = cwdsDAO.importV1(workspaceId, importRequest)(userInfo)
+    // massage the cWDS job into the response format Orch requires
+    Future.successful(
+      RequestComplete(Accepted, AsyncImportResponse(url = importRequest.url,
         jobId = cwdsJob.getJobId.toString,
-        workspace = WorkspaceName(workspaceNamespace, workspaceName))
-      RequestComplete(Accepted, asyncImportResponse)
-    }
+        workspace = WorkspaceName(workspaceNamespace, workspaceName)))
+    )
   }
 
   private def handleBatchRawlsResponse(entityType: String, response: Future[HttpResponse]): Future[PerRequestMessage] = {
@@ -394,7 +406,9 @@ class EntityService(rawlsDAO: RawlsDAO, importServiceDAO: ImportServiceDAO, cwds
 
     // if cwds.enabled, for cwds filetypes send the request to cWDS instead of import service
     if (cwdsDAO.isEnabled && cwdsDAO.getSupportedFormats.contains(importRequest.filetype.toLowerCase)) {
-      importToCWDS(workspaceNamespace, workspaceName, userInfo, importRequest)
+      getWorkspaceId(workspaceNamespace, workspaceName, userInfo) flatMap { workspaceId =>
+        importToCWDS(workspaceNamespace, workspaceName, workspaceId, userInfo, importRequest)
+      }
     } else {
       importServiceDAO.importJob(workspaceNamespace, workspaceName, importRequest, isUpsert = true)(userInfo)
     }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/EntityService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/EntityService.scala
@@ -1,9 +1,5 @@
 package org.broadinstitute.dsde.firecloud
 
-import java.io.{File, FileNotFoundException, FileOutputStream, InputStream}
-import java.net.{HttpURLConnection, URL}
-import java.text.SimpleDateFormat
-import java.util.zip.{ZipEntry, ZipException, ZipFile}
 import akka.http.scaladsl.model.StatusCodes._
 import akka.http.scaladsl.model.{HttpResponse, StatusCodes}
 import com.typesafe.scalalogging.LazyLogging
@@ -22,12 +18,16 @@ import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GcsObjectN
 import org.databiosphere.workspacedata.client.ApiException
 import spray.json.DefaultJsonProtocol._
 
+import java.io.{File, FileNotFoundException, FileOutputStream, InputStream}
+import java.net.{HttpURLConnection, URL}
 import java.nio.channels.Channels
 import java.nio.charset.StandardCharsets
+import java.text.SimpleDateFormat
 import java.util.concurrent.atomic.AtomicLong
-import scala.jdk.CollectionConverters._
+import java.util.zip.{ZipEntry, ZipException, ZipFile}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.io.Source
+import scala.jdk.CollectionConverters._
 import scala.language.postfixOps
 import scala.util.{Failure, Success, Try}
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/EntityServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/EntityServiceSpec.scala
@@ -14,9 +14,9 @@ import org.broadinstitute.dsde.rawls.model.{ErrorReport, ErrorReportSource}
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GcsObjectName, GcsPath}
 import org.databiosphere.workspacedata.client.ApiException
 import org.databiosphere.workspacedata.model.GenericJob
-import org.mockito.{ArgumentCaptor, ArgumentMatchers}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{doThrow, never, times, verify, when}
+import org.mockito.{ArgumentCaptor, ArgumentMatchers}
 import org.parboiled.common.FileUtils
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.concurrent.ScalaFutures


### PR DESCRIPTION
Include `workspaceId` in GCS path for cwds.  This will be used by cwds to guarantee that only `gs://` URIs pointing to the same `workspaceId` as requested can be used.  This prevents potential hijacking of other unauthorized workloads in the bucket.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] ~I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes~ (N/A)
- [ ] ~I've updated the RC_XXX release ticket with any manual steps required to release this change~ (N/A)
- [ ] ~I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing~ (N/A)

In all cases:

- [x] Get two thumbsworth of review and PO signoff if necessary
- [x] Verify all tests go green
- [x] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [x] Test this change deployed correctly and works on dev environment after deployment
