### PR TITLE
AJ-1784: move google dependencies to transitiveDependencyOverrides

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -23,11 +23,13 @@ object Dependencies {
   // by being listed here.
   // One reason to specify an override here is to avoid static-analysis security warnings.
   val transitiveDependencyOverrides: Seq[ModuleID] = Seq(
-    "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonV,
-    "com.fasterxml.jackson.core" % "jackson-databind" % jacksonHotfixV,
-    "com.fasterxml.jackson.core" % "jackson-core" % jacksonV,
-    "org.yaml" % "snakeyaml" % "1.33",
-    "org.apache.commons" % "commons-compress" % "1.26.2" // workbench-libs libraries pull this in
+    "com.fasterxml.jackson.core" % "jackson-annotations"        % jacksonV,
+    "com.fasterxml.jackson.core" % "jackson-databind"           % jacksonHotfixV,
+    "com.fasterxml.jackson.core" % "jackson-core"               % jacksonV,
+    "org.yaml"                   % "snakeyaml"                  % "1.33",
+    "org.apache.commons"         % "commons-compress"           % "1.26.2", // workbench-libs libraries pull this in
+    "com.google.apis"            % "google-api-services-pubsub" % "v1-rev20240730-2.0.0", // from workbench-google2
+    "com.google.apis"  % "google-api-services-admin-directory"  % "directory_v1-rev20240709-2.0.0" // from workbench-google2
   )
 
   val rootDependencies: Seq[ModuleID] = Seq(
@@ -81,9 +83,6 @@ object Dependencies {
       exclude("com.fasterxml.jackson.dataformat", "jackson-dataformat-cbor")
       exclude("org.apache.logging.log4j", "log4j-api")
       exclude("org.apache.logging.log4j", "log4j-core"),
-
-    excludeGuava("com.google.apis"     % "google-api-services-pubsub"       % "v1-rev20240702-2.0.0"),
-    excludeGuava("com.google.apis"     % "google-api-services-admin-directory"  % "directory_v1-rev20240709-2.0.0"),
 
     "com.github.jwt-scala"          %% "jwt-core"            % "10.0.1",
     // javax.mail is used only by MethodRepository.validatePublicOrEmail(). Consider


### PR DESCRIPTION
Supersedes #1408 .

When reviewing that other PR, I questioned why Orch has `google-api-services-pubsub` and `google-api-services-admin-directory` as direct dependencies; I thought those were pulled in by workbench-libs google2. In fact, they are; I assume Orch has these as direct dependencies so it can override those libraries to a later version.

In this PR, I move the direct dependencies to `transitiveDependencyOverrides` to be clearer about what's happening. I also incorporate the pubsub version bump from #1408. Finally, I reformat whitespace in `transitiveDependencyOverrides` for code cleanliness.

---

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the RC_XXX release ticket with any manual steps required to release this change
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge; you can delete your branch after this **unless it's for a hotfix**. In that case, don't delete it!
- [ ] Test this change deployed correctly and works on dev environment after deployment
