### PR TITLE
AJ-268: update to latest workbench-libs, which removes trial billing references

### DIFF
--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -7,17 +7,17 @@ object Dependencies {
   val jacksonHotfixV = "2.17.1" // for when only some of the Jackson libs have hotfix releases
   val akkaV = "2.6.19"
   val akkaHttpV = "10.2.10"
-  val workbenchLibsHash = "d314413"
+  val workbenchLibsHash = "9138393"
 
-  val workbenchModelV  = s"0.19-$workbenchLibsHash"
+  val workbenchModelV  = s"0.20-$workbenchLibsHash"
   val workbenchModel: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-model" % workbenchModelV
   val excludeWorkbenchModel = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-model_" + scalaV)
 
-  val workbenchGoogleV = s"0.30-$workbenchLibsHash"
+  val workbenchGoogleV = s"0.32-$workbenchLibsHash"
   val workbenchGoogle: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-google" % workbenchGoogleV excludeAll excludeWorkbenchModel
   val excludeWorkbenchGoogle = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-google_" + scalaV)
 
-  val workbenchServiceTestV = s"4.3-$workbenchLibsHash"
+  val workbenchServiceTestV = s"5.0-$workbenchLibsHash"
   val workbenchServiceTest: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-service-test" % workbenchServiceTestV % "test" classifier "tests" excludeAll (excludeWorkbenchGoogle, excludeWorkbenchModel)
 
   // Overrides for transitive dependencies. These apply - via Settings.scala - to all projects in this codebase.

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
   val jacksonV = "2.17.1"
   val jacksonHotfixV = "2.17.1" // for when only some of the Jackson libs have hotfix releases
   val nettyV = "4.1.111.Final"
-  val workbenchLibsHash = "a6ad7dc" // see https://github.com/broadinstitute/workbench-libs readme for hash values
+  val workbenchLibsHash = "9138393" // see https://github.com/broadinstitute/workbench-libs readme for hash values
 
   def excludeGuava(m: ModuleID): ModuleID = m.exclude("com.google.guava", "guava")
   val excludeAkkaActor =        ExclusionRule(organization = "com.typesafe.akka", name = "akka-actor_2.13")


### PR DESCRIPTION
This updates Orch's automation subdirectory (swat tests) to the latest versions of workbench-libs libraries. The latest version of service-test removes knowledge of the trial-billing SA. This is a prerequisite for removing knowledge of trial-billing from the github workflows that run the swat tests, which in turn unblocks removing that unused SA entirely.

This pulls in https://github.com/broadinstitute/workbench-libs/pull/1692

I am making this change across Sam, Leo, Rawls, and Orch:
* https://github.com/DataBiosphere/leonardo/pull/4685
* https://github.com/broadinstitute/sam/pull/1471
* https://github.com/broadinstitute/rawls/pull/2940
* https://github.com/broadinstitute/firecloud-orchestration/pull/1385

---

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
