### PR TITLE
[CORE-134] Fix daylight savings time test bug

### DIFF
--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/NihServiceUnitSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/NihServiceUnitSpec.scala
@@ -47,7 +47,7 @@ import java.nio.charset.StandardCharsets
 import java.security.{KeyPairGenerator, PrivateKey}
 import java.time.Instant
 import java.util.{Base64, UUID}
-import scala.concurrent.duration.Duration
+import scala.concurrent.duration.{Duration, DurationInt}
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.util.{Failure, Random, Success}
 
@@ -69,13 +69,17 @@ class NihServiceUnitSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEa
   val userTcgaOnly = genSamUser();
   val userTargetOnly = genSamUser();
 
+  // DateTimes must be modified in seconds instead of days to match implementation
+  val secondsIn30Days = 30.days.toSeconds.toInt
+
   var userNoAllowlistsLinkedAccount =
-    LinkedEraAccount(userNoAllowlists.id.value, "nihUsername1", new DateTime().plusDays(30))
+    LinkedEraAccount(userNoAllowlists.id.value, "nihUsername1", new DateTime().plusSeconds(secondsIn30Days))
   var userTcgaAndTargetLinkedAccount =
-    LinkedEraAccount(userTcgaAndTarget.id.value, "nihUsername2", new DateTime().plusDays(30))
-  var userTcgaOnlyLinkedAccount = LinkedEraAccount(userTcgaOnly.id.value, "nihUsername3", new DateTime().plusDays(30))
+    LinkedEraAccount(userTcgaAndTarget.id.value, "nihUsername2", new DateTime().plusSeconds(secondsIn30Days))
+  var userTcgaOnlyLinkedAccount =
+    LinkedEraAccount(userTcgaOnly.id.value, "nihUsername3", new DateTime().plusSeconds(secondsIn30Days))
   var userTargetOnlyLinkedAccount =
-    LinkedEraAccount(userTargetOnly.id.value, "nihUsername4", new DateTime().plusDays(30))
+    LinkedEraAccount(userTargetOnly.id.value, "nihUsername4", new DateTime().plusSeconds(secondsIn30Days))
 
   val samUsers = Seq(userNoLinkedAccount, userNoAllowlists, userTcgaAndTarget, userTcgaOnly, userTargetOnly)
   val linkedAccounts = Seq(userNoAllowlistsLinkedAccount,
@@ -635,7 +639,8 @@ class NihServiceUnitSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEa
 
   private def jwtForUser(linkedEraAccount: LinkedEraAccount): JWTWrapper = {
     val expiresInTheFuture: Long = linkedEraAccount.linkExpireTime.getMillis / 1000L
-    val issuedAt = Instant.ofEpochMilli(linkedEraAccount.linkExpireTime.minusDays(30).getMillis).getEpochSecond
+    val issuedAt =
+      Instant.ofEpochMilli(linkedEraAccount.linkExpireTime.minusSeconds(secondsIn30Days).getMillis).getEpochSecond
     val validStr = Jwt.encode(
       JwtClaim(s"""{"eraCommonsUsername": "${linkedEraAccount.linkedExternalId}"}""")
         .issuedAt(issuedAt)


### PR DESCRIPTION
Ticket: [https://broadworkbench.atlassian.net/browse/CORE-134](https://broadworkbench.atlassian.net/browse/CORE-134)

Previously, if the local timezone had an offset change in the next 30 days, certain tests would fail. I didn't figure out the full root cause, but it probably has to do with parts of the actual implementation using seconds (`NihLink(eraCommonsUsername, iat + 60 * 60 * 24 * 30)`) and the tests using days. Changing just `minusDays` to `minusSeconds` made it work, but I converted the `plusDays` as well for good measure.

The tests always passed in GH actions, so to replicate the problem and verify the solution (only within 30 days of a time changeover!):

```
git checkout 1646e20daaeca31c11e40fcc59e49986aa8833b;
TZ="America/New_York" sbt "testOnly *NihServiceUnitSpec";
git checkout 1e297af8e4fdc5b85f4faecab4f57fa43c1bdd81;
TZ="America/New_York" sbt "testOnly *NihServiceUnitSpec";
```

[https://xkcd.com/2867/](https://xkcd.com/2867/)