### PR TITLE
[CORE-69] Move automatic dependency updates to CORE from AJ

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,9 @@ updates:
     directory: "/"
     open-pull-requests-limit: 10
     reviewers:
-      - "@broadinstitute/dsp-analysis-journeys"
+      - "@DataBiosphere/broad-core-services"
     commit-message:
-      prefix: "[AJ-1784]"
+      prefix: "[CORE-72]"
     schedule:
       interval: "weekly"
       day: "monday"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: "/"
     open-pull-requests-limit: 10
     reviewers:
-      - "@DataBiosphere/broad-core-services"
+      - "@broadinstitute/broad-core-services"
     commit-message:
       prefix: "[CORE-72]"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
     reviewers:
       - "@broadinstitute/broad-core-services"
     commit-message:
-      prefix: "[CORE-72]"
+      prefix: "[CORE-69]"
     schedule:
       interval: "weekly"
       day: "monday"


### PR DESCRIPTION
Dependabot automatically tags an associated ticket and the AJ team.  The ticket was moved from AJ to CORE; this PR updates the ticket and which team is tagged on dependabot updates.