### PR TITLE
CORE-243: deprecate /register/userinfo API

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -6186,6 +6186,7 @@ paths:
       x-codegen-request-body-name: profile
   /register/userinfo:
     get:
+      deprecated: true
       tags:
         - Profile
       summary: Passes through to Google's userinfo API and returns its response


### PR DESCRIPTION
Copied from the release notes of CORE-243:

The `GET /register/userinfo` API endpoint at api.firecloud.org is now deprecated and will be deleted on or after Jan 19 2025. This endpoint does not function properly with Terra's latest login process.

Users can replicate the behavior of this endpoint by calling https://www.googleapis.com/oauth2/v3/userinfo directly or by following the directions in the "Obtaining user profile information" section at https://developers.google.com/identity/openid-connect/openid-connect#obtainuserinfo.

---

Developer's note: This endpoint has zero traffic in the last 30 days, other than our own security scans and a test call from me.

