### PR TITLE
CORE-107: save user profile for already-registered users

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/RegisterService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/RegisterService.scala
@@ -47,7 +47,7 @@ class RegisterService(val rawlsDao: RawlsDAO, val samDao: SamDAO, val thurloeDao
           _ <- saveProfileInThurloeAndSendRegistrationEmail(registrationResultUserInfo, basicProfile)
         } yield registerResult
       } else {
-        thurloeDao.saveProfile(userInfo, basicProfile) map (_ => isRegistered)
+        thurloeDao.saveProfile(userInfo.copy(id = isRegistered.userInfo.userSubjectId), basicProfile) map (_ => isRegistered)
       }
     } yield {
       RequestComplete(StatusCodes.OK, userStatus)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/RegisterService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/RegisterService.scala
@@ -47,7 +47,7 @@ class RegisterService(val rawlsDao: RawlsDAO, val samDao: SamDAO, val thurloeDao
           _ <- saveProfileInThurloeAndSendRegistrationEmail(registrationResultUserInfo, basicProfile)
         } yield registerResult
       } else {
-        Future.successful(isRegistered)
+        thurloeDao.saveProfile(userInfo, basicProfile) map (_ => isRegistered)
       }
     } yield {
       RequestComplete(StatusCodes.OK, userStatus)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/RegisterService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/RegisterService.scala
@@ -47,6 +47,13 @@ class RegisterService(val rawlsDao: RawlsDAO, val samDao: SamDAO, val thurloeDao
           _ <- saveProfileInThurloeAndSendRegistrationEmail(registrationResultUserInfo, basicProfile)
         } yield registerResult
       } else {
+        /* when updating the profile in Thurloe, make sure to send the update under the same user id as the profile
+           was originally created with. A given use can have a Sam id, a Google subject id, and a b2c Azure id; if we
+           send profile updates under a different id, Thurloe will create duplicate keys for the user.
+
+           Because the original profile was created during registration using `userInfo.userSubjectId` (see
+           `registrationResultUserInfo` above), we use that same id here.
+         */
         thurloeDao.saveProfile(userInfo.copy(id = isRegistered.userInfo.userSubjectId), basicProfile) map (_ => isRegistered)
       }
     } yield {

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockThurloeDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockThurloeDAO.scala
@@ -56,6 +56,7 @@ class MockThurloeDAO extends ThurloeDAO {
   var mockKeyValues: Map[String, Set[FireCloudKeyValue]] =
     Map(
       NORMAL_USER -> baseProfile,
+      "foo" -> baseProfile, // to match registeredUser, enabledUserInfo, unknownUserInfo from MockSamDao
       //TCGA users
       TCGA_LINKED -> baseProfile.++(Set(
         FireCloudKeyValue(Some("email"), Some(TCGA_LINKED)),

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/RegisterServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/RegisterServiceSpec.scala
@@ -1,27 +1,57 @@
 package org.broadinstitute.dsde.firecloud.service
 
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
+import org.broadinstitute.dsde.firecloud.HealthChecks.termsOfServiceUrl
 import org.broadinstitute.dsde.firecloud.dataaccess.{GoogleServicesDAO, RawlsDAO, SamDAO, ThurloeDAO}
-import org.broadinstitute.dsde.firecloud.model.UserInfo
-import org.broadinstitute.dsde.workbench.model.Notifications.{ActivationNotification, ActivationNotificationType, AzurePreviewActivationNotification, AzurePreviewActivationNotificationType}
+import org.broadinstitute.dsde.firecloud.model.{BasicProfile, RegistrationInfo, UserInfo, WorkbenchEnabled, WorkbenchUserInfo}
+import org.broadinstitute.dsde.workbench.model.Notifications.{ActivationNotification, AzurePreviewActivationNotification}
+import org.mockito.ArgumentMatchers
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito._
+import org.scalatest.BeforeAndAfterEach
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar.mock
 
-class RegisterServiceSpec extends AnyFlatSpec with Matchers {
+import scala.concurrent.duration.{Duration, SECONDS}
+import scala.concurrent.{Await, Future}
+import scala.util.Success
+
+class RegisterServiceSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEach {
 
   import scala.concurrent.ExecutionContext.Implicits.global
 
-  val rawlsDAO = mock[RawlsDAO]
-  val samDAO = mock[SamDAO]
-  val thurloeDAO = mock[ThurloeDAO]
-  val googleServicesDAO = mock[GoogleServicesDAO]
+  val rawlsDAO: RawlsDAO = mock[RawlsDAO]
+  val samDAO: SamDAO = mock[SamDAO]
+  val thurloeDAO: ThurloeDAO = mock[ThurloeDAO]
+  val googleServicesDAO: GoogleServicesDAO = mock[GoogleServicesDAO]
 
   val registerService = new RegisterService(rawlsDAO, samDAO, thurloeDAO, googleServicesDAO)
 
-  val azureB2CUserInfo = UserInfo("azure-b2c@example.com", OAuth2BearerToken("token"), 1, "0f3cd8e4-59c2-4bce-9c24-98c5a0c308c1", None)
-  val googleB2CUserInfo = UserInfo("google-b2c@example.com", OAuth2BearerToken("token"), 1, "0617047d-a81f-4724-b783-b5af51af9a70", Some(OAuth2BearerToken("some-google-token")))
-  val googleLegacyUserInfo = UserInfo("google-legacy@example.com", OAuth2BearerToken("token"), 1, "111111111111", None)
+  val azureB2CUserInfo: UserInfo = UserInfo("azure-b2c@example.com", OAuth2BearerToken("token"), 1, "0f3cd8e4-59c2-4bce-9c24-98c5a0c308c1", None)
+  val googleB2CUserInfo: UserInfo = UserInfo("google-b2c@example.com", OAuth2BearerToken("token"), 1, "0617047d-a81f-4724-b783-b5af51af9a70", Some(OAuth2BearerToken("some-google-token")))
+  val googleLegacyUserInfo: UserInfo = UserInfo("google-legacy@example.com", OAuth2BearerToken("token"), 1, "111111111111", None)
+
+  val profile: BasicProfile = BasicProfile(
+    firstName = "first",
+    lastName = "last",
+    title = "title",
+    contactEmail = Some("me@abc.com"),
+    institute = "inst",
+    researchArea = Some("research"),
+    programLocationCity = "city",
+    programLocationState = "state",
+    programLocationCountry = "country",
+    termsOfService = Some(termsOfServiceUrl),
+    department = Some("dept"),
+    interestInTerra = Some("interest")
+  )
+
+  override protected def beforeEach(): Unit = {
+    reset(samDAO)
+    reset(thurloeDAO)
+    super.beforeEach()
+  }
 
   "generateWelcomeEmail" should "generate an Azure welcome email for Azure B2C users" in {
     val notification = registerService.generateWelcomeEmail(azureB2CUserInfo)
@@ -36,6 +66,62 @@ class RegisterServiceSpec extends AnyFlatSpec with Matchers {
   it should "generate a standard welcome email for legacy Google users" in {
     val notification = registerService.generateWelcomeEmail(googleLegacyUserInfo)
     notification.getClass.getName shouldBe ActivationNotification.getClass.getName.stripSuffix("$")
+  }
+
+  behavior of "createUpdateProfile"
+
+  List(azureB2CUserInfo, googleB2CUserInfo, googleLegacyUserInfo) foreach { userInfo =>
+    it should s"both register and save profile for unregistered user ${userInfo.userEmail}" in {
+      // ARRANGE
+      // user is not registered; registration check returns google=false and ldap=false
+      when(samDAO.getRegistrationStatus(userInfo)).thenReturn(
+        Future.successful(
+          RegistrationInfo(
+            WorkbenchUserInfo(userInfo.id, userInfo.userEmail),
+            WorkbenchEnabled(google = false, ldap = false, allUsersGroup = false),
+            None)))
+      // registering this user returns successfully
+      when(samDAO.registerUser(any())(ArgumentMatchers.eq(userInfo))).thenReturn(Future.successful(
+        RegistrationInfo(
+          WorkbenchUserInfo(userInfo.id, userInfo.userEmail),
+          WorkbenchEnabled(google = true, ldap = true, allUsersGroup = true),
+          None)))
+      // saving to Thurloe returns successfully
+      when(thurloeDAO.saveProfile(userInfo, profile)).thenReturn(Future.successful(()))
+      when(thurloeDAO.saveKeyValues(ArgumentMatchers.eq(userInfo), any())).thenReturn(Future.successful(Success(())))
+
+      // ACT
+      // call createUpdateProfile for this previously-unregistered user
+      Await.result(registerService.createUpdateProfile(userInfo, profile), Duration(10, SECONDS))
+
+      // ASSERT
+      // createUpdateProfile should invoke both SamDAO.registerUser and ThurloeDAO.saveProfile
+      verify(samDAO, times(1)).registerUser(any())(ArgumentMatchers.eq(userInfo))
+      verify(thurloeDAO, times(1)).saveProfile(userInfo, profile)
+    }
+
+    it should s"save profile but not register for registered user ${userInfo.userEmail}" in {
+      // ARRANGE
+      // user is already registered; registration check returns google=true and ldap=true
+      when(samDAO.getRegistrationStatus(userInfo)).thenReturn(
+        Future.successful(
+          RegistrationInfo(
+            WorkbenchUserInfo(userInfo.id, userInfo.userEmail),
+            WorkbenchEnabled(google = true, ldap = true, allUsersGroup = true),
+            None)))
+      // saving to Thurloe returns successfully
+      when(thurloeDAO.saveProfile(userInfo, profile)).thenReturn(Future.successful(()))
+      when(thurloeDAO.saveKeyValues(ArgumentMatchers.eq(userInfo), any())).thenReturn(Future.successful(Success(())))
+
+      // ACT
+      // call createUpdateProfile for this previously-unregistered user
+      Await.result(registerService.createUpdateProfile(userInfo, profile), Duration(10, SECONDS))
+
+      // ASSERT
+      // createUpdateProfile should not invoke SamDAO.registerUser, but should invoke ThurloeDAO.saveProfile
+      verify(samDAO, never()).registerUser(any())(ArgumentMatchers.eq(userInfo))
+      verify(thurloeDAO, times(1)).saveProfile(userInfo, profile)
+    }
   }
 
 }


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/CORE-107

When users who are already registered attempt to update their user profile, we were not actually updating that profile. This PR fixes a regression from https://github.com/broadinstitute/firecloud-orchestration/pull/1405.
