### PR TITLE
[AN-242] Update MethodQuery schema in Swagger docs

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -7759,24 +7759,35 @@ components:
         namespace:
           type: string
           description: Namespace which contains AgoraEntity.
+          example: YOUR_NAMESPACE
         name:
           type: string
           description: Name of the AgoraEntity.
+          example: BWA
         synopsis:
           type: string
           description: Synopsis which contains AgoraEntity.
+          example: Quickly aligns short nucleotide sequences.
         snapshotComment:
           type: string
           description: Snapshot comment of AgoraEntity
+          example: Improved spline reticulation
         documentation:
           type: string
           description: Documentation of the AgoraEntity.
+          example: |
+            BWA is a software package for mapping low-divergent sequences
+            against a large reference genome, such as the human genome.
+            It consists of three algorithms: BWA-backtrack, BWA-SW and BWA-MEM.
         payload:
           type: string
           description: Payload of method -- must be in WDL format
+          example: |
+            task wc {File in_file command { cat ${in_file} | wc -l } output { Int count = read_int(stdout()) }}
         entityType:
           type: string
           description: Type of the AgoraEntity -- Task or Workflow.
+          example: Task
     MethodShort:
       required:
         - managers

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -7749,40 +7749,34 @@ components:
           format: int32
           default: 0
     MethodQuery:
+      required:
+        - namespace
+        - name
+        - payload
+        - entityType
       type: object
       properties:
         namespace:
           type: string
           description: Namespace which contains AgoraEntity.
-          default: YOUR_NAMESPACE
         name:
           type: string
           description: Name of the AgoraEntity.
-          default: BWA
         synopsis:
           type: string
           description: Synopsis which contains AgoraEntity.
-          default: Quickly aligns short nucleotide sequences.
         snapshotComment:
           type: string
           description: Snapshot comment of AgoraEntity
-          default: Improved spline reticulation
         documentation:
           type: string
           description: Documentation of the AgoraEntity.
-          default: |
-            BWA is a software package for mapping low-divergent sequences
-            against a large reference genome, such as the human genome.
-            It consists of three algorithms: BWA-backtrack, BWA-SW and BWA-MEM.
         payload:
           type: string
           description: Payload of method -- must be in WDL format
-          default: |
-            task wc {File in_file command { cat ${in_file} | wc -l } output { Int count = read_int(stdout()) }}
         entityType:
           type: string
           description: Type of the AgoraEntity -- Task or Workflow.
-          default: Task
     MethodShort:
       required:
         - managers


### PR DESCRIPTION
Jira ticket: https://broadworkbench.atlassian.net/browse/AN-242

## Context
The MethodQuery schema in Swagger is used only by a single endpoint: POST `/api/methods`. The description of this endpoint specifies that `namespace`, `name`, `payload`, and `entityType` must be included in the request body, which has been verified, but the MethodQuery schema does not list these properties as required. Also, the schema provides default values for all of its properties, none of which are actually used by Orchestration in the case that they are not provided.

## Changes
- Updated the MethodQuery schema to make the `namespace`, `name`, `payload`, and `entityType` properties required and to change all default property values to example property values.

## Testing
- Tested in a BEE that the Swagger page is updated.

## Visual aids
Before:
<img width="1278" alt="MethodQuery Swagger schema before image" src="https://github.com/user-attachments/assets/06519719-28fe-4ec8-a4b3-12a086a048e8">

After:
<img width="1279" alt="MethodQuery Swagger schema after image" src="https://github.com/user-attachments/assets/e7452530-3c04-4d79-be02-5ca896c0d1bc">

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [x] Get two thumbsworth of review and PO signoff if necessary
- [x] Verify all tests go green
- [x] Squash and merge. Make sure your branch deletes; GitHub should do this for you.
- [ ] Test this change deployed correctly and works on dev environment after deployment