### PR TITLE
[CORE-253] add dbgap members to allowlist

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
@@ -195,7 +195,11 @@ object FireCloudConfig {
         val phsId = config.getString("phsId")
         val consentGroup = config.getString("consentGroup")
 
-        NihAllowlist(name, WorkbenchGroupName(rawlsGroup), fileName, DbGapPermission(PhsId(phsId), ConsentGroup(consentGroup)))
+        NihAllowlist(name,
+                     WorkbenchGroupName(rawlsGroup),
+                     fileName,
+                     DbGapPermission(PhsId(phsId), ConsentGroup(consentGroup))
+        )
       }
     }.toSet
     val enabled = nih.optionalBoolean("enabled").getOrElse(true)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
@@ -192,8 +192,10 @@ object FireCloudConfig {
         val config = configObject.toConfig
         val rawlsGroup = config.getString("rawlsGroup")
         val fileName = config.getString("fileName")
+        val phsId = config.getString("phsId")
+        val consentGroup = config.getString("consentGroup")
 
-        NihAllowlist(name, WorkbenchGroupName(rawlsGroup), fileName)
+        NihAllowlist(name, WorkbenchGroupName(rawlsGroup), fileName, DbGapPermission(PhsId(phsId), ConsentGroup(consentGroup)))
       }
     }.toSet
     val enabled = nih.optionalBoolean("enabled").getOrElse(true)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/NihService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/NihService.scala
@@ -45,7 +45,7 @@ case class NihStatus(linkedNihUsername: Option[String] = None,
                      linkExpireTime: Option[Long] = None
 )
 
-case class NihAllowlist(name: String, groupToSync: WorkbenchGroupName, fileName: String)
+case class NihAllowlist(name: String, groupToSync: WorkbenchGroupName, fileName: String, dbGapPermission: DbGapPermission)
 
 case class NihDatasetPermission(name: String, authorized: Boolean)
 
@@ -252,11 +252,13 @@ class NihService(val samDao: SamDAO,
   // This syncs the specified allowlist in full
   private def syncNihAllowlistAllUsers(nihAllowlist: NihAllowlist): Future[Unit] = {
     val allowlistUsers = downloadNihAllowlist(nihAllowlist)
+    val dbGapSamGroup = FireCloudConfig.Nih.dbGapPermissionToGroup.get(nihAllowlist.dbGapPermission).map(WorkbenchGroupName)
 
     for {
+      samEmails <- Future.traverse(dbGapSamGroup.toList)( samDao.getGroupEmail(_)(getAdminAccessToken))
       ecmEmails <- getNihAllowlistTerraEmailsFromEcm(allowlistUsers)
       thurloeEmails <- getNihAllowlistTerraEmailsFromThurloe(allowlistUsers)
-      members = ecmEmails ++ thurloeEmails
+      members = ecmEmails ++ thurloeEmails ++ samEmails
       _ <- ensureAllowlistGroupsExists()
       // The request to Sam to completely overwrite the group with the list of actively linked users on the allowlist
       _ <- samDao.overwriteGroupMembers(nihAllowlist.groupToSync, ManagedGroupRoles.Member, members.toList)(

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/NihService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/NihService.scala
@@ -260,10 +260,10 @@ class NihService(val samDao: SamDAO,
       FireCloudConfig.Nih.dbGapPermissionToGroup.get(nihAllowlist.dbGapPermission).map(WorkbenchGroupName)
 
     for {
-      dbGapEmails <- Future.traverse(dbGapSamGroup.toList)(samDao.getGroupEmail(_)(getAdminAccessToken))
+      dbGapGroupEmail <- Future.traverse(dbGapSamGroup.toList)(samDao.getGroupEmail(_)(getAdminAccessToken))
       ecmEmails <- getNihAllowlistTerraEmailsFromEcm(allowlistUsers)
       thurloeEmails <- getNihAllowlistTerraEmailsFromThurloe(allowlistUsers)
-      members = ecmEmails ++ thurloeEmails ++ dbGapEmails
+      members = ecmEmails ++ thurloeEmails ++ dbGapGroupEmail
       _ <- ensureAllowlistGroupsExists()
       // The request to Sam to completely overwrite the group with the list of actively linked users on the allowlist
       _ <- samDao.overwriteGroupMembers(nihAllowlist.groupToSync, ManagedGroupRoles.Member, members.toList)(

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/NihService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/NihService.scala
@@ -45,7 +45,11 @@ case class NihStatus(linkedNihUsername: Option[String] = None,
                      linkExpireTime: Option[Long] = None
 )
 
-case class NihAllowlist(name: String, groupToSync: WorkbenchGroupName, fileName: String, dbGapPermission: DbGapPermission)
+case class NihAllowlist(name: String,
+                        groupToSync: WorkbenchGroupName,
+                        fileName: String,
+                        dbGapPermission: DbGapPermission
+)
 
 case class NihDatasetPermission(name: String, authorized: Boolean)
 
@@ -252,13 +256,14 @@ class NihService(val samDao: SamDAO,
   // This syncs the specified allowlist in full
   private def syncNihAllowlistAllUsers(nihAllowlist: NihAllowlist): Future[Unit] = {
     val allowlistUsers = downloadNihAllowlist(nihAllowlist)
-    val dbGapSamGroup = FireCloudConfig.Nih.dbGapPermissionToGroup.get(nihAllowlist.dbGapPermission).map(WorkbenchGroupName)
+    val dbGapSamGroup =
+      FireCloudConfig.Nih.dbGapPermissionToGroup.get(nihAllowlist.dbGapPermission).map(WorkbenchGroupName)
 
     for {
-      samEmails <- Future.traverse(dbGapSamGroup.toList)( samDao.getGroupEmail(_)(getAdminAccessToken))
+      dbGapEmails <- Future.traverse(dbGapSamGroup.toList)(samDao.getGroupEmail(_)(getAdminAccessToken))
       ecmEmails <- getNihAllowlistTerraEmailsFromEcm(allowlistUsers)
       thurloeEmails <- getNihAllowlistTerraEmailsFromThurloe(allowlistUsers)
-      members = ecmEmails ++ thurloeEmails ++ samEmails
+      members = ecmEmails ++ thurloeEmails ++ dbGapEmails
       _ <- ensureAllowlistGroupsExists()
       // The request to Sam to completely overwrite the group with the list of actively linked users on the allowlist
       _ <- samDao.overwriteGroupMembers(nihAllowlist.groupToSync, ManagedGroupRoles.Member, members.toList)(

--- a/src/test/resources/reference.conf
+++ b/src/test/resources/reference.conf
@@ -64,15 +64,21 @@ nih {
     "TARGET" {
       "fileName":"target-whitelist.txt",
       "rawlsGroup":"TARGET-dbGaP-Authorized",
-      "phsId":"phs002410",
+      "phsId":"phs002499",
       "consentGroup":"c1"
     },
     "TCGA" {
       "fileName":"tcga-whitelist.txt",
       "rawlsGroup":"TCGA-dbGaP-Authorized",
-      "phsId":"phs002409",
+      "phsId":"phs002555",
       "consentGroup":"c1"
     },
+    "RAS" {
+      "fileName":"dbgap_phs002409_c1_whitelist.txt",
+      "rawlsGroup":"dbgap_phs002409_c1",
+      "phsId":"phs002409",
+      "consentGroup":"c1"
+    }
     "BROKEN" {
       "fileName":"broken-whitelist.txt",
       "rawlsGroup":"this-doesnt-matter",

--- a/src/test/resources/reference.conf
+++ b/src/test/resources/reference.conf
@@ -63,15 +63,21 @@ nih {
   whitelists = {
     "TARGET" {
       "fileName":"target-whitelist.txt",
-      "rawlsGroup":"TARGET-dbGaP-Authorized"
+      "rawlsGroup":"TARGET-dbGaP-Authorized",
+      "phsId":"phs002410",
+      "consentGroup":"c1"
     },
     "TCGA" {
       "fileName":"tcga-whitelist.txt",
-      "rawlsGroup":"TCGA-dbGaP-Authorized"
+      "rawlsGroup":"TCGA-dbGaP-Authorized",
+      "phsId":"phs002409",
+      "consentGroup":"c1"
     },
     "BROKEN" {
       "fileName":"broken-whitelist.txt",
-      "rawlsGroup":"this-doesnt-matter"
+      "rawlsGroup":"this-doesnt-matter",
+      "phsId":"phs001234",
+      "consentGroup":"c2"
     }
   }
   rasIssuer = "https://stsstg.nih.gov"

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/NihServiceUnitSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/NihServiceUnitSpec.scala
@@ -76,8 +76,8 @@ class NihServiceUnitSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEa
   val userTcgaAndTarget = genSamUser();
   val userTcgaOnly = genSamUser();
   val userTargetOnly = genSamUser();
-  val userDbGapList = genSamUser();
-  val userDbGapGroup = genSamUser();
+  val userDbGap = genSamUser();
+  val dbGapGroupEmail = WorkbenchEmail(UUID.randomUUID().toString + "@email.com")
 
   // DateTimes must be modified in seconds instead of days to match implementation
   val secondsIn30Days = 30.days.toSeconds.toInt
@@ -90,26 +90,22 @@ class NihServiceUnitSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEa
     LinkedEraAccount(userTcgaOnly.id.value, "nihUsername3", new DateTime().plusSeconds(secondsIn30Days))
   var userTargetOnlyLinkedAccount =
     LinkedEraAccount(userTargetOnly.id.value, "nihUsername4", new DateTime().plusSeconds(secondsIn30Days))
-  var userDbGapListLinkedAccount =
-    LinkedEraAccount(userDbGapList.id.value, "nihUsername5", new DateTime().plusSeconds(secondsIn30Days))
-  var userDbGapGroupLinkedAccount =
-    LinkedEraAccount(userDbGapGroup.id.value, "nihUsername6", new DateTime().plusSeconds(secondsIn30Days))
+  var userDbGapLinkedAccount =
+    LinkedEraAccount(userDbGap.id.value, "nihUsername5", new DateTime().plusSeconds(secondsIn30Days))
 
   val samUsers = Seq(userNoLinkedAccount,
                      userNoAllowlists,
                      userTcgaAndTarget,
                      userTcgaOnly,
                      userTargetOnly,
-                     userDbGapList,
-                     userDbGapGroup
+                     userDbGap
   )
   val linkedAccounts = Seq(
     userNoAllowlistsLinkedAccount,
     userTcgaAndTargetLinkedAccount,
     userTcgaOnlyLinkedAccount,
     userTargetOnlyLinkedAccount,
-    userDbGapListLinkedAccount,
-    userDbGapGroupLinkedAccount
+    userDbGapLinkedAccount
   )
 
   val idToSamUser = samUsers.groupBy(_.id).view.mapValues(_.head).toMap
@@ -119,8 +115,7 @@ class NihServiceUnitSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEa
     userTcgaAndTarget.id -> userTcgaAndTargetLinkedAccount,
     userTcgaOnly.id -> userTcgaOnlyLinkedAccount,
     userTargetOnly.id -> userTargetOnlyLinkedAccount,
-    userDbGapList.id -> userDbGapListLinkedAccount,
-    userDbGapGroup.id -> userDbGapGroupLinkedAccount
+    userDbGap.id -> userDbGapLinkedAccount
   )
 
   val linkedAccountsByExternalId = Map(
@@ -128,8 +123,7 @@ class NihServiceUnitSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEa
     userTcgaAndTargetLinkedAccount.linkedExternalId -> userTcgaAndTargetLinkedAccount,
     userTcgaOnlyLinkedAccount.linkedExternalId -> userTcgaOnlyLinkedAccount,
     userTargetOnlyLinkedAccount.linkedExternalId -> userTargetOnlyLinkedAccount,
-    userDbGapListLinkedAccount.linkedExternalId -> userDbGapListLinkedAccount,
-    userDbGapGroupLinkedAccount.linkedExternalId -> userDbGapGroupLinkedAccount
+    userDbGapLinkedAccount.linkedExternalId -> userDbGapLinkedAccount
   )
 
   val samUserToGroups =
@@ -139,14 +133,14 @@ class NihServiceUnitSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEa
       userTcgaAndTarget.id -> Set("TCGA-dbGaP-Authorized", "TARGET-dbGaP-Authorized", "other-group"),
       userTcgaOnly.id -> Set("TCGA-dbGaP-Authorized", "other-group"),
       userTargetOnly.id -> Set("TARGET-dbGaP-Authorized", "other-group"),
-      userDbGapList.id -> Set("dbgap_phs002409_c1")
+      userDbGap.id -> Set("dbgap_phs002409_c1")
     )
 
   val samGroupMemberships =
     Map(
       "TCGA-dbGaP-Authorized" -> Set(userTcgaAndTarget.id, userTcgaOnly.id),
       "TARGET-dbGaP-Authorized" -> Set(userTcgaAndTarget.id, userTargetOnly.id),
-      "dbgap_phs002409_c1" -> Set(userDbGapList.id),
+      "dbgap_phs002409_c1" -> Set(userDbGap.id),
       "this-doesnt-matter" -> Set.empty
     )
 
@@ -157,7 +151,7 @@ class NihServiceUnitSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEa
       UUID.randomUUID().toString -> userTcgaAndTarget.id,
       UUID.randomUUID().toString -> userTcgaOnly.id,
       UUID.randomUUID().toString -> userTargetOnly.id,
-      UUID.randomUUID().toString -> userDbGapList.id
+      UUID.randomUUID().toString -> userDbGap.id
     )
 
   val userToAccessToken = accessTokenToUser.map(_.swap)
@@ -297,10 +291,10 @@ class NihServiceUnitSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEa
 
   it should "sync all users by including groups found with consentGroup + phsId" in {
     when(ecmDao.getActiveLinkedEraAccounts(ArgumentMatchers.eq(UserInfo(adminAccessToken, ""))))
-      .thenReturn(Future.successful(Seq(userDbGapListLinkedAccount)))
+      .thenReturn(Future.successful(Seq(userDbGapLinkedAccount)))
     when(thurloeDao.getAllUserValuesForKey(any[String])).thenReturn(Future.successful(Map.empty))
 
-    val emailsToSync = Set(userDbGapList.email, userDbGapGroup.email)
+    val emailsToSync = Set(userDbGap.email, dbGapGroupEmail)
     val nihStatus = Await
       .result(nihService.syncAllowlistAllUsers("RAS"), Duration.Inf)
       .asInstanceOf[PerRequest.RequestComplete[StatusCode]]
@@ -357,11 +351,6 @@ class NihServiceUnitSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEa
     )
     when(samDao.createGroup(any[WorkbenchGroupName])(ArgumentMatchers.eq(UserInfo(adminAccessToken, ""))))
       .thenReturn(Future.successful(()))
-    when(samDao.getGroupEmail(any())(any())).thenReturn(
-      Future.successful(
-        userDbGapList.email
-      )
-    )
 
     val ex = intercept[FireCloudException] {
       Await.result(nihService.syncAllowlistAllUsers("TARGET"), Duration.Inf)
@@ -372,11 +361,6 @@ class NihServiceUnitSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEa
   "syncAllNihWhitelistsAllUsers" should "sync all allowlists for all users" in {
     mockEcmUsers()
     when(thurloeDao.getAllUserValuesForKey(any[String])).thenReturn(Future.successful(Map.empty))
-    when(samDao.getGroupEmail(any())(any())).thenReturn(
-      Future.successful(
-        userDbGapList.email
-      )
-    )
 
     val targetEmailsToSync =
       Set(WorkbenchEmail(userTcgaAndTarget.email.value), WorkbenchEmail(userTargetOnly.email.value))
@@ -823,7 +807,7 @@ class NihServiceUnitSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEa
       }
     when(samDao.getGroupEmail(ArgumentMatchers.eq(WorkbenchGroupName("dbgap_phs002409_c1")))(any())).thenReturn(
       Future.successful(
-        userDbGapGroup.email
+        dbGapGroupEmail
       )
     )
 
@@ -890,7 +874,7 @@ class NihServiceUnitSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEa
           case "target-whitelist.txt" =>
             Seq(userTcgaAndTargetLinkedAccount.linkedExternalId, userTargetOnlyLinkedAccount.linkedExternalId)
           case "dbgap_phs002409_c1_whitelist.txt" =>
-            Seq(userDbGapListLinkedAccount.linkedExternalId)
+            Seq(userDbGapLinkedAccount.linkedExternalId)
           case "broken-whitelist.txt" => Seq.empty
         }
         new ByteArrayInputStream(nihUsernames.mkString("\n").getBytes(StandardCharsets.UTF_8))

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/NihServiceUnitSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/NihServiceUnitSpec.scala
@@ -76,7 +76,8 @@ class NihServiceUnitSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEa
   val userTcgaAndTarget = genSamUser();
   val userTcgaOnly = genSamUser();
   val userTargetOnly = genSamUser();
-  val userDbGap = genSamUser();
+  val userDbGapList = genSamUser();
+  val userDbGapGroup = genSamUser();
 
   // DateTimes must be modified in seconds instead of days to match implementation
   val secondsIn30Days = 30.days.toSeconds.toInt
@@ -89,12 +90,26 @@ class NihServiceUnitSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEa
     LinkedEraAccount(userTcgaOnly.id.value, "nihUsername3", new DateTime().plusSeconds(secondsIn30Days))
   var userTargetOnlyLinkedAccount =
     LinkedEraAccount(userTargetOnly.id.value, "nihUsername4", new DateTime().plusSeconds(secondsIn30Days))
+  var userDbGapListLinkedAccount =
+    LinkedEraAccount(userDbGapList.id.value, "nihUsername5", new DateTime().plusSeconds(secondsIn30Days))
+  var userDbGapGroupLinkedAccount =
+    LinkedEraAccount(userDbGapGroup.id.value, "nihUsername6", new DateTime().plusSeconds(secondsIn30Days))
 
-  val samUsers = Seq(userNoLinkedAccount, userNoAllowlists, userTcgaAndTarget, userTcgaOnly, userTargetOnly)
-  val linkedAccounts = Seq(userNoAllowlistsLinkedAccount,
-                           userTcgaAndTargetLinkedAccount,
-                           userTcgaOnlyLinkedAccount,
-                           userTargetOnlyLinkedAccount
+  val samUsers = Seq(userNoLinkedAccount,
+                     userNoAllowlists,
+                     userTcgaAndTarget,
+                     userTcgaOnly,
+                     userTargetOnly,
+                     userDbGapList,
+                     userDbGapGroup
+  )
+  val linkedAccounts = Seq(
+    userNoAllowlistsLinkedAccount,
+    userTcgaAndTargetLinkedAccount,
+    userTcgaOnlyLinkedAccount,
+    userTargetOnlyLinkedAccount,
+    userDbGapListLinkedAccount,
+    userDbGapGroupLinkedAccount
   )
 
   val idToSamUser = samUsers.groupBy(_.id).view.mapValues(_.head).toMap
@@ -103,14 +118,18 @@ class NihServiceUnitSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEa
     userNoAllowlists.id -> userNoAllowlistsLinkedAccount,
     userTcgaAndTarget.id -> userTcgaAndTargetLinkedAccount,
     userTcgaOnly.id -> userTcgaOnlyLinkedAccount,
-    userTargetOnly.id -> userTargetOnlyLinkedAccount
+    userTargetOnly.id -> userTargetOnlyLinkedAccount,
+    userDbGapList.id -> userDbGapListLinkedAccount,
+    userDbGapGroup.id -> userDbGapGroupLinkedAccount
   )
 
   val linkedAccountsByExternalId = Map(
     userNoAllowlistsLinkedAccount.linkedExternalId -> userNoAllowlistsLinkedAccount,
     userTcgaAndTargetLinkedAccount.linkedExternalId -> userTcgaAndTargetLinkedAccount,
     userTcgaOnlyLinkedAccount.linkedExternalId -> userTcgaOnlyLinkedAccount,
-    userTargetOnlyLinkedAccount.linkedExternalId -> userTargetOnlyLinkedAccount
+    userTargetOnlyLinkedAccount.linkedExternalId -> userTargetOnlyLinkedAccount,
+    userDbGapListLinkedAccount.linkedExternalId -> userDbGapListLinkedAccount,
+    userDbGapGroupLinkedAccount.linkedExternalId -> userDbGapGroupLinkedAccount
   )
 
   val samUserToGroups =
@@ -119,13 +138,15 @@ class NihServiceUnitSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEa
       userNoAllowlists.id -> Set("other-group"),
       userTcgaAndTarget.id -> Set("TCGA-dbGaP-Authorized", "TARGET-dbGaP-Authorized", "other-group"),
       userTcgaOnly.id -> Set("TCGA-dbGaP-Authorized", "other-group"),
-      userTargetOnly.id -> Set("TARGET-dbGaP-Authorized", "other-group")
+      userTargetOnly.id -> Set("TARGET-dbGaP-Authorized", "other-group"),
+      userDbGapList.id -> Set("dbgap_phs002409_c1")
     )
 
   val samGroupMemberships =
     Map(
       "TCGA-dbGaP-Authorized" -> Set(userTcgaAndTarget.id, userTcgaOnly.id),
       "TARGET-dbGaP-Authorized" -> Set(userTcgaAndTarget.id, userTargetOnly.id),
+      "dbgap_phs002409_c1" -> Set(userDbGapList.id),
       "this-doesnt-matter" -> Set.empty
     )
 
@@ -135,7 +156,8 @@ class NihServiceUnitSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEa
       UUID.randomUUID().toString -> userNoAllowlists.id,
       UUID.randomUUID().toString -> userTcgaAndTarget.id,
       UUID.randomUUID().toString -> userTcgaOnly.id,
-      UUID.randomUUID().toString -> userTargetOnly.id
+      UUID.randomUUID().toString -> userTargetOnly.id,
+      UUID.randomUUID().toString -> userDbGapList.id
     )
 
   val userToAccessToken = accessTokenToUser.map(_.swap)
@@ -207,7 +229,7 @@ class NihServiceUnitSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEa
   }
 
   private def verifyTargetGroupSynced(): Unit = {
-    val emailsToSync = Set(WorkbenchEmail(userTcgaAndTarget.email.value), WorkbenchEmail(userTargetOnly.email.value))
+    val emailsToSync = Set(userTcgaAndTarget.email, userTargetOnly.email)
     val nihStatus = Await
       .result(nihService.syncAllowlistAllUsers("TARGET"), Duration.Inf)
       .asInstanceOf[PerRequest.RequestComplete[StatusCode]]
@@ -229,7 +251,7 @@ class NihServiceUnitSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEa
     )(ArgumentMatchers.eq(UserInfo(adminAccessToken, "")))
   }
 
-  "syncWhitelistAllUsers" should "sync all users for a single allowlist from ECM" in {
+  "syncAllowlistAllUsers" should "sync all users for a single allowlist from ECM" in {
     mockEcmUsers()
     when(thurloeDao.getAllUserValuesForKey(any[String])).thenReturn(Future.successful(Map.empty))
 
@@ -273,43 +295,23 @@ class NihServiceUnitSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEa
     verifyTargetGroupSynced()
   }
 
-  it should "sync all users by combining dbGap group members with ECM and Thurloe" in {
+  it should "sync all users by including groups found with consentGroup + phsId" in {
     when(ecmDao.getActiveLinkedEraAccounts(ArgumentMatchers.eq(UserInfo(adminAccessToken, ""))))
-      .thenReturn(Future.successful(Seq(userTargetOnlyLinkedAccount)))
-    when(thurloeDao.getAllUserValuesForKey(ArgumentMatchers.eq("linkedNihUsername")))
-      .thenReturn(
-        Future.successful(
-          linkedAccountsBySamUserId
-            .removed(WorkbenchUserId(userTargetOnlyLinkedAccount.userId))
-            .map(tup => (tup._1.value, tup._2.linkedExternalId))
-        )
-      )
-    when(thurloeDao.getAllUserValuesForKey(ArgumentMatchers.eq("linkExpireTime")))
-      .thenReturn(
-        Future.successful(
-          linkedAccountsBySamUserId
-            .removed(WorkbenchUserId(userTargetOnlyLinkedAccount.userId))
-            .map(tup => (tup._1.value, (tup._2.linkExpireTime.getMillis / 1000L).toString))
-        )
-      )
-    when(samDao.getGroupEmail(any())(any())).thenReturn(
-      Future.successful(
-        userDbGap.email
-      )
-    )
+      .thenReturn(Future.successful(Seq(userDbGapListLinkedAccount)))
+    when(thurloeDao.getAllUserValuesForKey(any[String])).thenReturn(Future.successful(Map.empty))
 
-    val emailsToSync = Set(userTcgaAndTarget.email, userTargetOnly.email, userDbGap.email)
+    val emailsToSync = Set(userDbGapList.email, userDbGapGroup.email)
     val nihStatus = Await
-      .result(nihService.syncAllowlistAllUsers("TARGET"), Duration.Inf)
+      .result(nihService.syncAllowlistAllUsers("RAS"), Duration.Inf)
       .asInstanceOf[PerRequest.RequestComplete[StatusCode]]
       .response
 
     nihStatus should be(StatusCodes.NoContent)
     verify(googleDao, never()).getBucketObjectAsInputStream(FireCloudConfig.Nih.whitelistBucket, "tcga-whitelist.txt")
     verify(googleDao, times(1))
-      .getBucketObjectAsInputStream(FireCloudConfig.Nih.whitelistBucket, "target-whitelist.txt")
+      .getBucketObjectAsInputStream(FireCloudConfig.Nih.whitelistBucket, "dbgap_phs002409_c1_whitelist.txt")
     verify(samDao, times(1)).overwriteGroupMembers(
-      ArgumentMatchers.eq(WorkbenchGroupName("TARGET-dbGaP-Authorized")),
+      ArgumentMatchers.eq(WorkbenchGroupName("dbgap_phs002409_c1")),
       ArgumentMatchers.eq(ManagedGroupRoles.Member),
       ArgumentMatchers.argThat((list: List[WorkbenchEmail]) => list.toSet.equals(emailsToSync))
     )(ArgumentMatchers.eq(UserInfo(adminAccessToken, "")))
@@ -319,7 +321,6 @@ class NihServiceUnitSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEa
       ArgumentMatchers.argThat((list: List[WorkbenchEmail]) => list.toSet.equals(emailsToSync))
     )(ArgumentMatchers.eq(UserInfo(adminAccessToken, "")))
   }
-
 
   it should "respond with NOT FOUND if no allowlist is found" in {
     val nihStatus = Await
@@ -356,6 +357,11 @@ class NihServiceUnitSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEa
     )
     when(samDao.createGroup(any[WorkbenchGroupName])(ArgumentMatchers.eq(UserInfo(adminAccessToken, ""))))
       .thenReturn(Future.successful(()))
+    when(samDao.getGroupEmail(any())(any())).thenReturn(
+      Future.successful(
+        userDbGapList.email
+      )
+    )
 
     val ex = intercept[FireCloudException] {
       Await.result(nihService.syncAllowlistAllUsers("TARGET"), Duration.Inf)
@@ -366,6 +372,11 @@ class NihServiceUnitSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEa
   "syncAllNihWhitelistsAllUsers" should "sync all allowlists for all users" in {
     mockEcmUsers()
     when(thurloeDao.getAllUserValuesForKey(any[String])).thenReturn(Future.successful(Map.empty))
+    when(samDao.getGroupEmail(any())(any())).thenReturn(
+      Future.successful(
+        userDbGapList.email
+      )
+    )
 
     val targetEmailsToSync =
       Set(WorkbenchEmail(userTcgaAndTarget.email.value), WorkbenchEmail(userTargetOnly.email.value))
@@ -412,9 +423,11 @@ class NihServiceUnitSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEa
     nihStatus.linkedNihUsername should be(Some(linkedAccount.linkedExternalId))
     nihStatus.linkExpireTime should be(Some(linkedAccount.linkExpireTime.getMillis / 1000L))
     nihStatus.datasetPermissions should be(
-      Set(NihDatasetPermission("BROKEN", authorized = false),
-          NihDatasetPermission("TARGET", authorized = false),
-          NihDatasetPermission("TCGA", authorized = true)
+      Set(
+        NihDatasetPermission("BROKEN", authorized = false),
+        NihDatasetPermission("TARGET", authorized = false),
+        NihDatasetPermission("TCGA", authorized = true),
+        NihDatasetPermission("RAS", authorized = false)
       )
     )
 
@@ -808,6 +821,11 @@ class NihServiceUnitSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEa
             .map(user => WorkbenchUserInfo(user.id.value, user.email.value))
         )
       }
+    when(samDao.getGroupEmail(ArgumentMatchers.eq(WorkbenchGroupName("dbgap_phs002409_c1")))(any())).thenReturn(
+      Future.successful(
+        userDbGapGroup.email
+      )
+    )
 
   }
 
@@ -871,6 +889,8 @@ class NihServiceUnitSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEa
             Seq(userTcgaAndTargetLinkedAccount.linkedExternalId, userTcgaOnlyLinkedAccount.linkedExternalId)
           case "target-whitelist.txt" =>
             Seq(userTcgaAndTargetLinkedAccount.linkedExternalId, userTargetOnlyLinkedAccount.linkedExternalId)
+          case "dbgap_phs002409_c1_whitelist.txt" =>
+            Seq(userDbGapListLinkedAccount.linkedExternalId)
           case "broken-whitelist.txt" => Seq.empty
         }
         new ByteArrayInputStream(nihUsernames.mkString("\n").getBytes(StandardCharsets.UTF_8))

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/NihServiceUnitSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/NihServiceUnitSpec.scala
@@ -301,16 +301,8 @@ class NihServiceUnitSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEa
       .response
 
     nihStatus should be(StatusCodes.NoContent)
-    verify(googleDao, never()).getBucketObjectAsInputStream(FireCloudConfig.Nih.whitelistBucket, "tcga-whitelist.txt")
-    verify(googleDao, times(1))
-      .getBucketObjectAsInputStream(FireCloudConfig.Nih.whitelistBucket, "dbgap_phs002409_c1_whitelist.txt")
     verify(samDao, times(1)).overwriteGroupMembers(
       ArgumentMatchers.eq(WorkbenchGroupName("dbgap_phs002409_c1")),
-      ArgumentMatchers.eq(ManagedGroupRoles.Member),
-      ArgumentMatchers.argThat((list: List[WorkbenchEmail]) => list.toSet.equals(emailsToSync))
-    )(ArgumentMatchers.eq(UserInfo(adminAccessToken, "")))
-    verify(samDao, never()).overwriteGroupMembers(
-      ArgumentMatchers.eq(WorkbenchGroupName("other-group")),
       ArgumentMatchers.eq(ManagedGroupRoles.Member),
       ArgumentMatchers.argThat((list: List[WorkbenchEmail]) => list.toSet.equals(emailsToSync))
     )(ArgumentMatchers.eq(UserInfo(adminAccessToken, "")))

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/NihServiceUnitSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/NihServiceUnitSpec.scala
@@ -76,6 +76,7 @@ class NihServiceUnitSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEa
   val userTcgaAndTarget = genSamUser();
   val userTcgaOnly = genSamUser();
   val userTargetOnly = genSamUser();
+  val userDbGap = genSamUser();
 
   // DateTimes must be modified in seconds instead of days to match implementation
   val secondsIn30Days = 30.days.toSeconds.toInt
@@ -271,6 +272,54 @@ class NihServiceUnitSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEa
 
     verifyTargetGroupSynced()
   }
+
+  it should "sync all users by combining dbGap group members with ECM and Thurloe" in {
+    when(ecmDao.getActiveLinkedEraAccounts(ArgumentMatchers.eq(UserInfo(adminAccessToken, ""))))
+      .thenReturn(Future.successful(Seq(userTargetOnlyLinkedAccount)))
+    when(thurloeDao.getAllUserValuesForKey(ArgumentMatchers.eq("linkedNihUsername")))
+      .thenReturn(
+        Future.successful(
+          linkedAccountsBySamUserId
+            .removed(WorkbenchUserId(userTargetOnlyLinkedAccount.userId))
+            .map(tup => (tup._1.value, tup._2.linkedExternalId))
+        )
+      )
+    when(thurloeDao.getAllUserValuesForKey(ArgumentMatchers.eq("linkExpireTime")))
+      .thenReturn(
+        Future.successful(
+          linkedAccountsBySamUserId
+            .removed(WorkbenchUserId(userTargetOnlyLinkedAccount.userId))
+            .map(tup => (tup._1.value, (tup._2.linkExpireTime.getMillis / 1000L).toString))
+        )
+      )
+    when(samDao.getGroupEmail(any())(any())).thenReturn(
+      Future.successful(
+        userDbGap.email
+      )
+    )
+
+    val emailsToSync = Set(userTcgaAndTarget.email, userTargetOnly.email, userDbGap.email)
+    val nihStatus = Await
+      .result(nihService.syncAllowlistAllUsers("TARGET"), Duration.Inf)
+      .asInstanceOf[PerRequest.RequestComplete[StatusCode]]
+      .response
+
+    nihStatus should be(StatusCodes.NoContent)
+    verify(googleDao, never()).getBucketObjectAsInputStream(FireCloudConfig.Nih.whitelistBucket, "tcga-whitelist.txt")
+    verify(googleDao, times(1))
+      .getBucketObjectAsInputStream(FireCloudConfig.Nih.whitelistBucket, "target-whitelist.txt")
+    verify(samDao, times(1)).overwriteGroupMembers(
+      ArgumentMatchers.eq(WorkbenchGroupName("TARGET-dbGaP-Authorized")),
+      ArgumentMatchers.eq(ManagedGroupRoles.Member),
+      ArgumentMatchers.argThat((list: List[WorkbenchEmail]) => list.toSet.equals(emailsToSync))
+    )(ArgumentMatchers.eq(UserInfo(adminAccessToken, "")))
+    verify(samDao, never()).overwriteGroupMembers(
+      ArgumentMatchers.eq(WorkbenchGroupName("other-group")),
+      ArgumentMatchers.eq(ManagedGroupRoles.Member),
+      ArgumentMatchers.argThat((list: List[WorkbenchEmail]) => list.toSet.equals(emailsToSync))
+    )(ArgumentMatchers.eq(UserInfo(adminAccessToken, "")))
+  }
+
 
   it should "respond with NOT FOUND if no allowlist is found" in {
     val nihStatus = Await

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/NihServiceUnitSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/NihServiceUnitSpec.scala
@@ -93,13 +93,7 @@ class NihServiceUnitSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEa
   var userDbGapLinkedAccount =
     LinkedEraAccount(userDbGap.id.value, "nihUsername5", new DateTime().plusSeconds(secondsIn30Days))
 
-  val samUsers = Seq(userNoLinkedAccount,
-                     userNoAllowlists,
-                     userTcgaAndTarget,
-                     userTcgaOnly,
-                     userTargetOnly,
-                     userDbGap
-  )
+  val samUsers = Seq(userNoLinkedAccount, userNoAllowlists, userTcgaAndTarget, userTcgaOnly, userTargetOnly, userDbGap)
   val linkedAccounts = Seq(
     userNoAllowlistsLinkedAccount,
     userTcgaAndTargetLinkedAccount,


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/CORE-253

Relies on https://github.com/broadinstitute/terra-helmfile/pull/6021 .  (Tests are failing until that PR is merged) Now all items in an nih whitelist are required to have 4 elements: `fileName` and `rawlsGroup` as before, but additionally `phsId` and `consentGroup`.  When syncing whitelist users, orch will now look up the group associated with `phsId` and `consentGroup` and add the results in along with any users from the allowlist file.  

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge. Make sure your branch deletes; GitHub should do this for you.
- [ ] Test this change deployed correctly and works on dev environment after deployment
