### PR TITLE
CORE-126: scalafmt enforcement

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,4 +1,4 @@
 # .git-blame-ignore-revs
 
 # scalafmt mass change
-579d6ffd2c2d25c0e8cdab7ea83ca630de043c8b
+3686bb47a5b215733a46c3393a51e950fcaa635f

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,4 @@
+# .git-blame-ignore-revs
+
+# scalafmt mass change
+579d6ffd2c2d25c0e8cdab7ea83ca630de043c8b

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -1,0 +1,28 @@
+name: Check formatting for modified files with scalafmt
+
+on:
+  pull_request:
+    paths-ignore: ['**.md']
+
+jobs:
+  format:
+
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 17
+          cache: sbt
+
+      - name: Check formatting for modified files
+        run: |
+          sbt scalafmtCheckAll

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -5,6 +5,7 @@ import Version._
 import sbt.Keys._
 import sbt._
 import sbtassembly.AssemblyPlugin.autoImport._
+import org.scalafmt.sbt.ScalafmtPlugin.autoImport.scalafmtFilter
 
 object Settings {
 
@@ -41,9 +42,14 @@ object Settings {
     assembly / test := {}
   )
 
+  val scalafmtSettings = List(
+    Global / excludeLintKeys += scalafmtFilter,
+    Global / scalafmtFilter := "diff-ref=HEAD^"
+  )
+
   //common settings for all sbt subprojects
   val commonSettings =
-    commonBuildSettings ++ commonAssemblySettings ++ commonTestSettings ++ List(
+    commonBuildSettings ++ commonAssemblySettings ++ commonTestSettings ++ scalafmtSettings ++ List(
     organization  := "org.broadinstitute.dsde.firecloud",
     scalaVersion  := "2.13.15",
     resolvers := proxyResolvers ++: resolvers.value ++: commonResolvers,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,4 +4,6 @@ addSbtPlugin("io.spray" % "sbt-revolver" % "0.10.0")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.2.1")
 
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
+
 addDependencyTreePlugin


### PR DESCRIPTION
Followup to https://github.com/broadinstitute/firecloud-orchestration/pull/1468.

That other PR performed a mass reformat of code to meet `scalafmt` standards.

This PR adds:
* scalafmt configuration in Settings.scala to optimize formatting performance
* a format check in github actions for PRs
* introduction of [.git-blame-ignore-revs](https://github.com/broadinstitute/firecloud-orchestration/pull/1467/files#diff-f247fbfbe928b907db42554d0b3006b28dd11c25a59be031abda73b11a2c934a), so the mass reformat doesn't show up in git blames