### PR TITLE
CORE-207: optimize stringToTypedAttribute in TSV upload

### DIFF
--- a/benchmarks/src/main/scala/org/broadinstitute/dsde/firecloud/utils/TsvFileSupportBenchmark.scala
+++ b/benchmarks/src/main/scala/org/broadinstitute/dsde/firecloud/utils/TsvFileSupportBenchmark.scala
@@ -1,0 +1,61 @@
+package org.broadinstitute.dsde.firecloud.utils
+
+import org.broadinstitute.dsde.firecloud.model.{EntityUpdateDefinition, FlexibleModelSchema, ModelSchema}
+import org.broadinstitute.dsde.firecloud.service.TSVFileSupport
+import org.broadinstitute.dsde.firecloud.utils.TsvFileSupportBenchmark.TsvData
+import org.openjdk.jmh.annotations.{Benchmark, Scope, State}
+import org.openjdk.jmh.infra.Blackhole
+
+object TsvFileSupportBenchmark {
+  @State(Scope.Thread)
+  class TsvData {
+    val entityType: String = "sample"
+    val memberTypeOpt: Option[String] = None
+    // representation of the inbound TSV row
+    val row: Seq[String] = Seq(
+      "0005",
+      "foo",
+      "\"some\tquoted\tvalue\"",
+      "42",
+      "true",
+      "-123.456",
+      "gs://some-bucket/somefile.ext",
+      """{"entityType":"targetType", "entityName":"targetName"}""",
+      "[1,2,3,4,5]"
+    )
+    val colInfo: Seq[(String, Option[String])] = Seq(
+      ("sample_id", None),
+      ("string", None),
+      ("quotedstring", None),
+      ("int", None),
+      ("boolean", None),
+      ("double", None),
+      ("file", None),
+      ("reference", None),
+      ("array", None)
+    )
+    val modelSchema: ModelSchema = FlexibleModelSchema
+    val deleteEmptyValues: Boolean = false
+  }
+}
+
+class TsvFileSupportBenchmark {
+
+  @Benchmark
+  def makeEntityRows(blackHole: Blackhole, tsvData: TsvData): EntityUpdateDefinition = {
+
+    val result: EntityUpdateDefinition = TsvFileSupportHarness.setAttributesOnEntity(tsvData.entityType,
+                                                                                     tsvData.memberTypeOpt,
+                                                                                     tsvData.row,
+                                                                                     tsvData.colInfo,
+                                                                                     tsvData.modelSchema,
+                                                                                     tsvData.deleteEmptyValues
+    )
+    blackHole.consume(result)
+    result
+  }
+
+}
+
+// helper object to get access to TSVFileSupport trait
+object TsvFileSupportHarness extends TSVFileSupport {}

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/TSVFileSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/TSVFileSupport.scala
@@ -20,8 +20,8 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
 
 /**
- * The different types of tsv import/export formats
- */
+  * The different types of tsv import/export formats
+  */
 object TsvTypes {
   sealed trait TsvType
   case object ENTITY extends TsvType {
@@ -179,30 +179,73 @@ trait TSVFileSupport {
   Creates an AttributeValue whose implementation is more closely tied to the value of the input.
    */
   def stringToTypedAttribute(value: String): Attribute =
-    Try(java.lang.Integer.parseInt(value)) match {
-      case Success(intValue) => AttributeNumber(intValue)
-      case Failure(_) =>
-        Try(java.lang.Double.parseDouble(value)) match {
-          // because we represent AttributeNumber as a BigDecimal, and BigDecimal has no concept of infinity or NaN,
-          // if we find infinite/NaN numbers here, don't save them as AttributeNumber; instead let them fall through
-          // to AttributeString.
-          case Success(doubleValue)
-              if !Double.NegativeInfinity.equals(doubleValue)
-                && !Double.PositiveInfinity.equals(doubleValue)
-                && !Double.NaN.equals(doubleValue)
-                && !matchesLiteral(value) =>
-            AttributeNumber(doubleValue)
-          case _ =>
-            Try(BooleanUtils.toBoolean(value.toLowerCase, "true", "false")) match {
-              case Success(booleanValue) => AttributeBoolean(booleanValue)
-              case Failure(_) =>
-                Try(value.parseJson.convertTo[AttributeEntityReference]) match {
-                  case Success(ref) => ref
-                  case Failure(_)   => AttributeString(value)
-                }
-            }
-        }
+    // if this value starts and ends with a quote, it should always be treated as a string
+    if (value.startsWith("\"") && value.endsWith("\"")) {
+      AttributeString(value.substring(1, value.length - 1))
+    } else {
+      // else, inspect the value to find an appropriate datatype
+      toAttribute(value)
     }
+
+  // the `toAttribute` method checks the first non-whitespace character of inbound TSV cells.
+  private val possibleNumbers = "0123456789+-." // possible first characters for a number
+  private val possibleBooleans = "tfTF" // possible first characters for a boolean
+  private val possibleReferences = "{" // possible first characters for an entity reference
+  private val possibleNonStrings = possibleNumbers + possibleBooleans + possibleReferences
+
+  private def toAttribute(value: String): Attribute = {
+    val trimmed = value.trim
+    // empty string
+    if (trimmed.isEmpty) {
+      return AttributeString(value)
+    }
+    // find the first character of the inbound cell
+    val firstChar = trimmed.charAt(0)
+
+    // first char doesn't match any known starters; this is a string
+    if (!possibleNonStrings.contains(firstChar)) {
+      return AttributeString(value)
+    }
+
+    // could this be a number?
+    if (possibleNumbers.contains(firstChar)) {
+      Try(java.lang.Integer.parseInt(value)) match {
+        case Success(intValue) => return AttributeNumber(intValue)
+        case Failure(_) =>
+          Try(java.lang.Double.parseDouble(value)) match {
+            // because we represent AttributeNumber as a BigDecimal, and BigDecimal has no concept of infinity or NaN,
+            // if we find infinite/NaN numbers here, don't save them as AttributeNumber; instead let them fall through
+            // to AttributeString.
+            case Success(doubleValue)
+                if !Double.NegativeInfinity.equals(doubleValue)
+                  && !Double.PositiveInfinity.equals(doubleValue)
+                  && !Double.NaN.equals(doubleValue)
+                  && !matchesLiteral(value) =>
+              return AttributeNumber(doubleValue)
+            case _ => // noop
+          }
+      }
+    }
+
+    // could this be a boolean?
+    if (possibleBooleans.contains(firstChar)) {
+      Try(BooleanUtils.toBoolean(value.toLowerCase, "true", "false")) match {
+        case Success(booleanValue) => return AttributeBoolean(booleanValue)
+        case _                     => // noop
+      }
+    }
+
+    // could this be a reference?
+    if (possibleReferences.contains(firstChar)) {
+      Try(value.parseJson.convertTo[AttributeEntityReference]) match {
+        case Success(ref) => return ref
+        case _            => // noop
+      }
+    }
+
+    // it's a string.
+    AttributeString(value)
+  }
 
   def checkForJson(value: String): Attribute =
     Try(value.parseJson) match {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/TSVFileSupport.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/TSVFileSupport.scala
@@ -179,8 +179,8 @@ trait TSVFileSupport {
   Creates an AttributeValue whose implementation is more closely tied to the value of the input.
    */
   def stringToTypedAttribute(value: String): Attribute =
-    // if this value starts and ends with a quote, it should always be treated as a string
-    if (value.startsWith("\"") && value.endsWith("\"")) {
+    if (value.length > 1 && value.startsWith("\"") && value.endsWith("\"")) {
+      // if this value starts and ends with a quote, it should always be treated as a string
       AttributeString(value.substring(1, value.length - 1))
     } else {
       // else, inspect the value to find an appropriate datatype
@@ -197,54 +197,44 @@ trait TSVFileSupport {
     val trimmed = value.trim
     // empty string
     if (trimmed.isEmpty) {
-      return AttributeString(value)
-    }
-    // find the first character of the inbound cell
-    val firstChar = trimmed.charAt(0)
+      AttributeString(value)
+    } else {
+      // find the first character of the inbound cell
+      val firstChar = trimmed.charAt(0)
 
-    // first char doesn't match any known starters; this is a string
-    if (!possibleNonStrings.contains(firstChar)) {
-      return AttributeString(value)
-    }
-
-    // could this be a number?
-    if (possibleNumbers.contains(firstChar)) {
-      Try(java.lang.Integer.parseInt(value)) match {
-        case Success(intValue) => return AttributeNumber(intValue)
-        case Failure(_) =>
-          Try(java.lang.Double.parseDouble(value)) match {
-            // because we represent AttributeNumber as a BigDecimal, and BigDecimal has no concept of infinity or NaN,
-            // if we find infinite/NaN numbers here, don't save them as AttributeNumber; instead let them fall through
-            // to AttributeString.
-            case Success(doubleValue)
-                if !Double.NegativeInfinity.equals(doubleValue)
-                  && !Double.PositiveInfinity.equals(doubleValue)
-                  && !Double.NaN.equals(doubleValue)
-                  && !matchesLiteral(value) =>
-              return AttributeNumber(doubleValue)
-            case _ => // noop
+      // using the first character, try to convert the cell to a number, boolean, or reference
+      val maybeNonString: Option[Attribute] = firstChar match {
+        // first char doesn't match any known starters; this is a string
+        case _ if !possibleNonStrings.contains(firstChar) => Some(AttributeString(value))
+        // could this be a number?
+        case _ if possibleNumbers.contains(firstChar) =>
+          Try(java.lang.Integer.parseInt(value)) match {
+            case Success(intValue) => Some(AttributeNumber(intValue))
+            case Failure(_) =>
+              Try(java.lang.Double.parseDouble(value)) match {
+                // because we represent AttributeNumber as a BigDecimal, and BigDecimal has no concept of infinity or NaN,
+                // if we find infinite/NaN numbers here, don't save them as AttributeNumber; instead let them fall through
+                // to AttributeString.
+                case Success(doubleValue)
+                    if !Double.NegativeInfinity.equals(doubleValue)
+                      && !Double.PositiveInfinity.equals(doubleValue)
+                      && !Double.NaN.equals(doubleValue)
+                      && !matchesLiteral(value) =>
+                  Some(AttributeNumber(doubleValue))
+                case _ => None
+              }
           }
+        // could this be a boolean?
+        case _ if possibleBooleans.contains(firstChar) =>
+          Try(BooleanUtils.toBoolean(value.toLowerCase, "true", "false")).toOption.map(AttributeBoolean)
+        // could this be a boolean?
+        case _ if possibleReferences.contains(firstChar) =>
+          Try(value.parseJson.convertTo[AttributeEntityReference]).toOption
       }
-    }
 
-    // could this be a boolean?
-    if (possibleBooleans.contains(firstChar)) {
-      Try(BooleanUtils.toBoolean(value.toLowerCase, "true", "false")) match {
-        case Success(booleanValue) => return AttributeBoolean(booleanValue)
-        case _                     => // noop
-      }
+      // if we didn't find one of the other attributes, it's a string.
+      maybeNonString.getOrElse(AttributeString(value))
     }
-
-    // could this be a reference?
-    if (possibleReferences.contains(firstChar)) {
-      Try(value.parseJson.convertTo[AttributeEntityReference]) match {
-        case Success(ref) => return ref
-        case _            => // noop
-      }
-    }
-
-    // it's a string.
-    AttributeString(value)
   }
 
   def checkForJson(value: String): Attribute =

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/TSVFileSupportSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/TSVFileSupportSpec.scala
@@ -116,7 +116,7 @@ class TSVFileSupportSpec extends AnyFreeSpec with TSVFileSupport {
       Double.MinPositiveValue.toString -> AttributeNumber(Double.MinPositiveValue),
       Double.MaxValue.toString -> AttributeNumber(Double.MaxValue)
     )
-    val stringTestCases = List("", "string", "true525600", ",")
+    val stringTestCases = List("", "string", "true525600", ",", "\"")
     val referenceTestCases = Map(
       """{"entityType":"targetType","entityName":"targetName"}""" -> AttributeEntityReference("targetType",
                                                                                               "targetName"


### PR DESCRIPTION
This PR is an optimization found while researching CORE-207. This should be performance only; it has no functional impact to end users.

The `stringToTypedAttribute()` function is called for each cell in an uploaded TSV; this is a lot of invocations so any optimization here is useful.

1. *check the cell's first character*. Previously, we attempted to parse the cell as a number, a boolean, and a reference before giving up and calling it a string. In this PR, we grab the first non-whitespace character of the cell and compare it to a known list of possible first characters for the non-string datatypes - for instance, a boolean will always start with "t" or "f". This is faster than trying to parse the whole cell and results in a ~2.4x speedup in our new benchmark.

Raw benchmark numbers:

  | ops/sec | error +/- | vs.baseline | avg ops/sec | avg vs. baseline
-- | -- | -- | -- | -- | --
baseline (648c5f274c4af9541f1d71c4c50db6961aecc3ed) | 13,426.94 | 598.82 |   | 13,227.86 |  
  | 12,690.29 | 564.33 | 94.51% |   |  
  | 13,566.35 | 277.55 | 101.04% |   |  
first-character checks (ed275ec29fd487778f035b9a515377528ee00150) | 32,275.95 | 660.82 | 240.38% | 32,325.38 | 244.37%
  | 32,994.04 | 912.17 | 245.73% |   |  
  | 31,706.16 | 1,068.82 | 236.14% |   |  
more Scala-y (6ad61e4898a3b1cbc3cc91d210ce029b47196b05) | 32,781.50 | 564.73 | 244.15% | 32,126.14 | 242.87%
  | 31,982.75 | 1,143.94 | 238.20% |   |  
  | 31,614.16 | 634.61 | 235.45% |   |  

---

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge. Make sure your branch deletes; GitHub should do this for you.
- [ ] Test this change deployed correctly and works on dev environment after deployment
