### PR TITLE
[CORE-153] Group Scala Steward PRs for minor and patch version bumps

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -25,6 +25,38 @@
 #
 pullRequests.frequency = "0 0 ? * MON" # every monday at midnight
 
+# pullRequests.grouping allows you to specify how Scala Steward should group
+# your updates in order to reduce the number of pull-requests.
+#
+# Updates will be placed in the first group with which they match, starting
+# from the first in the array. Those that do not match any group will follow
+# the default procedure (one PR per update).
+#
+# Each element in the array will have the following schema:
+#
+#   - name (mandatory): the name of the group, will be used for things like naming the branch
+#   - title (optional): if provided it will be used as the title for the PR
+#   - filter (mandatory): a non-empty list containing the filters to use to know
+#                         if an update falls into this group.
+#
+# `filter` properties would have this format:
+#
+#    {
+#       version = "major" | "minor" | "patch" | "pre-release" | "build-metadata",
+#       group = "{group}",
+#       artifact = "{artifact}"
+#    }
+#
+# For more information on the values for the `version` filter visit https://semver.org/
+#
+# Every field in a `filter` is optional but at least one must be provided.
+#
+# For grouping every update together a filter like {group = "*"} can be # provided.
+#
+# To create a new PR for each unique combination of artifact-versions, include ${hash} in the name.
+#
+# Default: []
+pullRequests.grouping = [ { name = "minor_patch", title = "CORE-69: Minor and patch updates - ${artifactVersions}", filter = [ { version = "minor" }, { version = "patch" } ] } ]
 
 # Only these dependencies which match the given patterns are updated.
 #


### PR DESCRIPTION
Ticket: [CORE-153](https://broadworkbench.atlassian.net/browse/CORE-153)
* Group Scala Steward dependency updates 

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge. Make sure your branch deletes; GitHub should do this for you.
- [ ] Test this change deployed correctly and works on dev environment after deployment


[CORE-153]: https://broadworkbench.atlassian.net/browse/CORE-153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ