### PR TITLE
[CORE-321] Remove Deprecated getBucketUsage and getStorageCostEstimate APIs and Related Pricelist Code

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -55,53 +55,9 @@ googlecloud {
     "MULTI_REGIONAL": 0.026
   }
 
-  priceListUrl = "https://cloudpricingcalculator.appspot.com/static/data/pricelist.json"
   # egress key previouly was "CP-COMPUTEENGINE-INTERNET-EGRESS-NA-NA"
   priceListEgressKey = "CP-INTERNET-EGRESS-STANDARD-TIER-FROM-NA"
   priceListStorageKey = "CP-BIGSTORE-STANDARD"
-
-  defaultStoragePriceList = {
-    "us-central1": 0.02,
-    "us-east1": 0.02,
-    "us-east4": 0.023,
-    "us-west4": 0.023,
-    "us-west1": 0.02,
-    "us-west2": 0.023,
-    "us-west3": 0.023,
-    "europe-west1": 0.02,
-    "europe-west2": 0.023,
-    "europe-west3": 0.023,
-    "europe-central2": 0.023,
-    "europe-west4": 0.020,
-    "europe-west6": 0.025,
-    "europe-north1": 0.020,
-    "northamerica-northeast1": 0.023,
-    "northamerica-northeast2": 0.023,
-    "asia-east1": 0.02,
-    "asia-east2": 0.023,
-    "asia-northeast1": 0.023,
-    "asia-southeast2": 0.023,
-    "asia-northeast2": 0.023,
-    "asia-northeast3": 0.023,
-    "asia-southeast1": 0.02,
-    "australia-southeast1": 0.023,
-    "australia-southeast2": 0.023,
-    "southamerica-east1": 0.035,
-    "asia-south1": 0.023,
-    "asia-south2": 0.023,
-    "us": 0.026,
-    "europe": 0.026,
-    "asia": 0.026,
-    "asia1": 0.046,
-    "eur4": 0.036,
-    "nam4": 0.036
-  }
-
-  defaultEgressPriceList = {
-    "10240": 0.085,
-    "153600": 0.065,
-    "153601": 0.045
-  }
 }
 
 firecloud {

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -6767,7 +6767,7 @@ components:
         estimate:
           type: string
           description: The estimated monthly storage cost of the bucket
-        usageInByes:
+        usageInBytes:
           type: integer
           description: The current storage bucket usage in bytes
         lastUpdated:

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -3073,26 +3073,6 @@ paths:
                 $ref: '#/components/schemas/ErrorReport'
       x-passthrough: true
       x-passthrough-target: rawls
-  /api/workspaces/{workspaceNamespace}/{workspaceName}/bucketUsage:
-    get:
-      tags:
-        - Workspaces
-      summary: Get bucket usage
-      deprecated: true
-      description: Deprecated in favor of /api/workspaces/v2/{workspaceNamespace}/{workspaceName}/storageCostEstimate, which returns usage as well as cost
-      operationId: getBucketUsage
-      parameters:
-        - $ref: '#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#/components/parameters/workspaceNameParam'
-      responses:
-        200:
-          description: Successful Request
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/BucketUsageResponse'
-      x-passthrough: true
-      x-passthrough-target: rawls
   /api/workspaces/{workspaceNamespace}/{workspaceName}/catalog:
     get:
       tags:
@@ -4689,33 +4669,6 @@ paths:
           content: {}
       x-passthrough: true
       x-passthrough-target: rawls
-  /api/workspaces/{workspaceNamespace}/{workspaceName}/storageCostEstimate:
-    get:
-      tags:
-        - Workspaces
-      summary: Calculate an estimate of the monthly storage cost for the workspace
-        bucket
-      deprecated: true
-      description: Deprecated in favor of /api/workspaces/v2/{workspaceNamespace}/{workspaceName}/storageCostEstimate
-      operationId: getStorageCostEstimate
-      parameters:
-        - $ref: '#/components/parameters/workspaceNamespaceParam'
-        - $ref: '#/components/parameters/workspaceNameParam'
-        - $ref: '#/components/parameters/userProjectQueryParam'
-      responses:
-        200:
-          description: Successful Request
-          content:
-            'application/json':
-              schema:
-                $ref: '#/components/schemas/BucketStorageCost'
-        404:
-          description: Workspace not found
-          content: {}
-        500:
-          description: Internal Error
-          content: {}
-      x-passthrough: false
   /api/workspaces/{workspaceNamespace}/{workspaceName}/submissions:
     get:
       tags:
@@ -6773,32 +6726,6 @@ components:
         message:
           type: string
           description: informational message about the project
-      description: ""
-    BucketStorageCost:
-      required:
-        - estimate
-      type: object
-      properties:
-        estimate:
-          type: string
-          description: The estimated monthly storage cost of the bucket
-        lastUpdated:
-          type: string
-          format: timestamp
-          description: timestamp (UTC) marking the date that the bucket cost was last updated (YYYY-MM-DDThh:mm:ss.fffZ)
-      description: ""
-    BucketUsageResponse:
-      required:
-        - usageInBytes
-      type: object
-      properties:
-        usageInBytes:
-          type: integer
-          description: The current storage bucket usage in bytes
-        lastUpdated:
-          type: string
-          format: timestamp
-          description: timestamp (UTC) marking the date that the bucket usage was last updated (YYYY-MM-DDThh:mm:ss.fffZ)
       description: ""
     BucketStorageUsageAndCost:
       required:
@@ -10471,14 +10398,6 @@ components:
       in: path
       description: Submission ID
       required: true
-      schema:
-        type: string
-    userProjectQueryParam:
-      name: userProject
-      in: query
-      description: |
-        When specified, bill google storage requests to this project
-      required: false
       schema:
         type: string
     workflowIdParam:

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/Boot.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/Boot.scala
@@ -150,15 +150,7 @@ object Boot extends IOApp with LazyLogging {
       whenEnabled[AgoraDAO](FireCloudConfig.Agora.enabled, new HttpAgoraDAO(FireCloudConfig.Agora))
     val googleServicesDAO: GoogleServicesDAO = whenEnabled[GoogleServicesDAO](
       FireCloudConfig.GoogleCloud.enabled,
-      new HttpGoogleServicesDAO(
-        FireCloudConfig.GoogleCloud.priceListUrl,
-        GooglePriceList(GooglePrices(FireCloudConfig.GoogleCloud.defaultStoragePriceList,
-                                     UsTieredPriceItem(FireCloudConfig.GoogleCloud.defaultEgressPriceList)
-                        ),
-                        "v1",
-                        "1"
-        )
-      )
+      new HttpGoogleServicesDAO()
     )
     val shibbolethDAO: ShibbolethDAO =
       whenEnabled[ShibbolethDAO](FireCloudConfig.Shibboleth.enabled, new HttpShibbolethDAO)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
@@ -248,23 +248,8 @@ object FireCloudConfig {
       .asScala
       .map(key => key -> BigDecimal(storagePriceListConf.getDouble(key)))
       .toMap
-    lazy val priceListUrl = googlecloud.getString("priceListUrl")
     lazy val priceListEgressKey = googlecloud.getString("priceListEgressKey")
     lazy val priceListStorageKey = googlecloud.getString("priceListStorageKey")
-    lazy val defaultStoragePriceListConf = googlecloud.getConfig("defaultStoragePriceList")
-    lazy val defaultStoragePriceList = defaultStoragePriceListConf
-      .root()
-      .keySet()
-      .asScala
-      .map(key => key -> BigDecimal(defaultStoragePriceListConf.getDouble(key)))
-      .toMap
-    lazy val defaultEgressPriceListConf = googlecloud.getConfig("defaultEgressPriceList")
-    lazy val defaultEgressPriceList = defaultEgressPriceListConf
-      .root()
-      .keySet()
-      .asScala
-      .map(key => key.toLong -> BigDecimal(defaultEgressPriceListConf.getDouble(key)))
-      .toMap
     val enabled = googlecloud.optionalBoolean("enabled").getOrElse(true)
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/GoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/GoogleServicesDAO.scala
@@ -21,8 +21,6 @@ trait GoogleServicesDAO extends ReportsSubsystemStatus {
   def getBucketObjectAsInputStream(bucketName: String, objectKey: String): InputStream
   def getObjectResourceUrl(bucketName: String, objectKey: String): String
 
-  val fetchPriceList: Future[GooglePriceList]
-
   def writeObjectAsRawlsSA(bucketName: GcsBucketName, objectKey: GcsObjectName, objectContents: Array[Byte]): GcsPath
   def writeObjectAsRawlsSA(bucketName: GcsBucketName, objectKey: GcsObjectName, tempFile: File): GcsPath
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
@@ -40,11 +40,6 @@ import spray.json.{DefaultJsonProtocol, _}
 
 case class StoragePriceList(prices: Map[String, BigDecimal])
 
-/** Result from Google's pricing calculator price list
-  * (https://cloudpricingcalculator.appspot.com/static/data/pricelist.json).
-  */
-case class GooglePriceList(prices: GooglePrices, version: String, updated: String)
-
 /** Partial price list. Attributes can be added as needed to import prices for more products. */
 case class GooglePrices(cpBigstoreStorage: Map[String, BigDecimal], cpComputeengineInternetEgressNA: UsTieredPriceItem)
 
@@ -72,8 +67,6 @@ object GooglePriceListJsonProtocol extends DefaultJsonProtocol with SprayJsonSup
     FireCloudConfig.GoogleCloud.priceListStorageKey,
     FireCloudConfig.GoogleCloud.priceListEgressKey
   )
-  implicit val GooglePriceListFormat: RootJsonFormat[GooglePriceList] =
-    jsonFormat(GooglePriceList, "gcp_price_list", "version", "updated")
 }
 import org.broadinstitute.dsde.firecloud.dataaccess.GooglePriceListJsonProtocol._
 
@@ -108,7 +101,7 @@ object HttpGoogleServicesDAO {
       .getTokenValue
 }
 
-class HttpGoogleServicesDAO(priceListUrl: String, defaultPriceList: GooglePriceList)(
+class HttpGoogleServicesDAO()(
   implicit val system: ActorSystem,
   implicit val materializer: Materializer,
   implicit val executionContext: ExecutionContext
@@ -225,23 +218,6 @@ class HttpGoogleServicesDAO(priceListUrl: String, defaultPriceList: GooglePriceL
   def getObjectResourceUrl(bucketName: String, objectKey: String) = {
     val gcsStatUrl = "https://www.googleapis.com/storage/v1/b/%s/o/%s"
     gcsStatUrl.format(bucketName, java.net.URLEncoder.encode(objectKey, "UTF-8"))
-  }
-
-  /** Fetch the latest price list from Google. Returns only the subset of prices that we find we have use for. */
-  // Why is this a val? Because the price lists do not change very often. This prevents making an HTTP call to Google
-  // every time we want to calculate a cost estimate (which happens extremely often in the Terra UI)
-  // Because the price list is brittle and Google sometimes changes the names of keys in the JSON, there is a
-  // default cached value in configuration to use as a backup. If we fallback to it, the error will be logged
-  // but users will probably not notice a difference. They're cost *estimates*, after all.
-  lazy val fetchPriceList: Future[GooglePriceList] = {
-    val httpReq = Get(priceListUrl)
-
-    unAuthedRequestToObject[GooglePriceList](httpReq).recover { case t: Throwable =>
-      logger.error(
-        s"Unable to fetch/parse latest Google price list. A cached (possibly outdated) value will be used instead. Error: ${t.getMessage}"
-      )
-      defaultPriceList
-    }
   }
 
   override def deleteGoogleGroup(groupEmail: String): Unit = {

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAO.scala
@@ -36,39 +36,6 @@ import java.io.FileInputStream
 import scala.concurrent.{ExecutionContext, Future}
 import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Success, Try}
-import spray.json.{DefaultJsonProtocol, _}
-
-case class StoragePriceList(prices: Map[String, BigDecimal])
-
-/** Partial price list. Attributes can be added as needed to import prices for more products. */
-case class GooglePrices(cpBigstoreStorage: Map[String, BigDecimal], cpComputeengineInternetEgressNA: UsTieredPriceItem)
-
-/** Tiered price item containing only US currency.
-  *
-  * Used for egress, may need to be altered to work with other types in the future.
-  * Contains a map of the different tiers of pricing, where the key is the size in GB
-  * for that tier and the value is the cost in USD for that tier.
-  */
-case class UsTieredPriceItem(tiers: Map[Long, BigDecimal])
-
-object GooglePriceListJsonProtocol extends DefaultJsonProtocol with SprayJsonSupport {
-  implicit object UsTieredPriceItemFormat extends RootJsonFormat[UsTieredPriceItem] {
-    override def write(value: UsTieredPriceItem): JsValue = ???
-    override def read(json: JsValue): UsTieredPriceItem = json match {
-      case JsObject(values) =>
-        UsTieredPriceItem(values("tiers").asJsObject.fields.map { case (name, value) =>
-          name.toLong -> BigDecimal(value.toString)
-        })
-      case x => throw new DeserializationException("invalid value: " + x)
-    }
-  }
-  implicit val GooglePricesFormat: RootJsonFormat[GooglePrices] = jsonFormat(
-    GooglePrices,
-    FireCloudConfig.GoogleCloud.priceListStorageKey,
-    FireCloudConfig.GoogleCloud.priceListEgressKey
-  )
-}
-import org.broadinstitute.dsde.firecloud.dataaccess.GooglePriceListJsonProtocol._
 
 object HttpGoogleServicesDAO {
   // the minimal scopes needed to get through the auth proxy and populate our UserInfo model objects

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpRawlsDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpRawlsDAO.scala
@@ -67,28 +67,10 @@ class HttpRawlsDAO(implicit val system: ActorSystem,
       }
     }
 
-  override def getBucketUsage(ns: String, name: String)(implicit
-    userInfo: WithAccessToken
-  ): Future[BucketUsageResponse] =
-    authedRequestToObject[BucketUsageResponse](Get(rawlsBucketUsageUrl(ns, name)))
-
   override def getBucketUsageV2(ns: String, name: String)(implicit
     userInfo: WithAccessToken
   ): Future[BucketMetricsResponse] =
     authedRequestToObject[BucketMetricsResponse](Get(rawlsBucketUsageV2Url(ns, name)))
-
-  override def getBucketOptions(ns: String, name: String, userProject: Option[GoogleProjectId] = None)(implicit
-    userInfo: WithAccessToken
-  ): Future[WorkspaceBucketOptions] =
-    authedRequestToObject[WorkspaceBucketOptions](Get(getBucketOptionsUrl(ns, name, userProject)))
-
-  private def getBucketOptionsUrl(ns: String, name: String, userProject: Option[GoogleProjectId]): String =
-    rawlsBucketOptionsUrl(ns, name) + {
-      userProject match {
-        case Some(id) => rawlsBucketOptionsQueryString.format(id)
-        case None     => ""
-      }
-    }
 
   override def getWorkspaces(implicit userInfo: WithAccessToken): Future[Seq[WorkspaceListResponse]] =
     authedRequestToObject[Seq[WorkspaceListResponse]](Get(rawlsWorkpacesUrl),

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/RawlsDAO.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/dataaccess/RawlsDAO.scala
@@ -48,17 +48,9 @@ trait RawlsDAO extends LazyLogging with ReportsSubsystemStatus {
     FireCloudConfig.Rawls.workspacesUrl + s"/$workspaceNamespace/$workspaceName/methodconfigs"
   )
 
-  def rawlsBucketUsageUrl(workspaceNamespace: String, workspaceName: String): String = encodeUri(
-    FireCloudConfig.Rawls.workspacesUrl + s"/$workspaceNamespace/$workspaceName/bucketUsage"
-  )
-
   def rawlsBucketUsageV2Url(workspaceNamespace: String, workspaceName: String): String = encodeUri(
     FireCloudConfig.Rawls.workspacesUrl + s"/v2/$workspaceNamespace/$workspaceName/bucketUsage"
   )
-
-  lazy val rawlsBucketOptionsQueryString = "?userProject=%s"
-  def rawlsBucketOptionsUrl(workspaceNamespace: String, workspaceName: String): String =
-    encodeUri(FireCloudConfig.Rawls.workspacesUrl + s"/$workspaceNamespace/$workspaceName/bucketOptions")
 
   def rawlsEntitiesOfTypeUrl(workspaceNamespace: String, workspaceName: String, entityType: String): String = encodeUri(
     FireCloudConfig.Rawls.workspacesUrl + s"/$workspaceNamespace/$workspaceName/entities/$entityType"
@@ -68,13 +60,7 @@ trait RawlsDAO extends LazyLogging with ReportsSubsystemStatus {
 
   def isLibraryCurator(userInfo: UserInfo): Future[Boolean]
 
-  def getBucketUsage(ns: String, name: String)(implicit userInfo: WithAccessToken): Future[BucketUsageResponse]
-
   def getBucketUsageV2(ns: String, name: String)(implicit userInfo: WithAccessToken): Future[BucketMetricsResponse]
-
-  def getBucketOptions(ns: String, name: String, userProject: Option[GoogleProjectId])(implicit
-    userToken: WithAccessToken
-  ): Future[WorkspaceBucketOptions]
 
   def getWorkspaces(implicit userInfo: WithAccessToken): Future[Seq[WorkspaceListResponse]]
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
@@ -272,10 +272,6 @@ object ModelJsonProtocol extends WorkspaceJsonSupport with SprayJsonSupport with
   implicit val impCwdsResponse: RootJsonFormat[CwdsResponse] = jsonFormat3(CwdsResponse)
   implicit val impCwdsListResponse: RootJsonFormat[CwdsListResponse] = jsonFormat4(CwdsListResponse)
 
-  implicit val impWorkspaceStorageCostEstimate: RootJsonFormat[WorkspaceStorageCostEstimate] = jsonFormat2(
-    WorkspaceStorageCostEstimate
-  )
-
   implicit val impWorkspaceStorageUsageAndCostEstimate: RootJsonFormat[WorkspaceStorageUsageAndCostEstimate] =
     jsonFormat3(
       WorkspaceStorageUsageAndCostEstimate

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/Workspace.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/Workspace.scala
@@ -98,8 +98,6 @@ case class RawlsGroupMemberList(userEmails: Option[Seq[String]] = None,
                                 subGroupNames: Option[Seq[String]] = None
 )
 
-case class WorkspaceStorageCostEstimate(estimate: String, lastUpdated: Option[DateTime])
-
 case class WorkspaceStorageUsageAndCostEstimate(estimate: BigDecimal, usageInBytes: BigDecimal, lastUpdated: Instant)
 
 case class WorkspaceId(workspaceId: UUID)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceService.scala
@@ -67,23 +67,6 @@ class WorkspaceService(protected val argUserToken: WithAccessToken,
 
   val storagePriceList = FireCloudConfig.GoogleCloud.storagePriceList
 
-  def getStorageCostEstimate(workspaceNamespace: String,
-                             workspaceName: String,
-                             userProject: Option[GoogleProjectId]
-  ): Future[RequestComplete[WorkspaceStorageCostEstimate]] = for {
-    bucketUsage <- rawlsDAO.getBucketUsage(workspaceNamespace, workspaceName)
-    priceList <- googleServicesDAO.fetchPriceList
-    bucketOptions <- rawlsDAO.getBucketOptions(workspaceNamespace, workspaceName, userProject)
-  } yield {
-    val rate = priceList.prices.cpBigstoreStorage.getOrElse(
-      bucketOptions.location.toLowerCase,
-      priceList.prices.cpBigstoreStorage("us")
-    )
-    // Convert bytes to GB since rate is based on GB.
-    val estimate: BigDecimal = BigDecimal(bucketUsage.usageInBytes) / (1024 * 1024 * 1024) * rate
-    RequestComplete(WorkspaceStorageCostEstimate(f"$$$estimate%.2f", bucketUsage.lastUpdated))
-  }
-
   def getStorageCostEstimateV2(workspaceNamespace: String,
                                workspaceName: String
   ): Future[RequestComplete[WorkspaceStorageUsageAndCostEstimate]] =

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiService.scala
@@ -322,20 +322,6 @@ trait WorkspaceApiService extends FireCloudRequestBuilding with FireCloudDirecti
                   }
                 }
               } ~
-              path("storageCostEstimate") {
-                get {
-                  parameters("userProject".optional) { userProject =>
-                    requireUserInfo() { userInfo =>
-                      complete {
-                        workspaceServiceConstructor(userInfo).getStorageCostEstimate(workspaceNamespace,
-                                                                                     workspaceName,
-                                                                                     userProject.map(GoogleProjectId)
-                        )
-                      }
-                    }
-                  }
-                }
-              } ~
               path("tags") {
                 requireUserInfo() { userInfo =>
                   get {

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAOSpec.scala
@@ -38,17 +38,6 @@ class HttpGoogleServicesDAOSpec extends AnyFlatSpec with Matchers with PrivateMe
 
   behavior of "HttpGoogleServicesDAO"
 
-  it should "default to the cached price list if it cannot fetch/parse one from Google" in {
-    val errorGcsDAO = new HttpGoogleServicesDAO(priceListUrl + ".error", defaultPriceList)
-
-    val priceList: GooglePriceList = Await.result(errorGcsDAO.fetchPriceList, Duration.Inf)
-
-    priceList.version should startWith("v")
-    priceList.updated should not be empty
-    priceList.prices.cpBigstoreStorage("us") shouldBe BigDecimal(-0.11)
-    priceList.prices.cpComputeengineInternetEgressNA.tiers.size shouldBe 1
-  }
-
   it should "return GcsPath for a successful object upload" in {
     // create local storage service
     val db = LocalStorageHelper.getOptions().getService()

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAOSpec.scala
@@ -26,15 +26,9 @@ import scala.concurrent.Await
 class HttpGoogleServicesDAOSpec extends AnyFlatSpec with Matchers with PrivateMethodTester {
 
   val testProject = "broad-dsde-dev"
-  val priceListUrl = ConfigFactory.load().getString("googlecloud.priceListUrl")
-  val defaultPriceList = GooglePriceList(
-    GooglePrices(Map("us" -> BigDecimal(-0.11)), UsTieredPriceItem(Map(1L -> BigDecimal(-0.22)))),
-    "v1",
-    "1"
-  )
   implicit val system: ActorSystem = ActorSystem("HttpGoogleCloudStorageDAOSpec")
   import system.dispatcher
-  val gcsDAO = new HttpGoogleServicesDAO(priceListUrl, defaultPriceList)
+  val gcsDAO = new HttpGoogleServicesDAO()
 
   behavior of "HttpGoogleServicesDAO"
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockRawlsDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockRawlsDAO.scala
@@ -386,29 +386,11 @@ class MockRawlsDAO extends RawlsDAO {
   override def isLibraryCurator(userInfo: UserInfo): Future[Boolean] =
     Future.successful(userInfo.id == "curator")
 
-  override def getBucketUsage(ns: String, name: String)(implicit
-    userInfo: WithAccessToken
-  ): Future[BucketUsageResponse] =
-    Future.successful(BucketUsageResponse(BigInt("256000000000"), Option(new DateTime(0))))
-
   override def getBucketUsageV2(ns: String, name: String)(implicit
     userInfo: WithAccessToken
   ): Future[BucketMetricsResponse] =
     Future.successful(
       BucketMetricsResponse(Seq(BucketMetric("COLDLINE", 256000000000d), BucketMetric("REGIONAL", 102400000d)))
-    )
-
-  override def getBucketOptions(ns: String, name: String, userProject: Option[GoogleProjectId] = None)(implicit
-    userInfo: WithAccessToken
-  ): Future[WorkspaceBucketOptions] =
-    Future.successful(
-      WorkspaceBucketOptions(
-        false,
-        ns match {
-          case "europeWest1BucketWorkspace" => "europe-west1"
-          case _                            => "us-central1"
-        }
-      )
     )
 
   override def getWorkspace(ns: String, name: String)(implicit userToken: WithAccessToken): Future[WorkspaceResponse] =

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockGoogleServicesDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/mock/MockGoogleServicesDAO.scala
@@ -85,15 +85,6 @@ class MockGoogleServicesDAO extends GoogleServicesDAO {
   override def writeObjectAsRawlsSA(bucketName: GcsBucketName, objectKey: GcsObjectName, tempFile: File): GcsPath =
     GcsPath(bucketName, objectKey)
 
-  override val fetchPriceList: Future[GooglePriceList] =
-    Future.successful(
-      GooglePriceList(
-        GooglePrices(Map("us" -> 0.01, "europe-west1" -> 0.02), UsTieredPriceItem(Map(1024L -> BigDecimal(0.12)))),
-        "v0",
-        "18-November-2016"
-      )
-    )
-
   override def deleteGoogleGroup(groupEmail: String): Unit = ()
   override def createGoogleGroup(groupName: String): Option[String] = Option(
     "new-google-group@support.something.firecloud.org"

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/webservice/WorkspaceApiServiceSpec.scala
@@ -1079,40 +1079,6 @@ class WorkspaceApiServiceSpec
     }
 
     "Workspace storage cost estimate tests" - {
-      "when calling any method other than GET on workspaces/*/*/storageCostEstimate" - {
-        "should return 405 Method Not Allowed for anything other than GET" in {
-          List(HttpMethods.PUT, HttpMethods.POST, HttpMethods.PATCH, HttpMethods.DELETE) map { method =>
-            new RequestBuilder(method)(usBucketStorageCostEstimatePath) ~> dummyUserIdHeaders(dummyUserId) ~> sealRoute(
-              workspaceRoutes
-            ) ~> check {
-              status should be(MethodNotAllowed)
-            }
-          }
-        }
-      }
-
-      "when calling GET on workspaces/*/*/storageCostEstimate" - {
-        "should return 200 with result for us region" in
-          Get(usBucketStorageCostEstimatePath) ~> dummyUserIdHeaders(dummyUserId) ~> sealRoute(
-            workspaceRoutes
-          ) ~> check {
-            status should be(OK)
-            // 256000000000 / (1024 * 1024 * 1024) *0.01
-            responseAs[WorkspaceStorageCostEstimate].estimate should be("$2.38")
-          }
-      }
-
-      "when calling GET on workspaces/*/*/storageCostEstimate" - {
-        "should return 200 with result for different europe east 1 region." in
-          Get(europeWest1storageCostEstimatePath) ~> dummyUserIdHeaders(dummyUserId) ~> sealRoute(
-            workspaceRoutes
-          ) ~> check {
-            status should be(OK)
-            // 256000000000 / (1024 * 1024 * 1024) *0.02
-            responseAs[WorkspaceStorageCostEstimate].estimate should be("$4.77")
-          }
-      }
-
       "when calling GET on workspaces/v2/*/*/storageCostEstimate" - {
         "should return 200 with result" in
           Get(bucketStorageCostEstimateV2Path) ~> dummyUserIdHeaders(dummyUserId) ~> sealRoute(


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/CORE-321

This PR removes the [getBucketUsage](https://firecloud-orchestration.dsde-dev.broadinstitute.org/#/Workspaces/getBucketUsage) and [getStorageCostEstimate](https://firecloud-orchestration.dsde-dev.broadinstitute.org/#/Workspaces/getStorageCostEstimate) APIs, following 30 days of deprecation with no observed usage. Additionally, it removes related Google pricelist code and configuration.

#### Verification:
- Confirmed the endpoints are fully removed.
- Verified no active references remain in the codebase.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [X] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [X] Get two thumbsworth of review and PO signoff if necessary
- [X] Verify all tests go green
- [X] Squash and merge. Make sure your branch deletes; GitHub should do this for you.
- [X] Test this change deployed correctly and works on dev environment after deployment
