### PR TITLE
[CORE-315] Expand DataTable Autogeneration to Support ONT Sequencing Patterns

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/filematch/FileMatcher.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/filematch/FileMatcher.scala
@@ -2,7 +2,11 @@ package org.broadinstitute.dsde.firecloud.filematch
 
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.firecloud.filematch.result.{FailedMatchResult, FileMatchResult, SuccessfulMatchResult}
-import org.broadinstitute.dsde.firecloud.filematch.strategy.{FileRecognitionStrategy, IlluminaPairedEndStrategy}
+import org.broadinstitute.dsde.firecloud.filematch.strategy.{
+  FileRecognitionStrategy,
+  IlluminaPairedEndStrategy,
+  OntSingleReadStrategy
+}
 
 import java.nio.file.Path
 
@@ -16,7 +20,8 @@ import java.nio.file.Path
 class FileMatcher extends LazyLogging {
 
   // the list of recognition strategies to use
-  private val matchingStrategies: List[FileRecognitionStrategy] = List(new IlluminaPairedEndStrategy())
+  private val matchingStrategies: List[FileRecognitionStrategy] =
+    List(new IlluminaPairedEndStrategy(), new OntSingleReadStrategy())
 
   /**
     * Given a list of files, pair up those files according to our known recognition strategies.

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/filematch/FileMatcher.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/filematch/FileMatcher.scala
@@ -1,7 +1,12 @@
 package org.broadinstitute.dsde.firecloud.filematch
 
 import com.typesafe.scalalogging.LazyLogging
-import org.broadinstitute.dsde.firecloud.filematch.result.{FailedMatchResult, FileMatchResult, SuccessfulMatchResult}
+import org.broadinstitute.dsde.firecloud.filematch.result.{
+  FailedMatchResult,
+  FileMatchResult,
+  PartialMatchResult,
+  SuccessfulMatchResult
+}
 import org.broadinstitute.dsde.firecloud.filematch.strategy.{
   FileRecognitionStrategy,
   IlluminaPairedEndStrategy,
@@ -53,25 +58,32 @@ class FileMatcher extends LazyLogging {
     */
   private def performPairing(pathList: List[Path]): List[FileMatchResult] = {
     // find every path in the incoming pathList that is recognized by one of our known patterns
-    val desiredPairings: List[SuccessfulMatchResult] = findFirstFiles(pathList)
+    val (successfulMatches, partialMatches) = findFirstFiles(pathList).partition {
+      case _: SuccessfulMatchResult => true
+      case _: PartialMatchResult    => false
+    }
 
-    // remove the recognized firstFiles from the outstanding pathList
-    val remainingPaths: List[Path] = pathList diff desiredPairings.map(_.firstFile)
+    // remove the recognized firstFiles and partialMatches from the outstanding pathList
+    val remainingPaths: List[Path] = pathList.diff(
+      successfulMatches.collect { case s: SuccessfulMatchResult => s.firstFile } ++
+        partialMatches.collect { case p: PartialMatchResult => p.firstFile }
+    )
 
     // process the recognized "read 1" files, and look for their desired pairings in the outstanding pathList.
     // this will result in either SuccessfulMatchResult when the desired pairing is found, or PartialMatchResult
     // when the desired pairing is not found
-    val pairingResults: List[FileMatchResult] = findSecondFiles(remainingPaths, desiredPairings)
+    val pairingResults: List[FileMatchResult] =
+      findSecondFiles(remainingPaths, successfulMatches.collect { case s: SuccessfulMatchResult => s })
 
     // remove the recognized "read 2" files from the outstanding pathList
     val unrecognizedPaths: List[Path] = remainingPaths diff pairingResults.collect { case s: SuccessfulMatchResult =>
       s.secondFile
     }
     // translate the unrecognized paths into a FileMatchResult
-    val unrecognizedResults: List[FailedMatchResult] = unrecognizedPaths.map(path => FailedMatchResult(path))
+    val unrecognizedResults: List[FailedMatchResult] = unrecognizedPaths.map(FailedMatchResult(_))
 
     // return results, sorted by firstFile
-    (pairingResults ++ unrecognizedResults).sortBy(r => r.firstFile)
+    (pairingResults ++ partialMatches ++ unrecognizedResults).sortBy(_.firstFile)
   }
 
   /**
@@ -79,10 +91,11 @@ class FileMatcher extends LazyLogging {
     * @param pathList the list of files to inspect
     * @return pairing results
     */
-  private def findFirstFiles(pathList: List[Path]): List[SuccessfulMatchResult] =
+  private def findFirstFiles(pathList: List[Path]): List[FileMatchResult] =
     pathList.collect { path =>
       tryPairingStrategies(path) match {
         case success: SuccessfulMatchResult => success
+        case partial: PartialMatchResult    => partial
       }
     }
 
@@ -116,11 +129,12 @@ class FileMatcher extends LazyLogging {
     val strategyHit = matchingStrategies.collectFirst(strategy =>
       strategy.matchFirstFile(file) match {
         case success: SuccessfulMatchResult => success
+        case partial: PartialMatchResult    => partial
       }
     )
     strategyHit match {
       // The current file is recognized by one of our recognition strategies
-      case Some(desiredResult: SuccessfulMatchResult) => desiredResult
+      case Some(desiredResult: FileMatchResult) => desiredResult
       // the current file is not recognized
       case _ => FailedMatchResult(file)
     }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/filematch/FileMatcher.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/filematch/FileMatcher.scala
@@ -69,8 +69,7 @@ class FileMatcher extends LazyLogging {
     // process the recognized "read 1" files, and look for their desired pairings in the outstanding pathList.
     // this will result in either SuccessfulMatchResult when the desired pairing is found, or PartialMatchResult
     // when the desired pairing is not found
-    val pairingResults: List[FileMatchResult] =
-      findSecondFiles(remainingPaths, successfulMatches.collect { case s: SuccessfulMatchResult => s })
+    val pairingResults: List[FileMatchResult] = findSecondFiles(remainingPaths, successfulMatches)
 
     // remove the recognized "read 2" files from the outstanding pathList
     val unrecognizedPaths: List[Path] = remainingPaths diff pairingResults.collect { case s: SuccessfulMatchResult =>

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/filematch/FileMatcher.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/filematch/FileMatcher.scala
@@ -58,16 +58,13 @@ class FileMatcher extends LazyLogging {
     */
   private def performPairing(pathList: List[Path]): List[FileMatchResult] = {
     // find every path in the incoming pathList that is recognized by one of our known patterns
-    val (successfulMatches, partialMatches) = findFirstFiles(pathList).partition {
-      case _: SuccessfulMatchResult => true
-      case _: PartialMatchResult    => false
-    }
+    val matches = findFirstFiles(pathList)
+    val successfulMatches: List[SuccessfulMatchResult] = matches.collect { case x: SuccessfulMatchResult => x }
+    val partialMatches: List[PartialMatchResult] = matches.collect { case x: PartialMatchResult => x }
 
     // remove the recognized firstFiles and partialMatches from the outstanding pathList
-    val remainingPaths: List[Path] = pathList.diff(
-      successfulMatches.collect { case s: SuccessfulMatchResult => s.firstFile } ++
-        partialMatches.collect { case p: PartialMatchResult => p.firstFile }
-    )
+    val remainingPaths: List[Path] =
+      pathList.diff(successfulMatches.map(_.firstFile) ++ partialMatches.map(_.firstFile))
 
     // process the recognized "read 1" files, and look for their desired pairings in the outstanding pathList.
     // this will result in either SuccessfulMatchResult when the desired pairing is found, or PartialMatchResult

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/filematch/result/SuccessfulMatchResult.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/filematch/result/SuccessfulMatchResult.scala
@@ -16,4 +16,7 @@ case class SuccessfulMatchResult(firstFile: Path, secondFile: Path, id: String) 
 object SuccessfulMatchResult {
   def fromStrings(firstFile: String, secondFile: String, id: String): SuccessfulMatchResult =
     SuccessfulMatchResult(new java.io.File(firstFile).toPath, new java.io.File(secondFile).toPath, id)
+
+  def apply(firstFile: Path, id: String): SuccessfulMatchResult =
+    SuccessfulMatchResult(firstFile, null, id)
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/filematch/result/SuccessfulMatchResult.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/filematch/result/SuccessfulMatchResult.scala
@@ -16,7 +16,4 @@ case class SuccessfulMatchResult(firstFile: Path, secondFile: Path, id: String) 
 object SuccessfulMatchResult {
   def fromStrings(firstFile: String, secondFile: String, id: String): SuccessfulMatchResult =
     SuccessfulMatchResult(new java.io.File(firstFile).toPath, new java.io.File(secondFile).toPath, id)
-
-  def apply(firstFile: Path, id: String): SuccessfulMatchResult =
-    SuccessfulMatchResult(firstFile, null, id)
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/filematch/strategy/OntSingleReadStrategy.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/filematch/strategy/OntSingleReadStrategy.scala
@@ -1,44 +1,21 @@
 package org.broadinstitute.dsde.firecloud.filematch.strategy
 
 import org.broadinstitute.dsde.firecloud.filematch.result.{FailedMatchResult, FileMatchResult, SuccessfulMatchResult}
-import OntSingleReadStrategy.FILE_CONTAIN_ENDINGS
+import OntSingleReadStrategy.PATTERN
 
 import java.nio.file.{Path, Paths}
 import scala.util.matching.Regex
 
 class OntSingleReadStrategy extends FileRecognitionStrategy {
 
-  // Precompile regex patterns: (?i).*barcode\d+.*(\.fastq|\.fastq\.gz)$
-  private val compiledPatterns: Map[String, Regex] = FILE_CONTAIN_ENDINGS.map { case (key, values) =>
-    key -> new Regex(s"(?i).*${Regex.quote(key)}\\d+.*(${values.map(Regex.quote).mkString("|")})$$")
-  }
-
-  override def matchFirstFile(path: Path): FileMatchResult = {
-    val fileName = path.getFileName.toString
-
-    // Use precompiled regex patterns to match the file name
-    val foundMatch = compiledPatterns.find { case (_, regex) =>
-      regex.findFirstIn(fileName).isDefined
+  override def matchFirstFile(path: Path): FileMatchResult =
+    PATTERN.findFirstMatchIn(path.toString) match {
+      case Some(regexMatch) => SuccessfulMatchResult(path, Paths.get(""), regexMatch.group(1))
+      case None             => FailedMatchResult(path)
     }
-
-    foundMatch match {
-      // we found a "read1"
-      case Some((key, _)) =>
-        // Extract the matching value directly from the regex match
-        val value = FILE_CONTAIN_ENDINGS(key).find(value => fileName.endsWith(value)).get
-        // generate the id: strip the value and any characters before the extension from the filename.
-        val id = fileName.stripSuffix(value).replaceAll("\\..*$", "")
-        SuccessfulMatchResult(path, Paths.get(""), id)
-
-      // the file is not recognized
-      case None => FailedMatchResult(path)
-    }
-  }
 }
 
 object OntSingleReadStrategy {
-  // if the file contains ${key} and ends with any value in the list, it's an ONT single read file
-  val FILE_CONTAIN_ENDINGS: Map[String, List[String]] = Map(
-    "barcode" -> List(".fastq", ".fastq.gz")
-  )
+  // if the file contains barcode### and ends with .fastq or .fastq.gz, it's an ONT single read file
+  val PATTERN: Regex = "(?i)(.*barcode\\d+).*\\.fastq(?:.gz)*$".r
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/filematch/strategy/OntSingleReadStrategy.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/filematch/strategy/OntSingleReadStrategy.scala
@@ -17,5 +17,5 @@ class OntSingleReadStrategy extends FileRecognitionStrategy {
 
 object OntSingleReadStrategy {
   // if the file contains barcode### and ends with .fastq or .fastq.gz, it's an ONT single read file
-  val PATTERN: Regex = "(?i)(.*barcode\\d+).*\\.fastq(?:.gz)*$".r
+  val PATTERN: Regex = """(?i)(.*barcode\d+).*\.fastq(?:.gz)?$""".r
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/filematch/strategy/OntSingleReadStrategy.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/filematch/strategy/OntSingleReadStrategy.scala
@@ -8,20 +8,24 @@ import scala.util.matching.Regex
 
 class OntSingleReadStrategy extends FileRecognitionStrategy {
 
+  // Precompile regex patterns: (?i).*barcode\d+.*(\.clean\.fastq|\.clean\.fastq\.gz|\.fastq|\.fastq\.gz)$
+  private val compiledPatterns: Map[String, Regex] = FILE_CONTAIN_ENDINGS.map { case (key, values) =>
+    key -> new Regex(s"(?i).*${Regex.quote(key)}\\d+.*(${values.map(Regex.quote).mkString("|")})$$")
+  }
+
   override def matchFirstFile(path: Path): FileMatchResult = {
     val fileName = path.getFileName.toString
 
-    // Used regex to match the file name containing the key and ending with any of the specified values
-    val foundMatch = FILE_CONTAIN_ENDINGS.find { case (key, values) =>
-      val regex = new Regex(s".*${Regex.quote(key)}.*(${values.map(Regex.quote).mkString("|")})$$")
+    // Use precompiled regex patterns to match the file name
+    val foundMatch = compiledPatterns.find { case (_, regex) =>
       regex.findFirstIn(fileName).isDefined
     }
 
     foundMatch match {
       // we found a "read1"
-      case Some((_, values)) =>
-        // find the matching value
-        val value = values.find(value => fileName.endsWith(value)).get
+      case Some((key, regex)) =>
+        // Extract the matching value directly from the regex match
+        val value = FILE_CONTAIN_ENDINGS(key).find(value => fileName.endsWith(value)).get
         // generate the id: strip the value from the filename.
         val id = fileName.replace(value, "")
         SuccessfulMatchResult(path, Paths.get(""), id)
@@ -33,9 +37,8 @@ class OntSingleReadStrategy extends FileRecognitionStrategy {
 }
 
 object OntSingleReadStrategy {
-  // if the first file contains ${key} and ends with any of the values in the list, then this is a single read file
+  // if the file contains ${key} and ends with any value in the list, it's an ONT single read file
   val FILE_CONTAIN_ENDINGS: Map[String, List[String]] = Map(
-    "Complete_barcode" -> List(".clean.fastq"),
-    "barcode" -> List(".fastq", ".fastq.gz")
+    "barcode" -> List(".clean.fastq", ".clean.fastq.gz", ".fastq", ".fastq.gz")
   )
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/filematch/strategy/OntSingleReadStrategy.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/filematch/strategy/OntSingleReadStrategy.scala
@@ -1,0 +1,41 @@
+package org.broadinstitute.dsde.firecloud.filematch.strategy
+
+import org.broadinstitute.dsde.firecloud.filematch.result.{FailedMatchResult, FileMatchResult, SuccessfulMatchResult}
+import OntSingleReadStrategy.{fastqGz, FILE_STARTS_ENDINGS}
+
+import java.nio.file.{Path, Paths}
+
+class OntSingleReadStrategy extends FileRecognitionStrategy {
+
+  override def matchFirstFile(path: Path): FileMatchResult = {
+    // search known patterns for a "read1" file
+    val foundMatch = FILE_STARTS_ENDINGS.find { case (key, values) =>
+      path.getFileName.toString.startsWith(key) && values.exists(value => path.toString.endsWith(value))
+    }
+
+    foundMatch match {
+      // we found a "read1"
+      case Some((_, values)) =>
+        // find the matching value
+        val value = values.find(value => path.toString.endsWith(value)).get
+        // generate the id: strip the suffix from the filename.
+        val id = path.getFileName.toString.replace(value, "")
+
+        SuccessfulMatchResult(path, Paths.get(""), id)
+
+      // the file is not recognized
+      case None => FailedMatchResult(path)
+    }
+  }
+}
+
+object OntSingleReadStrategy {
+  private val fastqGz = ".fastq.gz"
+  // if the first file starts with ${key} and ends with any of the values in the list, then this is a single read file
+  val FILE_STARTS_ENDINGS: Map[String, List[String]] = Map(
+    "Complete_barcode" -> List(fastqGz, ".clean.fastq"),
+    "Incomplete_barcode" -> List(fastqGz),
+    "Repeat_barcode" -> List(fastqGz),
+    "barcode" -> List(fastqGz)
+  )
+}

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/filematch/strategy/OntSingleReadStrategy.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/filematch/strategy/OntSingleReadStrategy.scala
@@ -1,26 +1,29 @@
 package org.broadinstitute.dsde.firecloud.filematch.strategy
 
 import org.broadinstitute.dsde.firecloud.filematch.result.{FailedMatchResult, FileMatchResult, SuccessfulMatchResult}
-import OntSingleReadStrategy.{fastqGz, FILE_STARTS_ENDINGS}
+import OntSingleReadStrategy.FILE_CONTAIN_ENDINGS
 
 import java.nio.file.{Path, Paths}
+import scala.util.matching.Regex
 
 class OntSingleReadStrategy extends FileRecognitionStrategy {
 
   override def matchFirstFile(path: Path): FileMatchResult = {
-    // search known patterns for a "read1" file
-    val foundMatch = FILE_STARTS_ENDINGS.find { case (key, values) =>
-      path.getFileName.toString.startsWith(key) && values.exists(value => path.toString.endsWith(value))
+    val fileName = path.getFileName.toString
+
+    // Used regex to match the file name containing the key and ending with any of the specified values
+    val foundMatch = FILE_CONTAIN_ENDINGS.find { case (key, values) =>
+      val regex = new Regex(s".*${Regex.quote(key)}.*(${values.map(Regex.quote).mkString("|")})$$")
+      regex.findFirstIn(fileName).isDefined
     }
 
     foundMatch match {
       // we found a "read1"
       case Some((_, values)) =>
         // find the matching value
-        val value = values.find(value => path.toString.endsWith(value)).get
-        // generate the id: strip the suffix from the filename.
-        val id = path.getFileName.toString.replace(value, "")
-
+        val value = values.find(value => fileName.endsWith(value)).get
+        // generate the id: strip the value from the filename.
+        val id = fileName.replace(value, "")
         SuccessfulMatchResult(path, Paths.get(""), id)
 
       // the file is not recognized
@@ -30,12 +33,9 @@ class OntSingleReadStrategy extends FileRecognitionStrategy {
 }
 
 object OntSingleReadStrategy {
-  private val fastqGz = ".fastq.gz"
-  // if the first file starts with ${key} and ends with any of the values in the list, then this is a single read file
-  val FILE_STARTS_ENDINGS: Map[String, List[String]] = Map(
-    "Complete_barcode" -> List(fastqGz, ".clean.fastq"),
-    "Incomplete_barcode" -> List(fastqGz),
-    "Repeat_barcode" -> List(fastqGz),
-    "barcode" -> List(fastqGz)
+  // if the first file contains ${key} and ends with any of the values in the list, then this is a single read file
+  val FILE_CONTAIN_ENDINGS: Map[String, List[String]] = Map(
+    "Complete_barcode" -> List(".clean.fastq"),
+    "barcode" -> List(".fastq", ".fastq.gz")
   )
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/filematch/strategy/OntSingleReadStrategy.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/filematch/strategy/OntSingleReadStrategy.scala
@@ -8,7 +8,7 @@ import scala.util.matching.Regex
 
 class OntSingleReadStrategy extends FileRecognitionStrategy {
 
-  // Precompile regex patterns: (?i).*barcode\d+.*(\.clean\.fastq|\.clean\.fastq\.gz|\.fastq|\.fastq\.gz)$
+  // Precompile regex patterns: (?i).*barcode\d+.*(\.fastq|\.fastq\.gz)$
   private val compiledPatterns: Map[String, Regex] = FILE_CONTAIN_ENDINGS.map { case (key, values) =>
     key -> new Regex(s"(?i).*${Regex.quote(key)}\\d+.*(${values.map(Regex.quote).mkString("|")})$$")
   }
@@ -23,11 +23,11 @@ class OntSingleReadStrategy extends FileRecognitionStrategy {
 
     foundMatch match {
       // we found a "read1"
-      case Some((key, regex)) =>
+      case Some((key, _)) =>
         // Extract the matching value directly from the regex match
         val value = FILE_CONTAIN_ENDINGS(key).find(value => fileName.endsWith(value)).get
-        // generate the id: strip the value from the filename.
-        val id = fileName.replace(value, "")
+        // generate the id: strip the value and any characters before the extension from the filename.
+        val id = fileName.stripSuffix(value).replaceAll("\\..*$", "")
         SuccessfulMatchResult(path, Paths.get(""), id)
 
       // the file is not recognized
@@ -39,6 +39,6 @@ class OntSingleReadStrategy extends FileRecognitionStrategy {
 object OntSingleReadStrategy {
   // if the file contains ${key} and ends with any value in the list, it's an ONT single read file
   val FILE_CONTAIN_ENDINGS: Map[String, List[String]] = Map(
-    "barcode" -> List(".clean.fastq", ".clean.fastq.gz", ".fastq", ".fastq.gz")
+    "barcode" -> List(".fastq", ".fastq.gz")
   )
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/filematch/strategy/OntSingleReadStrategy.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/filematch/strategy/OntSingleReadStrategy.scala
@@ -9,7 +9,7 @@ import scala.util.matching.Regex
 class OntSingleReadStrategy extends FileRecognitionStrategy {
 
   override def matchFirstFile(path: Path): FileMatchResult =
-    path.toString match {
+    path.getFileName.toString match {
       case PATTERN(id) => SuccessfulMatchResult(path, id)
       case _           => FailedMatchResult(path)
     }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/filematch/strategy/OntSingleReadStrategy.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/filematch/strategy/OntSingleReadStrategy.scala
@@ -1,16 +1,16 @@
 package org.broadinstitute.dsde.firecloud.filematch.strategy
 
-import org.broadinstitute.dsde.firecloud.filematch.result.{FailedMatchResult, FileMatchResult, SuccessfulMatchResult}
+import org.broadinstitute.dsde.firecloud.filematch.result.{FailedMatchResult, FileMatchResult, PartialMatchResult}
 import OntSingleReadStrategy.PATTERN
 
-import java.nio.file.{Path, Paths}
+import java.nio.file.Path
 import scala.util.matching.Regex
 
 class OntSingleReadStrategy extends FileRecognitionStrategy {
 
   override def matchFirstFile(path: Path): FileMatchResult =
     path.getFileName.toString match {
-      case PATTERN(id) => SuccessfulMatchResult(path, id)
+      case PATTERN(id) => PartialMatchResult(path, id)
       case _           => FailedMatchResult(path)
     }
 }

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/filematch/strategy/OntSingleReadStrategy.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/filematch/strategy/OntSingleReadStrategy.scala
@@ -9,9 +9,9 @@ import scala.util.matching.Regex
 class OntSingleReadStrategy extends FileRecognitionStrategy {
 
   override def matchFirstFile(path: Path): FileMatchResult =
-    PATTERN.findFirstMatchIn(path.toString) match {
-      case Some(regexMatch) => SuccessfulMatchResult(path, Paths.get(""), regexMatch.group(1))
-      case None             => FailedMatchResult(path)
+    path.toString match {
+      case PATTERN(id) => SuccessfulMatchResult(path, Paths.get(""), id)
+      case _           => FailedMatchResult(path)
     }
 }
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/filematch/strategy/OntSingleReadStrategy.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/filematch/strategy/OntSingleReadStrategy.scala
@@ -10,7 +10,7 @@ class OntSingleReadStrategy extends FileRecognitionStrategy {
 
   override def matchFirstFile(path: Path): FileMatchResult =
     path.toString match {
-      case PATTERN(id) => SuccessfulMatchResult(path, Paths.get(""), id)
+      case PATTERN(id) => SuccessfulMatchResult(path, id)
       case _           => FailedMatchResult(path)
     }
 }

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/filematch/FileMatcherSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/filematch/FileMatcherSpec.scala
@@ -93,6 +93,27 @@ class FileMatcherSpec extends AnyFreeSpec with Matchers {
 
         actual shouldBe expected
       }
+      "should use multiple strategies in the same inputs" in {
+        // input includes hits on both IlluminaPairedEndStrategy and OntSingleReadStrategy
+        val input = List(
+          "Sample1_01.fastq.gz",
+          "Complete_barcode01.fastq.gz",
+          "Sample1_02.fastq.gz",
+          "Incomplete_barcode03.fastq.gz",
+          "Sample2_01.fastq.gz",
+          "Sample2_02.fastq.gz"
+        )
+
+        val expected = List(
+          PartialMatchResult.fromStrings("Complete_barcode01.fastq.gz", "Complete_barcode01"),
+          PartialMatchResult.fromStrings("Incomplete_barcode03.fastq.gz", "Incomplete_barcode03"),
+          SuccessfulMatchResult.fromStrings("Sample1_01.fastq.gz", "Sample1_02.fastq.gz", "Sample1"),
+          SuccessfulMatchResult.fromStrings("Sample2_01.fastq.gz", "Sample2_02.fastq.gz", "Sample2")
+        )
+        val actual = new FileMatcher().pairFiles(input)
+
+        actual shouldBe expected
+      }
     }
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/filematch/FileMatcherSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/filematch/FileMatcherSpec.scala
@@ -62,6 +62,37 @@ class FileMatcherSpec extends AnyFreeSpec with Matchers {
 
         actual shouldBe expected
       }
+      "should match single read files using OntSingleReadStrategy" in {
+        val input = List("Complete_barcode01.fastq.gz",
+                         "Complete_barcode02.clean.fastq",
+                         "Incomplete_barcode03.fastq.gz",
+                         "Repeat_barcode4.fastq.gz",
+                         "barcode5.fastq.gz"
+        )
+
+        val expected = List(
+          PartialMatchResult.fromStrings("Complete_barcode01.fastq.gz", "Complete_barcode01"),
+          PartialMatchResult.fromStrings("Complete_barcode02.clean.fastq", "Complete_barcode02"),
+          PartialMatchResult.fromStrings("Incomplete_barcode03.fastq.gz", "Incomplete_barcode03"),
+          PartialMatchResult.fromStrings("Repeat_barcode4.fastq.gz", "Repeat_barcode4"),
+          PartialMatchResult.fromStrings("barcode5.fastq.gz", "barcode5")
+        )
+        val actual = new FileMatcher().pairFiles(input)
+
+        actual shouldBe expected
+      }
+      "should return failed match results for unrecognized single read files" in {
+        val input = List("unknown_file.txt", "Complete_barcode01.fasta.gz", "Incomplete_barcode03.bam")
+
+        val expected = List(
+          FailedMatchResult.fromString("Complete_barcode01.fasta.gz"),
+          FailedMatchResult.fromString("Incomplete_barcode03.bam"),
+          FailedMatchResult.fromString("unknown_file.txt")
+        )
+        val actual = new FileMatcher().pairFiles(input)
+
+        actual shouldBe expected
+      }
     }
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/filematch/strategy/OntSingleReadStrategySpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/filematch/strategy/OntSingleReadStrategySpec.scala
@@ -12,59 +12,39 @@ class OntSingleReadStrategySpec extends AnyFreeSpec with Matchers {
 
   // set of input, expected test cases
   val recognizedTestCases: Map[String, SuccessfulMatchResult] = Map(
-    "Complete_barcode01.fastq.gz" -> SuccessfulMatchResult(toPath("Complete_barcode01.fastq.gz"),
-                                                           Paths.get(""),
-                                                           "Complete_barcode01"
-    ),
+    "Complete_barcode01.fastq.gz" -> SuccessfulMatchResult(toPath("Complete_barcode01.fastq.gz"), "Complete_barcode01"),
     "Complete_barcode02.clean.fastq" -> SuccessfulMatchResult(toPath("Complete_barcode02.clean.fastq"),
-                                                              Paths.get(""),
                                                               "Complete_barcode02"
     ),
     "Incomplete_barcode03.fastq.gz" -> SuccessfulMatchResult(toPath("Incomplete_barcode03.fastq.gz"),
-                                                             Paths.get(""),
                                                              "Incomplete_barcode03"
     ),
-    "Repeat_barcode4.fastq.gz" -> SuccessfulMatchResult(toPath("Repeat_barcode4.fastq.gz"),
-                                                        Paths.get(""),
-                                                        "Repeat_barcode4"
-    ),
-    "barcode5.fastq.gz" -> SuccessfulMatchResult(toPath("barcode5.fastq.gz"), Paths.get(""), "barcode5"),
+    "Repeat_barcode4.fastq.gz" -> SuccessfulMatchResult(toPath("Repeat_barcode4.fastq.gz"), "Repeat_barcode4"),
+    "barcode5.fastq.gz" -> SuccessfulMatchResult(toPath("barcode5.fastq.gz"), "barcode5"),
     "Repeat_barcode6.clean.fastq.gz" -> SuccessfulMatchResult(toPath("Repeat_barcode6.clean.fastq.gz"),
-                                                              Paths.get(""),
                                                               "Repeat_barcode6"
     ),
     "Repeat_BARCODE6.clean.fastq.gz" -> SuccessfulMatchResult(toPath("Repeat_BARCODE6.clean.fastq.gz"),
-                                                              Paths.get(""),
                                                               "Repeat_BARCODE6"
     ),
-    "Foo_barcode1.fastq" -> SuccessfulMatchResult(toPath("Foo_barcode1.fastq"), Paths.get(""), "Foo_barcode1"),
-    "Foo_barcode1.fastq.gz" -> SuccessfulMatchResult(toPath("Foo_barcode1.fastq.gz"), Paths.get(""), "Foo_barcode1"),
-    "Foo_barcode1.clean.fastq" -> SuccessfulMatchResult(toPath("Foo_barcode1.clean.fastq"),
-                                                        Paths.get(""),
-                                                        "Foo_barcode1"
-    ),
-    "Foo_barcode1.clean.fastq.gz" -> SuccessfulMatchResult(toPath("Foo_barcode1.clean.fastq.gz"),
-                                                           Paths.get(""),
-                                                           "Foo_barcode1"
-    ),
-    "barcode2.fastq" -> SuccessfulMatchResult(toPath("barcode2.fastq"), Paths.get(""), "barcode2"),
-    "barcode2.fastq.gz" -> SuccessfulMatchResult(toPath("barcode2.fastq.gz"), Paths.get(""), "barcode2"),
-    "barcode2.clean.fastq" -> SuccessfulMatchResult(toPath("barcode2.clean.fastq"), Paths.get(""), "barcode2"),
-    "barcode2.clean.fastq.gz" -> SuccessfulMatchResult(toPath("barcode2.clean.fastq.gz"), Paths.get(""), "barcode2"),
+    "Foo_barcode1.fastq" -> SuccessfulMatchResult(toPath("Foo_barcode1.fastq"), "Foo_barcode1"),
+    "Foo_barcode1.fastq.gz" -> SuccessfulMatchResult(toPath("Foo_barcode1.fastq.gz"), "Foo_barcode1"),
+    "Foo_barcode1.clean.fastq" -> SuccessfulMatchResult(toPath("Foo_barcode1.clean.fastq"), "Foo_barcode1"),
+    "Foo_barcode1.clean.fastq.gz" -> SuccessfulMatchResult(toPath("Foo_barcode1.clean.fastq.gz"), "Foo_barcode1"),
+    "barcode2.fastq" -> SuccessfulMatchResult(toPath("barcode2.fastq"), "barcode2"),
+    "barcode2.fastq.gz" -> SuccessfulMatchResult(toPath("barcode2.fastq.gz"), "barcode2"),
+    "barcode2.clean.fastq" -> SuccessfulMatchResult(toPath("barcode2.clean.fastq"), "barcode2"),
+    "barcode2.clean.fastq.gz" -> SuccessfulMatchResult(toPath("barcode2.clean.fastq.gz"), "barcode2"),
     "Barcode38934278247843.fastq" -> SuccessfulMatchResult(toPath("Barcode38934278247843.fastq"),
-                                                           Paths.get(""),
                                                            "Barcode38934278247843"
     ),
     "Barcode38934278247843.fastq.gz" -> SuccessfulMatchResult(toPath("Barcode38934278247843.fastq.gz"),
-                                                              Paths.get(""),
                                                               "Barcode38934278247843"
     ),
     "Barcode38934278247843.clean.fastq" -> SuccessfulMatchResult(toPath("Barcode38934278247843.clean.fastq"),
-                                                                 Paths.get(""),
                                                                  "Barcode38934278247843"
     ),
     "Barcode38934278247843.clean.fastq.gz" -> SuccessfulMatchResult(toPath("Barcode38934278247843.clean.fastq.gz"),
-                                                                    Paths.get(""),
                                                                     "Barcode38934278247843"
     )
   )

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/filematch/strategy/OntSingleReadStrategySpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/filematch/strategy/OntSingleReadStrategySpec.scala
@@ -77,7 +77,8 @@ class OntSingleReadStrategySpec extends AnyFreeSpec with Matchers {
       "barcode.fastq",
       "barcode.fastq.gz",
       "barcode.clean.fastq",
-      "barcode.clean.fastq.gz"
+      "barcode.clean.fastq.gz",
+      "Complete_barcode01.fastq.gz.gz.gz.gz.gz.gz"
     )
 
   "OntSingleReadStrategy" - {

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/filematch/strategy/OntSingleReadStrategySpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/filematch/strategy/OntSingleReadStrategySpec.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.dsde.firecloud.filematch.strategy
 
-import org.broadinstitute.dsde.firecloud.filematch.result.{FailedMatchResult, SuccessfulMatchResult}
+import org.broadinstitute.dsde.firecloud.filematch.result.{FailedMatchResult, PartialMatchResult}
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -11,41 +11,35 @@ class OntSingleReadStrategySpec extends AnyFreeSpec with Matchers {
   val strategy = new OntSingleReadStrategy
 
   // set of input, expected test cases
-  val recognizedTestCases: Map[String, SuccessfulMatchResult] = Map(
-    "Complete_barcode01.fastq.gz" -> SuccessfulMatchResult(toPath("Complete_barcode01.fastq.gz"), "Complete_barcode01"),
-    "Complete_barcode02.clean.fastq" -> SuccessfulMatchResult(toPath("Complete_barcode02.clean.fastq"),
-                                                              "Complete_barcode02"
+  val recognizedTestCases: Map[String, PartialMatchResult] = Map(
+    "Complete_barcode01.fastq.gz" -> PartialMatchResult(toPath("Complete_barcode01.fastq.gz"), "Complete_barcode01"),
+    "Complete_barcode02.clean.fastq" -> PartialMatchResult(toPath("Complete_barcode02.clean.fastq"),
+                                                           "Complete_barcode02"
     ),
-    "Incomplete_barcode03.fastq.gz" -> SuccessfulMatchResult(toPath("Incomplete_barcode03.fastq.gz"),
-                                                             "Incomplete_barcode03"
+    "Incomplete_barcode03.fastq.gz" -> PartialMatchResult(toPath("Incomplete_barcode03.fastq.gz"),
+                                                          "Incomplete_barcode03"
     ),
-    "Repeat_barcode4.fastq.gz" -> SuccessfulMatchResult(toPath("Repeat_barcode4.fastq.gz"), "Repeat_barcode4"),
-    "barcode5.fastq.gz" -> SuccessfulMatchResult(toPath("barcode5.fastq.gz"), "barcode5"),
-    "Repeat_barcode6.clean.fastq.gz" -> SuccessfulMatchResult(toPath("Repeat_barcode6.clean.fastq.gz"),
-                                                              "Repeat_barcode6"
-    ),
-    "Repeat_BARCODE6.clean.fastq.gz" -> SuccessfulMatchResult(toPath("Repeat_BARCODE6.clean.fastq.gz"),
-                                                              "Repeat_BARCODE6"
-    ),
-    "Foo_barcode1.fastq" -> SuccessfulMatchResult(toPath("Foo_barcode1.fastq"), "Foo_barcode1"),
-    "Foo_barcode1.fastq.gz" -> SuccessfulMatchResult(toPath("Foo_barcode1.fastq.gz"), "Foo_barcode1"),
-    "Foo_barcode1.clean.fastq" -> SuccessfulMatchResult(toPath("Foo_barcode1.clean.fastq"), "Foo_barcode1"),
-    "Foo_barcode1.clean.fastq.gz" -> SuccessfulMatchResult(toPath("Foo_barcode1.clean.fastq.gz"), "Foo_barcode1"),
-    "barcode2.fastq" -> SuccessfulMatchResult(toPath("barcode2.fastq"), "barcode2"),
-    "barcode2.fastq.gz" -> SuccessfulMatchResult(toPath("barcode2.fastq.gz"), "barcode2"),
-    "barcode2.clean.fastq" -> SuccessfulMatchResult(toPath("barcode2.clean.fastq"), "barcode2"),
-    "barcode2.clean.fastq.gz" -> SuccessfulMatchResult(toPath("barcode2.clean.fastq.gz"), "barcode2"),
-    "Barcode38934278247843.fastq" -> SuccessfulMatchResult(toPath("Barcode38934278247843.fastq"),
+    "Repeat_barcode4.fastq.gz" -> PartialMatchResult(toPath("Repeat_barcode4.fastq.gz"), "Repeat_barcode4"),
+    "barcode5.fastq.gz" -> PartialMatchResult(toPath("barcode5.fastq.gz"), "barcode5"),
+    "Repeat_barcode6.clean.fastq.gz" -> PartialMatchResult(toPath("Repeat_barcode6.clean.fastq.gz"), "Repeat_barcode6"),
+    "Repeat_BARCODE6.clean.fastq.gz" -> PartialMatchResult(toPath("Repeat_BARCODE6.clean.fastq.gz"), "Repeat_BARCODE6"),
+    "Foo_barcode1.fastq" -> PartialMatchResult(toPath("Foo_barcode1.fastq"), "Foo_barcode1"),
+    "Foo_barcode1.fastq.gz" -> PartialMatchResult(toPath("Foo_barcode1.fastq.gz"), "Foo_barcode1"),
+    "Foo_barcode1.clean.fastq" -> PartialMatchResult(toPath("Foo_barcode1.clean.fastq"), "Foo_barcode1"),
+    "Foo_barcode1.clean.fastq.gz" -> PartialMatchResult(toPath("Foo_barcode1.clean.fastq.gz"), "Foo_barcode1"),
+    "barcode2.fastq" -> PartialMatchResult(toPath("barcode2.fastq"), "barcode2"),
+    "barcode2.fastq.gz" -> PartialMatchResult(toPath("barcode2.fastq.gz"), "barcode2"),
+    "barcode2.clean.fastq" -> PartialMatchResult(toPath("barcode2.clean.fastq"), "barcode2"),
+    "barcode2.clean.fastq.gz" -> PartialMatchResult(toPath("barcode2.clean.fastq.gz"), "barcode2"),
+    "Barcode38934278247843.fastq" -> PartialMatchResult(toPath("Barcode38934278247843.fastq"), "Barcode38934278247843"),
+    "Barcode38934278247843.fastq.gz" -> PartialMatchResult(toPath("Barcode38934278247843.fastq.gz"),
                                                            "Barcode38934278247843"
     ),
-    "Barcode38934278247843.fastq.gz" -> SuccessfulMatchResult(toPath("Barcode38934278247843.fastq.gz"),
+    "Barcode38934278247843.clean.fastq" -> PartialMatchResult(toPath("Barcode38934278247843.clean.fastq"),
                                                               "Barcode38934278247843"
     ),
-    "Barcode38934278247843.clean.fastq" -> SuccessfulMatchResult(toPath("Barcode38934278247843.clean.fastq"),
+    "Barcode38934278247843.clean.fastq.gz" -> PartialMatchResult(toPath("Barcode38934278247843.clean.fastq.gz"),
                                                                  "Barcode38934278247843"
-    ),
-    "Barcode38934278247843.clean.fastq.gz" -> SuccessfulMatchResult(toPath("Barcode38934278247843.clean.fastq.gz"),
-                                                                    "Barcode38934278247843"
     )
   )
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/filematch/strategy/OntSingleReadStrategySpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/filematch/strategy/OntSingleReadStrategySpec.scala
@@ -28,11 +28,57 @@ class OntSingleReadStrategySpec extends AnyFreeSpec with Matchers {
                                                         Paths.get(""),
                                                         "Repeat_barcode4"
     ),
-    "barcode5.fastq.gz" -> SuccessfulMatchResult(toPath("barcode5.fastq.gz"), Paths.get(""), "barcode5")
+    "barcode5.fastq.gz" -> SuccessfulMatchResult(toPath("barcode5.fastq.gz"), Paths.get(""), "barcode5"),
+    "Repeat_barcode6.clean.fastq.gz" -> SuccessfulMatchResult(toPath("Repeat_barcode6.clean.fastq.gz"),
+                                                              Paths.get(""),
+                                                              "Repeat_barcode6"
+    ),
+    "Repeat_BARCODE6.clean.fastq.gz" -> SuccessfulMatchResult(toPath("Repeat_BARCODE6.clean.fastq.gz"),
+                                                              Paths.get(""),
+                                                              "Repeat_BARCODE6"
+    ),
+    "Foo_barcode1.fastq" -> SuccessfulMatchResult(toPath("Foo_barcode1.fastq"), Paths.get(""), "Foo_barcode1"),
+    "Foo_barcode1.fastq.gz" -> SuccessfulMatchResult(toPath("Foo_barcode1.fastq.gz"), Paths.get(""), "Foo_barcode1"),
+    "Foo_barcode1.clean.fastq" -> SuccessfulMatchResult(toPath("Foo_barcode1.clean.fastq"),
+                                                        Paths.get(""),
+                                                        "Foo_barcode1"
+    ),
+    "Foo_barcode1.clean.fastq.gz" -> SuccessfulMatchResult(toPath("Foo_barcode1.clean.fastq.gz"),
+                                                           Paths.get(""),
+                                                           "Foo_barcode1"
+    ),
+    "barcode2.fastq" -> SuccessfulMatchResult(toPath("barcode2.fastq"), Paths.get(""), "barcode2"),
+    "barcode2.fastq.gz" -> SuccessfulMatchResult(toPath("barcode2.fastq.gz"), Paths.get(""), "barcode2"),
+    "barcode2.clean.fastq" -> SuccessfulMatchResult(toPath("barcode2.clean.fastq"), Paths.get(""), "barcode2"),
+    "barcode2.clean.fastq.gz" -> SuccessfulMatchResult(toPath("barcode2.clean.fastq.gz"), Paths.get(""), "barcode2"),
+    "Barcode38934278247843.fastq" -> SuccessfulMatchResult(toPath("Barcode38934278247843.fastq"),
+                                                           Paths.get(""),
+                                                           "Barcode38934278247843"
+    ),
+    "Barcode38934278247843.fastq.gz" -> SuccessfulMatchResult(toPath("Barcode38934278247843.fastq.gz"),
+                                                              Paths.get(""),
+                                                              "Barcode38934278247843"
+    ),
+    "Barcode38934278247843.clean.fastq" -> SuccessfulMatchResult(toPath("Barcode38934278247843.clean.fastq"),
+                                                                 Paths.get(""),
+                                                                 "Barcode38934278247843"
+    ),
+    "Barcode38934278247843.clean.fastq.gz" -> SuccessfulMatchResult(toPath("Barcode38934278247843.clean.fastq.gz"),
+                                                                    Paths.get(""),
+                                                                    "Barcode38934278247843"
+    )
   )
 
   val unrecognizedInputs: List[String] =
-    List("unknown_file.txt", "Complete_barcode01.fasta.gz", "Incomplete_barcode03.bam")
+    List(
+      "unknown_file.txt",
+      "Complete_barcode01.fasta.gz",
+      "Incomplete_barcode03.bam",
+      "barcode.fastq",
+      "barcode.fastq.gz",
+      "barcode.clean.fastq",
+      "barcode.clean.fastq.gz"
+    )
 
   "OntSingleReadStrategy" - {
     recognizedTestCases foreach { case (inputString, expectedMatchResult) =>

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/filematch/strategy/OntSingleReadStrategySpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/filematch/strategy/OntSingleReadStrategySpec.scala
@@ -1,0 +1,54 @@
+package org.broadinstitute.dsde.firecloud.filematch.strategy
+
+import org.broadinstitute.dsde.firecloud.filematch.result.{FailedMatchResult, SuccessfulMatchResult}
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.nio.file.Paths
+
+class OntSingleReadStrategySpec extends AnyFreeSpec with Matchers {
+
+  val strategy = new OntSingleReadStrategy
+
+  // set of input, expected test cases
+  val recognizedTestCases: Map[String, SuccessfulMatchResult] = Map(
+    "Complete_barcode01.fastq.gz" -> SuccessfulMatchResult(toPath("Complete_barcode01.fastq.gz"),
+                                                           Paths.get(""),
+                                                           "Complete_barcode01"
+    ),
+    "Complete_barcode02.clean.fastq" -> SuccessfulMatchResult(toPath("Complete_barcode02.clean.fastq"),
+                                                              Paths.get(""),
+                                                              "Complete_barcode02"
+    ),
+    "Incomplete_barcode03.fastq.gz" -> SuccessfulMatchResult(toPath("Incomplete_barcode03.fastq.gz"),
+                                                             Paths.get(""),
+                                                             "Incomplete_barcode03"
+    ),
+    "Repeat_barcode4.fastq.gz" -> SuccessfulMatchResult(toPath("Repeat_barcode4.fastq.gz"),
+                                                        Paths.get(""),
+                                                        "Repeat_barcode4"
+    ),
+    "barcode5.fastq.gz" -> SuccessfulMatchResult(toPath("barcode5.fastq.gz"), Paths.get(""), "barcode5")
+  )
+
+  val unrecognizedInputs: List[String] =
+    List("unknown_file.txt", "Complete_barcode01.fasta.gz", "Incomplete_barcode03.bam")
+
+  "OntSingleReadStrategy" - {
+    recognizedTestCases foreach { case (inputString, expectedMatchResult) =>
+      s"should hit on recognized input file $inputString" in {
+        val matchResult = strategy.matchFirstFile(toPath(inputString))
+        matchResult shouldBe expectedMatchResult
+      }
+    }
+
+    unrecognizedInputs foreach { inputString =>
+      s"should miss on unrecognized input file $inputString" in {
+        val matchResult = strategy.matchFirstFile(toPath(inputString))
+        matchResult shouldBe FailedMatchResult(toPath(inputString))
+      }
+    }
+  }
+
+  private def toPath(input: String) = Paths.get(input)
+}


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/CORE-315

This PR extends the Data Table Autogeneration feature to support ONT (Oxford Nanopore Technologies) sequencing patterns. New regex patterns have been added to detect and classify ONT files, allowing them to be processed alongside Illumina files in the same data table.

[Test-Output-files.zip](https://github.com/user-attachments/files/19199255/Output-files.zip)


Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [x] Get two thumbsworth of review and PO signoff if necessary
- [x] Verify all tests go green
- [x] Squash and merge. Make sure your branch deletes; GitHub should do this for you.
- [ ] Test this change deployed correctly and works on dev environment after deployment
