### PR TITLE
AJ-2027: clean up compile warnings and unit test output

### DIFF
--- a/project/Testing.scala
+++ b/project/Testing.scala
@@ -10,6 +10,7 @@ object Testing {
   val commonTestSettings: Seq[Setting[_]] = List(
 
     Test / testOptions ++= Seq(Tests.Filter(s => !isIntegrationTest(s))),
+    Test / testOptions += Tests.Argument("-oD"), // D = individual test durations
     IntegrationTest / testOptions := Seq(Tests.Filter(s => isIntegrationTest(s))),
 
     // ES client attempts to set the number of processors that Netty should use.

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/NihService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/NihService.scala
@@ -167,7 +167,7 @@ class NihService(val samDao: SamDAO, val thurloeDao: ThurloeDAO, val googleDao: 
     ecmDao.putLinkedEraAccount(LinkedEraAccount(userInfo.id, nihLink))(getAdminAccessToken)
     .flatMap(_ => {
       logger.info("Successfully linked NIH account in ECM for user " + userInfo.id)
-      Future.successful(Success())
+      Future.successful(Success(()))
     }).recoverWith {
       case e =>
         logger.warn("Failed to link NIH account in ECM for user" + userInfo.id)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/NihService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/NihService.scala
@@ -249,6 +249,7 @@ class NihService(val samDao: SamDAO, val thurloeDao: ThurloeDAO, val googleDao: 
           case (Failure(t), Success(_)) => logger.error("Failed to link NIH Account in Thurloe", t)
           case (Success(_), Failure(t)) => logger.error("Failed to link NIH Account in ECM", t)
           case (Failure(t1), Failure(t2)) => logger.error("Failed to link NIH Account in Thurloe and ECM", t1, t2)
+          case _ => // unreachable case due to the if-condition above, but this case avoids compile warnings
         }
         RequestCompleteWithErrorReport(InternalServerError, "Error updating NIH link")
       }

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -8,11 +8,11 @@
         </encoder>
     </appender>
 
-    <logger name="PerformanceLogging" level="warn" additivity="false">
+    <logger name="PerformanceLogging" level="off" additivity="false">
         <appender-ref ref="console"/>
     </logger>
 
-    <logger name="org.broadinstitute.dsde" level="error" additivity="false">
+    <logger name="org.broadinstitute.dsde" level="off" additivity="false">
         <appender-ref ref="console"/>
     </logger>
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/NihServiceUnitSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/NihServiceUnitSpec.scala
@@ -213,7 +213,7 @@ class NihServiceUnitSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEa
      })
      when(samDao.overwriteGroupMembers(any(), any(), any())(any())).thenReturn(Future.failed(new RuntimeException(errorMessage)))
      when(samDao.listGroups(ArgumentMatchers.eq(UserInfo(adminAccessToken, "")))).thenReturn(Future.successful(samGroupMemberships.keys.map(groupName => FireCloudManagedGroupMembership(groupName, groupName + "@firecloud.org", "member")).toList))
-     when(samDao.createGroup(any[WorkbenchGroupName])(ArgumentMatchers.eq(UserInfo(adminAccessToken, "")))).thenReturn(Future.successful())
+     when(samDao.createGroup(any[WorkbenchGroupName])(ArgumentMatchers.eq(UserInfo(adminAccessToken, "")))).thenReturn(Future.successful((): Unit))
 
      val ex = intercept[FireCloudException] {
        Await.result(nihService.syncAllowlistAllUsers("TARGET"), Duration.Inf)
@@ -364,7 +364,7 @@ class NihServiceUnitSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEa
   }
 
   private def mockSamUsers(): Unit = {
-    when(samDao.overwriteGroupMembers(any(), any(), any())(any())).thenReturn(Future.successful())
+    when(samDao.overwriteGroupMembers(any(), any(), any())(any())).thenReturn(Future.successful((): Unit))
     when(samDao.listGroups(any[WithAccessToken])).thenAnswer(args => {
       Future {
         val userInfo = args.getArgument(0).asInstanceOf[WithAccessToken]
@@ -376,14 +376,14 @@ class NihServiceUnitSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEa
           .getOrElse(List.empty)
       }
     })
-    when(samDao.addGroupMember(any(), any(), any())(any())).thenReturn(Future.successful())
-    when(samDao.removeGroupMember(any(), any(), any())(any())).thenReturn(Future.successful())
+    when(samDao.addGroupMember(any(), any(), any())(any())).thenReturn(Future.successful((): Unit))
+    when(samDao.removeGroupMember(any(), any(), any())(any())).thenReturn(Future.successful((): Unit))
     when(samDao.isGroupMember(any[WorkbenchGroupName], any[UserInfo])).thenAnswer(args => Future {
       val groupName = args.getArgument(0).asInstanceOf[WorkbenchGroupName]
       val userInfo = args.getArgument(1).asInstanceOf[UserInfo]
       samGroupMemberships.get(groupName.value).exists(_.exists(_.value == userInfo.id))
     })
-    when(samDao.createGroup(any[WorkbenchGroupName])(ArgumentMatchers.eq(UserInfo(adminAccessToken, "")))).thenReturn(Future.successful())
+    when(samDao.createGroup(any[WorkbenchGroupName])(ArgumentMatchers.eq(UserInfo(adminAccessToken, "")))).thenReturn(Future.successful((): Unit))
     when(samDao.getUsersForIds(any[Seq[WorkbenchUserId]])(ArgumentMatchers.eq(UserInfo(adminAccessToken, "")))).thenAnswer(args => {
       val userIds = args.getArgument(0).asInstanceOf[Seq[WorkbenchUserId]]
       Future.successful(samUsers.filter(user => userIds.contains(WorkbenchUserId(user.id.value))).map(user => WorkbenchUserInfo(user.id.value, user.email.value)))
@@ -396,8 +396,8 @@ class NihServiceUnitSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEa
       val userInfo = args.getArgument(0).asInstanceOf[UserInfo]
       Future.successful(linkedAccountsBySamUserId.get(WorkbenchUserId(userInfo.id)))
     })
-    when(ecmDao.putLinkedEraAccount(any[LinkedEraAccount])(ArgumentMatchers.eq(UserInfo(adminAccessToken, "")))).thenReturn(Future.successful())
-    when(ecmDao.deleteLinkedEraAccount(any[UserInfo])(ArgumentMatchers.eq(UserInfo(adminAccessToken, "")))).thenReturn(Future.successful())
+    when(ecmDao.putLinkedEraAccount(any[LinkedEraAccount])(ArgumentMatchers.eq(UserInfo(adminAccessToken, "")))).thenReturn(Future.successful((): Unit))
+    when(ecmDao.deleteLinkedEraAccount(any[UserInfo])(ArgumentMatchers.eq(UserInfo(adminAccessToken, "")))).thenReturn(Future.successful((): Unit))
 
     when(ecmDao.getLinkedEraAccountForUsername(any[String])(ArgumentMatchers.eq(UserInfo(adminAccessToken, "")))).thenAnswer(args => {
       val externalId = args.getArgument(0).asInstanceOf[String]
@@ -422,9 +422,9 @@ class NihServiceUnitSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEa
       .thenReturn(Future.successful(samUsers.map(user => user.id.value -> user.email.value).toMap))
     when(thurloeDao.getAllUserValuesForKey(ArgumentMatchers.eq("linkedNihUsername"))).thenReturn(Future.successful(linkedAccountsBySamUserId.map(tup => (tup._1.value, tup._2.linkedExternalId))))
     when(thurloeDao.getAllUserValuesForKey(ArgumentMatchers.eq("linkExpireTime"))).thenReturn(Future.successful(linkedAccountsBySamUserId.map(tup => (tup._1.value, (tup._2.linkExpireTime.getMillis / 1000).toString))))
-    when(thurloeDao.saveKeyValues(any[UserInfo], any[Map[String, String]])).thenReturn(Future.successful(Success()))
-    when(thurloeDao.saveKeyValues(any[String], any[WithAccessToken], any[Map[String, String]])).thenReturn(Future.successful(Success()))
-    when(thurloeDao.deleteKeyValue(any[String], any[String], any[WithAccessToken])).thenReturn(Future.successful(Success()))
+    when(thurloeDao.saveKeyValues(any[UserInfo], any[Map[String, String]])).thenReturn(Future.successful(Success((): Unit)))
+    when(thurloeDao.saveKeyValues(any[String], any[WithAccessToken], any[Map[String, String]])).thenReturn(Future.successful(Success((): Unit)))
+    when(thurloeDao.deleteKeyValue(any[String], any[String], any[WithAccessToken])).thenReturn(Future.successful(Success((): Unit)))
   }
 
   private def mockGoogleServicesDAO(): Unit = {

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/NihServiceUnitSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/NihServiceUnitSpec.scala
@@ -213,7 +213,7 @@ class NihServiceUnitSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEa
      })
      when(samDao.overwriteGroupMembers(any(), any(), any())(any())).thenReturn(Future.failed(new RuntimeException(errorMessage)))
      when(samDao.listGroups(ArgumentMatchers.eq(UserInfo(adminAccessToken, "")))).thenReturn(Future.successful(samGroupMemberships.keys.map(groupName => FireCloudManagedGroupMembership(groupName, groupName + "@firecloud.org", "member")).toList))
-     when(samDao.createGroup(any[WorkbenchGroupName])(ArgumentMatchers.eq(UserInfo(adminAccessToken, "")))).thenReturn(Future.successful((): Unit))
+     when(samDao.createGroup(any[WorkbenchGroupName])(ArgumentMatchers.eq(UserInfo(adminAccessToken, "")))).thenReturn(Future.successful(()))
 
      val ex = intercept[FireCloudException] {
        Await.result(nihService.syncAllowlistAllUsers("TARGET"), Duration.Inf)
@@ -364,7 +364,7 @@ class NihServiceUnitSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEa
   }
 
   private def mockSamUsers(): Unit = {
-    when(samDao.overwriteGroupMembers(any(), any(), any())(any())).thenReturn(Future.successful((): Unit))
+    when(samDao.overwriteGroupMembers(any(), any(), any())(any())).thenReturn(Future.successful(()))
     when(samDao.listGroups(any[WithAccessToken])).thenAnswer(args => {
       Future {
         val userInfo = args.getArgument(0).asInstanceOf[WithAccessToken]
@@ -376,14 +376,14 @@ class NihServiceUnitSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEa
           .getOrElse(List.empty)
       }
     })
-    when(samDao.addGroupMember(any(), any(), any())(any())).thenReturn(Future.successful((): Unit))
-    when(samDao.removeGroupMember(any(), any(), any())(any())).thenReturn(Future.successful((): Unit))
+    when(samDao.addGroupMember(any(), any(), any())(any())).thenReturn(Future.successful(()))
+    when(samDao.removeGroupMember(any(), any(), any())(any())).thenReturn(Future.successful(()))
     when(samDao.isGroupMember(any[WorkbenchGroupName], any[UserInfo])).thenAnswer(args => Future {
       val groupName = args.getArgument(0).asInstanceOf[WorkbenchGroupName]
       val userInfo = args.getArgument(1).asInstanceOf[UserInfo]
       samGroupMemberships.get(groupName.value).exists(_.exists(_.value == userInfo.id))
     })
-    when(samDao.createGroup(any[WorkbenchGroupName])(ArgumentMatchers.eq(UserInfo(adminAccessToken, "")))).thenReturn(Future.successful((): Unit))
+    when(samDao.createGroup(any[WorkbenchGroupName])(ArgumentMatchers.eq(UserInfo(adminAccessToken, "")))).thenReturn(Future.successful(()))
     when(samDao.getUsersForIds(any[Seq[WorkbenchUserId]])(ArgumentMatchers.eq(UserInfo(adminAccessToken, "")))).thenAnswer(args => {
       val userIds = args.getArgument(0).asInstanceOf[Seq[WorkbenchUserId]]
       Future.successful(samUsers.filter(user => userIds.contains(WorkbenchUserId(user.id.value))).map(user => WorkbenchUserInfo(user.id.value, user.email.value)))
@@ -396,8 +396,8 @@ class NihServiceUnitSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEa
       val userInfo = args.getArgument(0).asInstanceOf[UserInfo]
       Future.successful(linkedAccountsBySamUserId.get(WorkbenchUserId(userInfo.id)))
     })
-    when(ecmDao.putLinkedEraAccount(any[LinkedEraAccount])(ArgumentMatchers.eq(UserInfo(adminAccessToken, "")))).thenReturn(Future.successful((): Unit))
-    when(ecmDao.deleteLinkedEraAccount(any[UserInfo])(ArgumentMatchers.eq(UserInfo(adminAccessToken, "")))).thenReturn(Future.successful((): Unit))
+    when(ecmDao.putLinkedEraAccount(any[LinkedEraAccount])(ArgumentMatchers.eq(UserInfo(adminAccessToken, "")))).thenReturn(Future.successful(()))
+    when(ecmDao.deleteLinkedEraAccount(any[UserInfo])(ArgumentMatchers.eq(UserInfo(adminAccessToken, "")))).thenReturn(Future.successful(()))
 
     when(ecmDao.getLinkedEraAccountForUsername(any[String])(ArgumentMatchers.eq(UserInfo(adminAccessToken, "")))).thenAnswer(args => {
       val externalId = args.getArgument(0).asInstanceOf[String]
@@ -422,9 +422,9 @@ class NihServiceUnitSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEa
       .thenReturn(Future.successful(samUsers.map(user => user.id.value -> user.email.value).toMap))
     when(thurloeDao.getAllUserValuesForKey(ArgumentMatchers.eq("linkedNihUsername"))).thenReturn(Future.successful(linkedAccountsBySamUserId.map(tup => (tup._1.value, tup._2.linkedExternalId))))
     when(thurloeDao.getAllUserValuesForKey(ArgumentMatchers.eq("linkExpireTime"))).thenReturn(Future.successful(linkedAccountsBySamUserId.map(tup => (tup._1.value, (tup._2.linkExpireTime.getMillis / 1000).toString))))
-    when(thurloeDao.saveKeyValues(any[UserInfo], any[Map[String, String]])).thenReturn(Future.successful(Success((): Unit)))
-    when(thurloeDao.saveKeyValues(any[String], any[WithAccessToken], any[Map[String, String]])).thenReturn(Future.successful(Success((): Unit)))
-    when(thurloeDao.deleteKeyValue(any[String], any[String], any[WithAccessToken])).thenReturn(Future.successful(Success((): Unit)))
+    when(thurloeDao.saveKeyValues(any[UserInfo], any[Map[String, String]])).thenReturn(Future.successful(Success(())))
+    when(thurloeDao.saveKeyValues(any[String], any[WithAccessToken], any[Map[String, String]])).thenReturn(Future.successful(Success(())))
+    when(thurloeDao.deleteKeyValue(any[String], any[String], any[WithAccessToken])).thenReturn(Future.successful(Success(())))
   }
 
   private def mockGoogleServicesDAO(): Unit = {


### PR DESCRIPTION
* show durations for each unit test
* suppress logging output during unit tests to reduce noise
* remove all compile-time warnings

After this PR, both compilation and unit test output are free of any stray warnings or messages; nice and clean.


---


Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [x] Verify all tests go green
- [ ] Squash and merge. Make sure your branch deletes; GitHub should do this for you.
- [ ] Test this change deployed correctly and works on dev environment after deployment
