### PR TITLE
AJ-1854 add concurrency groups to GH workflows

### DIFF
--- a/.github/workflows/es-int-tests.yml
+++ b/.github/workflows/es-int-tests.yml
@@ -1,15 +1,12 @@
 name: Elasticsearch Integration Tests
 
 on:
-  push:
-    paths-ignore:
-      - 'README.md'
   pull_request:
     branches: [ develop ]
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/es-int-tests.yml
+++ b/.github/workflows/es-int-tests.yml
@@ -1,6 +1,10 @@
 name: Elasticsearch Integration Tests
 
 on:
+  push:
+    branches: [ develop ]
+    paths-ignore:
+      - 'README.md'
   pull_request:
     branches: [ develop ]
   workflow_dispatch:

--- a/.github/workflows/es-int-tests.yml
+++ b/.github/workflows/es-int-tests.yml
@@ -8,6 +8,10 @@ on:
     branches: [ develop ]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   es-integration-tests:
     name: Elasticsearch Integration Tests

--- a/.github/workflows/es-int-tests.yml
+++ b/.github/workflows/es-int-tests.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref  }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/es-int-tests.yml
+++ b/.github/workflows/es-int-tests.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref  }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/orch-build-tag-publish-and-run-tests.yml
+++ b/.github/workflows/orch-build-tag-publish-and-run-tests.yml
@@ -5,13 +5,9 @@ name: orch-build-tag-publish-and-run-tests
 on:
   pull_request:
     paths-ignore: ['**.md']
-  push:
-    branches:
-      - develop
-    paths-ignore: ['**.md']
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/orch-build-tag-publish-and-run-tests.yml
+++ b/.github/workflows/orch-build-tag-publish-and-run-tests.yml
@@ -5,9 +5,13 @@ name: orch-build-tag-publish-and-run-tests
 on:
   pull_request:
     paths-ignore: ['**.md']
+  push:
+    branches:
+      - develop
+    paths-ignore: ['**.md']
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/orch-build-tag-publish-and-run-tests.yml
+++ b/.github/workflows/orch-build-tag-publish-and-run-tests.yml
@@ -9,6 +9,11 @@ on:
     branches:
       - develop
     paths-ignore: ['**.md']
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 env:
   GCR_REGISTRY: gcr.io/broad-dsp-gcr-public/firecloud-orchestration
   # Region-specific Google Docker repository where GOOGLE_PROJECT/REPOSITORY_NAME can be found

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches: [ develop ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
 

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -3,9 +3,13 @@ name: Scala CI
 on:
   pull_request:
     branches: [ develop ]
+  push:
+    paths-ignore:
+      - 'README.md'
+    branches: [ develop ]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -1,14 +1,11 @@
 name: Scala CI
 
 on:
-  push:
-    paths-ignore:
-      - 'README.md'
   pull_request:
     branches: [ develop ]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-1854

Adds concurrency groups to 3 workflows that run for pull requests.  Runs them only on `pull_request`, not also on `push`.  The one that creates a bee already uses `always()` for bee-destroy so there shouldn't be any rogue bees left lying around - verified by canceling after the bee had been created and saw that bee-destroy was run.


Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
