### PR TITLE
[CORE-227] Deprecate queueStatus API

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -2739,6 +2739,7 @@ paths:
       summary: workflow queue status
       description: List workflow counts by queueing state
       operationId: workflowQueueStatus
+      deprecated: true
       responses:
         200:
           description: Successful Request


### PR DESCRIPTION
Ticket: [CORE-227](https://broadworkbench.atlassian.net/browse/CORE-227)
* Deprecates this API as it is not used and no longer returns valuable information as Rawls submits workflows to Cromwell much faster than it did when the API was introduced. The API will be removed as part of [CORE-255](https://broadworkbench.atlassian.net/browse/CORE-255)

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge. Make sure your branch deletes; GitHub should do this for you.
- [ ] Test this change deployed correctly and works on dev environment after deployment


[CORE-227]: https://broadworkbench.atlassian.net/browse/CORE-227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CORE-255]: https://broadworkbench.atlassian.net/browse/CORE-255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ