### PR TITLE
CORE-191: list/get/create import jobs works for requester-pays workspace

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/EntityService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/EntityService.scala
@@ -351,8 +351,8 @@ class EntityService(rawlsDAO: RawlsDAO,
                runningOnly: Boolean,
                userInfo: UserInfo
   ): Future[List[CwdsListResponse]] =
-    rawlsDAO.getWorkspace(workspaceNamespace, workspaceName)(userInfo) map { workspace =>
-      cwdsDAO.listJobsV1(workspace.workspace.workspaceId, runningOnly)(userInfo)
+    rawlsDAO.getWorkspaceId(workspaceNamespace, workspaceName)(userInfo) map { workspaceId =>
+      cwdsDAO.listJobsV1(workspaceId.toString, runningOnly)(userInfo)
     } recover { case apiEx: ApiException =>
       throw wrapCwdsException(apiEx)
     }
@@ -362,8 +362,8 @@ class EntityService(rawlsDAO: RawlsDAO,
              jobId: String,
              userInfo: UserInfo
   ): Future[CwdsListResponse] =
-    rawlsDAO.getWorkspace(workspaceNamespace, workspaceName)(userInfo) map { workspace =>
-      val cwdsResponse = cwdsDAO.getJobV1(workspace.workspace.workspaceId, jobId)(userInfo)
+    rawlsDAO.getWorkspaceId(workspaceNamespace, workspaceName)(userInfo) map { workspaceId =>
+      val cwdsResponse = cwdsDAO.getJobV1(workspaceId.toString, jobId)(userInfo)
       logger.info(s"Found job $jobId in cWDS")
       cwdsResponse
     } recover { case apiEx: ApiException =>

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/EntityService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/EntityService.scala
@@ -203,12 +203,12 @@ class EntityService(rawlsDAO: RawlsDAO,
   ): Future[PerRequestMessage] = {
     import spray.json._
     val dataBytes = rawlsCalls.toJson.prettyPrint.getBytes(StandardCharsets.UTF_8)
-    getWorkspaceId(workspaceNamespace, workspaceName, userInfo) map { workspaceId =>
+    rawlsDAO.getWorkspaceId(workspaceNamespace, workspaceName)(userInfo) map { workspaceId =>
       val bucketToWrite = GcsBucketName(FireCloudConfig.Cwds.bucket)
       val fileToWrite = GcsObjectName(s"to-cwds/${workspaceId}/${java.util.UUID.randomUUID()}.json")
       val gcsPath = writeDataToGcs(bucketToWrite, fileToWrite, dataBytes)
       val importRequest = getRawlsJsonImportRequest(gcsPath, isUpsert)
-      importToCWDS(workspaceNamespace, workspaceName, workspaceId, userInfo, importRequest)
+      importToCWDS(workspaceNamespace, workspaceName, workspaceId.toString, userInfo, importRequest)
     }
   }
 
@@ -219,9 +219,6 @@ class EntityService(rawlsDAO: RawlsDAO,
 
   private def getRawlsJsonImportRequest(gcsPath: String, isUpsert: Boolean): AsyncImportRequest =
     AsyncImportRequest(gcsPath, FILETYPE_RAWLS, Some(ImportOptions(None, Some(isUpsert))))
-
-  private def getWorkspaceId(workspaceNamespace: String, workspaceName: String, userInfo: UserInfo): Future[String] =
-    rawlsDAO.getWorkspace(workspaceNamespace, workspaceName)(userInfo).map(_.workspace.workspaceId)
 
   private def importToCWDS(workspaceNamespace: String,
                            workspaceName: String,
@@ -339,8 +336,8 @@ class EntityService(rawlsDAO: RawlsDAO,
     if (importRequest.filetype.isEmpty)
       throw new FireCloudExceptionWithErrorReport(ErrorReport(BadRequest, "filetype must be specified"))
 
-    getWorkspaceId(workspaceNamespace, workspaceName, userInfo) map { workspaceId =>
-      importToCWDS(workspaceNamespace, workspaceName, workspaceId, userInfo, importRequest)
+    rawlsDAO.getWorkspaceId(workspaceNamespace, workspaceName)(userInfo) map { workspaceId =>
+      importToCWDS(workspaceNamespace, workspaceName, workspaceId.toString, userInfo, importRequest)
     } recover { case apiEx: ApiException =>
       throw wrapCwdsException(apiEx)
     }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpRawlsDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpRawlsDAO.scala
@@ -3,6 +3,7 @@ package org.broadinstitute.dsde.firecloud.dataaccess
 import akka.actor.ActorSystem
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
 import akka.http.scaladsl.model.StatusCodes._
+import akka.http.scaladsl.model.Uri.Query
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.unmarshalling.Unmarshal
 import akka.stream.Materializer
@@ -28,6 +29,7 @@ import org.broadinstitute.dsde.workbench.util.health.SubsystemStatus
 import spray.json.DefaultJsonProtocol._
 import spray.json._
 
+import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
 
@@ -90,6 +92,13 @@ class HttpRawlsDAO(implicit val system: ActorSystem,
 
   override def getWorkspace(ns: String, name: String)(implicit userToken: WithAccessToken): Future[WorkspaceResponse] =
     authedRequestToObject[WorkspaceResponse](Get(getWorkspaceUrl(ns, name)))
+
+  override def getWorkspaceId(ns: String, name: String)(implicit userToken: WithAccessToken): Future[UUID] = {
+    val targetUri = Uri(getWorkspaceUrl(ns, name)).withQuery(Query(("fields", "workspace.workspaceId")))
+    authedRequestToObject[WorkspaceIdResponse](Get(targetUri)) map { resp: WorkspaceIdResponse =>
+      resp.workspace.workspaceId
+    }
+  }
 
   override def patchWorkspaceAttributes(ns: String, name: String, attributeOperations: Seq[AttributeUpdateOperation])(
     implicit userToken: WithAccessToken

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/RawlsDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/RawlsDAO.scala
@@ -13,6 +13,7 @@ import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.workbench.util.health.Subsystems
 import org.broadinstitute.dsde.workbench.util.health.Subsystems.Subsystem
 
+import java.util.UUID
 import scala.concurrent.Future
 
 /**
@@ -71,6 +72,8 @@ trait RawlsDAO extends LazyLogging with ReportsSubsystemStatus {
   def getWorkspaces(implicit userInfo: WithAccessToken): Future[Seq[WorkspaceListResponse]]
 
   def getWorkspace(ns: String, name: String)(implicit userToken: WithAccessToken): Future[WorkspaceResponse]
+
+  def getWorkspaceId(ns: String, name: String)(implicit userToken: WithAccessToken): Future[UUID]
 
   def patchWorkspaceAttributes(ns: String, name: String, attributes: Seq[AttributeUpdateOperation])(implicit
     userToken: WithAccessToken

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
@@ -378,4 +378,8 @@ object ModelJsonProtocol extends WorkspaceJsonSupport with SprayJsonSupport {
   }
 
   implicit val impShareFormat: RootJsonFormat[Share] = jsonFormat4(Share)
+
+  implicit val impWorkspaceIdFormat: RootJsonFormat[WorkspaceId] = jsonFormat1(WorkspaceId)
+  implicit val impWorkspaceIdResponseFormat: RootJsonFormat[WorkspaceIdResponse] = jsonFormat1(WorkspaceIdResponse)
+
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/Workspace.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/Workspace.scala
@@ -4,6 +4,8 @@ import org.broadinstitute.dsde.firecloud.model.OrchMethodRepository.AgoraConfigu
 import org.broadinstitute.dsde.rawls.model._
 import org.joda.time.DateTime
 
+import java.util.UUID
+
 case class UIWorkspaceResponse(accessLevel: Option[String] = None,
                                canShare: Option[Boolean] = None,
                                catalog: Option[Boolean] = None,
@@ -96,3 +98,6 @@ case class RawlsGroupMemberList(userEmails: Option[Seq[String]] = None,
 )
 
 case class WorkspaceStorageCostEstimate(estimate: String, lastUpdated: Option[DateTime])
+
+case class WorkspaceId(workspaceId: UUID)
+case class WorkspaceIdResponse(workspace: WorkspaceId)

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/EntityServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/EntityServiceSpec.scala
@@ -160,8 +160,8 @@ class EntityServiceSpec extends BaseServiceSpec with BeforeAndAfterEach {
 
         when(cwdsDAO.isEnabled).thenReturn(true)
         when(cwdsDAO.getSupportedFormats).thenReturn(List("pfb", "tdrexport", "rawlsjson"))
-        when(rawlsDAO.getWorkspace(any[String], any[String])(any[UserInfo]))
-          .thenReturn(Future.successful(workspaceResponse))
+        when(rawlsDAO.getWorkspaceId(any[String], any[String])(any[UserInfo]))
+          .thenReturn(Future.successful(UUID.fromString(workspaceResponse.workspace.workspaceId)))
 
         entityService
           .importEntitiesFromTSV("workspaceNamespace", "workspaceName", tsvData, dummyUserInfo("token"), true)
@@ -176,7 +176,7 @@ class EntityServiceSpec extends BaseServiceSpec with BeforeAndAfterEach {
         val capturedRequest = argumentCaptor.getValue
         capturedRequest.options should be(Some(ImportOptions(None, Some(tsvType != "update"))))
         verify(rawlsDAO, times(1))
-          .getWorkspace(any[String], any[String])(any[UserInfo])
+          .getWorkspaceId(any[String], any[String])(any[UserInfo])
 
       }
     }
@@ -289,8 +289,8 @@ class EntityServiceSpec extends BaseServiceSpec with BeforeAndAfterEach {
 
       when(cwdsDAO.importV1(any[String], any[AsyncImportRequest])(any[UserInfo])).thenReturn(genericJob)
 
-      when(rawlsDAO.getWorkspace(any[String], any[String])(any[UserInfo]))
-        .thenReturn(Future.successful(workspaceResponse))
+      when(rawlsDAO.getWorkspaceId(any[String], any[String])(any[UserInfo]))
+        .thenReturn(Future.successful(UUID.fromString(workspaceResponse.workspace.workspaceId)))
 
       // create input
       val input = AsyncImportRequest(url = "https://example.com", filetype = importFiletype)
@@ -302,7 +302,7 @@ class EntityServiceSpec extends BaseServiceSpec with BeforeAndAfterEach {
       verify(cwdsDAO, times(1))
         .importV1(any[String], any[AsyncImportRequest])(any[UserInfo])
       verify(rawlsDAO, times(1))
-        .getWorkspace(any[String], any[String])(any[UserInfo])
+        .getWorkspaceId(any[String], any[String])(any[UserInfo])
     }
 
   }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockRawlsDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockRawlsDAO.scala
@@ -200,7 +200,7 @@ class MockRawlsDAO extends RawlsDAO {
   private val rawlsWorkspaceWithAttributes = WorkspaceDetails(
     "attributes",
     "att",
-    "id",
+    "00000000-0000-0000-0000-000000000000",
     "", // bucketname
     Some("wf-collection"),
     DateTime.now(),

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockRawlsDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockRawlsDAO.scala
@@ -563,6 +563,11 @@ class MockRawlsDAO extends RawlsDAO {
         )
     }
 
+  override def getWorkspaceId(ns: String, name: String)(implicit
+    userToken: WithAccessToken
+  ): Future[UUID] =
+    getWorkspace(ns, name) map { workspaceResponse => UUID.fromString(workspaceResponse.workspace.workspaceId) }
+
   override def getWorkspaces(implicit userInfo: WithAccessToken): Future[Seq[WorkspaceListResponse]] =
     Future.successful(
       Seq(


### PR DESCRIPTION
Creating, getting, and listing async data table import jobs did not work in requester-pays workspaces.

As part of these operations, Orchestration queries Rawls. It sends a workspace namespace+name, gets a response, and extracts the workspaceId from the response. However, the request it sent was for the entire workspace object, including bucket info. This would cause the request to fail for RP workspaces.

This PR introduces a new, optimized `getWorkspaceId` method for Orch to query Rawls. This request does not ask anything about buckets and therefore hits no problems in RP workspaces.

--- 

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [x] Verify all tests go green
- [ ] Squash and merge. Make sure your branch deletes; GitHub should do this for you.
- [ ] Test this change deployed correctly and works on dev environment after deployment
