### PR TITLE
AJ-59: save TSV to workspace bucket

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -3650,6 +3650,8 @@ paths:
         - Entities
       summary: |
         Write TSV file containing workspace entities of the specified type to the workspace bucket.
+      description: |
+        Requires write access to the workspace.
       operationId: bucketWriteEntitiesTSV
       parameters:
         - $ref: '#/components/parameters/workspaceNamespaceParam'
@@ -3680,7 +3682,6 @@ paths:
         414:
           description: |
             URI length exceeds the configured limit of 2048 characters.
-            Please use the POST endpoint when it's necessary to supply a large number of attribute names.
           content: {}
         500:
           description: Internal Server Error

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -3644,6 +3644,48 @@ paths:
           description: Internal Server Error
           content: {}
       x-passthrough: false
+  /api/workspaces/{workspaceNamespace}/{workspaceName}/entities/{entityType}/tsv/save:
+    post:
+      tags:
+        - Entities
+      summary: |
+        Write TSV file containing workspace entities of the specified type to the workspace bucket.
+      operationId: bucketWriteEntitiesTSV
+      parameters:
+        - $ref: '#/components/parameters/workspaceNamespaceParam'
+        - $ref: '#/components/parameters/workspaceNameParam'
+        - $ref: '#/components/parameters/entityTypeParam'
+        - name: attributeNames
+          in: query
+          description: comma separated list of ordered attribute names to be in downloaded
+            tsv
+          schema:
+            type: string
+        - name: model
+          in: query
+          description: firecloud (default) or flexible
+          schema:
+            type: string
+      responses:
+        200:
+          description: URL to saved file
+          content:
+            text/plain:
+              schema:
+                type: string
+                format: binary
+        404:
+          description: Workspace or entity type does not exist
+          content: {}
+        414:
+          description: |
+            URI length exceeds the configured limit of 2048 characters.
+            Please use the POST endpoint when it's necessary to supply a large number of attribute names.
+          content: {}
+        500:
+          description: Internal Server Error
+          content: {}
+      x-passthrough: false
   /api/workspaces/{workspaceNamespace}/{workspaceName}/entityQuery/{entityType}:
     get:
       tags:

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -3607,7 +3607,7 @@ paths:
       tags:
         - Entities
       summary: |
-        TSV file containing workspace entities of the specified type
+        Download a TSV file containing workspace entities
       operationId: downloadEntitiesTSV
       parameters:
         - $ref: '#/components/parameters/workspaceNamespaceParam'
@@ -3638,18 +3638,19 @@ paths:
         414:
           description: |
             URI length exceeds the configured limit of 2048 characters.
-            Please use the POST endpoint when it's necessary to supply a large number of attribute names.
+            When necessary to supply a large number of attribute names, please use one of:
+            * POST /api/workspaces/{workspaceNamespace}/{workspaceName}/entities/{entityType}/tsv
+            * POST /cookie-authed/workspaces/{workspaceNamespace}/{workspaceName}/entities/{entityType}/tsv
           content: {}
         500:
           description: Internal Server Error
           content: {}
       x-passthrough: false
-  /api/workspaces/{workspaceNamespace}/{workspaceName}/entities/{entityType}/tsv/save:
     post:
       tags:
         - Entities
       summary: |
-        Write TSV file containing workspace entities of the specified type to the workspace bucket.
+        Save TSV file containing workspace entities to the workspace bucket.
       description: |
         Requires write access to the workspace.
       operationId: bucketWriteEntitiesTSV
@@ -3657,17 +3658,21 @@ paths:
         - $ref: '#/components/parameters/workspaceNamespaceParam'
         - $ref: '#/components/parameters/workspaceNameParam'
         - $ref: '#/components/parameters/entityTypeParam'
-        - name: attributeNames
-          in: query
-          description: comma separated list of ordered attribute names to be in downloaded
-            tsv
-          schema:
-            type: string
-        - name: model
-          in: query
-          description: firecloud (default) or flexible
-          schema:
-            type: string
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                attributeNames:
+                  type: string
+                  description: comma separated list of ordered attribute names to
+                    be in downloaded tsv
+                model:
+                  type: string
+                  description: flexible or firecloud (firecloud model will be used
+                    by default)
+        required: true
       responses:
         200:
           description: URL to saved file
@@ -3678,10 +3683,6 @@ paths:
                 format: binary
         404:
           description: Workspace or entity type does not exist
-          content: {}
-        414:
-          description: |
-            URI length exceeds the configured limit of 2048 characters.
           content: {}
         500:
           description: Internal Server Error

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/GoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/GoogleServicesDAO.scala
@@ -1,6 +1,7 @@
 package org.broadinstitute.dsde.firecloud.dataaccess
 
 import akka.http.scaladsl.model.HttpResponse
+import better.files.File
 import com.google.api.services.storage.model.Bucket
 import org.broadinstitute.dsde.firecloud.model.WithAccessToken
 import org.broadinstitute.dsde.rawls.model.ErrorReportSource
@@ -28,6 +29,7 @@ trait GoogleServicesDAO extends ReportsSubsystemStatus {
   val fetchPriceList: Future[GooglePriceList]
   
   def writeObjectAsRawlsSA(bucketName: GcsBucketName, objectKey: GcsObjectName, objectContents: Array[Byte]): GcsPath
+  def writeObjectAsRawlsSA(bucketName: GcsBucketName, objectKey: GcsObjectName, tempFile: File): GcsPath
 
   def deleteGoogleGroup(groupEmail: String) : Unit
   def createGoogleGroup(groupName: String): Option[String]

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
@@ -4,6 +4,7 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
 import akka.http.scaladsl.model.HttpResponse
 import akka.stream.Materializer
+import better.files.File
 import cats.effect.std.Semaphore
 import cats.effect.unsafe.implicits.global
 import cats.effect.{IO, Resource}
@@ -22,6 +23,7 @@ import com.google.auth.http.HttpCredentialsAdapter
 import com.google.auth.oauth2.{GoogleCredentials, ServiceAccountCredentials}
 import com.typesafe.scalalogging.LazyLogging
 import fs2.Stream
+import fs2.io.file.{Files, Path}
 import org.broadinstitute.dsde.firecloud.FireCloudConfig
 import org.broadinstitute.dsde.firecloud.dataaccess.HttpGoogleServicesDAO._
 import org.broadinstitute.dsde.firecloud.model.WithAccessToken
@@ -147,25 +149,41 @@ class HttpGoogleServicesDAO(priceListUrl: String, defaultPriceList: GooglePriceL
     * @return path to the uploaded GCS object
     */
   override def writeObjectAsRawlsSA(bucketName: GcsBucketName, objectKey: GcsObjectName, objectContents: Array[Byte]): GcsPath = {
-    // if other methods in this class use google2/need these implicits, consider moving to the class level
-    // instead of here at the method level
-    implicit val logger: SelfAwareStructuredLogger[IO] = Slf4jLogger.getLogger[IO]
-
-    // create the storage service, using the Rawls SA credentials
-    // the Rawls SA json creds do not contain a project, so also specify the project explicitly
-    val storageResource = GoogleStorageService.resource(FireCloudConfig.Auth.rawlsSAJsonFile, Option.empty[Semaphore[IO]],
-       project = Some(GoogleProject(FireCloudConfig.FireCloud.serviceProject)))
-
     // call the upload implementation
-    streamUploadObject(storageResource, bucketName, objectKey, objectContents)
+    streamUploadObject(getStorageResource(), bucketName, objectKey, objectContents)
+  }
+
+  override def writeObjectAsRawlsSA(bucketName: GcsBucketName, objectKey: GcsObjectName, tempFile: File): GcsPath = {
+    // call the upload implementation
+    streamUploadObject(getStorageResource(), bucketName, objectKey, tempFile)
   }
 
   // separate method to perform the upload, to ease unit testing
   protected[dataaccess] def streamUploadObject(storageResource: Resource[IO, GoogleStorageService[IO]], bucketName: GcsBucketName,
                                    objectKey: GcsObjectName, objectContents: Array[Byte]): GcsPath = {
-    // create the stream of data to upload
     val dataStream: Stream[IO, Byte] = Stream.emits(objectContents).covary[IO]
+    streamUploadObject(storageResource, bucketName, objectKey, dataStream)
+  }
 
+  private def getStorageResource() = {
+    implicit val logger: SelfAwareStructuredLogger[IO] = Slf4jLogger.getLogger[IO]
+
+    // create the storage service, using the Rawls SA credentials
+    // the Rawls SA json creds do not contain a project, so also specify the project explicitly
+    GoogleStorageService.resource(FireCloudConfig.Auth.rawlsSAJsonFile, Option.empty[Semaphore[IO]],
+      project = Some(GoogleProject(FireCloudConfig.FireCloud.serviceProject)))
+  }
+
+  // separate method to perform the upload, to ease unit testing
+  protected[dataaccess] def streamUploadObject(storageResource: Resource[IO, GoogleStorageService[IO]], bucketName: GcsBucketName,
+                                               objectKey: GcsObjectName, tempFile: File): GcsPath = {
+    val dataStream: Stream[IO, Byte] = Files[IO].readAll(Path.fromNioPath(tempFile.path))
+    streamUploadObject(storageResource, bucketName, objectKey, dataStream)
+  }
+
+  // separate method to perform the upload, to ease unit testing
+  protected[dataaccess] def streamUploadObject(storageResource: Resource[IO, GoogleStorageService[IO]], bucketName: GcsBucketName,
+                                               objectKey: GcsObjectName, dataStream: Stream[IO, Byte]): GcsPath = {
     val uploadAttempt = storageResource.use { storageService =>
       // create the destination pipe to which we will write the file
       // N.B. workbench-libs' streamUploadBlob does not allow setting the Content-Type, so we don't set it

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/ExportEntitiesByTypeActor.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/ExportEntitiesByTypeActor.scala
@@ -1,29 +1,16 @@
 package org.broadinstitute.dsde.firecloud.service
 
-import java.io
-import akka.{Done, NotUsed}
-import akka.actor.{Actor, ActorRef, ActorSystem, Props}
-import akka.http.scaladsl.model.{ContentType, ContentTypes, HttpCharsets, HttpEntity, HttpResponse, MediaTypes, StatusCodes}
-import akka.http.scaladsl.server.RequestContext
-import akka.pattern.pipe
-import akka.stream._
-import akka.stream.scaladsl._
-import akka.stream.scaladsl.{Source => AkkaSource}
-
-import scala.io.Source
-import akka.http.scaladsl.model.HttpEntity.{ChunkStreamPart, Chunked}
+import akka.actor.ActorSystem
 import akka.http.scaladsl.model.headers.{Connection, ContentDispositionTypes, `Content-Disposition`}
-import akka.http.scaladsl.model.{ContentTypes, HttpResponse}
+import akka.http.scaladsl.model._
+import akka.stream._
+import akka.stream.scaladsl.{Source => AkkaSource, _}
 import akka.util.{ByteString, Timeout}
 import better.files.File
-import cats.effect.IO
 import com.typesafe.scalalogging.LazyLogging
-import fs2.Stream
-import fs2.io.file.{Files, Path}
 import org.broadinstitute.dsde.firecloud.dataaccess.{GoogleServicesDAO, RawlsDAO}
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
 import org.broadinstitute.dsde.firecloud.model.{UserInfo, _}
-import org.broadinstitute.dsde.firecloud.service.ExportEntitiesByTypeActor.ExportEntities
 import org.broadinstitute.dsde.firecloud.utils.TSVFormatter
 import org.broadinstitute.dsde.firecloud.{Application, FireCloudConfig, FireCloudExceptionWithErrorReport}
 import org.broadinstitute.dsde.rawls.model._

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/ExportEntitiesApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/ExportEntitiesApiService.scala
@@ -32,11 +32,11 @@ trait ExportEntitiesApiService extends Directives with RequestBuilding with Stan
           } ~
           path("save") {
             post {
-               complete {
-                 exportEntitiesByTypeConstructor(exportArgs).streamEntitiesToWorkspaceBucket() map { gcsPath =>
-                   RequestComplete(OK, s"gs://${gcsPath.bucketName}/${gcsPath.objectName.value}")
-                 }
+             complete {
+               exportEntitiesByTypeConstructor(exportArgs).streamEntitiesToWorkspaceBucket() map { gcsPath =>
+                 RequestComplete(OK, s"gs://${gcsPath.bucketName}/${gcsPath.objectName.value}")
                }
+             }
             }
           }
         }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/ExportEntitiesApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/ExportEntitiesApiService.scala
@@ -5,7 +5,7 @@ import akka.http.scaladsl.model.StatusCodes.OK
 import akka.http.scaladsl.server.{Directives, Route}
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.service.PerRequest.RequestComplete
-import org.broadinstitute.dsde.firecloud.service.{ExportEntitiesByTypeActor, ExportEntitiesByTypeArguments, FireCloudDirectives, FireCloudRequestBuilding}
+import org.broadinstitute.dsde.firecloud.service.{ExportEntitiesByTypeActor, ExportEntitiesByTypeArguments}
 import org.broadinstitute.dsde.firecloud.utils.StandardUserInfoDirectives
 
 import scala.concurrent.ExecutionContext

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAOSpec.scala
@@ -29,6 +29,7 @@ import scala.concurrent.ExecutionContext.global
 import scala.concurrent.duration.Duration
 import cats.effect.Temporal
 import cats.effect.std.Semaphore
+import fs2.Stream
 
 class HttpGoogleServicesDAOSpec extends AnyFlatSpec with Matchers with PrivateMethodTester {
 
@@ -63,7 +64,7 @@ class HttpGoogleServicesDAOSpec extends AnyFlatSpec with Matchers with PrivateMe
     val objectContents = "Hello world".getBytes(StandardCharsets.UTF_8)
 
     assertResult(GcsPath(bucketName, objectName)) {
-      gcsDAO.streamUploadObject(localStorage, bucketName, objectName, objectContents)
+      gcsDAO.streamUploadObject(localStorage, bucketName, objectName, Stream.emits(objectContents).covary[IO])
     }
   }
 
@@ -82,7 +83,7 @@ class HttpGoogleServicesDAOSpec extends AnyFlatSpec with Matchers with PrivateMe
     val objectContents = "Hello world".getBytes(StandardCharsets.UTF_8)
 
     val caught = intercept[StorageException] {
-      gcsDAO.streamUploadObject(localStorage, bucketName, objectName, objectContents)
+      gcsDAO.streamUploadObject(localStorage, bucketName, objectName, Stream.emits(objectContents).covary[IO])
     }
 
     assertResult(mockedException) {

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockGoogleServicesDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockGoogleServicesDAO.scala
@@ -1,6 +1,7 @@
 package org.broadinstitute.dsde.firecloud.mock
 
 import akka.http.scaladsl.model.HttpResponse
+import better.files.File
 import com.google.api.services.storage.model.Bucket
 import org.broadinstitute.dsde.firecloud.dataaccess._
 import org.broadinstitute.dsde.firecloud.model.WithAccessToken
@@ -79,6 +80,7 @@ class MockGoogleServicesDAO extends GoogleServicesDAO {
   override def getObjectResourceUrl(bucketName: String, objectKey: String): String = ""
 
   override def writeObjectAsRawlsSA(bucketName: GcsBucketName, objectKey: GcsObjectName, objectContents: Array[Byte]): GcsPath = GcsPath(bucketName, objectKey)
+  override def writeObjectAsRawlsSA(bucketName: GcsBucketName, objectKey: GcsObjectName, tempFile: File): GcsPath = GcsPath(bucketName, objectKey)
 
   override def getUserProfile(accessToken: WithAccessToken)
                              (implicit executionContext: ExecutionContext): Future[HttpResponse] = Future.failed(new UnsupportedOperationException)

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/ExportEntitiesByTypeServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/ExportEntitiesByTypeServiceSpec.scala
@@ -13,12 +13,19 @@ import akka.http.scaladsl.model.StatusCodes._
 import akka.http.scaladsl.model.Uri.Query
 import akka.http.scaladsl.model.headers.{Connection, `Content-Disposition`}
 import akka.http.scaladsl.testkit.RouteTestTimeout
+import akka.http.scaladsl.unmarshalling.Unmarshal
+import better.files.File
+import org.broadinstitute.dsde.firecloud.mock.MockGoogleServicesDAO
 import org.broadinstitute.dsde.workbench.model.ErrorReport
+import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GcsObjectName}
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.{reset, spy, times, verify}
+import org.scalatest.BeforeAndAfterEach
 
 import scala.concurrent.{Await, ExecutionContext}
 import scala.concurrent.duration._
 
-class ExportEntitiesByTypeServiceSpec extends BaseServiceSpec with ExportEntitiesApiService with CookieAuthedApiService {
+class ExportEntitiesByTypeServiceSpec extends BaseServiceSpec with ExportEntitiesApiService with CookieAuthedApiService with BeforeAndAfterEach {
 
   override val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
 
@@ -27,7 +34,12 @@ class ExportEntitiesByTypeServiceSpec extends BaseServiceSpec with ExportEntitie
 
   def actorRefFactory: ActorSystem = system
 
-  val exportEntitiesByTypeConstructor: ExportEntitiesByTypeArguments => ExportEntitiesByTypeActor = ExportEntitiesByTypeActor.constructor(app, actorRefFactory)
+  // spy on the MockGoogleServicesDAO. Note MockGoogleServicesDAO is a (non-mockito) concrete implementation, so this is
+  // adding a mockito layer on top of that.
+  val mockitoGoogleServicesDao = spy(classOf[MockGoogleServicesDAO])
+
+  val exportEntitiesByTypeConstructor: ExportEntitiesByTypeArguments => ExportEntitiesByTypeActor =
+    ExportEntitiesByTypeActor.constructor(app.copy(googleServicesDAO = mockitoGoogleServicesDao), actorRefFactory)
 
   val largeFireCloudEntitiesSampleTSVPath = "/api/workspaces/broad-dsde-dev/large/entities/sample/tsv"
   val largeFireCloudEntitiesSampleSetTSVPath = "/api/workspaces/broad-dsde-dev/largeSampleSet/entities/sample_set/tsv"
@@ -45,6 +57,11 @@ class ExportEntitiesByTypeServiceSpec extends BaseServiceSpec with ExportEntitie
   val filterProps: Seq[String] = MockRawlsDAO.largeSampleHeaders.take(5).map(_.name)
   // Grab the rest so we can double check the returned content to make sure the ignored ones aren't in the response.
   val missingProps: Seq[String] = MockRawlsDAO.largeSampleHeaders.drop(5).map(_.name)
+
+  override protected def beforeEach(): Unit = {
+    reset(mockitoGoogleServicesDao)
+    super.beforeEach()
+  }
 
   "ExportEntitiesApiService-ExportEntitiesByType" - {
 
@@ -192,6 +209,39 @@ class ExportEntitiesByTypeServiceSpec extends BaseServiceSpec with ExportEntitie
           handled should be(true)
           status should be(NotFound)
           errorReportCheck("Rawls", NotFound)
+        }
+      }
+    }
+
+  }
+
+  // TSV save-to-bucket shares a lot of code with TSV download. Therefore, most functionality is tested in the
+  // "ExportEntitiesApiService-ExportEntitiesByType" tests just above. Here, we add some additional tests that are
+  // specific to save-to-bucket.
+  "ExportEntitiesApiService-save to bucket" - {
+
+    "when calling GET on exporting a valid collection type" - {
+      "OK response is returned" in {
+        Post("/api/workspaces/broad-dsde-dev/valid/entities/sample_set/tsv/save") ~> dummyUserIdHeaders("1234") ~> sealRoute(exportEntitiesRoutes) ~> check {
+          handled should be(true)
+          status should be(OK)
+          verify(mockitoGoogleServicesDao, times(1)).writeObjectAsRawlsSA(any[GcsBucketName], any[GcsObjectName], any[File])
+          val result = Await.result(Unmarshal(response.entity).to[String], Duration.Inf)
+          // gs://bucketName/tsvexport/sample_set/sample_set-1727724455587.zip
+          result should fullyMatch regex """gs:\/\/bucketName\/tsvexport\/sample_set\/sample_set-[0-9]{13}.zip"""
+        }
+      }
+    }
+
+    "when calling GET on exporting a valid entity type" - {
+      "OK response is returned" in {
+        Post("/api/workspaces/broad-dsde-dev/valid/entities/sample/tsv/save") ~> dummyUserIdHeaders("1234") ~> sealRoute(exportEntitiesRoutes) ~> check {
+          handled should be(true)
+          status should be(OK)
+          verify(mockitoGoogleServicesDao, times(1)).writeObjectAsRawlsSA(any[GcsBucketName], any[GcsObjectName], any[File])
+          val result = Await.result(Unmarshal(response.entity).to[String], Duration.Inf)
+          // gs://bucketName/tsvexport/sample/sample-1727724455587.tsv
+          result should fullyMatch regex """gs:\/\/bucketName\/tsvexport\/sample\/sample-[0-9]{13}.tsv"""
         }
       }
     }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/ExportEntitiesByTypeServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/ExportEntitiesByTypeServiceSpec.scala
@@ -1,29 +1,26 @@
 package org.broadinstitute.dsde.firecloud.service
 
 import akka.actor.ActorSystem
-import akka.http.scaladsl.model.headers.ContentDispositionTypes
-import akka.stream.ActorMaterializer
-import org.broadinstitute.dsde.firecloud.dataaccess.MockRawlsDAO
-import org.broadinstitute.dsde.firecloud.model._
-import org.broadinstitute.dsde.firecloud.webservice.{CookieAuthedApiService, ExportEntitiesApiService}
 import akka.http.scaladsl.model.HttpEntity.ChunkStreamPart
-import akka.http.scaladsl.model.{ContentType, ContentTypes, FormData, HttpCharsets, HttpEntity, HttpMethods, MediaTypes, Uri}
-import akka.http.scaladsl.server.Route.{seal => sealRoute}
 import akka.http.scaladsl.model.StatusCodes._
 import akka.http.scaladsl.model.Uri.Query
-import akka.http.scaladsl.model.headers.{Connection, `Content-Disposition`}
+import akka.http.scaladsl.model.headers.{Connection, ContentDispositionTypes, `Content-Disposition`}
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.server.Route.{seal => sealRoute}
 import akka.http.scaladsl.testkit.RouteTestTimeout
 import akka.http.scaladsl.unmarshalling.Unmarshal
 import better.files.File
+import org.broadinstitute.dsde.firecloud.dataaccess.MockRawlsDAO
 import org.broadinstitute.dsde.firecloud.mock.MockGoogleServicesDAO
-import org.broadinstitute.dsde.workbench.model.ErrorReport
+import org.broadinstitute.dsde.firecloud.model._
+import org.broadinstitute.dsde.firecloud.webservice.{CookieAuthedApiService, ExportEntitiesApiService}
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GcsObjectName}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{reset, spy, times, verify}
 import org.scalatest.BeforeAndAfterEach
 
-import scala.concurrent.{Await, ExecutionContext}
 import scala.concurrent.duration._
+import scala.concurrent.{Await, ExecutionContext}
 
 class ExportEntitiesByTypeServiceSpec extends BaseServiceSpec with ExportEntitiesApiService with CookieAuthedApiService with BeforeAndAfterEach {
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/ExportEntitiesByTypeServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/ExportEntitiesByTypeServiceSpec.scala
@@ -219,7 +219,7 @@ class ExportEntitiesByTypeServiceSpec extends BaseServiceSpec with ExportEntitie
 
     "when calling GET on exporting a valid collection type" - {
       "OK response is returned" in {
-        Post("/api/workspaces/broad-dsde-dev/valid/entities/sample_set/tsv/save") ~> dummyUserIdHeaders("1234") ~> sealRoute(exportEntitiesRoutes) ~> check {
+        Post("/api/workspaces/broad-dsde-dev/valid/entities/sample_set/tsv") ~> dummyUserIdHeaders("1234") ~> sealRoute(exportEntitiesRoutes) ~> check {
           handled should be(true)
           status should be(OK)
           verify(mockitoGoogleServicesDao, times(1)).writeObjectAsRawlsSA(any[GcsBucketName], any[GcsObjectName], any[File])
@@ -232,7 +232,7 @@ class ExportEntitiesByTypeServiceSpec extends BaseServiceSpec with ExportEntitie
 
     "when calling GET on exporting a valid entity type" - {
       "OK response is returned" in {
-        Post("/api/workspaces/broad-dsde-dev/valid/entities/sample/tsv/save") ~> dummyUserIdHeaders("1234") ~> sealRoute(exportEntitiesRoutes) ~> check {
+        Post("/api/workspaces/broad-dsde-dev/valid/entities/sample/tsv") ~> dummyUserIdHeaders("1234") ~> sealRoute(exportEntitiesRoutes) ~> check {
           handled should be(true)
           status should be(OK)
           verify(mockitoGoogleServicesDao, times(1)).writeObjectAsRawlsSA(any[GcsBucketName], any[GcsObjectName], any[File])


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/AJ-59

A new API which will save a TSV file to the current workspace's bucket.

The TSV file is (intentionally) the exact same format as the TSV file you would download via your browser. Inside the bucket, it saves to "/tsvexport/${entityType}/${entityType}-${timestamp}.tsv" (or .zip for set tables).

The API returns the path in the bucket to which it saved the TSV.

Here's a screenshot after calling the API twice for the "pedigree" table. The second invocation only downloaded a couple columns; that's why the sizes are so different:
![Screenshot 30-09-2024 at 16 47](https://github.com/user-attachments/assets/1fe3e43d-250a-4c3a-abc2-7d8c053a51e7)

_see my comments inline for reviewing!_

---

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge. Make sure your branch deletes; GitHub should do this for you.
- [ ] Test this change deployed correctly and works on dev environment after deployment
