### PR TITLE
CORE-252 Passport based auth domains

### DIFF
--- a/local-dev/templates/firecloud-orchestration.conf
+++ b/local-dev/templates/firecloud-orchestration.conf
@@ -117,6 +117,17 @@ firecloud {
 	userAdminAccount = "google@test.firecloud.org"
 }
 
+nih {
+  whitelistBucket = firecloud-whitelist-dev
+  whitelists = {}
+  rasIssuer = "https://stsstg.nih.gov"
+  rasVisaType = "https://ras.nih.gov/visas/v1.1"
+  dbGapPermissionAndGroup = [
+    {phsId = "phs002409", consentGroup = "c1", groupName = "dbgap_phs002409_c1"},
+    {phsId = "phs002410", consentGroup = "c1", groupName = "dbgap_phs002410_c1"},
+  ]
+}
+
 shibboleth {
 	publicKeyUrl = "https://broad-shibboleth-prod.appspot.com/dev/public-key.pem"
 }

--- a/local-dev/templates/firecloud-orchestration.conf
+++ b/local-dev/templates/firecloud-orchestration.conf
@@ -100,6 +100,11 @@ cwds {
 externalCreds {
   baseUrl = "https://externalcreds.dsde-dev.broadinstitute.org"
   enabled = true
+  topicProject = "broad-dsde-dev"
+  topicName = "ecm-events"
+  subscriptionName = "ecm-events-fcorch"
+  ackDeadLine = 10m
+  subscriberQueueSize = 10
 }
 
 firecloud {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -59,7 +59,7 @@ object Dependencies {
     "org.broadinstitute.dsde.workbench" %% "sam-client"       % "v0.0.343",
     "org.broadinstitute.dsde.workbench" %% "workbench-notifications" %s"0.8-$workbenchLibsHash",
     "org.databiosphere" % "workspacedataservice-client-okhttp-jakarta" % "0.2.167-SNAPSHOT",
-    "bio.terra" % "externalcreds-client-resttemplate" % "1.44.0-20240725.201427-1" excludeAll(excludeSpring, excludeSpringBoot),
+    "bio.terra" % "externalcreds-client-resttemplate" % "1.56.0-SNAPSHOT" excludeAll(excludeSpring, excludeSpringBoot),
     "org.springframework" % "spring-web" % "6.2.1" excludeAll(excludeSpringBoot, excludeSpringJcl),
 
     "com.typesafe.akka"   %%  "akka-actor"           % akkaV,

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -98,3 +98,8 @@ googlecloud {
 firecloud {
   max-filematching-bucket-files = 25000
 }
+
+sam {
+  groupResourceType = "managed-group"
+  groupMemberPolicy = "member"
+}

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/Boot.scala
@@ -2,96 +2,134 @@ package org.broadinstitute.dsde.firecloud
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
-import cats.effect.IO
+import cats.effect.std.Queue
+import cats.effect.{IO, Resource}
 import cats.effect.unsafe.IORuntime
 import com.typesafe.scalalogging.LazyLogging
+import fs2.Stream
 import org.broadinstitute.dsde.firecloud.dataaccess._
 import org.broadinstitute.dsde.firecloud.elastic.ElasticUtils
-import org.broadinstitute.dsde.firecloud.model.{ModelSchema, UserInfo, WithAccessToken}
+import org.broadinstitute.dsde.firecloud.model.{ExternalCredsMessage, ModelSchema, UserInfo, WithAccessToken}
 import org.broadinstitute.dsde.firecloud.service._
 import org.broadinstitute.dsde.firecloud.utils.DisabledServiceFactory
+import org.broadinstitute.dsde.workbench.google2.GoogleSubscriber
 import org.broadinstitute.dsde.workbench.oauth2.{ClientId, OpenIDConnectConfiguration}
 import org.broadinstitute.dsde.workbench.util.health.HealthMonitor
+import org.broadinstitute.dsde.workbench.util2.messaging.{CloudSubscriber, ReceivedMessage}
 import org.elasticsearch.client.transport.TransportClient
+import org.typelevel.log4cats.StructuredLogger
 
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.reflect.ClassTag
 
 object Boot extends App with LazyLogging {
 
   private def startup(): Unit = {
-    // we need an ActorSystem to host our application in
-    implicit val system: ActorSystem = ActorSystem("FireCloud-Orchestration-API")
-
-    val app: Application = buildApplication
-
-    val agoraPermissionServiceConstructor: (UserInfo) => AgoraPermissionService =
-      AgoraPermissionService.constructor(app)
-    val exportEntitiesByTypeActorConstructor: (ExportEntitiesByTypeArguments) => ExportEntitiesByTypeActor =
-      ExportEntitiesByTypeActor.constructor(app, system)
-    val entityServiceConstructor: (ModelSchema) => EntityService = EntityService.constructor(app)
-    val libraryServiceConstructor: (UserInfo) => LibraryService = LibraryService.constructor(app)
-    val ontologyServiceConstructor: () => OntologyService = OntologyService.constructor(app)
-    val namespaceServiceConstructor: (UserInfo) => NamespaceService = NamespaceService.constructor(app)
-    val nihServiceConstructor: () => NihService = NihService.constructor(app)
-    val registerServiceConstructor: () => RegisterService = RegisterService.constructor(app)
-    val workspaceServiceConstructor: (WithAccessToken) => WorkspaceService = WorkspaceService.constructor(app)
-    val permissionReportServiceConstructor: (UserInfo) => PermissionReportService =
-      PermissionReportService.constructor(app)
-    val userServiceConstructor: (UserInfo) => UserService = UserService.constructor(app)
-    val shareLogServiceConstructor: () => ShareLogService = ShareLogService.constructor(app)
-    val managedGroupServiceConstructor: (WithAccessToken) => ManagedGroupService = ManagedGroupService.constructor(app)
-
-    // Boot HealthMonitor actor
-    val healthChecks = new HealthChecks(app)
-    val healthMonitorChecks = healthChecks.healthMonitorChecks
-    val healthMonitor =
-      system.actorOf(HealthMonitor.props(healthMonitorChecks().keySet)(healthMonitorChecks), "health-monitor")
-    system.scheduler.scheduleWithFixedDelay(3.seconds, 1.minute, healthMonitor, HealthMonitor.CheckAll)
-
-    val statusServiceConstructor: () => StatusService = StatusService.constructor(healthMonitor)
-
-    val runningService: Future[Unit] = for {
-      oauth2Config <- OpenIDConnectConfiguration[IO](
-        FireCloudConfig.Auth.authorityEndpoint,
-        ClientId(FireCloudConfig.Auth.oidcClientId),
-        extraAuthParams = Some("prompt=login"),
-        authorityEndpointWithGoogleBillingScope = FireCloudConfig.Auth.authorityEndpointWithGoogleBillingScope
-      ).unsafeToFuture()(IORuntime.global)
-
-      service <- Future {
-        new FireCloudApiServiceImpl(
-          agoraPermissionServiceConstructor,
-          exportEntitiesByTypeActorConstructor,
-          entityServiceConstructor,
-          libraryServiceConstructor,
-          ontologyServiceConstructor,
-          namespaceServiceConstructor,
-          nihServiceConstructor,
-          registerServiceConstructor,
-          workspaceServiceConstructor,
-          statusServiceConstructor,
-          permissionReportServiceConstructor,
-          userServiceConstructor,
-          shareLogServiceConstructor,
-          managedGroupServiceConstructor,
-          oauth2Config
+    implicit val slogger: StructuredLogger[IO] = org.typelevel.log4cats.slf4j.Slf4jLogger.getLogger[IO]
+    val processesResource = for {
+      service <- fireCloudApiServiceResource()
+      externalCredsSubscriber <- createExternalCredsSubscriber()
+    } yield {
+      implicit val system: ActorSystem = service.system
+      List(
+        externalCredsSubscriber.messages.evalMap { msg =>
+          service.nihServiceConstructor().processExternalCredsMessage(msg)
+        },
+        Stream.eval(externalCredsSubscriber.start),
+        Stream.eval(
+          IO.fromFuture(
+            IO(
+              Http()
+                .newServerAt("0.0.0.0", 8080)
+                .bindFlow(service.route)
+                .recover { case t: Throwable =>
+                  logger.error("FATAL - failure starting http server", t)
+                }
+            )
+          )
         )
+      )
+    }
+
+    processesResource
+      .use { processes =>
+        Stream
+          .emits(processes)
+          .covary[IO]
+          .parJoin(processes.length)
+          .handleErrorWith(error => Stream.emit(logger.error("FATAL - error starting Firecloud Orchestration", error)))
+          .compile
+          .drain
       }
-
-      binding <- Http().newServerAt("0.0.0.0", 8080).bind(service.route)
-      _ <- binding.whenTerminated
-
-    } yield {}
-
-    runningService
-      .recover { case t: Throwable =>
-        logger.error("FATAL - error starting Firecloud Orchestration", t)
-      }
-      .flatMap(_ => system.terminate())
+      .unsafeRunSync()(IORuntime.global)
   }
+
+  private def fireCloudApiServiceResource(): Resource[IO, FireCloudApiService] =
+    Resource.make {
+      // we need an ActorSystem to host our application in
+      implicit val system: ActorSystem = ActorSystem("FireCloud-Orchestration-API")
+
+      val app: Application = buildApplication
+
+      val agoraPermissionServiceConstructor: (UserInfo) => AgoraPermissionService =
+        AgoraPermissionService.constructor(app)
+      val exportEntitiesByTypeActorConstructor: (ExportEntitiesByTypeArguments) => ExportEntitiesByTypeActor =
+        ExportEntitiesByTypeActor.constructor(app, system)
+      val entityServiceConstructor: (ModelSchema) => EntityService = EntityService.constructor(app)
+      val libraryServiceConstructor: (UserInfo) => LibraryService = LibraryService.constructor(app)
+      val ontologyServiceConstructor: () => OntologyService = OntologyService.constructor(app)
+      val namespaceServiceConstructor: (UserInfo) => NamespaceService = NamespaceService.constructor(app)
+      val nihServiceConstructor: () => NihService = NihService.constructor(app)
+      val registerServiceConstructor: () => RegisterService = RegisterService.constructor(app)
+      val workspaceServiceConstructor: (WithAccessToken) => WorkspaceService = WorkspaceService.constructor(app)
+      val permissionReportServiceConstructor: (UserInfo) => PermissionReportService =
+        PermissionReportService.constructor(app)
+      val userServiceConstructor: (UserInfo) => UserService = UserService.constructor(app)
+      val shareLogServiceConstructor: () => ShareLogService = ShareLogService.constructor(app)
+      val managedGroupServiceConstructor: (WithAccessToken) => ManagedGroupService =
+        ManagedGroupService.constructor(app)
+
+      // Boot HealthMonitor actor
+      val healthChecks = new HealthChecks(app)
+      val healthMonitorChecks = healthChecks.healthMonitorChecks
+      val healthMonitor =
+        system.actorOf(HealthMonitor.props(healthMonitorChecks().keySet)(healthMonitorChecks), "health-monitor")
+      system.scheduler.scheduleWithFixedDelay(3.seconds, 1.minute, healthMonitor, HealthMonitor.CheckAll)
+
+      val statusServiceConstructor: () => StatusService = StatusService.constructor(healthMonitor)
+
+      for {
+        oauth2Config <- OpenIDConnectConfiguration[IO](
+          FireCloudConfig.Auth.authorityEndpoint,
+          ClientId(FireCloudConfig.Auth.oidcClientId),
+          extraAuthParams = Some("prompt=login"),
+          authorityEndpointWithGoogleBillingScope = FireCloudConfig.Auth.authorityEndpointWithGoogleBillingScope
+        )
+
+        service <- IO {
+          new FireCloudApiServiceImpl(
+            agoraPermissionServiceConstructor,
+            exportEntitiesByTypeActorConstructor,
+            entityServiceConstructor,
+            libraryServiceConstructor,
+            ontologyServiceConstructor,
+            namespaceServiceConstructor,
+            nihServiceConstructor,
+            registerServiceConstructor,
+            workspaceServiceConstructor,
+            statusServiceConstructor,
+            permissionReportServiceConstructor,
+            userServiceConstructor,
+            shareLogServiceConstructor,
+            managedGroupServiceConstructor,
+            oauth2Config
+          )
+        }
+      } yield service
+    } { service =>
+      IO.fromFuture(IO(service.system.terminate())).void
+    }
 
   private def buildApplication(implicit system: ActorSystem) = {
     // can't be disabled
@@ -152,6 +190,29 @@ object Boot extends App with LazyLogging {
                 ecmDAO
     )
   }
+
+  private def createExternalCredsSubscriber()(implicit
+    logger: StructuredLogger[IO]
+  ): Resource[IO, CloudSubscriber[IO, ExternalCredsMessage]] =
+    if (FireCloudConfig.ExternalCreds.enabled) {
+      import ExternalCredsMessage.externalCredsMessageDecoder
+      for {
+        queue <- Resource.eval(
+          Queue.bounded[IO, ReceivedMessage[ExternalCredsMessage]](FireCloudConfig.ExternalCreds.subscriberQueueSize)
+        )
+        subscriber <- GoogleSubscriber.resource[IO, ExternalCredsMessage](
+          FireCloudConfig.ExternalCreds.subscriberConfig,
+          queue
+        )
+      } yield subscriber
+    } else {
+      logger.info("External Creds service is disabled, not subscribing to messages")
+      Resource.pure[IO, CloudSubscriber[IO, ExternalCredsMessage]](new CloudSubscriber[IO, ExternalCredsMessage] {
+        override def start: IO[Unit] = IO.unit
+        override def stop: IO[Unit] = IO.unit
+        override def messages: fs2.Stream[IO, ReceivedMessage[ExternalCredsMessage]] = fs2.Stream.empty
+      })
+    }
 
   private def whenEnabled[T: ClassTag](enabled: Boolean, realService: => T): T =
     if (enabled) {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/Boot.scala
@@ -3,7 +3,7 @@ package org.broadinstitute.dsde.firecloud
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import cats.effect.std.Queue
-import cats.effect.{IO, Resource}
+import cats.effect.{ExitCode, IO, IOApp, Resource}
 import cats.effect.unsafe.IORuntime
 import com.typesafe.scalalogging.LazyLogging
 import fs2.Stream
@@ -23,9 +23,9 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.reflect.ClassTag
 
-object Boot extends App with LazyLogging {
+object Boot extends IOApp with LazyLogging {
 
-  private def startup(): Unit = {
+  private def startup(): IO[Unit] = {
     implicit val slogger: StructuredLogger[IO] = org.typelevel.log4cats.slf4j.Slf4jLogger.getLogger[IO]
     val processesResource = for {
       service <- fireCloudApiServiceResource()
@@ -68,7 +68,6 @@ object Boot extends App with LazyLogging {
           .compile
           .drain
       }
-      .unsafeRunSync()(IORuntime.global)
   }
 
   private def fireCloudApiServiceResource(): Resource[IO, FireCloudApiService] =
@@ -227,5 +226,5 @@ object Boot extends App with LazyLogging {
       DisabledServiceFactory.newDisabledService
     }
 
-  startup()
+  override def run(args: List[String]): IO[ExitCode] = startup().as(ExitCode.Success)
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/Boot.scala
@@ -216,7 +216,7 @@ object Boot extends IOApp with LazyLogging {
         override def start: IO[Unit] = IO.unit
         override def stop: IO[Unit] = IO.unit
         override def messages: fs2.Stream[IO, ReceivedMessage[ExternalCredsMessage]] =
-          fs2.Stream.never // never prevents early termination
+          fs2.Stream.never(IO.asyncForIO) // never prevents early termination
       })
     }
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/Boot.scala
@@ -215,7 +215,8 @@ object Boot extends IOApp with LazyLogging {
       Resource.pure[IO, CloudSubscriber[IO, ExternalCredsMessage]](new CloudSubscriber[IO, ExternalCredsMessage] {
         override def start: IO[Unit] = IO.unit
         override def stop: IO[Unit] = IO.unit
-        override def messages: fs2.Stream[IO, ReceivedMessage[ExternalCredsMessage]] = fs2.Stream.empty
+        override def messages: fs2.Stream[IO, ReceivedMessage[ExternalCredsMessage]] =
+          fs2.Stream.never // never prevents early termination
       })
     }
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/Boot.scala
@@ -33,10 +33,15 @@ object Boot extends App with LazyLogging {
     } yield {
       implicit val system: ActorSystem = service.system
       List(
+        // process for handling messages from the external creds service for RAS passport updates
         externalCredsSubscriber.messages.evalMap { msg =>
           service.nihServiceConstructor().processExternalCredsMessage(msg)
         },
+
+        // start the subscriber
         Stream.eval(externalCredsSubscriber.start),
+
+        // start the http server
         Stream.eval(
           IO.fromFuture(
             IO(
@@ -52,6 +57,7 @@ object Boot extends App with LazyLogging {
       )
     }
 
+    // run all the processes concurrently
     processesResource
       .use { processes =>
         Stream

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
@@ -107,6 +107,9 @@ object FireCloudConfig {
   object Sam {
     private val sam = config.getConfig("sam")
     val baseUrl = sam.getString("baseUrl")
+
+    val groupResourceType = sam.getString("groupResourceType")
+    val groupMemberPolicy = sam.getString("groupMemberPolicy")
   }
 
   object CromIAM {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
@@ -2,11 +2,15 @@ package org.broadinstitute.dsde.firecloud
 
 import akka.http.scaladsl.model.Uri
 import akka.http.scaladsl.model.Uri.{Authority, Host, Query}
+import com.google.pubsub.v1.{ProjectSubscriptionName, TopicName}
 import com.typesafe.config.{Config, ConfigFactory, ConfigObject}
 import org.broadinstitute.dsde.firecloud.service.{FireCloudDirectiveUtils, NihAllowlist}
 import org.broadinstitute.dsde.rawls.model.{EntityQuery, SortDirections}
+import org.broadinstitute.dsde.workbench.google2.SubscriberConfig
 import org.broadinstitute.dsde.workbench.model.WorkbenchGroupName
 
+import java.util.concurrent.TimeUnit
+import scala.concurrent.duration.FiniteDuration
 import scala.jdk.CollectionConverters._
 import scala.util.Try
 
@@ -142,6 +146,16 @@ object FireCloudConfig {
     private lazy val externalCreds = config.getConfig("externalCreds")
     lazy val baseUrl: String = externalCreds.getString("baseUrl")
     lazy val enabled: Boolean = externalCreds.getBoolean("enabled")
+    lazy val subscriberConfig = SubscriberConfig(
+      Auth.firecloudAdminSAJsonFile,
+      TopicName.of(externalCreds.getString("topicProject"), externalCreds.getString("topicName")),
+      Option(ProjectSubscriptionName.of(FireCloud.serviceProject, externalCreds.getString("subscriptionName"))),
+      FiniteDuration(externalCreds.getDuration("ackDeadLine").toMillis(), TimeUnit.MILLISECONDS),
+      None,
+      None,
+      None
+    )
+    lazy val subscriberQueueSize: Int = externalCreds.getInt("subscriberQueueSize")
   }
 
   object FireCloud {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
@@ -4,6 +4,7 @@ import akka.http.scaladsl.model.Uri
 import akka.http.scaladsl.model.Uri.{Authority, Host, Query}
 import com.google.pubsub.v1.{ProjectSubscriptionName, TopicName}
 import com.typesafe.config.{Config, ConfigFactory, ConfigObject}
+import org.broadinstitute.dsde.firecloud.model.{ConsentGroup, DbGapPermission, PhsId}
 import org.broadinstitute.dsde.firecloud.service.{FireCloudDirectiveUtils, NihAllowlist}
 import org.broadinstitute.dsde.rawls.model.{EntityQuery, SortDirections}
 import org.broadinstitute.dsde.workbench.google2.SubscriberConfig
@@ -193,6 +194,19 @@ object FireCloudConfig {
       }
     }.toSet
     val enabled = nih.optionalBoolean("enabled").getOrElse(true)
+    lazy val rasVisaType = nih.getString("rasVisaType")
+    lazy val rasIssuer = nih.getString("rasIssuer")
+    lazy val dbGapPermissionToGroup: Map[DbGapPermission, String] = {
+      val dbGapPermissionToGroupConfigs = nih.getConfigList("dbGapPermissionAndGroup")
+
+      dbGapPermissionToGroupConfigs.asScala.collect { config =>
+        val phsId = PhsId(config.getString("phsId"))
+        val consentGroup = ConsentGroup(config.getString("consentGroup"))
+        val groupName = config.getString("groupName")
+
+        DbGapPermission(phsId, consentGroup) -> groupName
+      }.toMap
+    }
   }
 
   object ElasticSearch {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/DisabledExternalCredsDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/DisabledExternalCredsDAO.scala
@@ -7,32 +7,42 @@ import scala.concurrent.Future
 
 class DisabledExternalCredsDAO extends ExternalCredsDAO with LazyLogging {
 
-  override def getLinkedAccount(implicit userInfo: UserInfo): Future[Option[LinkedEraAccount]] = Future.successful {
+  override def getLinkedAccount(userInfo: UserInfo): Future[Option[LinkedEraAccount]] = Future.successful {
     logger.warn("Getting Linked eRA Account from ECM, but ECM is disabled.")
     None
   }
 
-  override def putLinkedEraAccount(
-    linkedEraAccount: LinkedEraAccount
-  )(implicit orchInfo: WithAccessToken): Future[Unit] = Future.successful {
-    logger.warn("Putting Linked eRA Account to ECM, but ECM is disabled.")
-  }
+  override def putLinkedEraAccount(linkedEraAccount: LinkedEraAccount, orchInfo: WithAccessToken): Future[Unit] =
+    Future.successful {
+      logger.warn("Putting Linked eRA Account to ECM, but ECM is disabled.")
+    }
 
-  override def deleteLinkedEraAccount(userInfo: UserInfo)(implicit orchInfo: WithAccessToken): Future[Unit] =
+  override def deleteLinkedEraAccount(userInfo: UserInfo, orchInfo: WithAccessToken): Future[Unit] =
     Future.successful {
       logger.warn("Deleting Linked eRA Account from ECM, but ECM is disabled.")
     }
 
-  override def getLinkedEraAccountForUsername(
-    username: String
-  )(implicit orchInfo: WithAccessToken): Future[Option[LinkedEraAccount]] = Future.successful {
+  override def getLinkedEraAccountForUsername(username: String,
+                                              orchInfo: WithAccessToken
+  ): Future[Option[LinkedEraAccount]] = Future.successful {
     logger.warn("Getting Linked eRA Account for username from ECM, but ECM is disabled.")
     None
   }
 
-  override def getActiveLinkedEraAccounts(implicit orchInfo: WithAccessToken): Future[Seq[LinkedEraAccount]] =
+  override def getActiveLinkedEraAccounts(orchInfo: WithAccessToken): Future[Seq[LinkedEraAccount]] =
     Future.successful {
       logger.warn("Getting Active Linked eRA Accounts from ECM, but ECM is disabled.")
+      Seq.empty
+    }
+
+  override def getVisas(provider: String,
+                        userId: String,
+                        issuer: String,
+                        visaType: String,
+                        orchInfo: WithAccessToken
+  ): Future[Seq[AnyRef]] =
+    Future.successful {
+      logger.warn("Getting Visas from ECM, but ECM is disabled.")
       Seq.empty
     }
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ExternalCredsDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/ExternalCredsDAO.scala
@@ -8,20 +8,25 @@ import scala.concurrent.Future
 trait ExternalCredsDAO {
 
   @throws(classOf[ApiException])
-  def getLinkedAccount(implicit userInfo: UserInfo): Future[Option[LinkedEraAccount]]
+  def getLinkedAccount(userInfo: UserInfo): Future[Option[LinkedEraAccount]]
 
   @throws(classOf[ApiException])
-  def putLinkedEraAccount(linkedEraAccount: LinkedEraAccount)(implicit orchInfo: WithAccessToken): Future[Unit]
+  def putLinkedEraAccount(linkedEraAccount: LinkedEraAccount, orchInfo: WithAccessToken): Future[Unit]
 
   @throws(classOf[ApiException])
-  def deleteLinkedEraAccount(userInfo: UserInfo)(implicit orchInfo: WithAccessToken): Future[Unit]
+  def deleteLinkedEraAccount(userInfo: UserInfo, orchInfo: WithAccessToken): Future[Unit]
 
   @throws(classOf[ApiException])
-  def getLinkedEraAccountForUsername(username: String)(implicit
-    orchInfo: WithAccessToken
-  ): Future[Option[LinkedEraAccount]]
+  def getLinkedEraAccountForUsername(username: String, orchInfo: WithAccessToken): Future[Option[LinkedEraAccount]]
 
   @throws(classOf[ApiException])
-  def getActiveLinkedEraAccounts(implicit orchInfo: WithAccessToken): Future[Seq[LinkedEraAccount]]
+  def getActiveLinkedEraAccounts(orchInfo: WithAccessToken): Future[Seq[LinkedEraAccount]]
 
+  @throws(classOf[ApiException])
+  def getVisas(provider: String,
+               userId: String,
+               issuer: String,
+               visaType: String,
+               orchInfo: WithAccessToken
+  ): Future[Seq[AnyRef]]
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpExternalCredsDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpExternalCredsDAO.scala
@@ -25,7 +25,7 @@ class HttpExternalCredsDAO(implicit val executionContext: ExecutionContext) exte
       case _ => throw new WorkbenchException(s"Failed to $operation: ${e.getMessage}")
     }
 
-  override def getLinkedAccount(implicit userInfo: UserInfo): Future[Option[LinkedEraAccount]] = Future {
+  override def getLinkedAccount(userInfo: UserInfo): Future[Option[LinkedEraAccount]] = Future {
     val oauthApi: OauthApi = getOauthApi(userInfo.accessToken.token)
     try {
       val linkInfo = oauthApi.getLink(Provider.ERA_COMMONS)
@@ -35,14 +35,13 @@ class HttpExternalCredsDAO(implicit val executionContext: ExecutionContext) exte
     }
   }
 
-  override def putLinkedEraAccount(
-    linkedEraAccount: LinkedEraAccount
-  )(implicit orchInfo: WithAccessToken): Future[Unit] = Future {
-    val adminApi = getAdminApi(orchInfo.accessToken.token)
-    adminApi.putLinkedAccountWithFakeToken(unapply(linkedEraAccount), Provider.ERA_COMMONS)
-  }
+  override def putLinkedEraAccount(linkedEraAccount: LinkedEraAccount, orchInfo: WithAccessToken): Future[Unit] =
+    Future {
+      val adminApi = getAdminApi(orchInfo.accessToken.token)
+      adminApi.putLinkedAccountWithFakeToken(unapply(linkedEraAccount), Provider.ERA_COMMONS)
+    }
 
-  override def deleteLinkedEraAccount(userInfo: UserInfo)(implicit orchInfo: WithAccessToken): Future[Unit] = Future {
+  override def deleteLinkedEraAccount(userInfo: UserInfo, orchInfo: WithAccessToken): Future[Unit] = Future {
     val adminApi = getAdminApi(orchInfo.accessToken.token)
     try
       adminApi.adminDeleteLinkedAccount(userInfo.id, Provider.ERA_COMMONS)
@@ -51,9 +50,9 @@ class HttpExternalCredsDAO(implicit val executionContext: ExecutionContext) exte
     }
   }
 
-  override def getLinkedEraAccountForUsername(
-    username: String
-  )(implicit orchInfo: WithAccessToken): Future[Option[LinkedEraAccount]] = Future {
+  override def getLinkedEraAccountForUsername(username: String,
+                                              orchInfo: WithAccessToken
+  ): Future[Option[LinkedEraAccount]] = Future {
     val adminApi = getAdminApi(orchInfo.accessToken.token)
     try {
       val adminLinkInfo = adminApi.getLinkedAccountForExternalId(Provider.ERA_COMMONS, username)
@@ -63,10 +62,20 @@ class HttpExternalCredsDAO(implicit val executionContext: ExecutionContext) exte
     }
   }
 
-  override def getActiveLinkedEraAccounts(implicit orchInfo: WithAccessToken): Future[Seq[LinkedEraAccount]] = Future {
+  override def getActiveLinkedEraAccounts(orchInfo: WithAccessToken): Future[Seq[LinkedEraAccount]] = Future {
     val adminApi = getAdminApi(orchInfo.accessToken.token)
     val adminLinkInfos = adminApi.getActiveLinkedAccounts(Provider.ERA_COMMONS)
     adminLinkInfos.asScala.map(LinkedEraAccount.apply).toSeq
+  }
+
+  override def getVisas(provider: String,
+                        userId: String,
+                        issuer: String,
+                        visaType: String,
+                        orchInfo: WithAccessToken
+  ): Future[Seq[AnyRef]] = Future {
+    val adminApi = getAdminApi(orchInfo.accessToken.token)
+    adminApi.getVisas(Provider.fromValue(provider), userId, issuer, visaType).asScala.toSeq
   }
 
   private def getApi(accessToken: String): ApiClient = {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpSamDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpSamDAO.scala
@@ -4,10 +4,10 @@ import java.net.URLEncoder
 import java.nio.charset.StandardCharsets.UTF_8
 import akka.actor.ActorSystem
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
-import akka.http.scaladsl.model.HttpRequest
+import akka.http.scaladsl.model.{HttpRequest, StatusCode, StatusCodes}
 import akka.http.scaladsl.unmarshalling.Unmarshal
 import akka.stream.Materializer
-import org.broadinstitute.dsde.firecloud.FireCloudExceptionWithErrorReport
+import org.broadinstitute.dsde.firecloud.{FireCloudConfig, FireCloudExceptionWithErrorReport}
 import org.broadinstitute.dsde.firecloud.model.ErrorReportExtensions.FCErrorReport
 import org.broadinstitute.dsde.firecloud.model.ManagedGroupRoles.ManagedGroupRole
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
@@ -27,7 +27,11 @@ import org.broadinstitute.dsde.firecloud.model.{
   WorkbenchUserInfo
 }
 import org.broadinstitute.dsde.firecloud.utils.RestJsonClient
-import org.broadinstitute.dsde.rawls.model.RawlsUserEmail
+import org.broadinstitute.dsde.rawls.{RawlsException, RawlsExceptionWithErrorReport}
+import org.broadinstitute.dsde.rawls.model.{ErrorReport, RawlsUserEmail, WorkspaceJsonSupport}
+import org.broadinstitute.dsde.workbench.client.sam.{ApiCallback, ApiClient, ApiException}
+import org.broadinstitute.dsde.workbench.client.sam.api.{ResourcesApi, UsersApi}
+import org.broadinstitute.dsde.workbench.client.sam.model.BulkMembershipUpdateRequestV2
 import org.broadinstitute.dsde.workbench.model.WorkbenchIdentityJsonSupport._
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.model.{WorkbenchEmail, WorkbenchGroupName, WorkbenchUserId}
@@ -35,18 +39,24 @@ import org.broadinstitute.dsde.workbench.util.health.SubsystemStatus
 import spray.json.DefaultJsonProtocol._
 import spray.json.{JsValue, JsonFormat, RootJsonFormat}
 
-import scala.concurrent.{ExecutionContext, Future}
+import java.util
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
+import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.jdk.CollectionConverters._
+import scala.util.Try
 
 /**
-  * Created by mbemis on 8/21/17.
-  */
+ * Created by mbemis on 8/21/17.
+ */
 class HttpSamDAO(implicit
   val system: ActorSystem,
   val materializer: Materializer,
-  implicit val executionContext: ExecutionContext
+  val executionContext: ExecutionContext
 ) extends SamDAO
     with RestJsonClient
     with SprayJsonSupport {
+
+  val timeout: FiniteDuration = 1.minute
 
   override def listWorkspaceResources(implicit userInfo: WithAccessToken): Future[Seq[UserPolicy]] =
     authedRequestToObject[Seq[UserPolicy]](Get(samListResources("workspace")),
@@ -195,4 +205,63 @@ class HttpSamDAO(implicit
       ok = response.status.isSuccess
       message <- if (ok) Future.successful(None) else Unmarshal(response.entity).to[String].map(Option(_))
     } yield SubsystemStatus(ok, message.map(List(_)))
+
+  override def bulkUpdateGroups(request: List[BulkMembershipUpdateRequestV2], user: WithAccessToken): Future[Unit] = {
+    val sam = new ResourcesApi(newApiClient(user))
+    val callback = new SamApiCallback[Void]("bulkMembershipUpdateV2")
+
+    sam.bulkMembershipUpdateV2Async(request.asJava, callback)
+    callback.future.map(_ => ())
+  }
+
+  private def newApiClient(user: WithAccessToken) = {
+    val apiClient = new ApiClient()
+    apiClient.setAccessToken(user.accessToken.token)
+    apiClient.setBasePath(FireCloudConfig.Sam.baseUrl)
+    apiClient
+  }
+
+  private class SamApiCallback[T](functionName: String) extends ApiCallback[T] {
+    private val promise = Promise[T]()
+
+    override def onFailure(e: ApiException,
+                           statusCode: Int,
+                           responseHeaders: util.Map[String, util.List[String]]
+    ): Unit =
+      try {
+        val response = Option(e.getResponseBody).getOrElse(e.getMessage)
+
+        // attempt to propagate an ErrorReport from Sam. If we can't understand Sam's response as an ErrorReport,
+        // create our own error message.
+        import WorkspaceJsonSupport.ErrorReportFormat
+        import spray.json._
+        val errorReport = Try(response.parseJson.convertTo[ErrorReport]).recover { case _: Throwable =>
+          val sc = Try(StatusCode.int2StatusCode(statusCode)).getOrElse(StatusCodes.InternalServerError)
+          ErrorReport(sc, s"Sam call to $functionName failed with error '$response'", e)
+        }.get
+
+        val exceptionWithErrorReport = new FireCloudExceptionWithErrorReport(errorReport)
+        logger.info(s"Sam call to $functionName failed", exceptionWithErrorReport)
+        promise.failure(exceptionWithErrorReport)
+      } catch {
+        case wtf: Throwable =>
+          logger.info("unexpected exception parsing error response from sam, failing with raw error", wtf)
+          // must be 100% certain that promise.failure is called otherwise the promise will never be fulfilled
+          promise.failure(e)
+      }
+
+    override def onSuccess(result: T, statusCode: Int, responseHeaders: util.Map[String, util.List[String]]): Unit =
+      promise.success(result)
+
+    override def onUploadProgress(bytesWritten: Long, contentLength: Long, done: Boolean): Unit = ()
+
+    override def onDownloadProgress(bytesRead: Long, contentLength: Long, done: Boolean): Unit = ()
+
+    def future: Future[T] = {
+      val timeoutFuture: Future[T] = akka.pattern.after(timeout, system.scheduler)(
+        Future.failed(new RawlsException(s"Sam call to $functionName timed out"))
+      )
+      Future.firstCompletedOf(Seq(promise.future, timeoutFuture))
+    }
+  }
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/SamDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/SamDAO.scala
@@ -18,6 +18,7 @@ import org.broadinstitute.dsde.firecloud.model.{
   WorkbenchUserInfo
 }
 import org.broadinstitute.dsde.rawls.model.{ErrorReportSource, RawlsUserEmail}
+import org.broadinstitute.dsde.workbench.client.sam.model.BulkMembershipUpdateRequestV2
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.model.{WorkbenchEmail, WorkbenchGroupName, WorkbenchUserId}
 import org.broadinstitute.dsde.workbench.util.health.Subsystems
@@ -49,25 +50,34 @@ trait SamDAO extends LazyLogging with ReportsSubsystemStatus {
 
   val samManagedGroupsBase: String = FireCloudConfig.Sam.baseUrl + "/api/groups"
   val samManagedGroupBase: String = FireCloudConfig.Sam.baseUrl + "/api/group"
+
   def samManagedGroup(groupName: WorkbenchGroupName): String = samManagedGroupBase + s"/$groupName"
+
   def samManagedGroupRequestAccess(groupName: WorkbenchGroupName): String =
     samManagedGroup(groupName) + "/requestAccess"
+
   def samManagedGroupPolicy(groupName: WorkbenchGroupName, policyName: ManagedGroupRole): String =
     samManagedGroup(groupName) + s"/$policyName"
+
   def samManagedGroupAlterMember(groupName: WorkbenchGroupName,
                                  policyName: ManagedGroupRole,
                                  email: WorkbenchEmail
   ): String = samManagedGroupPolicy(groupName, policyName) + s"/${URLEncoder.encode(email.value, UTF_8.name)}"
 
   val samResourceBase: String = FireCloudConfig.Sam.baseUrl + s"/api/resource"
+
   def samResource(resourceTypeName: String, resourceId: String): String =
     samResourceBase + s"/$resourceTypeName/$resourceId"
+
   def samResourceRoles(resourceTypeName: String, resourceId: String): String =
     samResource(resourceTypeName, resourceId) + "/roles"
+
   def samResourcePolicies(resourceTypeName: String, resourceId: String): String =
     samResource(resourceTypeName, resourceId) + "/policies"
+
   def samResourcePolicy(resourceTypeName: String, resourceId: String, policyName: String): String =
     samResourcePolicies(resourceTypeName, resourceId) + s"/$policyName"
+
   def samResourcePolicyAlterMember(resourceTypeName: String,
                                    resourceId: String,
                                    policyName: String,
@@ -76,11 +86,13 @@ trait SamDAO extends LazyLogging with ReportsSubsystemStatus {
     samResourcePolicy(resourceTypeName, resourceId, policyName) + s"/${URLEncoder.encode(email.value, UTF_8.name)}"
 
   val samResourcesBase: String = FireCloudConfig.Sam.baseUrl + s"/api/resources/v1"
+
   def samListResources(resourceTypeName: String): String = samResourcesBase + s"/$resourceTypeName"
 
   def registerUser(termsOfService: Option[String])(implicit userInfo: WithAccessToken): Future[RegistrationInfo]
 
   def registerUserSelf(acceptsTermsOfService: Boolean)(implicit userInfo: WithAccessToken): Future[SamUserResponse]
+
   def getRegistrationStatus(implicit userInfo: WithAccessToken): Future[RegistrationInfo]
 
   def getUserIds(email: RawlsUserEmail)(implicit userInfo: WithAccessToken): Future[UserIdInfo]
@@ -92,33 +104,46 @@ trait SamDAO extends LazyLogging with ReportsSubsystemStatus {
   def listWorkspaceResources(implicit userInfo: WithAccessToken): Future[Seq[UserPolicy]]
 
   def createGroup(groupName: WorkbenchGroupName)(implicit userInfo: WithAccessToken): Future[Unit]
+
   def deleteGroup(groupName: WorkbenchGroupName)(implicit userInfo: WithAccessToken): Future[Unit]
+
   def listGroups(implicit userInfo: WithAccessToken): Future[List[FireCloudManagedGroupMembership]]
+
   def getGroupEmail(groupName: WorkbenchGroupName)(implicit userInfo: WithAccessToken): Future[WorkbenchEmail]
+
   def isGroupMember(groupName: WorkbenchGroupName, userInfo: UserInfo): Future[Boolean]
+
   def listGroupPolicyEmails(groupName: WorkbenchGroupName, policyName: ManagedGroupRole)(implicit
     userInfo: WithAccessToken
   ): Future[List[WorkbenchEmail]]
+
   def addGroupMember(groupName: WorkbenchGroupName, role: ManagedGroupRole, email: WorkbenchEmail)(implicit
     userInfo: WithAccessToken
   ): Future[Unit]
+
   def removeGroupMember(groupName: WorkbenchGroupName, role: ManagedGroupRole, email: WorkbenchEmail)(implicit
     userInfo: WithAccessToken
   ): Future[Unit]
+
   def overwriteGroupMembers(groupName: WorkbenchGroupName, role: ManagedGroupRole, memberList: List[WorkbenchEmail])(
     implicit userInfo: WithAccessToken
   ): Future[Unit]
+
   def requestGroupAccess(groupName: WorkbenchGroupName)(implicit userInfo: WithAccessToken): Future[Unit]
 
   def addPolicyMember(resourceTypeName: String, resourceId: String, policyName: String, email: WorkbenchEmail)(implicit
     userInfo: WithAccessToken
   ): Future[Unit]
+
   def setPolicyPublic(resourceTypeName: String, resourceId: String, policyName: String, public: Boolean)(implicit
     userInfo: WithAccessToken
   ): Future[Unit]
 
   def getPetServiceAccountTokenForUser(user: WithAccessToken, scopes: Seq[String]): Future[AccessToken]
+
   def getPetServiceAccountKeyForUser(user: WithAccessToken, project: GoogleProject): Future[String]
 
   val serviceName = SamDAO.serviceName
+
+  def bulkUpdateGroups(request: List[BulkMembershipUpdateRequestV2], user: WithAccessToken): Future[Unit]
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/DbGapPermission.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/DbGapPermission.scala
@@ -4,4 +4,4 @@ import org.broadinstitute.dsde.workbench.model.ValueObject
 
 case class PhsId(value: String) extends ValueObject
 case class ConsentGroup(value: String) extends ValueObject
-case class DbGapPermission (phsId: PhsId, consentGroup: ConsentGroup)
+case class DbGapPermission(phsId: PhsId, consentGroup: ConsentGroup)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/DbGapPermission.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/DbGapPermission.scala
@@ -1,0 +1,7 @@
+package org.broadinstitute.dsde.firecloud.model
+
+import org.broadinstitute.dsde.workbench.model.ValueObject
+
+case class PhsId(value: String) extends ValueObject
+case class ConsentGroup(value: String) extends ValueObject
+case class DbGapPermission (phsId: PhsId, consentGroup: ConsentGroup)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ExternalCredsMessage.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ExternalCredsMessage.scala
@@ -1,0 +1,10 @@
+package org.broadinstitute.dsde.firecloud.model
+
+import io.circe.Decoder
+
+case class ExternalCredsMessage (providerName: String, userId: String)
+
+object ExternalCredsMessage {
+  implicit val externalCredsMessageDecoder: Decoder[ExternalCredsMessage] =
+    Decoder.forProduct2("providerName", "userId")(ExternalCredsMessage.apply)
+}

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ExternalCredsMessage.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ExternalCredsMessage.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.firecloud.model
 
 import io.circe.Decoder
 
-case class ExternalCredsMessage (providerName: String, userId: String)
+case class ExternalCredsMessage(providerName: String, userId: String)
 
 object ExternalCredsMessage {
   implicit val externalCredsMessageDecoder: Decoder[ExternalCredsMessage] =

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/NihService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/NihService.scala
@@ -3,7 +3,9 @@ package org.broadinstitute.dsde.firecloud.service
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.StatusCodes._
-import cats.effect.IO
+import cats.effect.kernel.Outcome.Succeeded
+import cats.effect.{IO, Outcome}
+import cats.implicits.toTraverseOps
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.dataaccess.{
   ExternalCredsDAO,
@@ -23,6 +25,7 @@ import org.broadinstitute.dsde.firecloud.{
   FireCloudExceptionWithErrorReport
 }
 import org.broadinstitute.dsde.rawls.model.ErrorReport
+import org.broadinstitute.dsde.workbench.client.sam.model.{BulkMembershipUpdateRequestV2, PolicyMembershipUpdate}
 import org.broadinstitute.dsde.workbench.model.{WorkbenchEmail, WorkbenchGroupName, WorkbenchUserId}
 import org.broadinstitute.dsde.workbench.util2.messaging.ReceivedMessage
 import org.slf4j.LoggerFactory
@@ -30,8 +33,10 @@ import pdi.jwt.{Jwt, JwtAlgorithm}
 import spray.json.DefaultJsonProtocol._
 import spray.json._
 
+import java.util
 import scala.concurrent.{ExecutionContext, Future}
 import scala.io.Source
+import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Success, Try}
 
 case class NihStatus(linkedNihUsername: Option[String] = None,
@@ -68,10 +73,79 @@ class NihService(val samDao: SamDAO,
 
   private val nihAllowlists: Set[NihAllowlist] = FireCloudConfig.Nih.whitelists
 
-  def processExternalCredsMessage(externalCredsMessage: ReceivedMessage[ExternalCredsMessage]): IO[Unit] =
-    IO {
-      logger.info("Processing external creds message: " + externalCredsMessage.msg)
+  def processExternalCredsMessage(externalCredsMessage: ReceivedMessage[ExternalCredsMessage]): IO[Unit] = {
+    val groupUpdateIO = for {
+      visas <- IO.fromFuture(
+        IO(
+          ecmDao.getVisas(
+            externalCredsMessage.msg.providerName,
+            externalCredsMessage.msg.userId,
+            FireCloudConfig.Nih.rasIssuer,
+            FireCloudConfig.Nih.rasVisaType,
+            getAdminAccessToken
+          )
+        )
+      )
+      userDbGapPermissions = extractDbGapPermissionsFromVisas(visas)
+      groupUpdates = determineGroupUpdates(externalCredsMessage.msg.userId, userDbGapPermissions)
+      _ <- ensureGroupsExists(groupUpdates)
+      _ <- logMessageHandling(groupUpdates, externalCredsMessage.msg)
+      _ <- IO.fromFuture(IO(samDao.bulkUpdateGroups(groupUpdates, getAdminAccessToken)))
+    } yield externalCredsMessage.ackHandler.ack()
+
+    groupUpdateIO.handleError { e =>
+      logger.error(s"Error processing ${externalCredsMessage.msg}: ${e.getMessage}", e)
+      externalCredsMessage.ackHandler.nack()
     }
+  }
+
+  private def logMessageHandling(groupUpdates: List[BulkMembershipUpdateRequestV2], message: ExternalCredsMessage) =
+    IO {
+      val (addGroups, removeGroups) =
+        groupUpdates.partition(_.getPolicyUpdates.asScala.exists(Option(_).forall(_.getRemoveUserIds.isEmpty)))
+      logger.info(
+        s"Handling $message, adding to groups: [${addGroups.map(_.getResourceId).mkString(", ")}], removing from groups: [${removeGroups.map(_.getResourceId).mkString(", ")}]"
+      )
+    }
+
+  private def ensureGroupsExists(groupUpdates: List[BulkMembershipUpdateRequestV2]): IO[Unit] =
+    for {
+      groups <- IO.fromFuture(IO(samDao.listGroups(getAdminAccessToken)))
+      missingGroupNames = groupUpdates.map(_.getResourceId.toLowerCase()).toSet -- groups
+        .map(_.groupName.toLowerCase)
+        .toSet
+      _ <- missingGroupNames.toList.traverse { groupName =>
+        IO.fromFuture(IO(samDao.createGroup(WorkbenchGroupName(groupName))(getAdminAccessToken)))
+      }
+    } yield ()
+
+  private def determineGroupUpdates(userId: String, userDbGapPermissions: Seq[DbGapPermission]) =
+    FireCloudConfig.Nih.dbGapPermissionToGroup.map { case (permission, group) =>
+      val policyMembershipUpdate = new PolicyMembershipUpdate().policyName("member")
+      if (userDbGapPermissions.contains(permission)) {
+        policyMembershipUpdate.addAddUserIdsItem(userId)
+      } else {
+        policyMembershipUpdate.addRemoveUserIdsItem(userId)
+      }
+      new BulkMembershipUpdateRequestV2()
+        .resourceTypeName("managed-group")
+        .resourceId(group)
+        .addPolicyUpdatesItem(policyMembershipUpdate)
+    }.toList
+
+  private def extractDbGapPermissionsFromVisas(visas: Seq[AnyRef]) =
+    for {
+      visa <- visas
+      visaMap = visa.asInstanceOf[util.Map[String, Object]].asScala
+      dbGapPermissions = visaMap
+        .getOrElse("ras_dbgap_permissions", new util.ArrayList[Object]())
+        .asInstanceOf[util.List[Object]]
+        .asScala
+      dbGapPermission <- dbGapPermissions
+      dbGapPermissionMap = dbGapPermission.asInstanceOf[util.Map[String, Object]].asScala
+    } yield DbGapPermission(PhsId(dbGapPermissionMap("phs_id").asInstanceOf[String]),
+                            ConsentGroup(dbGapPermissionMap("consent_group").asInstanceOf[String])
+    )
 
   def getNihStatus(userInfo: UserInfo): Future[PerRequestMessage] =
     getNihStatusFromEcm(userInfo).flatMap {
@@ -195,7 +269,7 @@ class NihService(val samDao: SamDAO,
 
   private def linkNihAccountEcm(userInfo: UserInfo, nihLink: NihLink): Future[Try[Unit]] =
     ecmDao
-      .putLinkedEraAccount(LinkedEraAccount(userInfo.id, nihLink))(getAdminAccessToken)
+      .putLinkedEraAccount(LinkedEraAccount(userInfo.id, nihLink), getAdminAccessToken)
       .flatMap { _ =>
         logger.info("Successfully linked NIH account in ECM for user " + userInfo.id)
         Future.successful(Success(()))
@@ -218,7 +292,7 @@ class NihService(val samDao: SamDAO,
     } yield ()
 
   private def unlinkNihAccountEcm(userInfo: UserInfo): Future[Unit] =
-    ecmDao.deleteLinkedEraAccount(userInfo)(getAdminAccessToken)
+    ecmDao.deleteLinkedEraAccount(userInfo, getAdminAccessToken)
 
   private def unlinkNihAccountThurloe(userInfo: UserInfo): Future[Unit] = {
     val nihKeys = Set("linkedNihUsername", "linkExpireTime")

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/NihService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/NihService.scala
@@ -3,6 +3,7 @@ package org.broadinstitute.dsde.firecloud.service
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.StatusCodes._
+import cats.effect.IO
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.dataaccess.{
   ExternalCredsDAO,
@@ -23,6 +24,7 @@ import org.broadinstitute.dsde.firecloud.{
 }
 import org.broadinstitute.dsde.rawls.model.ErrorReport
 import org.broadinstitute.dsde.workbench.model.{WorkbenchEmail, WorkbenchGroupName, WorkbenchUserId}
+import org.broadinstitute.dsde.workbench.util2.messaging.ReceivedMessage
 import org.slf4j.LoggerFactory
 import pdi.jwt.{Jwt, JwtAlgorithm}
 import spray.json.DefaultJsonProtocol._
@@ -65,6 +67,11 @@ class NihService(val samDao: SamDAO,
   def getAdminAccessToken: WithAccessToken = UserInfo(googleDao.getAdminUserAccessToken, "")
 
   private val nihAllowlists: Set[NihAllowlist] = FireCloudConfig.Nih.whitelists
+
+  def processExternalCredsMessage(externalCredsMessage: ReceivedMessage[ExternalCredsMessage]): IO[Unit] =
+    IO {
+      logger.info("Processing external creds message: " + externalCredsMessage.msg)
+    }
 
   def getNihStatus(userInfo: UserInfo): Future[PerRequestMessage] =
     getNihStatusFromEcm(userInfo).flatMap {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/NihService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/NihService.scala
@@ -33,6 +33,7 @@ import pdi.jwt.{Jwt, JwtAlgorithm}
 import spray.json.DefaultJsonProtocol._
 import spray.json._
 
+import java.time.Instant
 import java.util
 import scala.concurrent.{ExecutionContext, Future}
 import scala.io.Source
@@ -88,7 +89,7 @@ class NihService(val samDao: SamDAO,
       )
       userDbGapPermissions = extractDbGapPermissionsFromVisas(visas)
       groupUpdates = determineGroupUpdates(externalCredsMessage.msg.userId, userDbGapPermissions)
-      _ <- ensureGroupsExists(groupUpdates)
+      _ <- ensureDbGapGroupsExist()
       _ <- logMessageHandling(groupUpdates, externalCredsMessage.msg)
       _ <- IO.fromFuture(IO(samDao.bulkUpdateGroups(groupUpdates, getAdminAccessToken)))
     } yield externalCredsMessage.ackHandler.ack()
@@ -108,12 +109,11 @@ class NihService(val samDao: SamDAO,
       )
     }
 
-  private def ensureGroupsExists(groupUpdates: List[BulkMembershipUpdateRequestV2]): IO[Unit] =
+  private def ensureDbGapGroupsExist(): IO[Unit] =
     for {
       groups <- IO.fromFuture(IO(samDao.listGroups(getAdminAccessToken)))
-      missingGroupNames = groupUpdates.map(_.getResourceId.toLowerCase()).toSet -- groups
-        .map(_.groupName.toLowerCase)
-        .toSet
+      groupNames = groups.map(_.groupName.toLowerCase).toSet
+      missingGroupNames = FireCloudConfig.Nih.dbGapPermissionToGroup.values.toSet -- groupNames
       _ <- missingGroupNames.toList.traverse { groupName =>
         IO.fromFuture(IO(samDao.createGroup(WorkbenchGroupName(groupName))(getAdminAccessToken)))
       }
@@ -121,14 +121,14 @@ class NihService(val samDao: SamDAO,
 
   private def determineGroupUpdates(userId: String, userDbGapPermissions: Seq[DbGapPermission]) =
     FireCloudConfig.Nih.dbGapPermissionToGroup.map { case (permission, group) =>
-      val policyMembershipUpdate = new PolicyMembershipUpdate().policyName("member")
+      val policyMembershipUpdate = new PolicyMembershipUpdate().policyName(FireCloudConfig.Sam.groupMemberPolicy)
       if (userDbGapPermissions.contains(permission)) {
         policyMembershipUpdate.addAddUserIdsItem(userId)
       } else {
         policyMembershipUpdate.addRemoveUserIdsItem(userId)
       }
       new BulkMembershipUpdateRequestV2()
-        .resourceTypeName("managed-group")
+        .resourceTypeName(FireCloudConfig.Sam.groupResourceType)
         .resourceId(group)
         .addPolicyUpdatesItem(policyMembershipUpdate)
     }.toList
@@ -141,10 +141,10 @@ class NihService(val samDao: SamDAO,
         .getOrElse("ras_dbgap_permissions", new util.ArrayList[Object]())
         .asInstanceOf[util.List[Object]]
         .asScala
-      dbGapPermission <- dbGapPermissions
-      dbGapPermissionMap = dbGapPermission.asInstanceOf[util.Map[String, Object]].asScala
-    } yield DbGapPermission(PhsId(dbGapPermissionMap("phs_id").asInstanceOf[String]),
-                            ConsentGroup(dbGapPermissionMap("consent_group").asInstanceOf[String])
+      dbGapPermission <- dbGapPermissions.map(_.asInstanceOf[util.Map[String, Object]].asScala)
+      if dbGapPermission("expiration").asInstanceOf[Long] > Instant.now.getEpochSecond
+    } yield DbGapPermission(PhsId(dbGapPermission("phs_id").asInstanceOf[String]),
+                            ConsentGroup(dbGapPermission("consent_group").asInstanceOf[String])
     )
 
   def getNihStatus(userInfo: UserInfo): Future[PerRequestMessage] =

--- a/src/test/resources/reference.conf
+++ b/src/test/resources/reference.conf
@@ -74,6 +74,12 @@ nih {
       "rawlsGroup":"this-doesnt-matter"
     }
   }
+  rasIssuer = "https://stsstg.nih.gov"
+  rasVisaType = "https://ras.nih.gov/visas/v1.1"
+  dbGapPermissionAndGroup = [
+    {phsId = "phs002409", consentGroup = "c1", groupName = "dbgap_phs002409_c1"},
+    {phsId = "phs002410", consentGroup = "c1", groupName = "dbgap_phs002410_c1"},
+  ]
 }
 
 elasticsearch {

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockSamDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockSamDAO.scala
@@ -19,6 +19,7 @@ import org.broadinstitute.dsde.firecloud.model.{
 }
 import org.broadinstitute.dsde.workbench.util.health.SubsystemStatus
 import org.broadinstitute.dsde.rawls.model.{ErrorReport, RawlsUserEmail}
+import org.broadinstitute.dsde.workbench.client.sam.model.BulkMembershipUpdateRequestV2
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.model.{
   AzureB2CId,
@@ -203,4 +204,6 @@ class MockSamDAO extends SamDAO {
   override def getUsersForIds(samUserIds: Seq[WorkbenchUserId])(implicit
     userInfo: WithAccessToken
   ): Future[Seq[WorkbenchUserInfo]] = Future.successful(Seq())
+
+  override def bulkUpdateGroups(request: List[BulkMembershipUpdateRequestV2], user: WithAccessToken): Future[Unit] = ???
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/NihServiceUnitSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/NihServiceUnitSpec.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.dsde.firecloud.service
 
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import akka.http.scaladsl.model.{StatusCode, StatusCodes}
+import cats.effect.unsafe.implicits.global
 import org.broadinstitute.dsde.firecloud.FireCloudConfig
 import org.broadinstitute.dsde.firecloud.FireCloudException
 import org.broadinstitute.dsde.firecloud.dataaccess.{
@@ -12,12 +13,16 @@ import org.broadinstitute.dsde.firecloud.dataaccess.{
   ThurloeDAO
 }
 import org.broadinstitute.dsde.firecloud.model.{
+  ConsentGroup,
+  DbGapPermission,
+  ExternalCredsMessage,
   FireCloudKeyValue,
   FireCloudManagedGroupMembership,
   JWTWrapper,
   LinkedEraAccount,
   ManagedGroupRoles,
   NihLink,
+  PhsId,
   ProfileWrapper,
   SamUser,
   UserInfo,
@@ -32,6 +37,8 @@ import org.broadinstitute.dsde.workbench.model.{
   WorkbenchUserId
 }
 import org.broadinstitute.dsde.rawls.model.ErrorReport
+import org.broadinstitute.dsde.workbench.client.sam.model.{BulkMembershipUpdateRequestV2, PolicyMembershipUpdate}
+import org.broadinstitute.dsde.workbench.util2.messaging.{AckHandler, ReceivedMessage}
 import org.joda.time.DateTime
 import org.mockito.{ArgumentMatchers, Mockito}
 import org.mockito.ArgumentMatchers.any
@@ -46,6 +53,7 @@ import java.io.ByteArrayInputStream
 import java.nio.charset.StandardCharsets
 import java.security.{KeyPairGenerator, PrivateKey}
 import java.time.Instant
+import java.util
 import java.util.{Base64, UUID}
 import scala.concurrent.duration.{Duration, DurationInt}
 import scala.concurrent.{Await, ExecutionContext, Future}
@@ -506,6 +514,209 @@ class NihServiceUnitSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEa
     verify(thurloeDao, times(1)).deleteKeyValue(user.id.value, "linkedNihUsername", userInfo)
     verify(thurloeDao, times(1)).deleteKeyValue(user.id.value, "linkExpireTime", userInfo)
 
+  }
+
+  /**
+   * Verify that given config with 2 dbgap group and a user with a visa with 1 permission,
+   * the user is added to the group and removed from the other group
+   */
+  "processExternalCredsMessage" should "add and remove user" in {
+    val ackHandler = mock[AckHandler]
+    val provider = "ras"
+    val userId = UUID.randomUUID().toString
+
+    // these match config
+    val addPermission = DbGapPermission(PhsId("phs002409"), ConsentGroup("c1"))
+    val removePermissions = DbGapPermission(PhsId("phs002410"), ConsentGroup("c1"))
+
+    val visa = new java.util.HashMap[String, Object]()
+    val dbGapPermissions = new util.ArrayList[util.HashMap[String, Object]]()
+    visa.put("ras_dbgap_permissions", dbGapPermissions)
+    val permission = new java.util.HashMap[String, Object]()
+    permission.put("phs_id", addPermission.phsId.value)
+    permission.put("consent_group", addPermission.consentGroup.value)
+    permission.put("expiration",
+                   java.lang.Long.valueOf(Instant.now().plusSeconds(60).getEpochSecond) // future expiration
+    )
+    dbGapPermissions.add(permission)
+
+    val orchAdmin = UserInfo(adminAccessToken, "")
+    when(
+      ecmDao.getVisas(provider, userId, FireCloudConfig.Nih.rasIssuer, FireCloudConfig.Nih.rasVisaType, orchAdmin)
+    ).thenReturn(Future.successful(Seq(visa)))
+
+    when(samDao.listGroups(orchAdmin)).thenReturn(Future.successful(FireCloudConfig.Nih.dbGapPermissionToGroup.map {
+      case (_, groupName) => FireCloudManagedGroupMembership(groupName, groupName + "@firecloud.org", "admin")
+    }.toList))
+
+    when(
+      samDao.bulkUpdateGroups(
+        List(
+          new BulkMembershipUpdateRequestV2()
+            .resourceTypeName(FireCloudConfig.Sam.groupResourceType)
+            .resourceId(
+              FireCloudConfig.Nih.dbGapPermissionToGroup(addPermission)
+            )
+            .addPolicyUpdatesItem(
+              new PolicyMembershipUpdate().policyName(FireCloudConfig.Sam.groupMemberPolicy).addAddUserIdsItem(userId)
+            ),
+          new BulkMembershipUpdateRequestV2()
+            .resourceTypeName(FireCloudConfig.Sam.groupResourceType)
+            .resourceId(
+              FireCloudConfig.Nih.dbGapPermissionToGroup(removePermissions)
+            )
+            .addPolicyUpdatesItem(
+              new PolicyMembershipUpdate()
+                .policyName(FireCloudConfig.Sam.groupMemberPolicy)
+                .addRemoveUserIdsItem(userId)
+            )
+        ),
+        orchAdmin
+      )
+    ).thenReturn(Future.successful(()))
+
+    nihService
+      .processExternalCredsMessage(
+        ReceivedMessage[ExternalCredsMessage](ExternalCredsMessage(provider, userId), None, Instant.now(), ackHandler)
+      )
+      .unsafeRunSync()
+
+    verify(ackHandler).ack()
+  }
+
+  /**
+   * same as add and remove user but the permission is expired so the user should be removed from both groups
+   */
+  it should "ignore expired permission" in {
+    val ackHandler = mock[AckHandler]
+    val provider = "ras"
+    val userId = UUID.randomUUID().toString
+
+    // these match config
+    val expiredPermission = DbGapPermission(PhsId("phs002409"), ConsentGroup("c1"))
+    val removePermissions = DbGapPermission(PhsId("phs002410"), ConsentGroup("c1"))
+
+    val visa = new java.util.HashMap[String, Object]()
+    val dbGapPermissions = new util.ArrayList[util.HashMap[String, Object]]()
+    visa.put("ras_dbgap_permissions", dbGapPermissions)
+    val permission = new java.util.HashMap[String, Object]()
+    permission.put("phs_id", expiredPermission.phsId.value)
+    permission.put("consent_group", expiredPermission.consentGroup.value)
+    permission.put("expiration",
+                   java.lang.Long.valueOf(Instant.now().minusSeconds(60).getEpochSecond) // past expiration
+    )
+    dbGapPermissions.add(permission)
+
+    val orchAdmin = UserInfo(adminAccessToken, "")
+    when(
+      ecmDao.getVisas(provider, userId, FireCloudConfig.Nih.rasIssuer, FireCloudConfig.Nih.rasVisaType, orchAdmin)
+    ).thenReturn(Future.successful(Seq(visa)))
+
+    when(samDao.listGroups(orchAdmin)).thenReturn(Future.successful(FireCloudConfig.Nih.dbGapPermissionToGroup.map {
+      case (_, groupName) => FireCloudManagedGroupMembership(groupName, groupName + "@firecloud.org", "admin")
+    }.toList))
+
+    when(
+      samDao.bulkUpdateGroups(
+        List(
+          new BulkMembershipUpdateRequestV2()
+            .resourceTypeName(FireCloudConfig.Sam.groupResourceType)
+            .resourceId(
+              FireCloudConfig.Nih.dbGapPermissionToGroup(expiredPermission)
+            )
+            .addPolicyUpdatesItem(
+              new PolicyMembershipUpdate()
+                .policyName(FireCloudConfig.Sam.groupMemberPolicy)
+                .addRemoveUserIdsItem(userId)
+            ),
+          new BulkMembershipUpdateRequestV2()
+            .resourceTypeName(FireCloudConfig.Sam.groupResourceType)
+            .resourceId(
+              FireCloudConfig.Nih.dbGapPermissionToGroup(removePermissions)
+            )
+            .addPolicyUpdatesItem(
+              new PolicyMembershipUpdate()
+                .policyName(FireCloudConfig.Sam.groupMemberPolicy)
+                .addRemoveUserIdsItem(userId)
+            )
+        ),
+        orchAdmin
+      )
+    ).thenReturn(Future.successful(()))
+
+    nihService
+      .processExternalCredsMessage(
+        ReceivedMessage[ExternalCredsMessage](ExternalCredsMessage(provider, userId), None, Instant.now(), ackHandler)
+      )
+      .unsafeRunSync()
+
+    verify(ackHandler).ack()
+  }
+
+  it should "remove all permissions when no visas" in {
+    val ackHandler = mock[AckHandler]
+    val provider = "ras"
+    val userId = UUID.randomUUID().toString
+
+    val orchAdmin = UserInfo(adminAccessToken, "")
+    when(
+      ecmDao.getVisas(provider, userId, FireCloudConfig.Nih.rasIssuer, FireCloudConfig.Nih.rasVisaType, orchAdmin)
+    ).thenReturn(Future.successful(Seq.empty))
+
+    when(samDao.listGroups(orchAdmin)).thenReturn(Future.successful(FireCloudConfig.Nih.dbGapPermissionToGroup.map {
+      case (_, groupName) => FireCloudManagedGroupMembership(groupName, groupName + "@firecloud.org", "admin")
+    }.toList))
+
+    when(
+      samDao.bulkUpdateGroups(
+        FireCloudConfig.Nih.dbGapPermissionToGroup.map { case (_, groupName) =>
+          new BulkMembershipUpdateRequestV2()
+            .resourceTypeName(FireCloudConfig.Sam.groupResourceType)
+            .resourceId(groupName)
+            .addPolicyUpdatesItem(
+              new PolicyMembershipUpdate()
+                .policyName(FireCloudConfig.Sam.groupMemberPolicy)
+                .addRemoveUserIdsItem(userId)
+            )
+        }.toList,
+        orchAdmin
+      )
+    ).thenReturn(Future.successful(()))
+
+    nihService
+      .processExternalCredsMessage(
+        ReceivedMessage[ExternalCredsMessage](ExternalCredsMessage(provider, userId), None, Instant.now(), ackHandler)
+      )
+      .unsafeRunSync()
+
+    verify(ackHandler).ack()
+  }
+
+  it should "nack when there is an exception" in {
+    val ackHandler = mock[AckHandler]
+    val provider = "ras"
+    val userId = UUID.randomUUID().toString
+
+    val orchAdmin = UserInfo(adminAccessToken, "")
+    when(
+      ecmDao.getVisas(provider, userId, FireCloudConfig.Nih.rasIssuer, FireCloudConfig.Nih.rasVisaType, orchAdmin)
+    ).thenReturn(Future.successful(Seq.empty))
+
+    when(samDao.listGroups(orchAdmin)).thenReturn(Future.successful(FireCloudConfig.Nih.dbGapPermissionToGroup.map {
+      case (_, groupName) => FireCloudManagedGroupMembership(groupName, groupName + "@firecloud.org", "admin")
+    }.toList))
+
+    when(
+      samDao.bulkUpdateGroups(any(), any())
+    ).thenReturn(Future.failed(new RuntimeException("oops")))
+
+    nihService
+      .processExternalCredsMessage(
+        ReceivedMessage[ExternalCredsMessage](ExternalCredsMessage(provider, userId), None, Instant.now(), ackHandler)
+      )
+      .unsafeRunSync()
+
+    verify(ackHandler).nack()
   }
 
   private def mockSamUsers(): Unit = {

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/NihServiceUnitSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/NihServiceUnitSpec.scala
@@ -391,7 +391,7 @@ class NihServiceUnitSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEa
   it should "continue, but return an error of ECM returns an error" in {
     mockShibbolethDAO()
     mockThurloeUsers()
-    when(ecmDao.putLinkedEraAccount(any[LinkedEraAccount])(any[WithAccessToken]))
+    when(ecmDao.putLinkedEraAccount(any[LinkedEraAccount], any[WithAccessToken]))
       .thenReturn(Future.failed(new RuntimeException("ECM is down")))
 
     val user = userTcgaOnly
@@ -459,8 +459,8 @@ class NihServiceUnitSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEa
       linkedAccount.linkExpireTime.minusMillis(linkedAccount.linkExpireTime.getMillisOfSecond)
     )
 
-    verify(ecmDao, times(1)).putLinkedEraAccount(ArgumentMatchers.eq(expectedLinkedAccount))(
-      ArgumentMatchers.eq(UserInfo(adminAccessToken, ""))
+    verify(ecmDao, times(1)).putLinkedEraAccount(ArgumentMatchers.eq(expectedLinkedAccount),
+                                                 ArgumentMatchers.eq(UserInfo(adminAccessToken, ""))
     )
     verify(googleDao, times(1)).getBucketObjectAsInputStream(FireCloudConfig.Nih.whitelistBucket, "tcga-whitelist.txt")
     verify(googleDao, times(1)).getBucketObjectAsInputStream(FireCloudConfig.Nih.whitelistBucket,
@@ -500,8 +500,8 @@ class NihServiceUnitSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEa
       ArgumentMatchers.eq(ManagedGroupRoles.Member),
       ArgumentMatchers.eq(WorkbenchEmail(user.email.value))
     )(ArgumentMatchers.eq(UserInfo(adminAccessToken, "")))
-    verify(ecmDao, times(1)).deleteLinkedEraAccount(ArgumentMatchers.eq(userInfo))(
-      ArgumentMatchers.eq(UserInfo(adminAccessToken, ""))
+    verify(ecmDao, times(1)).deleteLinkedEraAccount(ArgumentMatchers.eq(userInfo),
+                                                    ArgumentMatchers.eq(UserInfo(adminAccessToken, ""))
     )
     verify(thurloeDao, times(1)).deleteKeyValue(user.id.value, "linkedNihUsername", userInfo)
     verify(thurloeDao, times(1)).deleteKeyValue(user.id.value, "linkExpireTime", userInfo)
@@ -556,12 +556,12 @@ class NihServiceUnitSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEa
       val userInfo = args.getArgument(0).asInstanceOf[UserInfo]
       Future.successful(linkedAccountsBySamUserId.get(WorkbenchUserId(userInfo.id)))
     }
-    when(ecmDao.putLinkedEraAccount(any[LinkedEraAccount])(ArgumentMatchers.eq(UserInfo(adminAccessToken, ""))))
+    when(ecmDao.putLinkedEraAccount(any[LinkedEraAccount], ArgumentMatchers.eq(UserInfo(adminAccessToken, ""))))
       .thenReturn(Future.successful(()))
-    when(ecmDao.deleteLinkedEraAccount(any[UserInfo])(ArgumentMatchers.eq(UserInfo(adminAccessToken, ""))))
+    when(ecmDao.deleteLinkedEraAccount(any[UserInfo], ArgumentMatchers.eq(UserInfo(adminAccessToken, ""))))
       .thenReturn(Future.successful(()))
 
-    when(ecmDao.getLinkedEraAccountForUsername(any[String])(ArgumentMatchers.eq(UserInfo(adminAccessToken, ""))))
+    when(ecmDao.getLinkedEraAccountForUsername(any[String], ArgumentMatchers.eq(UserInfo(adminAccessToken, ""))))
       .thenAnswer { args =>
         val externalId = args.getArgument(0).asInstanceOf[String]
         Future.successful(linkedAccountsByExternalId.get(externalId))


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/CORE-252

includes refactoring of Boot.scala to be more Catsy to be compatible with the workbench libs pubsub stuff

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge. Make sure your branch deletes; GitHub should do this for you.
- [ ] Test this change deployed correctly and works on dev environment after deployment
