### PR TITLE
AJ-1784: switch to mockserver-netty-no-dependencies

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -50,8 +50,7 @@ pullRequests.frequency = "0 0 ? * MON" # every monday at midnight
 # these require nontrivial changes to calling code and business logic. See AJ-266.
 updates.ignore = [
   { groupId = "org.elasticsearch.client", artifactId = "transport" },   # AJ-266
-  { groupId = "org.apache.lucene", artifactId = "lucene-queryparser" }, # AJ-266
-  { groupId = "org.mock-server", artifactId = "mockserver-netty" }      # AJ-423
+  { groupId = "org.apache.lucene", artifactId = "lucene-queryparser" } # AJ-266
 ]
 
 # If set, Scala Steward will only create or update `n` PRs each time it runs (see `pullRequests.frequency` above).

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -89,7 +89,7 @@ object Dependencies {
     "com.github.pathikrit"          %% "better-files"        % "3.9.2",
 
     "org.scalatest"                 %% "scalatest"           % "3.2.19"   % "test",
-    "org.mock-server"                % "mockserver-netty"    % "5.15.0"  % "test",
+    "org.mock-server"                % "mockserver-netty-no-dependencies"    % "5.15.0"  % "test",
     // provides testing mocks
     "com.google.cloud"               % "google-cloud-nio"    % "0.127.20" % "test",
     "org.scalatestplus"             %% "mockito-4-5"         % "3.2.12.0" % "test"


### PR DESCRIPTION
From https://www.mock-server.com/where/maven_central.html:

> * org.mock-server:mockserver-netty-no-dependencies:5.14.0 - compiled code and transitive dependencies bundled into a single jar, with packages for most transitive dependencies being updated to avoid clashes with dependencies from projects importing MockServer. This has no transitive dependencies and so is the recommended best option.
> * org.mock-server:mockserver-netty:5.14.0 - only compiled code with transitive dependencies pulled in by Maven, Gradle, etc. As per normal Maven or Ivy dependencies this includes transitive dependencies (in its pom.xml) which would be pulled in by Maven, Gradle, Ivy, SBT, etc unless explicitly excluded.

We are switching to the "recommended best option". Multiple transitive deps pulled in by `mockserver-netty` have warnings on them; let's see if this works any better.



Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [x] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
