### PR TITLE
AJ-1784: update to Akka module versions 24.05

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,8 +1,8 @@
 import sbt._
 
 object Dependencies {
-  val akkaV = "2.6.19"
-  val akkaHttpV = "10.2.10"
+  val akkaV = "2.9.3"
+  val akkaHttpV = "10.6.3"
   val jacksonV = "2.17.1"
   val jacksonHotfixV = "2.17.1" // for when only some of the Jackson libs have hotfix releases
   val nettyV = "4.1.111.Final"

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -13,7 +13,8 @@ object Settings {
   val commonResolvers = List(
     "artifactory-releases" at artifactory + "libs-release",
     "artifactory-snapshots" at artifactory + "libs-snapshot",
-    "jitpack.io" at "https://jitpack.io"
+    "jitpack.io" at "https://jitpack.io",
+    "Akka library repository" at "https://repo.akka.io/maven"
   )
 
   val proxyResolvers = List(

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/model/SamResourceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/model/SamResourceSpec.scala
@@ -7,7 +7,6 @@ import spray.json._
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
 import spray.json.DefaultJsonProtocol._
 
-import scala.util.parsing.json.JSONFormat
 
 class SamResourceSpec extends AnyFreeSpec with Matchers {
 


### PR DESCRIPTION
See https://akka.io/blog/news/2024/05/17/akka-24.05-released

Upgrades to this latest version of Akka libraries.

These are pretty big jumps, but I have read through the migration guides and do not see anything that needs attention.

---

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [x] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
