### PR TITLE
CORE-406: ensure getStorageCostEstimateV2 usageInBytes is an integer

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/Workspace.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/Workspace.scala
@@ -98,7 +98,7 @@ case class RawlsGroupMemberList(userEmails: Option[Seq[String]] = None,
                                 subGroupNames: Option[Seq[String]] = None
 )
 
-case class WorkspaceStorageUsageAndCostEstimate(estimate: BigDecimal, usageInBytes: BigDecimal, lastUpdated: Instant)
+case class WorkspaceStorageUsageAndCostEstimate(estimate: BigDecimal, usageInBytes: BigInt, lastUpdated: Instant)
 
 case class WorkspaceId(workspaceId: UUID)
 case class WorkspaceIdResponse(workspace: WorkspaceId)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceService.scala
@@ -81,7 +81,10 @@ class WorkspaceService(protected val argUserToken: WithAccessToken,
           (sumBytes + metric.valueInBytes, sumEstimate + estimate)
       }
       RequestComplete(
-        WorkspaceStorageUsageAndCostEstimate(totalEstimate.setScale(2, RoundingMode.HALF_UP), totalBytes, Instant.now)
+        WorkspaceStorageUsageAndCostEstimate(totalEstimate.setScale(2, RoundingMode.HALF_UP),
+                                             totalBytes.toBigInt,
+                                             Instant.now
+        )
       )
     }) recoverWith {
       case e: NoSuchElementException =>


### PR DESCRIPTION
CORE-406

Ensure the `usageInBytes` value in the `getStorageCostEstimateV2` API is an integer.

The code changes in this PR are not actually necessary. The API returns the sum of values from Rawls' bucket-usage API. As of https://github.com/broadinstitute/rawls/pull/3228, Rawls will only return integers, so their sum will always be an int. Nonetheless, this PR adds type safety.