### PR TITLE
[CORE-340] Update rawls-model from v0.0.299-SNAP to v0.0.314-SNAP

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -48,7 +48,7 @@ object Dependencies {
     "com.typesafe.scala-logging"    %% "scala-logging"       % "3.9.5",
 
     "org.parboiled" % "parboiled-core" % "1.4.1",
-    excludeGuava("org.broadinstitute.dsde"       %% "rawls-model"         % "v0.0.299-SNAP")
+    excludeGuava("org.broadinstitute.dsde"       %% "rawls-model"         % "v0.0.314-SNAP")
       exclude("com.typesafe.scala-logging", "scala-logging_2.13")
       exclude("com.typesafe.akka", "akka-stream_2.13")
       exclude("com.google.code.findbugs", "jsr305")

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -8274,11 +8274,16 @@ components:
           description: Method configuration source name
     RawlsBillingProjectResponse:
       required:
+        - id
         - projectName
         - invalidBillingAccount
         - roles
       type: object
       properties:
+        id:
+          type: string
+          format: uuid
+          description: the uuid of the project
         projectName:
           type: string
           description: the name of the project


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/CORE-340

Updates org.broadinstitute.dsde:rawls-model from `v0.0.299-SNAP` to `v0.0.314-SNAP`

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [x] Get two thumbsworth of review and PO signoff if necessary
- [x] Verify all tests go green
- [x] Squash and merge. Make sure your branch deletes; GitHub should do this for you.
- [x] Test this change deployed correctly and works on dev environment after deployment
