### PR TITLE
[CORE-53] Refactor storage cost estimate to use Rawls

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -48,7 +48,7 @@ object Dependencies {
     "com.typesafe.scala-logging"    %% "scala-logging"       % "3.9.5",
 
     "org.parboiled" % "parboiled-core" % "1.4.1",
-    excludeGuava("org.broadinstitute.dsde"       %% "rawls-model"         % "v0.0.195-SNAP")
+    excludeGuava("org.broadinstitute.dsde"       %% "rawls-model"         % "v0.0.218-SNAP")
       exclude("com.typesafe.scala-logging", "scala-logging_2.13")
       exclude("com.typesafe.akka", "akka-stream_2.13")
       exclude("com.google.code.findbugs", "jsr305")

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -4695,6 +4695,12 @@ paths:
       parameters:
         - $ref: '#/components/parameters/workspaceNamespaceParam'
         - $ref: '#/components/parameters/workspaceNameParam'
+        - name: userProject
+          in: path
+          description: google project to bill request to
+          required: false
+          schema:
+            type: string
       responses:
         200:
           description: Successful Request

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -4695,12 +4695,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/workspaceNamespaceParam'
         - $ref: '#/components/parameters/workspaceNameParam'
-        - name: userProject
-          in: path
-          description: google project to bill request to
-          required: false
-          schema:
-            type: string
+        - $ref: '#/components/parameters/userProjectQueryParam'
       responses:
         200:
           description: Successful Request
@@ -10421,6 +10416,14 @@ components:
       in: path
       description: Submission ID
       required: true
+      schema:
+        type: string
+    userProjectQueryParam:
+      name: userProject
+      in: query
+      description: |
+        When specified, bill google storage requests to this project
+      required: false
       schema:
         type: string
     workflowIdParam:

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/GoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/GoogleServicesDAO.scala
@@ -4,7 +4,7 @@ import akka.http.scaladsl.model.HttpResponse
 import better.files.File
 import com.google.api.services.storage.model.Bucket
 import org.broadinstitute.dsde.firecloud.model.WithAccessToken
-import org.broadinstitute.dsde.rawls.model.ErrorReportSource
+import org.broadinstitute.dsde.rawls.model.{ErrorReportSource, GoogleProjectId}
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GcsObjectName, GcsPath}
 import org.broadinstitute.dsde.workbench.util.health.Subsystems.Subsystem
 import org.broadinstitute.dsde.workbench.util.health.{SubsystemStatus, Subsystems}
@@ -39,7 +39,7 @@ trait GoogleServicesDAO extends ReportsSubsystemStatus {
 
   def publishMessages(fullyQualifiedTopic: String, messages: Seq[String]): Future[Unit]
 
-  def getBucket(bucketName: String, petKey: String): Option[Bucket]
+  def getBucket(bucketName: String, petKey: String, userProject: Option[GoogleProjectId]): Option[Bucket]
 
   def listBucket(bucketName: GcsBucketName, prefix: Option[String], recursive: Boolean): List[GcsObjectName]
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/GoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/GoogleServicesDAO.scala
@@ -2,9 +2,8 @@ package org.broadinstitute.dsde.firecloud.dataaccess
 
 import akka.http.scaladsl.model.HttpResponse
 import better.files.File
-import com.google.api.services.storage.model.Bucket
 import org.broadinstitute.dsde.firecloud.model.WithAccessToken
-import org.broadinstitute.dsde.rawls.model.{ErrorReportSource, GoogleProjectId}
+import org.broadinstitute.dsde.rawls.model.ErrorReportSource
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GcsObjectName, GcsPath}
 import org.broadinstitute.dsde.workbench.util.health.Subsystems.Subsystem
 import org.broadinstitute.dsde.workbench.util.health.{SubsystemStatus, Subsystems}

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/GoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/GoogleServicesDAO.scala
@@ -39,7 +39,5 @@ trait GoogleServicesDAO extends ReportsSubsystemStatus {
 
   def publishMessages(fullyQualifiedTopic: String, messages: Seq[String]): Future[Unit]
 
-  def getBucket(bucketName: String, petKey: String, userProject: Option[GoogleProjectId]): Option[Bucket]
-
   def listBucket(bucketName: GcsBucketName, prefix: Option[String], recursive: Boolean): List[GcsObjectName]
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
@@ -29,6 +29,7 @@ import org.broadinstitute.dsde.firecloud.dataaccess.HttpGoogleServicesDAO._
 import org.broadinstitute.dsde.firecloud.model.WithAccessToken
 import org.broadinstitute.dsde.firecloud.service.FireCloudRequestBuilding
 import org.broadinstitute.dsde.firecloud.utils.RestJsonClient
+import org.broadinstitute.dsde.rawls.model.GoogleProjectId
 import org.broadinstitute.dsde.workbench.google2.{GcsBlobName, GoogleStorageService}
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GcsObjectName, GcsPath, GoogleProject}
 import org.broadinstitute.dsde.workbench.util.health.SubsystemStatus
@@ -223,7 +224,7 @@ class HttpGoogleServicesDAO(priceListUrl: String, defaultPriceList: GooglePriceL
     storage.objects().get(bucketName, objectKey).executeMediaAsInputStream
   }
 
-  def getBucket(bucketName: String, petKey: String): Option[Bucket] = {
+  def getBucket(bucketName: String, petKey: String, userProject: Option[GoogleProjectId]): Option[Bucket] = {
     val keyStream = new ByteArrayInputStream(petKey.getBytes)
     val credential =
       getScopedServiceAccountCredentials(ServiceAccountCredentials.fromStream(keyStream), storageReadOnly)
@@ -232,14 +233,17 @@ class HttpGoogleServicesDAO(priceListUrl: String, defaultPriceList: GooglePriceL
       .setApplicationName(appName)
       .build()
 
-    Try(executeGoogleRequest[Bucket](storage.buckets().get(bucketName))) match {
+    val request = storage.buckets().get(bucketName)
+    userProject.map(id => request.setUserProject(id.value))
+
+    Try(executeGoogleRequest[Bucket](request)) match {
       case Failure(ex) =>
         // handle this case so we can give a good log message. In the future we may handle this
         // differently, such as returning an empty list.
         logger.warn(s"could not get $bucketName", ex)
         throw ex
       case Success(response) =>
-        return Option(response)
+        Option(response)
     }
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
@@ -17,7 +17,6 @@ import com.google.api.services.directory.model.{Group, Member}
 import com.google.api.services.directory.{Directory, DirectoryScopes}
 import com.google.api.services.pubsub.model.{PublishRequest, PubsubMessage}
 import com.google.api.services.pubsub.{Pubsub, PubsubScopes}
-import com.google.api.services.storage.model.Bucket
 import com.google.api.services.storage.{Storage, StorageScopes}
 import com.google.auth.http.HttpCredentialsAdapter
 import com.google.auth.oauth2.{GoogleCredentials, ServiceAccountCredentials}
@@ -29,7 +28,6 @@ import org.broadinstitute.dsde.firecloud.dataaccess.HttpGoogleServicesDAO._
 import org.broadinstitute.dsde.firecloud.model.WithAccessToken
 import org.broadinstitute.dsde.firecloud.service.FireCloudRequestBuilding
 import org.broadinstitute.dsde.firecloud.utils.RestJsonClient
-import org.broadinstitute.dsde.rawls.model.GoogleProjectId
 import org.broadinstitute.dsde.workbench.google2.{GcsBlobName, GoogleStorageService}
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GcsObjectName, GcsPath, GoogleProject}
 import org.broadinstitute.dsde.workbench.util.health.SubsystemStatus
@@ -37,7 +35,7 @@ import org.typelevel.log4cats.SelfAwareStructuredLogger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 import spray.json.{DefaultJsonProtocol, _}
 
-import java.io.{ByteArrayInputStream, FileInputStream}
+import java.io.FileInputStream
 import scala.concurrent.{ExecutionContext, Future}
 import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Success, Try}

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
@@ -224,29 +224,6 @@ class HttpGoogleServicesDAO(priceListUrl: String, defaultPriceList: GooglePriceL
     storage.objects().get(bucketName, objectKey).executeMediaAsInputStream
   }
 
-  def getBucket(bucketName: String, petKey: String, userProject: Option[GoogleProjectId]): Option[Bucket] = {
-    val keyStream = new ByteArrayInputStream(petKey.getBytes)
-    val credential =
-      getScopedServiceAccountCredentials(ServiceAccountCredentials.fromStream(keyStream), storageReadOnly)
-
-    val storage = new Storage.Builder(httpTransport, jsonFactory, new HttpCredentialsAdapter(credential))
-      .setApplicationName(appName)
-      .build()
-
-    val request = storage.buckets().get(bucketName)
-    userProject.map(id => request.setUserProject(id.value))
-
-    Try(executeGoogleRequest[Bucket](request)) match {
-      case Failure(ex) =>
-        // handle this case so we can give a good log message. In the future we may handle this
-        // differently, such as returning an empty list.
-        logger.warn(s"could not get $bucketName", ex)
-        throw ex
-      case Success(response) =>
-        Option(response)
-    }
-  }
-
   def getObjectResourceUrl(bucketName: String, objectKey: String) = {
     val gcsStatUrl = "https://www.googleapis.com/storage/v1/b/%s/o/%s"
     gcsStatUrl.format(bucketName, java.net.URLEncoder.encode(objectKey, "UTF-8"))

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpRawlsDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpRawlsDAO.scala
@@ -3,7 +3,6 @@ package org.broadinstitute.dsde.firecloud.dataaccess
 import akka.actor.ActorSystem
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
 import akka.http.scaladsl.model.StatusCodes._
-import akka.http.scaladsl.model.Uri.Query
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.unmarshalling.Unmarshal
 import akka.stream.Materializer
@@ -26,7 +25,6 @@ import org.broadinstitute.dsde.rawls.model.{
   _
 }
 import org.broadinstitute.dsde.workbench.util.health.SubsystemStatus
-import org.joda.time.DateTime
 import spray.json.DefaultJsonProtocol._
 import spray.json._
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpRawlsDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpRawlsDAO.scala
@@ -72,6 +72,19 @@ class HttpRawlsDAO(implicit val system: ActorSystem,
   ): Future[BucketUsageResponse] =
     authedRequestToObject[BucketUsageResponse](Get(rawlsBucketUsageUrl(ns, name)))
 
+  override def getBucketOptions(ns: String, name: String, userProject: Option[GoogleProjectId] = None)(implicit
+    userInfo: WithAccessToken
+  ): Future[WorkspaceBucketOptions] =
+    authedRequestToObject[WorkspaceBucketOptions](Get(getBucketOptionsUrl(ns, name, userProject)))
+
+  private def getBucketOptionsUrl(ns: String, name: String, userProject: Option[GoogleProjectId]): String =
+    rawlsBucketOptionsUrl(ns, name) + {
+      userProject match {
+        case Some(id) => rawlsBucketOptionsQueryString.format(id)
+        case None     => ""
+      }
+    }
+
   override def getWorkspaces(implicit userInfo: WithAccessToken): Future[Seq[WorkspaceListResponse]] =
     authedRequestToObject[Seq[WorkspaceListResponse]](Get(rawlsWorkpacesUrl),
                                                       label = Some("HttpRawlsDAO.getWorkspaces")

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/RawlsDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/RawlsDAO.scala
@@ -12,7 +12,6 @@ import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.AttributeUp
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.workbench.util.health.Subsystems
 import org.broadinstitute.dsde.workbench.util.health.Subsystems.Subsystem
-import org.joda.time.DateTime
 
 import scala.concurrent.Future
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/RawlsDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/RawlsDAO.scala
@@ -51,6 +51,10 @@ trait RawlsDAO extends LazyLogging with ReportsSubsystemStatus {
     FireCloudConfig.Rawls.workspacesUrl + s"/$workspaceNamespace/$workspaceName/bucketUsage"
   )
 
+  lazy val rawlsBucketOptionsQueryString = "?userProject=%s"
+  def rawlsBucketOptionsUrl(workspaceNamespace: String, workspaceName: String): String =
+    encodeUri(FireCloudConfig.Rawls.workspacesUrl + s"/$workspaceNamespace/$workspaceName/bucketOptions")
+
   def rawlsEntitiesOfTypeUrl(workspaceNamespace: String, workspaceName: String, entityType: String): String = encodeUri(
     FireCloudConfig.Rawls.workspacesUrl + s"/$workspaceNamespace/$workspaceName/entities/$entityType"
   )
@@ -60,6 +64,10 @@ trait RawlsDAO extends LazyLogging with ReportsSubsystemStatus {
   def isLibraryCurator(userInfo: UserInfo): Future[Boolean]
 
   def getBucketUsage(ns: String, name: String)(implicit userInfo: WithAccessToken): Future[BucketUsageResponse]
+
+  def getBucketOptions(ns: String, name: String, userProject: Option[GoogleProjectId])(implicit
+    userToken: WithAccessToken
+  ): Future[WorkspaceBucketOptions]
 
   def getWorkspaces(implicit userInfo: WithAccessToken): Future[Seq[WorkspaceListResponse]]
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceService.scala
@@ -68,31 +68,19 @@ class WorkspaceService(protected val argUserToken: WithAccessToken,
   def getStorageCostEstimate(workspaceNamespace: String,
                              workspaceName: String,
                              userProject: Option[GoogleProjectId]
-  ): Future[RequestComplete[WorkspaceStorageCostEstimate]] =
-    rawlsDAO.getWorkspace(workspaceNamespace, workspaceName) flatMap { workspaceResponse =>
-      val workspaceProjectId = workspaceResponse.workspace.googleProject.value
-      samDao.getPetServiceAccountKeyForUser(userToken, GoogleProject(workspaceProjectId)) flatMap { petKey =>
-        googleServicesDAO.getBucket(workspaceResponse.workspace.bucketName,
-                                    petKey,
-                                    userProject.getOrElse(GoogleProjectId(workspaceProjectId)).some
-        ) match {
-          case Some(bucket) =>
-            rawlsDAO.getBucketUsage(workspaceNamespace, workspaceName).zip(googleServicesDAO.fetchPriceList) map {
-              case (usage, priceList) =>
-                val rate = priceList.prices.cpBigstoreStorage.getOrElse(bucket.getLocation.toLowerCase(),
-                                                                        priceList.prices.cpBigstoreStorage("us")
-                )
-                // Convert bytes to GB since rate is based on GB.
-                val estimate: BigDecimal = BigDecimal(usage.usageInBytes) / (1024 * 1024 * 1024) * rate
-                RequestComplete(WorkspaceStorageCostEstimate(f"$$$estimate%.2f", usage.lastUpdated))
-            }
-          case None =>
-            throw new FireCloudExceptionWithErrorReport(
-              ErrorReport(StatusCodes.InternalServerError, "Unable to fetch bucket to calculate storage cost")
-            )
-        }
-      }
-    }
+  ): Future[RequestComplete[WorkspaceStorageCostEstimate]] = for {
+    bucketUsage <- rawlsDAO.getBucketUsage(workspaceNamespace, workspaceName)
+    priceList <- googleServicesDAO.fetchPriceList
+    bucketOptions <- rawlsDAO.getBucketOptions(workspaceNamespace, workspaceName, userProject)
+  } yield {
+    val rate = priceList.prices.cpBigstoreStorage.getOrElse(
+      bucketOptions.location.toLowerCase,
+      priceList.prices.cpBigstoreStorage("us")
+    )
+    // Convert bytes to GB since rate is based on GB.
+    val estimate: BigDecimal = BigDecimal(bucketUsage.usageInBytes) / (1024 * 1024 * 1024) * rate
+    RequestComplete(WorkspaceStorageCostEstimate(f"$$$estimate%.2f", bucketUsage.lastUpdated))
+  }
 
   def updateWorkspaceAttributes(workspaceNamespace: String,
                                 workspaceName: String,

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceService.scala
@@ -3,7 +3,6 @@ package org.broadinstitute.dsde.firecloud.service
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
 import akka.http.scaladsl.model.headers._
 import akka.http.scaladsl.model.{ContentTypes, StatusCodes}
-import cats.implicits.catsSyntaxOptionId
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.dataaccess._
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
@@ -25,7 +24,6 @@ import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.{
 }
 import org.broadinstitute.dsde.rawls.model.WorkspaceACLJsonSupport._
 import org.broadinstitute.dsde.rawls.model._
-import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import spray.json.DefaultJsonProtocol._
 
 import scala.concurrent.{ExecutionContext, Future}

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceService.scala
@@ -3,6 +3,7 @@ package org.broadinstitute.dsde.firecloud.service
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
 import akka.http.scaladsl.model.headers._
 import akka.http.scaladsl.model.{ContentTypes, StatusCodes}
+import cats.implicits.catsSyntaxOptionId
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.dataaccess._
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
@@ -65,13 +66,16 @@ class WorkspaceService(protected val argUserToken: WithAccessToken,
   implicit val userToken: WithAccessToken = argUserToken
 
   def getStorageCostEstimate(workspaceNamespace: String,
-                             workspaceName: String
+                             workspaceName: String,
+                             userProject: Option[GoogleProjectId]
   ): Future[RequestComplete[WorkspaceStorageCostEstimate]] =
     rawlsDAO.getWorkspace(workspaceNamespace, workspaceName) flatMap { workspaceResponse =>
-      samDao.getPetServiceAccountKeyForUser(userToken,
-                                            GoogleProject(workspaceResponse.workspace.googleProject.value)
-      ) flatMap { petKey =>
-        googleServicesDAO.getBucket(workspaceResponse.workspace.bucketName, petKey) match {
+      val workspaceProjectId = workspaceResponse.workspace.googleProject.value
+      samDao.getPetServiceAccountKeyForUser(userToken, GoogleProject(workspaceProjectId)) flatMap { petKey =>
+        googleServicesDAO.getBucket(workspaceResponse.workspace.bucketName,
+                                    petKey,
+                                    userProject.getOrElse(GoogleProjectId(workspaceProjectId)).some
+        ) match {
           case Some(bucket) =>
             rawlsDAO.getBucketUsage(workspaceNamespace, workspaceName).zip(googleServicesDAO.fetchPriceList) map {
               case (usage, priceList) =>

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiService.scala
@@ -405,12 +405,12 @@ trait WorkspaceApiService extends FireCloudRequestBuilding with FireCloudDirecti
                 } ~
                 path("storageCostEstimate") {
                   get {
-                    parameters("userProject".as[GoogleProjectId].optional) { userProject =>
+                    parameters("userProject".optional) { userProject =>
                       requireUserInfo() { userInfo =>
                         complete {
                           workspaceServiceConstructor(userInfo).getStorageCostEstimate(workspaceNamespace,
                                                                                        workspaceName,
-                                                                                       userProject
+                                                                                       userProject.map(GoogleProjectId)
                           )
                         }
                       }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiService.scala
@@ -405,9 +405,14 @@ trait WorkspaceApiService extends FireCloudRequestBuilding with FireCloudDirecti
                 } ~
                 path("storageCostEstimate") {
                   get {
-                    requireUserInfo() { userInfo =>
-                      complete {
-                        workspaceServiceConstructor(userInfo).getStorageCostEstimate(workspaceNamespace, workspaceName)
+                    parameters("userProject".as[GoogleProjectId].optional) { userProject =>
+                      requireUserInfo() { userInfo =>
+                        complete {
+                          workspaceServiceConstructor(userInfo).getStorageCostEstimate(workspaceNamespace,
+                                                                                       workspaceName,
+                                                                                       userProject
+                          )
+                        }
                       }
                     }
                   }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockRawlsDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockRawlsDAO.scala
@@ -187,6 +187,8 @@ object MockRawlsDAO {
     )
   )
 
+  val bucketLocation = "us-central1"
+
 }
 
 /**
@@ -340,7 +342,7 @@ class MockRawlsDAO extends RawlsDAO {
     catalog = Some(false),
     rawlsWorkspaceWithAttributes,
     Some(WorkspaceSubmissionStats(None, None, runningSubmissionsCount = 0)),
-    Some(WorkspaceBucketOptions(false)),
+    Some(WorkspaceBucketOptions(false, bucketLocation)),
     Some(Set.empty),
     None
   )
@@ -351,7 +353,7 @@ class MockRawlsDAO extends RawlsDAO {
     catalog = Some(false),
     publishedRawlsWorkspaceWithAttributes,
     Some(WorkspaceSubmissionStats(None, None, runningSubmissionsCount = 0)),
-    Some(WorkspaceBucketOptions(false)),
+    Some(WorkspaceBucketOptions(false, bucketLocation)),
     Some(Set.empty),
     None
   )
@@ -389,6 +391,19 @@ class MockRawlsDAO extends RawlsDAO {
   ): Future[BucketUsageResponse] =
     Future.successful(BucketUsageResponse(BigInt("256000000000"), Option(new DateTime(0))))
 
+  override def getBucketOptions(ns: String, name: String, userProject: Option[GoogleProjectId] = None)(implicit
+    userInfo: WithAccessToken
+  ): Future[WorkspaceBucketOptions] =
+    Future.successful(
+      WorkspaceBucketOptions(
+        false,
+        ns match {
+          case "europeWest1BucketWorkspace" => "europe-west1"
+          case _                            => "us-central1"
+        }
+      )
+    )
+
   override def getWorkspace(ns: String, name: String)(implicit userToken: WithAccessToken): Future[WorkspaceResponse] =
     ns match {
       case "projectowner" =>
@@ -400,7 +415,7 @@ class MockRawlsDAO extends RawlsDAO {
             catalog = Some(false),
             newWorkspace,
             Some(WorkspaceSubmissionStats(None, None, runningSubmissionsCount = 0)),
-            Some(WorkspaceBucketOptions(false)),
+            Some(WorkspaceBucketOptions(false, bucketLocation)),
             Some(Set.empty),
             None
           )
@@ -414,7 +429,7 @@ class MockRawlsDAO extends RawlsDAO {
             catalog = Some(false),
             newWorkspace,
             Some(WorkspaceSubmissionStats(None, None, runningSubmissionsCount = 0)),
-            Some(WorkspaceBucketOptions(false)),
+            Some(WorkspaceBucketOptions(false, bucketLocation)),
             Some(Set.empty),
             None
           )
@@ -429,7 +444,7 @@ class MockRawlsDAO extends RawlsDAO {
             catalog = Some(false),
             publishedRawlsWorkspaceWithAttributes,
             Some(WorkspaceSubmissionStats(None, None, runningSubmissionsCount = 0)),
-            Some(WorkspaceBucketOptions(false)),
+            Some(WorkspaceBucketOptions(false, bucketLocation)),
             Some(Set.empty),
             None
           )
@@ -443,7 +458,7 @@ class MockRawlsDAO extends RawlsDAO {
             catalog = Some(true),
             publishedRawlsWorkspaceWithAttributes,
             Some(WorkspaceSubmissionStats(None, None, runningSubmissionsCount = 0)),
-            Some(WorkspaceBucketOptions(false)),
+            Some(WorkspaceBucketOptions(false, bucketLocation)),
             Some(Set.empty),
             None
           )
@@ -457,7 +472,7 @@ class MockRawlsDAO extends RawlsDAO {
             catalog = Some(false),
             publishedRawlsWorkspaceWithAttributes,
             Some(WorkspaceSubmissionStats(None, None, runningSubmissionsCount = 0)),
-            Some(WorkspaceBucketOptions(false)),
+            Some(WorkspaceBucketOptions(false, bucketLocation)),
             Some(Set.empty),
             None
           )
@@ -471,7 +486,7 @@ class MockRawlsDAO extends RawlsDAO {
             catalog = Some(false),
             rawlsWorkspaceWithAttributes,
             Some(WorkspaceSubmissionStats(None, None, runningSubmissionsCount = 0)),
-            Some(WorkspaceBucketOptions(false)),
+            Some(WorkspaceBucketOptions(false, bucketLocation)),
             Some(Set.empty),
             None
           )
@@ -485,7 +500,7 @@ class MockRawlsDAO extends RawlsDAO {
             catalog = Some(false),
             publishedRawlsWorkspaceWithAttributes,
             Some(WorkspaceSubmissionStats(None, None, runningSubmissionsCount = 0)),
-            Some(WorkspaceBucketOptions(false)),
+            Some(WorkspaceBucketOptions(false, bucketLocation)),
             Some(Set.empty),
             None
           )
@@ -499,7 +514,7 @@ class MockRawlsDAO extends RawlsDAO {
             catalog = Some(false),
             unpublishedRawlsWorkspaceLibraryValid,
             Some(WorkspaceSubmissionStats(None, None, runningSubmissionsCount = 0)),
-            Some(WorkspaceBucketOptions(false)),
+            Some(WorkspaceBucketOptions(false, bucketLocation)),
             Some(Set.empty),
             None
           )
@@ -513,7 +528,7 @@ class MockRawlsDAO extends RawlsDAO {
             catalog = Some(false),
             newWorkspace.copy(bucketName = "usBucket"),
             Some(WorkspaceSubmissionStats(None, None, runningSubmissionsCount = 0)),
-            Some(WorkspaceBucketOptions(false)),
+            Some(WorkspaceBucketOptions(false, bucketLocation)),
             Some(Set.empty),
             None
           )
@@ -527,7 +542,7 @@ class MockRawlsDAO extends RawlsDAO {
             catalog = Some(false),
             newWorkspace.copy(bucketName = "europeWest1Bucket"),
             Some(WorkspaceSubmissionStats(None, None, runningSubmissionsCount = 0)),
-            Some(WorkspaceBucketOptions(false)),
+            Some(WorkspaceBucketOptions(false, bucketLocation)),
             Some(Set.empty),
             None
           )
@@ -541,7 +556,7 @@ class MockRawlsDAO extends RawlsDAO {
             catalog = Some(false),
             newWorkspace,
             Some(WorkspaceSubmissionStats(None, None, runningSubmissionsCount = 0)),
-            Some(WorkspaceBucketOptions(false)),
+            Some(WorkspaceBucketOptions(false, bucketLocation)),
             Some(Set.empty),
             None
           )

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockGoogleServicesDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockGoogleServicesDAO.scala
@@ -105,11 +105,6 @@ class MockGoogleServicesDAO extends GoogleServicesDAO {
   override def addMemberToAnonymizedGoogleGroup(groupName: String, targetUserEmail: String): Option[String] = Option(
     "user-email@something.com"
   )
-  override def getBucket(bucketName: String, petKey: String): Option[Bucket] =
-    bucketName match {
-      case "usBucket"          => Option(new Bucket().setName("usBucket").setLocation("US"))
-      case "europeWest1Bucket" => Option(new Bucket().setName("europeWest1").setLocation("EUROPE-WEST1"))
-    }
 
   def status: Future[SubsystemStatus] = Future(SubsystemStatus(ok = true, messages = None))
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockGoogleServicesDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockGoogleServicesDAO.scala
@@ -2,7 +2,6 @@ package org.broadinstitute.dsde.firecloud.mock
 
 import akka.http.scaladsl.model.HttpResponse
 import better.files.File
-import com.google.api.services.storage.model.Bucket
 import org.broadinstitute.dsde.firecloud.dataaccess._
 import org.broadinstitute.dsde.firecloud.model.WithAccessToken
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GcsObjectName, GcsPath}

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/LibraryServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/LibraryServiceSpec.scala
@@ -110,6 +110,8 @@ class LibraryServiceSpec
     state = WorkspaceState.Ready
   )
 
+  val bucketLocation = "us-central1"
+
   val DULAdditionalJsObject =
     """
       |{
@@ -354,7 +356,7 @@ class LibraryServiceSpec
           Some(false),
           testWorkspace.copy(attributes = Some(Map(discoverableWSAttribute -> AttributeValueList(Seq.empty)))),
           Some(WorkspaceSubmissionStats(None, None, runningSubmissionsCount = 0)),
-          Some(WorkspaceBucketOptions(false)),
+          Some(WorkspaceBucketOptions(false, bucketLocation)),
           Some(Set.empty),
           None
         )
@@ -372,7 +374,7 @@ class LibraryServiceSpec
             Some(Map(discoverableWSAttribute -> AttributeValueList(Seq(AttributeString("group1")))))
           ),
           Some(WorkspaceSubmissionStats(None, None, runningSubmissionsCount = 0)),
-          Some(WorkspaceBucketOptions(false)),
+          Some(WorkspaceBucketOptions(false, bucketLocation)),
           Some(Set.empty),
           None
         )
@@ -398,7 +400,7 @@ class LibraryServiceSpec
             )
           ),
           Some(WorkspaceSubmissionStats(None, None, runningSubmissionsCount = 0)),
-          Some(WorkspaceBucketOptions(false)),
+          Some(WorkspaceBucketOptions(false, bucketLocation)),
           Some(Set.empty),
           None
         )

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceServiceSpec.scala
@@ -157,7 +157,7 @@ class MockRawlsDeleteWSDAO(implicit val executionContext: ExecutionContext) exte
             catalog = Some(false),
             newWorkspace,
             Some(WorkspaceSubmissionStats(None, None, runningSubmissionsCount = 0)),
-            Some(WorkspaceBucketOptions(false)),
+            Some(WorkspaceBucketOptions(false, MockRawlsDAO.bucketLocation)),
             Some(Set.empty),
             None
           )
@@ -171,7 +171,7 @@ class MockRawlsDeleteWSDAO(implicit val executionContext: ExecutionContext) exte
             catalog = Some(false),
             unpublishsuccess,
             Some(WorkspaceSubmissionStats(None, None, runningSubmissionsCount = 0)),
-            Some(WorkspaceBucketOptions(false)),
+            Some(WorkspaceBucketOptions(false, MockRawlsDAO.bucketLocation)),
             Some(Set.empty),
             None
           )
@@ -185,7 +185,7 @@ class MockRawlsDeleteWSDAO(implicit val executionContext: ExecutionContext) exte
             catalog = Some(false),
             unpublishfailure,
             Some(WorkspaceSubmissionStats(None, None, runningSubmissionsCount = 0)),
-            Some(WorkspaceBucketOptions(false)),
+            Some(WorkspaceBucketOptions(false, MockRawlsDAO.bucketLocation)),
             Some(Set.empty),
             None
           )
@@ -199,7 +199,7 @@ class MockRawlsDeleteWSDAO(implicit val executionContext: ExecutionContext) exte
             catalog = Some(false),
             newWorkspace,
             Some(WorkspaceSubmissionStats(None, None, runningSubmissionsCount = 0)),
-            Some(WorkspaceBucketOptions(false)),
+            Some(WorkspaceBucketOptions(false, MockRawlsDAO.bucketLocation)),
             Some(Set.empty),
             None
           )

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceTagsServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceTagsServiceSpec.scala
@@ -360,7 +360,7 @@ class MockTagsRawlsDao extends MockRawlsDAO with Assertions {
     catalog = Some(false),
     ws,
     Some(WorkspaceSubmissionStats(None, None, runningSubmissionsCount = 0)),
-    Some(WorkspaceBucketOptions(false)),
+    Some(WorkspaceBucketOptions(false, MockRawlsDAO.bucketLocation)),
     Some(Set.empty),
     None
   )

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiServiceSpec.scala
@@ -151,6 +151,8 @@ class WorkspaceApiServiceSpec
 
   val dummyUserId = "1234"
 
+  val bucketLocation = "us-central1"
+
   val protectedRawlsWorkspace = WorkspaceDetails(
     "attributes",
     "att",
@@ -230,7 +232,7 @@ class WorkspaceApiServiceSpec
     catalog = Some(false),
     protectedRawlsWorkspace,
     Some(WorkspaceSubmissionStats(None, None, runningSubmissionsCount = 0)),
-    Some(WorkspaceBucketOptions(false)),
+    Some(WorkspaceBucketOptions(false, bucketLocation)),
     Some(Set.empty),
     None
   )
@@ -241,7 +243,7 @@ class WorkspaceApiServiceSpec
     catalog = Some(false),
     authDomainRawlsWorkspace,
     Some(WorkspaceSubmissionStats(None, None, runningSubmissionsCount = 0)),
-    Some(WorkspaceBucketOptions(false)),
+    Some(WorkspaceBucketOptions(false, bucketLocation)),
     Some(Set.empty),
     None
   )
@@ -252,7 +254,7 @@ class WorkspaceApiServiceSpec
     catalog = Some(false),
     nonAuthDomainRawlsWorkspace,
     Some(WorkspaceSubmissionStats(None, None, runningSubmissionsCount = 0)),
-    Some(WorkspaceBucketOptions(false)),
+    Some(WorkspaceBucketOptions(false, bucketLocation)),
     Some(Set.empty),
     None
   )
@@ -1518,18 +1520,6 @@ class WorkspaceApiServiceSpec
             status should be(OK)
             // 256000000000 / (1024 * 1024 * 1024) *0.01
             responseAs[WorkspaceStorageCostEstimate].estimate should be("$2.38")
-          }
-        }
-      }
-
-      "when calling GET on workspaces/*/*/storageCostEstimate" - {
-        "should return 200 with result for different europe east 1 region." in {
-          Get(europeWest1storageCostEstimatePath) ~> dummyUserIdHeaders(dummyUserId) ~> sealRoute(
-            workspaceRoutes
-          ) ~> check {
-            status should be(OK)
-            // 256000000000 / (1024 * 1024 * 1024) *0.02
-            responseAs[WorkspaceStorageCostEstimate].estimate should be("$4.77")
           }
         }
       }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiServiceSpec.scala
@@ -1523,6 +1523,18 @@ class WorkspaceApiServiceSpec
           }
         }
       }
+
+      "when calling GET on workspaces/*/*/storageCostEstimate" - {
+        "should return 200 with result for different europe east 1 region." in {
+          Get(europeWest1storageCostEstimatePath) ~> dummyUserIdHeaders(dummyUserId) ~> sealRoute(
+            workspaceRoutes
+          ) ~> check {
+            status should be(OK)
+            // 256000000000 / (1024 * 1024 * 1024) *0.02
+            responseAs[WorkspaceStorageCostEstimate].estimate should be("$4.77")
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Rawls now supports getting workspace bucket location, so Orchestration doesn't have to directly request this information from Google, which was causing incorrect behavior around requester pays. This change modifies the storage cost estimate API so that it uses Rawls to get bucket location (for rate calculations). It also adds an optional `userProject` query parameter so that a reader may use the API to get a storage cost estimate on a requester pays workspace if they provide a project to bill.

For UI users, this will fix the error in getting estimated cost on requester pays workspaces for writers and owners. It won't look any different for readers, because the UI hides estimated cost from readers in the first place.

-----

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge. Make sure your branch deletes; GitHub should do this for you.
- [ ] Test this change deployed correctly and works on dev environment after deployment
