### PR TITLE
CORE-165: restore TOS passthroughs

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/PassthroughApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/PassthroughApiService.scala
@@ -25,6 +25,7 @@ trait PassthroughApiService extends Directives with StreamingPassthrough {
     pathPrefix("version" / "executionEngine")(streamingPassthrough(s"$rawls/version/executionEngine")),
     // Sam
     pathPrefix("api" / "proxyGroup")(streamingPassthrough(s"$sam/api/google/user/proxyGroup")),
+    pathPrefix("register" / "user")(streamingPassthrough(s"$sam/register/user")),
     pathPrefix("register")(streamingPassthrough(s"$sam/register/user")),
     pathPrefix("tos")(streamingPassthrough(s"$sam/tos")),
 


### PR DESCRIPTION
#1517 broke the terms-of-service passthroughs; this restores them.

---

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [x] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge. Make sure your branch deletes; GitHub should do this for you.
- [ ] Test this change deployed correctly and works on dev environment after deployment
