### PR TITLE
AJ-1784: remove override for grpc-xds

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -22,8 +22,7 @@ object Dependencies {
     "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonV,
     "com.fasterxml.jackson.core" % "jackson-databind" % jacksonHotfixV,
     "com.fasterxml.jackson.core" % "jackson-core" % jacksonV,
-    "org.yaml" % "snakeyaml" % "1.33",
-    "io.grpc" % "grpc-xds" % "1.56.1"
+    "org.yaml" % "snakeyaml" % "1.33"
   )
 
   val rootDependencies: Seq[ModuleID] = Seq(


### PR DESCRIPTION
With the override in place, `grpc-xds` was pinned to the specified version: 1.56.1.

Without the override, the version of `grpc-xds` is free to be specified by its parent libraries, and ends up at 1.59.0 according to `sbt dependencyTree | grep grpc-xds`. 

This PR removes the override.

---

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [x] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
