### PR TITLE
[WOR-1808] Add workspace settings routes

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -48,7 +48,7 @@ object Dependencies {
     "com.typesafe.scala-logging"    %% "scala-logging"       % "3.9.5",
 
     "org.parboiled" % "parboiled-core" % "1.4.1",
-    excludeGuava("org.broadinstitute.dsde"       %% "rawls-model"         % "339209ac")
+    excludeGuava("org.broadinstitute.dsde"       %% "rawls-model"         % "8ffac131")
       exclude("com.typesafe.scala-logging", "scala-logging_2.13")
       exclude("com.typesafe.akka", "akka-stream_2.13")
       exclude("com.google.code.findbugs", "jsr305")

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -6,6 +6,7 @@ workspace {
   model="model.json"
   authPrefix="/api"
   workspacesPath="/workspaces"
+  workspacesV2Path="/workspaces/v2"
   workspacesAclPath="/workspaces/%s/%s/acl"
   entitiesPath="/workspaces/%s/%s/entities"
   entityQueryPath="/workspaces/%s/%s/entityQuery"

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -5239,6 +5239,304 @@ paths:
           description: Internal Server Error
           content: {}
       x-passthrough: false
+  /api/workspaces/v2/{workspaceNamespace}/{workspaceName}:
+    delete:
+      tags:
+        - WorkspacesV2
+      summary: Delete workspace
+      description: Starts a job to delete a workspace and all of its contents.
+      operationId: deleteWorkspaceV2
+      parameters:
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
+      responses:
+        202:
+          description: Delete request accepted. Workspace bucket will be deleted within
+            24 hours.
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/WorkspaceDeletionResult'
+        400:
+          description: Workspace is not in a deletable state.
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        403:
+          description: Insufficient permissions to delete workspace (must be owner)
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        409:
+          description: Workspace is already being deleted.
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        404:
+          description: Workspace not found
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        500:
+          $ref: '#/components/responses/RawlsInternalError'
+  /api/workspaces/v2/{workspaceNamespace}/{workspaceName}/clone:
+    post:
+      tags:
+        - WorkspacesV2
+      summary: Clone workspace
+      description: Clone a workspace, asynchronously if possible
+      operationId: cloneWorkspace
+      parameters:
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
+      requestBody:
+        description: Request for new workspace
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/WorkspaceRequestClone'
+        required: true
+      responses:
+        201:
+          description: Successful Request
+          headers:
+            Location:
+              description: The path to the newly cloned workspace
+              schema:
+                type: string
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/WorkspaceDetails'
+        400:
+          description: Workspace namespace is not ready
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        403:
+          description: User does not have access to create workspace in namespace
+            or user does not have permission to set attributes in the namespace
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        404:
+          description: Source workspace not found
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        409:
+          description: Destination workspace already exists
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        422:
+          description: Destination workspace must match source's authorization domain,
+            if the dest has one
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        500:
+          $ref: '#/components/responses/RawlsInternalError'
+      x-codegen-request-body-name: workspaceRequest
+
+  /api/workspaces/v2/{workspaceNamespace}/{workspaceName}/bucketMigration:
+    get:
+      tags:
+        - WorkspacesV2
+      summary: list bucket migration attempts for workspace. empty list for workspaces that have not been migrated before
+      description: list bucket migration attempts for workspace. empty list for workspaces that have not been migrated before
+      operationId: listBucketMigrationsForWorkspace
+      parameters:
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
+      responses:
+        200:
+          description: Successful Request
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/WorkspaceMigrationMetadata'
+        403:
+          description: You must be an owner to list migration attempts
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        404:
+          description: Workspace not found or you do not have access to it
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        500:
+          $ref: '#/components/responses/RawlsInternalError'
+    post:
+      tags:
+        - WorkspacesV2
+      summary: start bucket migration attempt for Google workspace or restart failed past attempt
+      description: start bucket migration attempt for Google workspace or restart failed past attempt
+      operationId: startBucketMigrationForWorkspace
+      parameters:
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
+      responses:
+        201:
+          description: Workspace scheduled for migration
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/WorkspaceMigrationMetadata'
+        400:
+          description: This workspace is ineligible for migration.
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        403:
+          description: You must be an owner to start migration attempts
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        404:
+          description: Workspace not found or you do not have access to it
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        500:
+          $ref: '#/components/responses/RawlsInternalError'
+  /api/workspaces/v2/{workspaceNamespace}/{workspaceName}/bucketMigration/progress:
+    get:
+      tags:
+        - WorkspacesV2
+      summary: get bucket migration progress for workspace
+      description: get bucket migration progress for workspace
+      operationId: getBucketMigrationProgressForWorkspace
+      parameters:
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
+      responses:
+        200:
+          description: Successful Request
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/MultiregionalBucketMigrationProgress'
+        403:
+          description: You must be an owner to get migration progress
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        404:
+          description: Workspace not found, you do not have access to it, or it has not been migrated before
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        500:
+          $ref: '#/components/responses/RawlsInternalError'
+  /api/workspaces/v2/bucketMigration:
+    post:
+      tags:
+        - WorkspacesV2
+      summary: batch start Google workspace bucket migrations or restart failed past attempts
+      description: batch start bucket migration attempts for Google workspaces or restart failed past attempts
+      operationId: batchStartBucketMigrationForWorkspaces
+      requestBody:
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/BatchMigrateRequestBody'
+      responses:
+        201:
+          description: Workspaces scheduled for migration
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/WorkspaceMigrationMetadata'
+        400:
+          description: Some or all workspaces in billing project were ineligible for migration. Eligible workspaces are scheduled for migration and ineligible workspaces will be included in error message.
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        403:
+          description: You must be an owner to start migration attempts
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        500:
+          $ref: '#/components/responses/RawlsInternalError'
+    get:
+      tags:
+        - WorkspacesV2
+      summary: get workspaces eligible for bucket migration and their migration progress if it exists
+      description: get workspaces eligible for bucket migration and their migration progress if it exists
+      operationId: getEligibleWorkspacesForBucketMigrationWithProgress
+      responses:
+        200:
+          description: Successful Request
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  type: object
+                  description: Returns metadata in the shape workspaceNamespace/workspaceName -> bucket migration progress where the progress is null for workspaces that have not been scheduled for migration before.
+                  additionalProperties:
+                    $ref: '#/components/schemas/MultiregionalBucketMigrationProgress'
+        500:
+          $ref: '#/components/responses/RawlsInternalError'
+  /api/workspaces/v2/bucketMigration/getProgress:
+    post:
+      tags:
+        - WorkspacesV2
+      summary: fetch bucket migration progress for multiple Google workspaces
+      description: fetch bucket migration progress for multiple Google workspaces
+      operationId: getBucketMigrationProgressForWorkspaceList
+      requestBody:
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/BatchMigrateRequestBody'
+      responses:
+        200:
+          description: Successful Request
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  type: object
+                  description: Returns metadata in the shape workspaceNamespace/workspaceName -> bucket migration progress where the progress is null for workspaces that have not been scheduled for migration before.
+                  additionalProperties:
+                    $ref: '#/components/schemas/MultiregionalBucketMigrationProgress'
+        403:
+          description: You must be an owner of all requested workspaces
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        500:
+          $ref: '#/components/responses/RawlsInternalError'
   /api/workspaces/v2/{workspaceNamespace}/{workspaceName}/settings:
     get:
       tags:
@@ -8906,6 +9204,22 @@ components:
           items:
             type: string
       description: ""
+    WorkspaceDeletionResult:
+      type: object
+      description: Workspace deletion metadata
+      properties:
+        gcpContext:
+          $ref: '#/components/schemas/GcpWorkspaceDeletionContext'
+        jobId:
+          type: string
+          description: Deletion job ID
+    GcpWorkspaceDeletionContext:
+      type: object
+      description: Workspace deletion context information for a GCP workspace
+      properties:
+        bucketName:
+          type: string
+          description: Name of the workspace's GCP bucket, if present
     WorkspaceDetails:
       required:
         - bucketName
@@ -9018,6 +9332,19 @@ components:
         workspaceSubmissionStats:
           description: GCP workspace submission statistics, deprecated as part of the list response due to slow performance. This field will continue to be supported on individual workspace details.
           deprecated: true
+      description: ""
+    WorkspaceName:
+      required:
+        - name
+        - namespace
+      type: object
+      properties:
+        namespace:
+          type: string
+          description: The namespace (billing project) the workspace belongs to
+        name:
+          type: string
+          description: The name of the workspace
       description: ""
     WorkspaceRequest:
       required:
@@ -9225,6 +9552,101 @@ components:
           description: number of usages of the tag
           format: int32
           example: 5
+    WorkspaceMigrationMetadata:
+      description: Represents the status of a workspace migration
+      type: object
+      required:
+        - id
+        - created
+        - updated
+      properties:
+        id:
+          type: integer
+          description: migration attempt number for this workspace
+        created:
+          type: string
+          format: date-time
+          description: when the migration was scheduled
+        started:
+          type: string
+          format: date-time
+          description: when the system started the migration
+        updated:
+          type: string
+          format: date-time
+          description: when the system last updated the migration
+        finished:
+          type: string
+          format: date-time
+          description: when the system finished executing the migration
+        outcome:
+          $ref: '#/components/schemas/WorkspaceMigrationOutcome'
+    WorkspaceMigrationOutcome:
+      description: Represents the result of a workspace migration attempt
+      oneOf:
+        - $ref: '#/components/schemas/WorkspaceMigrationSuccess'
+        - $ref: '#/components/schemas/WorkspaceMigrationFailure'
+    WorkspaceMigrationSuccess:
+      type: string
+      enum:
+        - success
+    WorkspaceMigrationFailure:
+      type: object
+      required:
+        - failure
+      properties:
+        failure:
+          description: Supplementary failure information
+          type: string
+    BatchMigrateRequestBody:
+      description: List of workspace names
+      type: array
+      items:
+        $ref: '#/components/schemas/WorkspaceName'
+    MultiregionalBucketMigrationProgress:
+      description: Represents the progress of a workspace bucket through the multiregional bucket migration pipeline
+      type: object
+      required:
+        - migrationStep
+      properties:
+        migrationStep:
+          description: User facing step of migration
+          type: string
+          enum:
+            - ScheduledForMigration
+            - PreparingTransferToTempBucket
+            - TransferringToTempBucket
+            - PreparingTransferToFinalBucket
+            - TransferringToFinalBucket
+            - FinishingUp
+            - Finished
+        outcome:
+          $ref: '#/components/schemas/WorkspaceMigrationOutcome'
+        tempBucketTransferProgress:
+          $ref: '#/components/schemas/StorageTransferJobProgress'
+        finalBucketTransferProgress:
+          $ref: '#/components/schemas/StorageTransferJobProgress'
+    StorageTransferJobProgress:
+      description: Represents the progress of a single Storage Transfer Service job to move a bucket
+      type: object
+      required:
+        - totalBytesToTransfer
+        - bytesTransferred
+        - totalObjectsToTransfer
+        - objectsTransferred
+      properties:
+        totalBytesToTransfer:
+          description: total bytes that this job will transfer
+          type: integer
+        bytesTransferred:
+          description: bytes that this job has transferred so far
+          type: integer
+        totalObjectsToTransfer:
+          description: total objects that this job will transfer
+          type: integer
+        objectsTransferred:
+          description: objects that this job has transferred so far
+          type: integer
     ConfigurationPayload:
       type: object
       properties:

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -34,6 +34,7 @@ tags:
   - name: Version
   - name: Womtool
   - name: Workspaces
+  - name: WorkspacesV2
 security:
   - oidc: []
 paths:
@@ -5238,6 +5239,84 @@ paths:
           description: Internal Server Error
           content: {}
       x-passthrough: false
+  /api/workspaces/v2/{workspaceNamespace}/{workspaceName}/settings:
+    get:
+      tags:
+        - WorkspacesV2
+      summary: Get workspace settings
+      description: Get the settings for a workspace
+      operationId: getWorkspaceSettings
+      parameters:
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
+      responses:
+        200:
+          description: Success
+          content:
+            'application/json':
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/WorkspaceSetting'
+        403:
+          description: User does not have access to requested workspace
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        404:
+          description: Workspace not found
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        500:
+          $ref: '#/components/responses/RawlsInternalError'
+    put:
+      tags:
+        - WorkspacesV2
+      summary: Update workspace settings
+      description: Update the settings for a workspace. Unspecified setting types will be left unchanged.
+      operationId: updateWorkspaceSettings
+      parameters:
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
+      requestBody:
+        description: New settings for the workspace
+        content:
+          'application/json':
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/WorkspaceSetting'
+        required: true
+      responses:
+        200:
+          description: Success
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/WorkspaceSettingsResponse'
+        400:
+          description: Invalid settings
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        403:
+          description: User must be an owner of the workspace to overwrite settings
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        404:
+          description: Workspace not found
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/ErrorReport'
+        500:
+          $ref: '#/components/responses/RawlsInternalError'
   /cookie-authed/workspaces/{workspaceNamespace}/{workspaceName}/entities/{entityType}/tsv:
     get:
       tags:
@@ -9029,6 +9108,91 @@ components:
         workspaceSubmissionStats:
           $ref: '#/components/schemas/WorkspaceSubmissionStats'
       description: ""
+    WorkspaceSettingsResponse:
+      required:
+        - successes
+        - failures
+      type: object
+      properties:
+        successes:
+          type: array
+          description: The settings that were successfully applied
+          items:
+            $ref: '#/components/schemas/WorkspaceSetting'
+        failures:
+          $ref: '#/components/schemas/FailedWorkspaceSettingsResponse'
+    FailedWorkspaceSettingsResponse:
+      type: object
+      description: The settings that failed to apply. The key is the setting type that failed.
+      additionalProperties:
+        $ref: '#/components/schemas/ErrorReport'
+    WorkspaceSetting:
+      required:
+        - settingType
+        - config
+      type: object
+      properties:
+        settingType:
+          type: string
+          description: The type of the workspace setting
+          enum:
+            - GcpBucketLifecycle
+            - GcpBucketSoftDelete
+        config:
+          description: The configuration of the workspace setting
+          oneOf:
+            - $ref: '#/components/schemas/WorkspaceSettingGcpBucketLifecycleConfig'
+            - $ref: '#/components/schemas/WorkspaceSettingGcpBucketSoftDeleteConfig'
+    WorkspaceSettingGcpBucketLifecycleConfig:
+      required:
+        - rules
+      type: object
+      properties:
+        rules:
+          type: array
+          description: The lifecycle rules for the workspace bucket
+          items:
+            $ref: '#/components/schemas/GcpBucketLifecycleRule'
+    GcpBucketLifecycleRule:
+      required:
+        - action
+        - conditions
+      type: object
+      properties:
+        action:
+          $ref: '#/components/schemas/GcpBucketLifecycleAction'
+        conditions:
+          $ref: '#/components/schemas/GcpBucketLifecycleCondition'
+    GcpBucketLifecycleAction:
+      required:
+        - actionType
+      type: object
+      properties:
+        actionType:
+          type: string
+          description: The type of the lifecycle action
+          enum:
+            - Delete
+    GcpBucketLifecycleCondition:
+      type: object
+      minProperties: 1
+      properties:
+        age:
+          type: integer
+          description: The age of the object in days
+        matchesPrefix:
+          type: array
+          description: Object name prefixes that this rule applies to
+          items:
+            type: string
+    WorkspaceSettingGcpBucketSoftDeleteConfig:
+      required:
+        - retentionDurationInSeconds
+      type: object
+      properties:
+        retentionDurationInSeconds:
+          type: integer
+          description: The length of time to retain soft-deleted objects for, in seconds
     WorkspaceSubmissionStats:
       required:
         - runningSubmissionsCount

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -5289,7 +5289,7 @@ paths:
         - WorkspacesV2
       summary: Clone workspace
       description: Clone a workspace, asynchronously if possible
-      operationId: cloneWorkspace
+      operationId: cloneWorkspaceV2
       parameters:
         - $ref: '#/components/parameters/workspaceNamespaceParam'
         - $ref: '#/components/parameters/workspaceNameParam'

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudApiService.scala
@@ -67,6 +67,7 @@ trait FireCloudApiService extends CookieAuthedApiService
   with OauthApiService
   with RegisterApiService
   with WorkspaceApiService
+  with WorkspaceV2ApiService
   with NotificationsApiService
   with MethodConfigurationApiService
   with BillingApiService
@@ -214,6 +215,7 @@ trait FireCloudApiService extends CookieAuthedApiService
       userServiceRoutes ~
       managedGroupServiceRoutes ~
       workspaceRoutes ~
+      workspaceV2Routes ~
       notificationsRoutes ~
       statusRoutes ~
       ga4ghRoutes ~

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
@@ -47,6 +47,8 @@ object FireCloudConfig {
     val authUrl = baseUrl + authPrefix
     val workspacesPath = workspace.getString("workspacesPath")
     val workspacesUrl = authUrl + workspacesPath
+    val workspacesV2Path = workspace.getString("workspacesV2Path")
+    val workspacesV2Url = authUrl + workspacesV2Path
     val entitiesPath = workspace.getString("entitiesPath")
     val entityQueryPath = workspace.getString("entityQueryPath")
     val workspacesEntitiesCopyPath = workspace.getString("workspacesEntitiesCopyPath")

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceV2ApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceV2ApiService.scala
@@ -1,15 +1,18 @@
 package org.broadinstitute.dsde.firecloud.webservice
 
-import akka.http.scaladsl.model.HttpMethods
 import akka.http.scaladsl.server.Route
 
 import org.broadinstitute.dsde.firecloud.FireCloudConfig
 import org.broadinstitute.dsde.firecloud.service.{FireCloudDirectives, FireCloudRequestBuilding}
-import org.broadinstitute.dsde.firecloud.utils.StandardUserInfoDirectives
+import org.broadinstitute.dsde.firecloud.utils.{StandardUserInfoDirectives, StreamingPassthrough}
 
 import scala.concurrent.ExecutionContext
 
-trait WorkspaceV2ApiService extends FireCloudRequestBuilding with FireCloudDirectives with StandardUserInfoDirectives {
+trait WorkspaceV2ApiService
+    extends FireCloudRequestBuilding
+    with FireCloudDirectives
+    with StandardUserInfoDirectives
+    with StreamingPassthrough {
 
   implicit val executionContext: ExecutionContext
 
@@ -21,15 +24,8 @@ trait WorkspaceV2ApiService extends FireCloudRequestBuilding with FireCloudDirec
         (workspaceNamespace, workspaceName) => {
           val workspaceV2Path = encodeUri(rawlsWorkspacesV2Root + "/%s/%s".format(workspaceNamespace, workspaceName))
           path("settings") {
-            get {
-              requireUserInfo() { _ =>
-                passthrough(workspaceV2Path + "/settings", HttpMethods.GET)
-              }
-            } ~
-            put {
-              requireUserInfo() { _ =>
-                passthrough(workspaceV2Path + "/settings", HttpMethods.PUT)
-              }
+            requireUserInfo() { _ =>
+              streamingPassthrough(workspaceV2Path + "/settings")
             }
           }
         }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceV2ApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceV2ApiService.scala
@@ -1,0 +1,38 @@
+package org.broadinstitute.dsde.firecloud.webservice
+
+import akka.http.scaladsl.model.HttpMethods
+import akka.http.scaladsl.server.Route
+
+import org.broadinstitute.dsde.firecloud.FireCloudConfig
+import org.broadinstitute.dsde.firecloud.service.{FireCloudDirectives, FireCloudRequestBuilding}
+import org.broadinstitute.dsde.firecloud.utils.StandardUserInfoDirectives
+
+import scala.concurrent.ExecutionContext
+
+trait WorkspaceV2ApiService extends FireCloudRequestBuilding with FireCloudDirectives with StandardUserInfoDirectives {
+
+  implicit val executionContext: ExecutionContext
+
+  lazy val rawlsWorkspacesV2Root: String = FireCloudConfig.Rawls.workspacesV2Url
+
+  val workspaceV2Routes: Route =
+    pathPrefix("api" / "workspaces" / "v2") {
+      pathPrefix(Segment / Segment) {
+        (workspaceNamespace, workspaceName) => {
+          val workspaceV2Path = encodeUri(rawlsWorkspacesV2Root + "/%s/%s".format(workspaceNamespace, workspaceName))
+          path("settings") {
+            get {
+              requireUserInfo() { _ =>
+                passthrough(workspaceV2Path + "/settings", HttpMethods.GET)
+              }
+            } ~
+            put {
+              requireUserInfo() { _ =>
+                passthrough(workspaceV2Path + "/settings", HttpMethods.PUT)
+              }
+            }
+          }
+        }
+      }
+    }
+}

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceV2ApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceV2ApiService.scala
@@ -3,32 +3,15 @@ package org.broadinstitute.dsde.firecloud.webservice
 import akka.http.scaladsl.server.Route
 
 import org.broadinstitute.dsde.firecloud.FireCloudConfig
-import org.broadinstitute.dsde.firecloud.service.{FireCloudDirectives, FireCloudRequestBuilding}
-import org.broadinstitute.dsde.firecloud.utils.{StandardUserInfoDirectives, StreamingPassthrough}
+import org.broadinstitute.dsde.firecloud.service.FireCloudDirectives
+import org.broadinstitute.dsde.firecloud.utils.StreamingPassthrough
 
-import scala.concurrent.ExecutionContext
+trait WorkspaceV2ApiService extends FireCloudDirectives with StreamingPassthrough {
 
-trait WorkspaceV2ApiService
-    extends FireCloudRequestBuilding
-    with FireCloudDirectives
-    with StandardUserInfoDirectives
-    with StreamingPassthrough {
-
-  implicit val executionContext: ExecutionContext
-
-  lazy val rawlsWorkspacesV2Root: String = FireCloudConfig.Rawls.workspacesV2Url
+  private val rawlsWorkspacesV2Root: String = FireCloudConfig.Rawls.workspacesV2Url
 
   val workspaceV2Routes: Route =
     pathPrefix("api" / "workspaces" / "v2") {
-      pathPrefix(Segment / Segment) {
-        (workspaceNamespace, workspaceName) => {
-          val workspaceV2Path = encodeUri(rawlsWorkspacesV2Root + "/%s/%s".format(workspaceNamespace, workspaceName))
-          path("settings") {
-            requireUserInfo() { _ =>
-              streamingPassthrough(workspaceV2Path + "/settings")
-            }
-          }
-        }
-      }
+      streamingPassthrough(rawlsWorkspacesV2Root)
     }
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceV2ApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceV2ApiServiceSpec.scala
@@ -57,33 +57,17 @@ class WorkspaceV2ApiServiceSpec extends BaseServiceSpec with WorkspaceV2ApiServi
     rawlsServer.stop
   }
 
-  "WorkspaceService Passthrough Negative Tests" - {
-
-    "Passthrough tests on the /workspaces/v2/segment/segment/settings path" - {
-      "MethodNotAllowed error is returned for HTTP POST, PATCH, DELETE methods" in {
-        List(HttpMethods.POST, HttpMethods.PATCH, HttpMethods.DELETE) map {
-          method =>
-            new RequestBuilder(method)(settingsPath) ~> dummyUserIdHeaders(dummyUserId) ~> sealRoute(workspaceV2Routes) ~> check {
-              status should equal(MethodNotAllowed)
-            }
-        }
-      }
-    }
-    }
-
   "WorkspaceService Passthrough Tests" - {
 
-    "Passthrough tests on the GET /workspaces/v2/%s/%s/settings path" - {
-      s"OK status is returned for HTTP GET" in {
+    "Passthrough tests on the /workspaces/v2/segment/segment/settings path" - {
+      s"OK status is returned for HTTP GET if Rawls returns it" in {
         stubRawlsService(HttpMethods.GET, settingsPath, OK)
         Get(settingsPath) ~> dummyUserIdHeaders(dummyUserId) ~> sealRoute(workspaceV2Routes) ~> check {
           status should equal(OK)
         }
       }
-    }
 
-    "Passthrough tests on the PUT /workspaces/v2/%s/%s/settings path" - {
-      s"OK status is returned for HTTP PUT" in {
+      s"OK status is returned for HTTP PUT if Rawls returns it" in {
         stubRawlsService(HttpMethods.PUT, settingsPath, OK)
         Put(settingsPath) ~> dummyUserIdHeaders(dummyUserId) ~> sealRoute(workspaceV2Routes) ~> check {
           status should equal(OK)

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceV2ApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceV2ApiServiceSpec.scala
@@ -1,88 +1,22 @@
 package org.broadinstitute.dsde.firecloud.webservice
 
-import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
-import akka.http.scaladsl.model.StatusCodes.OK
-import akka.http.scaladsl.model.{HttpMethod, HttpMethods, StatusCode}
-import akka.http.scaladsl.server.Route.{seal => sealRoute}
-
-import org.broadinstitute.dsde.firecloud.FireCloudConfig
-import org.broadinstitute.dsde.firecloud.mock.MockUtils
+import akka.http.scaladsl.model.HttpMethods
 import org.broadinstitute.dsde.firecloud.service.BaseServiceSpec
-import org.mockserver.integration.ClientAndServer
-import org.mockserver.integration.ClientAndServer.startClientAndServer
-import org.scalatest.BeforeAndAfterEach
+import org.broadinstitute.dsde.firecloud.FireCloudConfig
 
 import scala.concurrent.ExecutionContext
 
-class WorkspaceV2ApiServiceSpec
-    extends BaseServiceSpec
-    with WorkspaceV2ApiService
-    with BeforeAndAfterEach
-    with SprayJsonSupport {
+class WorkspaceV2ApiServiceSpec extends BaseServiceSpec with WorkspaceV2ApiService {
 
   override val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
 
-  // Mock remote endpoints
-  private final val workspacesV2Root = FireCloudConfig.Rawls.authPrefix + FireCloudConfig.Rawls.workspacesV2Path
-  private final val workspacesV2Path = workspacesV2Root + "/%s/%s".format("namespace", "name")
+  private val testableRoutes = workspaceV2Routes
 
-  private final val settingsPath = workspacesV2Path + "/settings"
+  "WorkspaceV2 passthrough" - {
 
-  val dummyUserId = "1234"
-
-  var rawlsServer: ClientAndServer = _
-
-  /** Stubs the mock Rawls service to respond to a request. Used for testing passthroughs.
-    *
-    * @param method HTTP method to respond to
-    * @param path   request path
-    * @param status status for the response
-    */
-  def stubRawlsService(method: HttpMethod,
-                       path: String,
-                       status: StatusCode,
-                       body: Option[String] = None,
-                       query: Option[(String, String)] = None,
-                       requestBody: Option[String] = None): Unit = {
-    rawlsServer.reset()
-    val request = org.mockserver.model.HttpRequest.request()
-      .withMethod(method.name)
-      .withPath(path)
-    if (query.isDefined)
-      request.withQueryStringParameter(query.get._1, query.get._2)
-    requestBody.foreach(request.withBody)
-    val response = org.mockserver.model.HttpResponse.response()
-      .withHeaders(MockUtils.header).withStatusCode(status.intValue)
-    if (body.isDefined) response.withBody(body.get)
-    rawlsServer
-      .when(request)
-      .respond(response)
-  }
-
-  override def beforeAll(): Unit = {
-    rawlsServer = startClientAndServer(MockUtils.workspaceServerPort)
-  }
-
-  override def afterAll(): Unit = {
-    rawlsServer.stop
-  }
-
-  "WorkspaceService Passthrough Tests" - {
-
-    "Passthrough tests on the /workspaces/v2/segment/segment/settings path" - {
-      s"OK status is returned for HTTP GET if Rawls returns it" in {
-        stubRawlsService(HttpMethods.GET, settingsPath, OK)
-        Get(settingsPath) ~> dummyUserIdHeaders(dummyUserId) ~> sealRoute(workspaceV2Routes) ~> check {
-          status should equal(OK)
-        }
-      }
-
-      s"OK status is returned for HTTP PUT if Rawls returns it" in {
-        stubRawlsService(HttpMethods.PUT, settingsPath, OK)
-        Put(settingsPath) ~> dummyUserIdHeaders(dummyUserId) ~> sealRoute(workspaceV2Routes) ~> check {
-          status should equal(OK)
-        }
-      }
+    "should pass through HTTP GET for settings" in {
+      val settingsEndpoint = FireCloudConfig.Rawls.workspacesV2Url + "/namespace/name/settings"
+      checkIfPassedThrough(testableRoutes, HttpMethods.GET, settingsEndpoint, toBeHandled = true)
     }
   }
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceV2ApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceV2ApiServiceSpec.scala
@@ -1,0 +1,94 @@
+package org.broadinstitute.dsde.firecloud.webservice
+
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
+import akka.http.scaladsl.model.StatusCodes.{MethodNotAllowed, OK}
+import akka.http.scaladsl.model.{HttpMethod, HttpMethods, StatusCode}
+import akka.http.scaladsl.server.Route.{seal => sealRoute}
+
+import org.broadinstitute.dsde.firecloud.FireCloudConfig
+import org.broadinstitute.dsde.firecloud.mock.MockUtils
+import org.broadinstitute.dsde.firecloud.service.BaseServiceSpec
+import org.mockserver.integration.ClientAndServer
+import org.mockserver.integration.ClientAndServer.startClientAndServer
+import org.scalatest.BeforeAndAfterEach
+
+import scala.concurrent.ExecutionContext
+
+class WorkspaceV2ApiServiceSpec extends BaseServiceSpec with WorkspaceV2ApiService with BeforeAndAfterEach with SprayJsonSupport {
+
+  override val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
+
+  // Mock remote endpoints
+  private final val workspacesV2Root = FireCloudConfig.Rawls.authPrefix + FireCloudConfig.Rawls.workspacesV2Path
+  private final val workspacesV2Path = workspacesV2Root + "/%s/%s".format("namespace", "name")
+
+  private final val settingsPath = workspacesV2Path + "/settings"
+
+  val dummyUserId = "1234"
+
+  var rawlsServer: ClientAndServer = _
+
+  /** Stubs the mock Rawls service to respond to a request. Used for testing passthroughs.
+   *
+   * @param method HTTP method to respond to
+   * @param path   request path
+   * @param status status for the response
+   */
+  def stubRawlsService(method: HttpMethod, path: String, status: StatusCode, body: Option[String] = None, query: Option[(String, String)] = None, requestBody: Option[String] = None): Unit = {
+    rawlsServer.reset()
+    val request = org.mockserver.model.HttpRequest.request()
+      .withMethod(method.name)
+      .withPath(path)
+    if (query.isDefined) request.withQueryStringParameter(query.get._1, query.get._2)
+    requestBody.foreach(request.withBody)
+    val response = org.mockserver.model.HttpResponse.response()
+      .withHeaders(MockUtils.header).withStatusCode(status.intValue)
+    if (body.isDefined) response.withBody(body.get)
+    rawlsServer
+      .when(request)
+      .respond(response)
+  }
+
+  override def beforeAll(): Unit = {
+    rawlsServer = startClientAndServer(MockUtils.workspaceServerPort)
+  }
+
+  override def afterAll(): Unit = {
+    rawlsServer.stop
+  }
+
+  "WorkspaceService Passthrough Negative Tests" - {
+
+    "Passthrough tests on the /workspaces/v2/segment/segment/settings path" - {
+      "MethodNotAllowed error is returned for HTTP POST, PATCH, DELETE methods" in {
+        List(HttpMethods.POST, HttpMethods.PATCH, HttpMethods.DELETE) map {
+          method =>
+            new RequestBuilder(method)(settingsPath) ~> dummyUserIdHeaders(dummyUserId) ~> sealRoute(workspaceV2Routes) ~> check {
+              status should equal(MethodNotAllowed)
+            }
+        }
+      }
+    }
+    }
+
+  "WorkspaceService Passthrough Tests" - {
+
+    "Passthrough tests on the GET /workspaces/v2/%s/%s/settings path" - {
+      s"OK status is returned for HTTP GET" in {
+        stubRawlsService(HttpMethods.GET, settingsPath, OK)
+        Get(settingsPath) ~> dummyUserIdHeaders(dummyUserId) ~> sealRoute(workspaceV2Routes) ~> check {
+          status should equal(OK)
+        }
+      }
+    }
+
+    "Passthrough tests on the PUT /workspaces/v2/%s/%s/settings path" - {
+      s"OK status is returned for HTTP PUT" in {
+        stubRawlsService(HttpMethods.PUT, settingsPath, OK)
+        Put(settingsPath) ~> dummyUserIdHeaders(dummyUserId) ~> sealRoute(workspaceV2Routes) ~> check {
+          status should equal(OK)
+        }
+      }
+    }
+  }
+}

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceV2ApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceV2ApiServiceSpec.scala
@@ -1,7 +1,7 @@
 package org.broadinstitute.dsde.firecloud.webservice
 
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
-import akka.http.scaladsl.model.StatusCodes.{MethodNotAllowed, OK}
+import akka.http.scaladsl.model.StatusCodes.OK
 import akka.http.scaladsl.model.{HttpMethod, HttpMethods, StatusCode}
 import akka.http.scaladsl.server.Route.{seal => sealRoute}
 
@@ -14,7 +14,11 @@ import org.scalatest.BeforeAndAfterEach
 
 import scala.concurrent.ExecutionContext
 
-class WorkspaceV2ApiServiceSpec extends BaseServiceSpec with WorkspaceV2ApiService with BeforeAndAfterEach with SprayJsonSupport {
+class WorkspaceV2ApiServiceSpec
+    extends BaseServiceSpec
+    with WorkspaceV2ApiService
+    with BeforeAndAfterEach
+    with SprayJsonSupport {
 
   override val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
 
@@ -29,17 +33,23 @@ class WorkspaceV2ApiServiceSpec extends BaseServiceSpec with WorkspaceV2ApiServi
   var rawlsServer: ClientAndServer = _
 
   /** Stubs the mock Rawls service to respond to a request. Used for testing passthroughs.
-   *
-   * @param method HTTP method to respond to
-   * @param path   request path
-   * @param status status for the response
-   */
-  def stubRawlsService(method: HttpMethod, path: String, status: StatusCode, body: Option[String] = None, query: Option[(String, String)] = None, requestBody: Option[String] = None): Unit = {
+    *
+    * @param method HTTP method to respond to
+    * @param path   request path
+    * @param status status for the response
+    */
+  def stubRawlsService(method: HttpMethod,
+                       path: String,
+                       status: StatusCode,
+                       body: Option[String] = None,
+                       query: Option[(String, String)] = None,
+                       requestBody: Option[String] = None): Unit = {
     rawlsServer.reset()
     val request = org.mockserver.model.HttpRequest.request()
       .withMethod(method.name)
       .withPath(path)
-    if (query.isDefined) request.withQueryStringParameter(query.get._1, query.get._2)
+    if (query.isDefined)
+      request.withQueryStringParameter(query.get._1, query.get._2)
     requestBody.foreach(request.withBody)
     val response = org.mockserver.model.HttpResponse.response()
       .withHeaders(MockUtils.header).withStatusCode(status.intValue)


### PR DESCRIPTION
These changes update Orchestration to use the newly published rawls model which includes workspace settings, and add documentation for workspace settings to the Swagger. Also, there are changes made to support routing for `workspace/v2` endpoints in general.

---

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge. Make sure your branch deletes; GitHub should do this for you.
- [ ] Test this change deployed correctly and works on dev environment after deployment
