### PR TITLE
CORE-69: update guava, workbench-google2; exclude from google2

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
   val jacksonV = "2.18.3"
   val jacksonHotfixV = "2.18.3" // for when only some of the Jackson libs have hotfix releases
   val nettyV = "4.1.119.Final"
-  val workbenchLibsHash = "3e0cf25" // see https://github.com/broadinstitute/workbench-libs readme for hash values
+  val workbenchLibsHash = "70c7d82" // see https://github.com/broadinstitute/workbench-libs readme for hash values
 
   def excludeGuava(m: ModuleID): ModuleID = m.exclude("com.google.guava", "guava")
   val excludeAkkaActor =        ExclusionRule(organization = "com.typesafe.akka", name = "akka-actor_2.13")
@@ -38,7 +38,7 @@ object Dependencies {
     // TODO: can these move to sbt's dependencyOverrides?
     "io.netty"                       % "netty-handler"       % nettyV, // netty is needed by the Elasticsearch client at runtime
     "org.apache.lucene"              % "lucene-queryparser"  % "6.6.6", // pin to this version; it's the latest compatible with our elasticsearch client
-    "com.google.guava"               % "guava"               % "33.4.0-jre",
+    "com.google.guava"               % "guava"               % "33.4.5-jre",
     // END transitive dependency overrides
 
     // elasticsearch requires log4j, but we redirect log4j to logback
@@ -54,10 +54,19 @@ object Dependencies {
       exclude("com.google.code.findbugs", "jsr305")
       excludeAll(excludeAkkaHttp, excludeSprayJson),
     excludeGuava("org.broadinstitute.dsde.workbench" %% "workbench-util"  % s"0.10-$workbenchLibsHash"),
-    "org.broadinstitute.dsde.workbench" %% "workbench-google2" % s"0.36-$workbenchLibsHash",
-    "org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % s"0.8-$workbenchLibsHash",
+    "org.broadinstitute.dsde.workbench" %% "workbench-google2" % s"0.37-$workbenchLibsHash"
+      // we don't need all the libraries that workbench-google2 pulls in
+      exclude("com.google.cloud", "google-cloud-bigquery")
+      exclude("com.google.cloud", "google-cloud-billing")
+      exclude("com.google.cloud", "google-cloud-compute")
+      exclude("com.google.cloud", "google-cloud-container")
+      exclude("com.google.cloud", "google-cloud-dataproc")
+      exclude("com.google.cloud", "google-cloud-kms")
+      exclude("com.google.cloud", "google-cloud-resourcemanager")
+      exclude("com.google.cloud", "google-cloud-storage-transfer"),
+    "org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % s"0.9-$workbenchLibsHash",
     "org.broadinstitute.dsde.workbench" %% "sam-client"       % "v0.0.370",
-    "org.broadinstitute.dsde.workbench" %% "workbench-notifications" %s"0.8-$workbenchLibsHash",
+    "org.broadinstitute.dsde.workbench" %% "workbench-notifications" %s"1.1-$workbenchLibsHash",
     "org.databiosphere" % "workspacedataservice-client-okhttp-jakarta" % "0.2.167-SNAPSHOT",
     "bio.terra" % "externalcreds-client-resttemplate" % "1.83.0-SNAPSHOT" excludeAll(excludeSpring, excludeSpringBoot),
     "org.springframework" % "spring-web" % "6.2.4" excludeAll(excludeSpringBoot, excludeSpringJcl),


### PR DESCRIPTION
This PR resolves some issues in Scala Steward's https://github.com/broadinstitute/firecloud-orchestration/pull/1594.

In that other PR, we hit an `sbt assembly` conflict due to different versions of `com.google.auto.value:auto-value-annotations` being present - one pulled in by guava, another pulled in by the BigQuery library which is transitively required by `workbench-google2`.

In this PR:
* update `guava`
* update `workbench-google2` to latest
* exclude a bunch of unnecessary google libs that `workbench-google2` was pulling in, including the BQ lib in conflict with guava.