### PR TITLE
AJ-1749: bubble up cwds error codes

### DIFF
--- a/src/test/scala/org/broadinstitute/dsde/firecloud/EntityServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/EntityServiceSpec.scala
@@ -317,9 +317,9 @@ class EntityServiceSpec extends BaseServiceSpec with BeforeAndAfterEach {
       val getJobFuture = entityService.getJob("workspaceNamespace", "workspaceName", jobId, dummyUserInfo("mytoken"))
 
       ScalaFutures.whenReady(getJobFuture.failed) { actual =>
-        actual shouldBe a [ApiException]
-        val apiEx = actual.asInstanceOf[ApiException]
-        apiEx.getCode shouldEqual StatusCodes.NotFound.intValue
+        actual shouldBe a [FireCloudExceptionWithErrorReport]
+        val apiEx = actual.asInstanceOf[FireCloudExceptionWithErrorReport]
+        apiEx.errorReport.statusCode should contain(StatusCodes.NotFound)
       }
     }
     "should escalate cWDS's error" in {
@@ -339,9 +339,9 @@ class EntityServiceSpec extends BaseServiceSpec with BeforeAndAfterEach {
       val getJobFuture = entityService.getJob("workspaceNamespace", "workspaceName", jobId, dummyUserInfo("mytoken"))
 
       ScalaFutures.whenReady(getJobFuture.failed) { actual =>
-        actual shouldBe a [ApiException]
-        val apiEx = actual.asInstanceOf[ApiException]
-        apiEx.getCode shouldBe StatusCodes.ImATeapot.intValue
+        actual shouldBe a [FireCloudExceptionWithErrorReport]
+        val apiEx = actual.asInstanceOf[FireCloudExceptionWithErrorReport]
+        apiEx.errorReport.statusCode should contain (StatusCodes.ImATeapot)
         apiEx.getMessage should(include("cWDS unit test intentional error"))
       }
     }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiServiceSpec.scala
@@ -1016,7 +1016,7 @@ class WorkspaceApiServiceSpec extends BaseServiceSpec with WorkspaceApiService w
         (Post(pfbImportPath, PFBImportRequest("https://bad.request.avro"))
           ~> dummyUserIdHeaders(dummyUserId)
           ~> sealRoute(workspaceRoutes)) ~> check {
-            status should equal(InternalServerError) // TODO: bubble up 400 / BadRequest
+            status should equal(BadRequest)
             responseAs[String] should include ("Bad request as reported by cwds")
           }
       }
@@ -1025,7 +1025,7 @@ class WorkspaceApiServiceSpec extends BaseServiceSpec with WorkspaceApiService w
         (Post(pfbImportPath, PFBImportRequest("https://forbidden.avro"))
           ~> dummyUserIdHeaders(dummyUserId)
           ~> sealRoute(workspaceRoutes)) ~> check {
-          status should equal(InternalServerError) // TODO: bubble up 403 / Forbidden
+          status should equal(Forbidden)
           responseAs[String] should include ("Missing Authorization: Bearer token in header")
         }
       }
@@ -1034,7 +1034,7 @@ class WorkspaceApiServiceSpec extends BaseServiceSpec with WorkspaceApiService w
         (Post(pfbImportPath, PFBImportRequest("https://its.lawsuit.time.avro"))
           ~> dummyUserIdHeaders(dummyUserId)
           ~> sealRoute(workspaceRoutes)) ~> check {
-          status should equal(InternalServerError) // TODO: bubble up 451 / UnavailableForLegalReasons
+          status should equal(UnavailableForLegalReasons)
           responseAs[String] should include ("cwds message")
         }
       }
@@ -1069,7 +1069,7 @@ class WorkspaceApiServiceSpec extends BaseServiceSpec with WorkspaceApiService w
             (Post(importJobPath, AsyncImportRequest("https://bad.request.avro", filetype))
               ~> dummyUserIdHeaders(dummyUserId)
               ~> sealRoute(workspaceRoutes)) ~> check {
-              status should equal(InternalServerError) // TODO: bubble up 400 / BadRequest
+              status should equal(BadRequest)
               responseAs[String] should include ("Bad request as reported by cwds")
             }
           }
@@ -1078,7 +1078,7 @@ class WorkspaceApiServiceSpec extends BaseServiceSpec with WorkspaceApiService w
             (Post(importJobPath, AsyncImportRequest("https://forbidden.avro", filetype))
               ~> dummyUserIdHeaders(dummyUserId)
               ~> sealRoute(workspaceRoutes)) ~> check {
-              status should equal(InternalServerError) // TODO: bubble up 403 / Forbidden
+              status should equal(Forbidden)
               responseAs[String] should include ("Missing Authorization: Bearer token in header")
             }
           }
@@ -1087,7 +1087,7 @@ class WorkspaceApiServiceSpec extends BaseServiceSpec with WorkspaceApiService w
             (Post(importJobPath, AsyncImportRequest("https://its.lawsuit.time.avro", filetype))
               ~> dummyUserIdHeaders(dummyUserId)
               ~> sealRoute(workspaceRoutes)) ~> check {
-              status should equal(InternalServerError) // TODO: bubble up 451 / UnavailableForLegalReasons
+              status should equal(UnavailableForLegalReasons)
               responseAs[String] should include ("cwds message")
             }
           }


### PR DESCRIPTION
If the cWDS client throws an exception, bubble up its http response codes and try to make a nice error message. Followup to https://github.com/broadinstitute/firecloud-orchestration/pull/1355#discussion_r1610121885.



---

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [x] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
