### PR TITLE
AJ-1749: respect importService.enabled for listing jobs

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/Boot.scala
@@ -98,7 +98,7 @@ object Boot extends App with LazyLogging {
     // can be disabled
     val agoraDAO: AgoraDAO = whenEnabled[AgoraDAO](FireCloudConfig.Agora.enabled, new HttpAgoraDAO(FireCloudConfig.Agora))
     val googleServicesDAO: GoogleServicesDAO = whenEnabled[GoogleServicesDAO](FireCloudConfig.GoogleCloud.enabled, new HttpGoogleServicesDAO(FireCloudConfig.GoogleCloud.priceListUrl, GooglePriceList(GooglePrices(FireCloudConfig.GoogleCloud.defaultStoragePriceList, UsTieredPriceItem(FireCloudConfig.GoogleCloud.defaultEgressPriceList)), "v1", "1")))
-    val importServiceDAO: ImportServiceDAO = whenEnabled[ImportServiceDAO](FireCloudConfig.ImportService.enabled, new HttpImportServiceDAO)
+    val importServiceDAO: ImportServiceDAO = whenEnabled[ImportServiceDAO](FireCloudConfig.ImportService.enabled, new HttpImportServiceDAO(FireCloudConfig.ImportService.enabled))
     val shibbolethDAO: ShibbolethDAO = whenEnabled[ShibbolethDAO](FireCloudConfig.Shibboleth.enabled, new HttpShibbolethDAO)
     val cwdsDAO: CwdsDAO = whenEnabled[CwdsDAO](FireCloudConfig.Cwds.enabled, new HttpCwdsDAO(FireCloudConfig.Cwds.enabled, FireCloudConfig.Cwds.supportedFormats))
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/EntityService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/EntityService.scala
@@ -287,7 +287,11 @@ class EntityService(rawlsDAO: RawlsDAO, importServiceDAO: ImportServiceDAO, cwds
 
     for {
       // get jobs from Import Service
-      importServiceJobs <- importServiceDAO.listJobs(workspaceNamespace, workspaceName, runningOnly)(userInfo)
+      importServiceJobs <- if (importServiceDAO.isEnabled) {
+        importServiceDAO.listJobs(workspaceNamespace, workspaceName, runningOnly)(userInfo)
+      } else {
+        Future.successful(List.empty)
+      }
       // get jobs from cWDS
       cwdsJobs <- if (cwdsDAO.isEnabled) {
         rawlsDAO.getWorkspace(workspaceNamespace, workspaceName)(userInfo) map { workspace =>

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpImportServiceDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpImportServiceDAO.scala
@@ -18,10 +18,12 @@ import spray.json.DefaultJsonProtocol._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
 
-class HttpImportServiceDAO(implicit val system: ActorSystem, implicit val materializer: Materializer, implicit val executionContext: ExecutionContext)
+class HttpImportServiceDAO(enabled: Boolean = true)(implicit val system: ActorSystem, implicit val materializer: Materializer, implicit val executionContext: ExecutionContext)
   extends ImportServiceDAO with RestJsonClient with SprayJsonSupport {
 
   implicit val errorReportSource: ErrorReportSource = ErrorReportSource("FireCloud")
+
+  override def isEnabled: Boolean = enabled
 
   override def importJob(workspaceNamespace: String, workspaceName: String, importRequest: AsyncImportRequest, isUpsert: Boolean)(implicit userInfo: UserInfo): Future[PerRequestMessage] = {
     doImport(workspaceNamespace, workspaceName, isUpsert, importRequest)
@@ -104,6 +106,5 @@ class HttpImportServiceDAO(implicit val system: ActorSystem, implicit val materi
         nonStrictEntity.toStrict(10.seconds).map(_.data.utf8String)
     }
   }
-
 
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ImportServiceDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ImportServiceDAO.scala
@@ -13,6 +13,8 @@ object ImportServiceFiletypes {
 
 trait ImportServiceDAO {
 
+  def isEnabled: Boolean
+
   def importJob(workspaceNamespace: String,
                 workspaceName: String,
                 importRequest: AsyncImportRequest,

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockImportServiceDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockImportServiceDAO.scala
@@ -49,4 +49,6 @@ class MockImportServiceDAO extends ImportServiceDAO {
   : Future[ImportServiceListResponse] = {
     Future.successful(ImportServiceListResponse(jobId, "status", "filetype", None))
   }
+
+  override def isEnabled: Boolean = true
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiServiceJobSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiServiceJobSpec.scala
@@ -60,6 +60,7 @@ class WorkspaceApiServiceJobSpec extends BaseServiceSpec with WorkspaceApiServic
           s"should call ImportServiceDAO.listJobs with running_only=$runningOnly" in {
             // reset mock invocation counts and configure its return value
             clearInvocations(mockitoImportServiceDAO)
+            when(mockitoImportServiceDAO.isEnabled).thenReturn(true)
             when(mockitoImportServiceDAO.listJobs(any[String], any[String], any[Boolean])(any[UserInfo])).thenReturn(
               Future.successful(importList))
             // execute the route


### PR DESCRIPTION
Respect the `importServiceEnabled` [config setting](https://github.com/broadinstitute/terra-helmfile/blob/7a8fa345af1cba66e09b50117c37ec97aaab9f8d/values/app/firecloudorch/live/prod.yaml#L10) when listing jobs. This will allow us to disable import service and drain traffic from it, before committing fully to https://github.com/broadinstitute/firecloud-orchestration/pull/1355.

Tested in my BEE, and working as expected:
* This branch + Import Service pod turned off + `importServiceEnabled` conf flag `true`: errors on Data tab
* This branch + Import Service pod turned off + `importServiceEnabled` conf flag `false`: no errors

Requires https://github.com/broadinstitute/terra-helmfile/pull/5555 for full effect, but the two PRs can be merged independently.

---


Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [x] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
