### PR TITLE
AJ-1916: use scala-sbt baseimage with correct versions

### DIFF
--- a/automation/Dockerfile-tests
+++ b/automation/Dockerfile-tests
@@ -1,4 +1,4 @@
-FROM hseeberger/scala-sbt:eclipse-temurin-17.0.2_1.6.2_2.13.8
+FROM sbtscala/scala-sbt:eclipse-temurin-jammy-17.0.10_7_1.10.0_2.13.14
 
 COPY src /app/src
 COPY test.sh /app

--- a/jenkins/ittests.sh
+++ b/jenkins/ittests.sh
@@ -6,7 +6,7 @@ set -eux
 ./docker/run-es.sh start
 
 # execute tests, overriding elasticsearch.urls to point at the linked container
-SBT_IMAGE=hseeberger/scala-sbt:eclipse-temurin-17.0.2_1.6.2_2.13.8
+SBT_IMAGE=sbtscala/scala-sbt:eclipse-temurin-jammy-17.0.10_7_1.10.0_2.13.14
 docker run --rm \
   --link elasticsearch-ittest:elasticsearch-ittest \
   -v sbt-cache:/root/.sbt \

--- a/local-dev/templates/docker-rsync-local-orch.sh
+++ b/local-dev/templates/docker-rsync-local-orch.sh
@@ -111,7 +111,7 @@ start_server () {
     -p 5051:5051 \
     --network=fc-orch \
     -e JAVA_OPTS="$DOCKER_JAVA_OPTS" \
-    hseeberger/scala-sbt:eclipse-temurin-17.0.2_1.6.2_2.13.8 \
+    sbtscala/scala-sbt:eclipse-temurin-jammy-17.0.10_7_1.10.0_2.13.14 \
     sbt \~reStart
 
     docker cp config/firecloud-account.pem orch-sbt:/etc/firecloud-account.pem

--- a/script/build.sh
+++ b/script/build.sh
@@ -96,7 +96,7 @@ function make_jar()
 
     docker run --rm -e GIT_MODEL_HASH=${GIT_MODEL_HASH} \
         -v $PWD:/working -w /working -v jar-cache:/root/.ivy -v jar-cache:/root/.ivy2 \
-        hseeberger/scala-sbt:eclipse-temurin-17.0.2_1.6.2_2.13.8 /working/src/docker/install.sh /working
+        sbtscala/scala-sbt:eclipse-temurin-jammy-17.0.10_7_1.10.0_2.13.14 /working/src/docker/install.sh /working
 }
 
 function docker_cmd()

--- a/script/build_jar.sh
+++ b/script/build_jar.sh
@@ -12,7 +12,7 @@ docker run --rm -e GIT_MODEL_HASH=${GIT_MODEL_HASH} \
   -v $PWD:/working \
   -v jar-cache:/root/.ivy -v jar-cache:/root/.ivy2 \
   -w /working \
-  hseeberger/scala-sbt:eclipse-temurin-17.0.2_1.6.2_2.13.8 /working/src/docker/clean_install.sh /working
+  sbtscala/scala-sbt:eclipse-temurin-jammy-17.0.10_7_1.10.0_2.13.14 /working/src/docker/clean_install.sh /working
 
 EXIT_CODE=$?
 


### PR DESCRIPTION
Before this PR, we were using the `seeberger/scala-sbt:eclipse-temurin-17.0.2_1.6.2_2.13.8` docker image in many places. This image comes with sbt 1.6.2 and scala 2.13.8 preinstalled. However, those are not the sbt and scala versions in use. So, it meant that we immediately had to download sbt and scala to do anything.

In this PR:
* switch to the `sbtscala/scala-sbt:eclipse-temurin-jammy-17.0.10_7_1.10.0_2.13.14` docker image, which comes with Orch's versions of Scala and sbt preinstalled

Additionally, the [`hseeberger/scala-sbt`](https://hub.docker.com/r/hseeberger/scala-sbt) image hasn't had an update in ~2 years. The [`sbtscala/scala-sbt`](https://hub.docker.com/r/sbtscala/scala-sbt) image comes directly from `sbt`. At the bottom of the `sbtscala/scala-sbt` page on Dockerhub, they explicitly say:

> Older images that were published before we migrated to the sbtscala organization are available at https://hub.docker.com/r/hseeberger/scala-sbt


See also: https://github.com/broadinstitute/rawls/pull/2815

---

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [x] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
