### PR TITLE
CORE-377: config kill switch to disable Library routes

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/PublishedWorkspaceSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/PublishedWorkspaceSpec.scala
@@ -24,7 +24,7 @@ class PublishedWorkspaceSpec extends AnyFreeSpec with WorkspaceFixtures with Mat
   "a user with publish permissions" - {
     "can publish a workspace" - {
 
-      "published workspace should be visible in the library table" in {
+      "published workspace should be visible in the library table" ignore {
 
         val curatorUser = UserPool.chooseCurator
         implicit val curatorAuthToken: AuthToken = curatorUser.makeAuthToken()
@@ -56,7 +56,7 @@ class PublishedWorkspaceSpec extends AnyFreeSpec with WorkspaceFixtures with Mat
       }
 
       "can clone a published workspace" - {
-        "cloned workspace should default to unpublished status" in {
+        "cloned workspace should default to unpublished status" ignore {
 
           val curatorUser = UserPool.chooseCurator
           implicit val curatorAuthToken: AuthToken = curatorUser.makeAuthToken()
@@ -85,7 +85,7 @@ class PublishedWorkspaceSpec extends AnyFreeSpec with WorkspaceFixtures with Mat
           }(UserPool.chooseProjectOwner.makeAuthToken(billingScopes))
         }
 
-        "cloned workspace should default to visible to 'all users'" in {
+        "cloned workspace should default to visible to 'all users'" ignore {
 
           val curatorUser = UserPool.chooseCurator
           implicit val curatorAuthToken: AuthToken = curatorUser.makeAuthToken()
@@ -118,7 +118,7 @@ class PublishedWorkspaceSpec extends AnyFreeSpec with WorkspaceFixtures with Mat
 
       }
 
-      "publish a dataset with consent codes" in {
+      "publish a dataset with consent codes" ignore {
 
         val curatorUser = UserPool.chooseCurator
         implicit val authToken: AuthToken = curatorUser.makeAuthToken()
@@ -139,7 +139,7 @@ class PublishedWorkspaceSpec extends AnyFreeSpec with WorkspaceFixtures with Mat
         }(UserPool.chooseProjectOwner.makeAuthToken(billingScopes))
       }
 
-      "publish a dataset with tags" in {
+      "publish a dataset with tags" ignore {
 
         val tags = Map("tag:tags" -> Seq("testing", "diabetes", "PublishedWorkspaceSpec"))
         val curatorUser = UserPool.chooseCurator

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -116,3 +116,7 @@ sam {
   # orch's average latency is 226ms, so probabaly 4 concurrent requests is what orch handles and only a fraction of those are sam's part
   maxConcurrentRequests = 15
 }
+
+elasticsearch {
+  libraryEnabled = false
+}

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudApiService.scala
@@ -190,6 +190,14 @@ trait FireCloudApiService
       logRequests &
       noCacheNoStore
 
+  // CORE-377: library routes are enabled/disabled via config (default: disabled) as a scream test.
+  //   Once we are sure they are unused, we should delete the code instead of disabling.
+  private val maybeEnabledLibraryRoutes: server.Route = if (FireCloudConfig.ElasticSearch.libraryEnabled) {
+    libraryRoutes
+  } else {
+    reject
+  }
+
   def route: server.Route = routeWrappers {
     cromIamEngineRoutes ~
       exportEntitiesRoutes ~
@@ -197,7 +205,7 @@ trait FireCloudApiService
       exportEntitiesRoutes ~
       entityRoutes ~
       healthServiceRoutes ~
-      libraryRoutes ~
+      maybeEnabledLibraryRoutes ~
       namespaceRoutes ~
       oauthRoutes ~
       profileRoutes ~

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
@@ -230,6 +230,7 @@ object FireCloudConfig {
     lazy val shareLogIndexName: String = elasticsearch.getString("shareLogIndex")
     lazy val maxAggregations: Int = Try(elasticsearch.getInt("maxAggregations")).getOrElse(1000)
     val enabled = elasticsearch.optionalBoolean("enabled").getOrElse(true)
+    val libraryEnabled = elasticsearch.optionalBoolean("libraryEnabled").getOrElse(true)
   }
 
   def parseESServers(confString: String): Seq[Authority] =


### PR DESCRIPTION
CORE-377

Adds a config flag `elasticsearch.libraryEnabled` which turns on/off all of the routes in `LibraryApiService`. All the implementation code remains in place, so we can easilyand quickly toggle these routes as needed during a scream test.

We'll delete the implementation code in a follow-on ticket/PR; I assume in CORE-382.