### PR TITLE
Make `MockCwdsDAO` like `MockImportServiceDao`

### DIFF
--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockCwdsDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockCwdsDAO.scala
@@ -1,34 +1,80 @@
 package org.broadinstitute.dsde.firecloud.dataaccess
 
+import akka.http.scaladsl.model.StatusCodes.{BadRequest, EnhanceYourCalm, Forbidden, UnavailableForLegalReasons}
+import org.broadinstitute.dsde.firecloud.FireCloudExceptionWithErrorReport
+import org.broadinstitute.dsde.firecloud.dataaccess.ImportServiceFiletypes.{FILETYPE_PFB, FILETYPE_RAWLS, FILETYPE_TDR}
 import org.broadinstitute.dsde.firecloud.model.{AsyncImportRequest, ImportServiceListResponse, UserInfo}
+import org.broadinstitute.dsde.rawls.model.{ErrorReport, ErrorReportSource}
 import org.databiosphere.workspacedata.model.GenericJob
 import org.databiosphere.workspacedata.model.GenericJob.{JobTypeEnum, StatusEnum}
 
 import java.time.OffsetDateTime
 import java.util.UUID
 
-class MockCwdsDAO(enabled: Boolean = true) extends CwdsDAO {
+class MockCwdsDAO(
+    enabled: Boolean = true,
+    supportedFormats: List[String] = List("pfb", "tdrexport", "rawlsjson")
+) extends HttpCwdsDAO(enabled, supportedFormats) {
+  implicit val errorReportSource: ErrorReportSource = ErrorReportSource(
+    "MockCWDS"
+  )
+  override def listJobsV1(workspaceId: String, runningOnly: Boolean)(implicit
+      userInfo: UserInfo
+  ): List[ImportServiceListResponse] = List()
 
-  override def isEnabled: Boolean = enabled
-
-  override def getSupportedFormats: List[String] = List("pfb", "tdrexport", "rawlsjson")
-  override def listJobsV1(workspaceId: String, runningOnly: Boolean)(implicit userInfo: UserInfo)
-  : List[ImportServiceListResponse] = List()
-
-  override def getJobV1(workspaceId: String, jobId: String)(implicit userInfo: UserInfo): ImportServiceListResponse =
+  override def getJobV1(workspaceId: String, jobId: String)(implicit
+      userInfo: UserInfo
+  ): ImportServiceListResponse =
     ImportServiceListResponse(jobId, "ReadyForUpsert", "pfb", None)
 
-  override def importV1(workspaceId: String,
-                        asyncImportRequest: AsyncImportRequest
-                       )(implicit userInfo: UserInfo): GenericJob = {
+  override def importV1(
+      workspaceId: String,
+      importRequest: AsyncImportRequest
+  )(implicit userInfo: UserInfo): GenericJob = {
+    importRequest.filetype match {
+      case FILETYPE_PFB | FILETYPE_TDR =>
+        if (importRequest.url.contains("forbidden"))
+          throw new FireCloudExceptionWithErrorReport(
+            ErrorReport(
+              Forbidden,
+              "Missing Authorization: Bearer token in header"
+            )
+          )
+        else if (importRequest.url.contains("bad.request"))
+          throw new FireCloudExceptionWithErrorReport(
+            ErrorReport(
+              BadRequest,
+              "Bad request as reported by import service"
+            )
+          )
+        else if (importRequest.url.contains("its.lawsuit.time"))
+          throw new FireCloudExceptionWithErrorReport(
+            ErrorReport(
+              UnavailableForLegalReasons,
+              "import service message"
+            )
+          )
+        else if (importRequest.url.contains("good")) makeJob(workspaceId)
+        else
+          throw new FireCloudExceptionWithErrorReport(
+            ErrorReport(EnhanceYourCalm, "Enhance your calm")
+          )
+      case FILETYPE_RAWLS => ???
+      case _              => ???
+    }
+  }
+
+  private def makeJob(
+      workspaceId: String
+  ) = {
     val genericJob: GenericJob = new GenericJob
     genericJob.setJobId(UUID.randomUUID())
     genericJob.setStatus(StatusEnum.RUNNING)
     genericJob.setJobType(JobTypeEnum.DATA_IMPORT)
-    genericJob.setInstanceId(UUID.fromString(workspaceId)) // will this cause a problem in tests? Some test data has non-UUIDs.
+    // will this cause a problem in tests? Some test data has non-UUIDs.
+    genericJob.setInstanceId(UUID.fromString(workspaceId))
     genericJob.setCreated(OffsetDateTime.now())
     genericJob.setUpdated(OffsetDateTime.now())
-
     genericJob
   }
 }


### PR DESCRIPTION
Does this seem reasonable?  I'm not sure if throwing errors off is the correct way to simulate what `MockImportServiceDao` does.

-------

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
