### PR TITLE
CORE-247: try to fix 'Non-standard status codes cannot be created' error

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/EntityService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/EntityService.scala
@@ -11,7 +11,7 @@ import org.broadinstitute.dsde.firecloud.model.{ModelSchema, _}
 import org.broadinstitute.dsde.firecloud.service.PerRequest.{PerRequestMessage, RequestComplete}
 import org.broadinstitute.dsde.firecloud.service.TsvTypes.TsvType
 import org.broadinstitute.dsde.firecloud.service.{TSVFileSupport, TsvTypes}
-import org.broadinstitute.dsde.firecloud.utils.TSVLoadFile
+import org.broadinstitute.dsde.firecloud.utils.{StatusCodeUtils, TSVLoadFile}
 import org.broadinstitute.dsde.rawls.model._
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GcsObjectName}
 import org.databiosphere.workspacedata.client.ApiException
@@ -59,6 +59,7 @@ class EntityService(rawlsDAO: RawlsDAO,
                     modelSchema: ModelSchema
 )(implicit val executionContext: ExecutionContext)
     extends TSVFileSupport
+    with StatusCodeUtils
     with LazyLogging {
 
   val format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZZ")
@@ -379,7 +380,7 @@ class EntityService(rawlsDAO: RawlsDAO,
     }
     // if human-readable message extraction fails, just default to the ApiException message
     val errMsg = Try(extractMessage(apiEx.getResponseBody)).toOption.getOrElse(apiEx.getMessage)
-    new FireCloudExceptionWithErrorReport(ErrorReport(apiEx.getCode, errMsg))
+    new FireCloudExceptionWithErrorReport(ErrorReport(statusCodeFrom(apiEx.getCode), errMsg))
   }
 
   def getEntitiesWithType(workspaceNamespace: String,

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
@@ -55,8 +55,11 @@ object ModelJsonProtocol extends WorkspaceJsonSupport with SprayJsonSupport {
     override def write(code: StatusCode): JsValue = JsNumber(code.intValue)
 
     override def read(json: JsValue): StatusCode = json match {
-      case JsNumber(n) => n.intValue
-      case _           => throw DeserializationException("unexpected json type")
+      case JsNumber(n) =>
+        Try(StatusCode.int2StatusCode(n.intValue)).getOrElse(
+          throw DeserializationException(s"unexpected code value: ${n.intValue}")
+        )
+      case _ => throw DeserializationException("unexpected json type")
     }
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
@@ -13,6 +13,7 @@ import org.broadinstitute.dsde.firecloud.model.Project.ProjectRoles.ProjectRole
 import org.broadinstitute.dsde.firecloud.model.Project._
 import org.broadinstitute.dsde.firecloud.model.SamResource.{AccessPolicyName, ResourceId, UserPolicy}
 import org.broadinstitute.dsde.firecloud.model.ShareLog.{Share, ShareType}
+import org.broadinstitute.dsde.firecloud.utils.StatusCodeUtils
 import org.broadinstitute.dsde.rawls.model.UserModelJsonSupport._
 import org.broadinstitute.dsde.rawls.model.WorkspaceACLJsonSupport.WorkspaceAccessLevelFormat
 import org.broadinstitute.dsde.rawls.model._
@@ -25,7 +26,7 @@ import spray.json._
 import scala.util.{Failure, Success, Try}
 
 //noinspection TypeAnnotation,RedundantNewCaseClass
-object ModelJsonProtocol extends WorkspaceJsonSupport with SprayJsonSupport {
+object ModelJsonProtocol extends WorkspaceJsonSupport with SprayJsonSupport with StatusCodeUtils {
   import spray.json.DefaultJsonProtocol._
 
   def optionalEntryIntReader(fieldName: String, data: Map[String, JsValue]): Option[Int] =
@@ -55,11 +56,8 @@ object ModelJsonProtocol extends WorkspaceJsonSupport with SprayJsonSupport {
     override def write(code: StatusCode): JsValue = JsNumber(code.intValue)
 
     override def read(json: JsValue): StatusCode = json match {
-      case JsNumber(n) =>
-        Try(StatusCode.int2StatusCode(n.intValue)).getOrElse(
-          throw DeserializationException(s"unexpected code value: ${n.intValue}")
-        )
-      case _ => throw DeserializationException("unexpected json type")
+      case JsNumber(n) => statusCodeFrom(n.intValue)
+      case _           => throw DeserializationException("unexpected json type")
     }
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/utils/EnabledUserDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/utils/EnabledUserDirectives.scala
@@ -18,7 +18,7 @@ import org.broadinstitute.dsde.workbench.util.FutureSupport.toFutureTry
 import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.util.{Failure, Success}
 
-trait EnabledUserDirectives extends LazyLogging with SprayJsonSupport {
+trait EnabledUserDirectives extends LazyLogging with SprayJsonSupport with StatusCodeUtils {
 
   // Hardcode an ErrorReportSource to allow differentiating between enabled-user errors and other errors.
   implicit val errorReportSource: ErrorReportSource = ErrorReportSource("Orchestration-enabled-check")
@@ -58,7 +58,7 @@ trait EnabledUserDirectives extends LazyLogging with SprayJsonSupport {
             s"ApiException exception checking enabled status for user ${userInfo.userEmail}: (${apiex.getMessage}) while calling $uri",
             apiex
           )
-          val code = StatusCode.int2StatusCode(apiex.getCode)
+          val code = statusCodeFrom(apiex.getCode)
           if (code == StatusCodes.NotFound) {
             throwErrorReport(StatusCodes.Unauthorized, "User is not registered.")
           } else {
@@ -99,9 +99,7 @@ trait EnabledUserDirectives extends LazyLogging with SprayJsonSupport {
               case Failure(_)         => response
             }
             throw new FireCloudExceptionWithErrorReport(
-              ErrorReport(StatusCode.int2StatusCode(statusCode),
-                          s"Sam call to $functionName failed with error '$stringErrMsg'"
-              )
+              ErrorReport(statusCodeFrom(statusCode), s"Sam call to $functionName failed with error '$stringErrMsg'")
             )
           }
       }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/utils/EnabledUserDirectives.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/utils/EnabledUserDirectives.scala
@@ -58,7 +58,7 @@ trait EnabledUserDirectives extends LazyLogging with SprayJsonSupport with Statu
             s"ApiException exception checking enabled status for user ${userInfo.userEmail}: (${apiex.getMessage}) while calling $uri",
             apiex
           )
-          val code = statusCodeFrom(apiex.getCode)
+          val code = statusCodeFrom(apiex.getCode, Option(StatusCodes.InternalServerError))
           if (code == StatusCodes.NotFound) {
             throwErrorReport(StatusCodes.Unauthorized, "User is not registered.")
           } else {
@@ -99,7 +99,9 @@ trait EnabledUserDirectives extends LazyLogging with SprayJsonSupport with Statu
               case Failure(_)         => response
             }
             throw new FireCloudExceptionWithErrorReport(
-              ErrorReport(statusCodeFrom(statusCode), s"Sam call to $functionName failed with error '$stringErrMsg'")
+              ErrorReport(statusCodeFrom(statusCode, Option(StatusCodes.InternalServerError)),
+                          s"Sam call to $functionName failed with error '$stringErrMsg'"
+              )
             )
           }
       }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/utils/StatusCodeUtils.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/utils/StatusCodeUtils.scala
@@ -20,8 +20,8 @@ trait StatusCodeUtils {
     Try(StatusCode.int2StatusCode(intCode)).getOrElse(
       default.getOrElse(
         StatusCodes.custom(intCode,
-                           reason = "unknown status",
-                           defaultMessage = "unknown status",
+                           reason = s"unknown status $intCode",
+                           defaultMessage = s"unknown status $intCode",
                            isSuccess = false,
                            allowsEntity = true
         )

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/utils/StatusCodeUtils.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/utils/StatusCodeUtils.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.dsde.firecloud.utils
 
-import akka.http.scaladsl.model.{StatusCode, StatusCodes}
+import akka.http.scaladsl.model.StatusCode
 import akka.http.scaladsl.model.StatusCodes.InternalServerError
 
 import scala.util.Try

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/utils/StatusCodeUtils.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/utils/StatusCodeUtils.scala
@@ -1,7 +1,6 @@
 package org.broadinstitute.dsde.firecloud.utils
 
-import akka.http.scaladsl.model.StatusCode
-import akka.http.scaladsl.model.StatusCodes.InternalServerError
+import akka.http.scaladsl.model.{StatusCode, StatusCodes}
 
 import scala.util.Try
 
@@ -12,12 +11,21 @@ trait StatusCodeUtils {
     * thrown by StatusCode.int2StatusCode when supplied with an unknown code and returns
     * a default status code instead.
     *
-    * @param int the integer value to translate
+    * @param intCode the integer value to translate
     * @param default the code to return if the integer value is unknown;
     *                defaults to Internal Server Error
     * @return the final status code
     */
-  def statusCodeFrom(int: Int, default: StatusCode = InternalServerError): StatusCode =
-    Try(StatusCode.int2StatusCode(int)).getOrElse(default)
+  def statusCodeFrom(intCode: Int, default: Option[StatusCode] = None): StatusCode =
+    Try(StatusCode.int2StatusCode(intCode)).getOrElse(
+      default.getOrElse(
+        StatusCodes.custom(intCode,
+                           reason = "unknown status",
+                           defaultMessage = "unknown status",
+                           isSuccess = false,
+                           allowsEntity = true
+        )
+      )
+    )
 
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/utils/StatusCodeUtils.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/utils/StatusCodeUtils.scala
@@ -1,0 +1,23 @@
+package org.broadinstitute.dsde.firecloud.utils
+
+import akka.http.scaladsl.model.{StatusCode, StatusCodes}
+import akka.http.scaladsl.model.StatusCodes.InternalServerError
+
+import scala.util.Try
+
+trait StatusCodeUtils {
+
+  /**
+    * Safely translates an integer to a StatusCode. This method avoids the RuntimeException
+    * thrown by StatusCode.int2StatusCode when supplied with an unknown code and returns
+    * a default status code instead.
+    *
+    * @param int the integer value to translate
+    * @param default the code to return if the integer value is unknown;
+    *                defaults to Internal Server Error
+    * @return the final status code
+    */
+  def statusCodeFrom(int: Int, default: StatusCode = InternalServerError): StatusCode =
+    Try(StatusCode.int2StatusCode(int)).getOrElse(default)
+
+}

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/UserApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/UserApiService.scala
@@ -187,7 +187,10 @@ trait UserApiService
         }
       case x =>
         // if we get any other error from Sam, pass that error on
-        respondWithErrorReport(x.intValue, "Unexpected response validating registration: " + x.toString, requestContext)
+        respondWithErrorReport(statusCodeFrom(x.intValue),
+                               "Unexpected response validating registration: " + x.toString,
+                               requestContext
+        )
     }
 
   private def handleOkResponse(regInfo: RegistrationInfoV2,
@@ -232,7 +235,7 @@ trait UserApiService
               }
             }
           case x =>
-            respondWithErrorReport(x.intValue,
+            respondWithErrorReport(statusCodeFrom(x.intValue),
                                    "Unexpected response validating registration: " + x.toString,
                                    requestContext
             )

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/utils/StatusCodeUtilsSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/utils/StatusCodeUtilsSpec.scala
@@ -28,7 +28,7 @@ class StatusCodeUtilsSpec extends AnyFlatSpec with StatusCodeUtils {
       val actual = statusCodeFrom(intCode)
       actual.intValue() shouldBe intCode
       actual.isSuccess() shouldBe false
-      actual.defaultMessage() shouldBe "unknown status"
+      actual.defaultMessage() shouldBe s"unknown status $intCode"
     }
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/utils/StatusCodeUtilsSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/utils/StatusCodeUtilsSpec.scala
@@ -24,14 +24,17 @@ class StatusCodeUtilsSpec extends AnyFlatSpec with StatusCodeUtils {
   val unknownCodes: List[Int] = List(-1, 0, 42, 222, 555)
 
   unknownCodes.foreach { intCode =>
-    it should s"default unknown code $intCode to InternalServerError" in {
-      statusCodeFrom(intCode) shouldBe InternalServerError
+    it should s"create a custom status code $intCode for unknown values" in {
+      val actual = statusCodeFrom(intCode)
+      actual.intValue() shouldBe intCode
+      actual.isSuccess() shouldBe false
+      actual.defaultMessage() shouldBe "unknown status"
     }
   }
 
   unknownCodes.foreach { intCode =>
     it should s"default unknown code $intCode to the caller-supplied default" in {
-      statusCodeFrom(intCode, ImATeapot) shouldBe ImATeapot
+      statusCodeFrom(intCode, Option(ImATeapot)) shouldBe ImATeapot
     }
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/utils/StatusCodeUtilsSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/utils/StatusCodeUtilsSpec.scala
@@ -1,0 +1,38 @@
+package org.broadinstitute.dsde.firecloud.utils
+
+import akka.http.scaladsl.model.StatusCode
+import akka.http.scaladsl.model.StatusCodes._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+
+class StatusCodeUtilsSpec extends AnyFlatSpec with StatusCodeUtils {
+
+  behavior of "statusCodeFrom"
+
+  val expectedCases: Map[Int, StatusCode] = Map(
+    200 -> OK,
+    404 -> NotFound,
+    503 -> ServiceUnavailable
+  )
+
+  expectedCases.foreach { case (intCode, statusCode) =>
+    it should s"handle known code $intCode" in {
+      statusCodeFrom(intCode) shouldBe statusCode
+    }
+  }
+
+  val unknownCodes: List[Int] = List(-1, 0, 42, 222, 555)
+
+  unknownCodes.foreach { intCode =>
+    it should s"default unknown code $intCode to InternalServerError" in {
+      statusCodeFrom(intCode) shouldBe InternalServerError
+    }
+  }
+
+  unknownCodes.foreach { intCode =>
+    it should s"default unknown code $intCode to the caller-supplied default" in {
+      statusCodeFrom(intCode, ImATeapot) shouldBe ImATeapot
+    }
+  }
+
+}


### PR DESCRIPTION
CORE-247

Orch regularly logs an exception "java.lang.RuntimeException: Non-standard status codes cannot be created by implicit conversion. Use `StatusCodes.custom` instead." These are relatively frequent according to Sentry:
![Screenshot 06-01-2025 at 10 47](https://github.com/user-attachments/assets/45b76431-d8a7-4788-8dd1-534587d71856)

I tracked this down to the `int2StatusCode()` method in akka-http: https://github.com/akka/akka-http/blob/d89e97411266a2fd7d79931e96cf1770d57ec071/akka-http-core/src/main/scala/akka/http/scaladsl/model/StatusCode.scala#L26-L29

I believe the trigger of this error is connection failures to Sam, Rawls, or some other external service. These failures can return status code 0 indicating a failure to connect - but 0 is a non-standard code according to akka-http.

This PR adds a `StatusCodeUtils` class and `statusCodeFrom()` method which wraps akka-http's `int2StatusCode()`, avoiding its exception. I've updated all the calls to `int2StatusCode()` to use our safe wrapper instead - some of those calls were implicit.

---


Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [x] Verify all tests go green
- [ ] Squash and merge. Make sure your branch deletes; GitHub should do this for you.
- [ ] Test this change deployed correctly and works on dev environment after deployment
