### PR TITLE
AJ-1730: sunset BDBag support [DO NOT MERGE UNTIL MAY 16]

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -93,8 +93,6 @@ object Dependencies {
 
     "org.scalatest"                 %% "scalatest"           % "3.2.18"   % "test",
     "org.mock-server"                % "mockserver-netty"    % "5.15.0"  % "test",
-    // jaxb-api needed by WorkspaceApiServiceSpec.bagitService() method
-    "javax.xml.bind"                 % "jaxb-api"            % "2.3.1"   % "test",
     // provides testing mocks
     "com.google.cloud"               % "google-cloud-nio"    % "0.127.16" % "test",
     "org.scalatestplus"             %% "mockito-4-5"         % "3.2.12.0" % "test"

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -9,7 +9,6 @@ workspace {
   workspacesAclPath="/workspaces/%s/%s/acl"
   entitiesPath="/workspaces/%s/%s/entities"
   entityQueryPath="/workspaces/%s/%s/entityQuery"
-  entityBagitMaximumSize=200000000
   importEntitiesPath="/workspaces/%s/%s/importEntities"
   workspacesEntitiesCopyPath="/workspaces/entities/copy"
   submissionsPath="/workspaces/%s/%s/submissions"

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -3775,39 +3775,6 @@ paths:
           description: Internal Error
           content: {}
       x-passthrough: false
-  /api/workspaces/{workspaceNamespace}/{workspaceName}/importBagit:
-    post:
-      tags:
-        - Entities
-      deprecated: true
-      summary: Import entity TSVs from a zipped [BagIt](https://tools.ietf.org/html/draft-kunze-bagit-14)
-        directory, whose payload contains two files - participants.tsv and samples.tsv
-      operationId: importBagit
-      parameters:
-        - $ref: '#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#/components/parameters/workspaceNameParam'
-      requestBody:
-        description: JSON object containing bagit URL
-        content:
-          'application/json':
-            schema:
-              $ref: '#/components/schemas/BagitRequest'
-        required: true
-      responses:
-        200:
-          description: Successful Request
-          content: {}
-        400:
-          description: Bad Request
-          content: {}
-        404:
-          description: Source Workspace not found
-          content: {}
-        500:
-          description: Internal Error
-          content: {}
-      x-passthrough: false
-      x-codegen-request-body-name: bagitImportRequest
   /api/workspaces/{workspaceNamespace}/{workspaceName}/importEntities:
     post:
       tags:
@@ -6415,21 +6382,6 @@ components:
             service
           format: int32
       description: Stuff you need to know about calls
-    BagitRequest:
-      required:
-        - bagitURL
-        - format
-      type: object
-      properties:
-        bagitURL:
-          type: string
-          description: link to publically accessible zipped BagIt directory
-        format:
-          type: string
-          description: the type of the files inside the bagit. Currently this must
-            be the string "TSV".
-          enum:
-            - TSV
     ConfigurationIngest:
       required:
         - inputs

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
@@ -49,7 +49,6 @@ object FireCloudConfig {
     val workspacesUrl = authUrl + workspacesPath
     val entitiesPath = workspace.getString("entitiesPath")
     val entityQueryPath = workspace.getString("entityQueryPath")
-    val entityBagitMaximumSize = workspace.getInt("entityBagitMaximumSize")
     val workspacesEntitiesCopyPath = workspace.getString("workspacesEntitiesCopyPath")
     def workspacesEntitiesCopyUrl(linkExistingEntities: Boolean) = authUrl + workspacesEntitiesCopyPath + "?linkExistingEntities=%s".format(linkExistingEntities)
     val submissionsCountPath = workspace.getString("submissionsCountPath")

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
@@ -237,7 +237,6 @@ object ModelJsonProtocol extends WorkspaceJsonSupport with SprayJsonSupport {
   implicit val impCurator: RootJsonFormat[Curator] = jsonFormat1(Curator)
   implicit val impUserImportPermission: RootJsonFormat[UserImportPermission] = jsonFormat2(UserImportPermission)
 
-  implicit val impBagitImportRequest: RootJsonFormat[BagitImportRequest] = jsonFormat2(BagitImportRequest)
   implicit val impPFBImportRequest: RootJsonFormat[PFBImportRequest] = jsonFormat1(PFBImportRequest)
   implicit val impOptions: RootJsonFormat[ImportOptions] = jsonFormat2(ImportOptions)
   implicit val impAsyncImportRequest: RootJsonFormat[AsyncImportRequest] = jsonFormat3(AsyncImportRequest)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/Workspace.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/Workspace.scala
@@ -22,8 +22,6 @@ case class EntityCopyWithoutDestinationDefinition(
 
 case class EntityId(entityType: String, entityName: String)
 
-case class BagitImportRequest(bagitURL: String, format: String)
-
 // legacy class specific to PFB import; prefer AsyncImportRequest instead
 case class PFBImportRequest(url: String)
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiService.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.dsde.firecloud.webservice
 
-import akka.http.scaladsl.model.StatusCodes.{Accepted, OK}
+import akka.http.scaladsl.model.StatusCodes.OK
 
 import java.text.SimpleDateFormat
 import akka.http.scaladsl.model.Uri.Query
@@ -22,7 +22,6 @@ import org.slf4j.{Logger, LoggerFactory}
 import spray.json.DefaultJsonProtocol._
 
 import scala.concurrent.ExecutionContext
-import scala.util.Try
 
 trait WorkspaceApiService extends FireCloudRequestBuilding with FireCloudDirectives with StandardUserInfoDirectives {
 
@@ -142,15 +141,6 @@ trait WorkspaceApiService extends FireCloudRequestBuilding with FireCloudDirecti
                             entityServiceConstructor(FirecloudModelSchema).importEntitiesFromTSV(workspaceNamespace, workspaceName, entitiesTSV, userInfo, deleteEmptyValues = deleteEmptyValues)
                           }
                         }
-                      }
-                    }
-                  }
-                } ~
-                path("importBagit"){
-                  post {
-                    requireUserInfo() { userInfo =>
-                      entity(as[BagitImportRequest]) { bagitRq =>
-                        complete { entityServiceConstructor(FirecloudModelSchema).importBagit(workspaceNamespace, workspaceName, bagitRq, userInfo) }
                       }
                     }
                   }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/EntityServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/EntityServiceSpec.scala
@@ -23,7 +23,6 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.mockito.MockitoSugar.{mock => mockito}
 
 import java.util.UUID
-import java.util.zip.ZipFile
 import scala.concurrent.ExecutionContext.Implicits._
 import scala.concurrent.Future
 import scala.reflect.classTag
@@ -41,84 +40,6 @@ class EntityServiceSpec extends BaseServiceSpec with BeforeAndAfterEach {
   }
 
   private def dummyUserInfo(tokenStr: String) = UserInfo("dummy", OAuth2BearerToken(tokenStr), -1, "dummy")
-
-  "EntityClient should extract TSV files out of bagit zips" - {
-    "with neither participants nor samples in the zip" in {
-      val zip = new ZipFile("src/test/resources/testfiles/bagit/nothingbag.zip")
-      EntityService.unzipTSVs("nothingbag", zip) { (participants, samples) =>
-        participants shouldBe None
-        samples shouldBe None
-        Future.successful(RequestComplete(StatusCodes.OK))
-      }
-    }
-
-    "with both participants and samples in a zip with a flat file structure" in {
-      val zip = new ZipFile("src/test/resources/testfiles/bagit/flat_testbag.zip")
-      EntityService.unzipTSVs("flat_testbag", zip) { (participants, samples) =>
-        participants.map(_.stripLineEnd) shouldEqual Some("imagine this is a participants.tsv in a flat file structure")
-        samples.map(_.stripLineEnd) shouldEqual Some("imagine this is a samples.tsv in a flat file structure")
-        Future.successful(RequestComplete(StatusCodes.OK))
-      }
-    }
-
-    "with only participants in a zip with a flat file structure" in {
-      val zip = new ZipFile("src/test/resources/testfiles/bagit/participants_only_flat_testbag.zip")
-      EntityService.unzipTSVs("participants_only_flat_testbag", zip) { (participants, samples) =>
-        participants.map(_.stripLineEnd) shouldEqual Some("imagine this is a participants.tsv all alone in a flat file structure")
-        samples.map(_.stripLineEnd) shouldEqual None
-        Future.successful(RequestComplete(StatusCodes.OK))
-      }
-    }
-
-    "with only samples in a zip with a flat file structure" in {
-      val zip = new ZipFile("src/test/resources/testfiles/bagit/samples_only_flat_testbag.zip")
-      EntityService.unzipTSVs("samples_only_flat_testbag", zip) { (participants, samples) =>
-        participants.map(_.stripLineEnd) shouldEqual None
-        samples.map(_.stripLineEnd) shouldEqual Some("imagine this is a samples.tsv all alone in a flat file structure")
-        Future.successful(RequestComplete(StatusCodes.OK))
-      }
-    }
-
-    "with both participants and samples in a zip with a nested file structure" in {
-      val zip = new ZipFile("src/test/resources/testfiles/bagit/nested_testbag.zip")
-      EntityService.unzipTSVs("nested_testbag", zip) { (participants, samples) =>
-        participants.map(_.stripLineEnd) shouldEqual Some("imagine this is a participants.tsv in a nested file structure")
-        samples.map(_.stripLineEnd) shouldEqual Some("imagine this is a samples.tsv in a nested file structure")
-        Future.successful(RequestComplete(StatusCodes.OK))
-      }
-    }
-
-    "with both participants and samples and an extra tsv file in a zip with a nested file structure" in {
-      val zip = new ZipFile("src/test/resources/testfiles/bagit/extra_file_nested_testbag.zip")
-      EntityService.unzipTSVs("extra_file_nested_testbag", zip) { (participants, samples) =>
-        participants.map(_.stripLineEnd) shouldEqual Some("imagine this is a participants.tsv in a nested file structure")
-        samples.map(_.stripLineEnd) shouldEqual Some("imagine this is a samples.tsv in a nested file structure")
-        Future.successful(RequestComplete(StatusCodes.OK))
-      }
-    }
-
-    "with multiple participants in a zip with a flat file structure" in {
-      val zip = new ZipFile("src/test/resources/testfiles/bagit/duplicate_participants_nested_testbag.zip")
-
-      val ex = intercept[FireCloudExceptionWithErrorReport] {
-        EntityService.unzipTSVs("duplicate_participants_nested_testbag", zip) { (_, _) =>
-          Future.successful(RequestComplete(StatusCodes.OK))
-        }
-      }
-      ex.errorReport.message shouldEqual "More than one participants.tsv file found in bagit duplicate_participants_nested_testbag"
-    }
-
-    "with multiple samples in a zip with a flat file structure" in {
-      val zip = new ZipFile("src/test/resources/testfiles/bagit/duplicate_samples_nested_testbag.zip")
-
-      val ex = intercept[FireCloudExceptionWithErrorReport] {
-        EntityService.unzipTSVs("duplicate_samples_nested_testbag", zip) { (_, _) =>
-          Future.successful(RequestComplete(StatusCodes.OK))
-        }
-      }
-      ex.errorReport.message shouldEqual "More than one samples.tsv file found in bagit duplicate_samples_nested_testbag"
-    }
-  }
 
   "EntityService.importEntitiesFromTSV()" - {
     val tsvParticipants = FileUtils.readAllTextFromResource("testfiles/tsv/ADD_PARTICIPANTS.txt")

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockUtils.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockUtils.scala
@@ -19,7 +19,6 @@ object MockUtils {
   val ontologyServerPort = 8993
   val samServerPort = 8994
   val cromiamServerPort = 8995
-  val bagitServerPort = 9393
   val importServiceServerPort = 9394
 
    def randomPositiveInt(): Int = {


### PR DESCRIPTION
AJ-1730

Fully deletes the `importBagit` API, which was previously deprecated.

---

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [x] Get two thumbsworth of review and PO signoff if necessary
- [x] Verify all tests go green
- [x] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [x] Test this change deployed correctly and works on dev environment after deployment
