### PR TITLE
CORE-308 configurable and sane concurrent sam connections

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -111,4 +111,8 @@ firecloud {
 sam {
   groupResourceType = "managed-group"
   groupMemberPolicy = "member"
+  # at the time of writing each orch instance handles 15 rps max, let them make concurrent sam requests
+  # this is probably overkill because 15 rps is not the same as 15 concurrent requests
+  # orch's average latency is 226ms, so probabaly 4 concurrent requests is what orch handles and only a fraction of those are sam's part
+  maxConcurrentRequests = 15
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
@@ -110,6 +110,7 @@ object FireCloudConfig {
 
     val groupResourceType = sam.getString("groupResourceType")
     val groupMemberPolicy = sam.getString("groupMemberPolicy")
+    val maxConcurrentRequests = sam.getInt("maxConcurrentRequests")
   }
 
   object CromIAM {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpSamDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpSamDAO.scala
@@ -59,8 +59,8 @@ class HttpSamDAO(implicit
 
   val timeout: FiniteDuration = 1.minute
   private val dispatcher = new Dispatcher()
-  dispatcher.setMaxRequests(1000)
-  dispatcher.setMaxRequestsPerHost(100)
+  dispatcher.setMaxRequests(FireCloudConfig.Sam.maxConcurrentRequests)
+  dispatcher.setMaxRequestsPerHost(FireCloudConfig.Sam.maxConcurrentRequests)
   private val httpClient = new ApiClient().getHttpClient.newBuilder().dispatcher(dispatcher).build()
 
   override def listWorkspaceResources(implicit userInfo: WithAccessToken): Future[Seq[UserPolicy]] =


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/CORE-308

make sam concurrent connections configurable and more reasonable

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge. Make sure your branch deletes; GitHub should do this for you.
- [ ] Test this change deployed correctly and works on dev environment after deployment
