### PR TITLE
CORE-69: update guava, workbench-google2; exclude from google2 - take 2

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,6 @@ object Dependencies {
   val nettyV = "4.1.119.Final"
   val workbenchLibsHash = "70c7d82" // see https://github.com/broadinstitute/workbench-libs readme for hash values
 
-  def excludeGuava(m: ModuleID): ModuleID = m.exclude("com.google.guava", "guava")
   val excludeAkkaActor =        ExclusionRule(organization = "com.typesafe.akka", name = "akka-actor_2.13")
   val excludeAkkaStream =       ExclusionRule(organization = "com.typesafe.akka", name = "akka-stream_2.13")
   val excludeAkkaHttp = ExclusionRule(organization = "com.typesafe.akka", name = "akka-http_2.13")
@@ -23,6 +22,7 @@ object Dependencies {
   // by being listed here.
   // One reason to specify an override here is to avoid static-analysis security warnings.
   val transitiveDependencyOverrides: Seq[ModuleID] = Seq(
+    "com.google.guava"           % "guava"                      % "33.4.5-jre",
     "com.fasterxml.jackson.core" % "jackson-annotations"        % jacksonV,
     "com.fasterxml.jackson.core" % "jackson-databind"           % jacksonHotfixV,
     "com.fasterxml.jackson.core" % "jackson-core"               % jacksonV,
@@ -38,7 +38,6 @@ object Dependencies {
     // TODO: can these move to sbt's dependencyOverrides?
     "io.netty"                       % "netty-handler"       % nettyV, // netty is needed by the Elasticsearch client at runtime
     "org.apache.lucene"              % "lucene-queryparser"  % "6.6.6", // pin to this version; it's the latest compatible with our elasticsearch client
-    "com.google.guava"               % "guava"               % "33.4.5-jre",
     // END transitive dependency overrides
 
     // elasticsearch requires log4j, but we redirect log4j to logback
@@ -48,12 +47,12 @@ object Dependencies {
     "com.typesafe.scala-logging"    %% "scala-logging"       % "3.9.5",
 
     "org.parboiled" % "parboiled-core" % "1.4.1",
-    excludeGuava("org.broadinstitute.dsde"       %% "rawls-model"         % "v0.0.331-SNAP")
+    "org.broadinstitute.dsde"       %% "rawls-model"         % "v0.0.331-SNAP"
       exclude("com.typesafe.scala-logging", "scala-logging_2.13")
       exclude("com.typesafe.akka", "akka-stream_2.13")
       exclude("com.google.code.findbugs", "jsr305")
       excludeAll(excludeAkkaHttp, excludeSprayJson),
-    excludeGuava("org.broadinstitute.dsde.workbench" %% "workbench-util"  % s"0.10-$workbenchLibsHash"),
+    "org.broadinstitute.dsde.workbench" %% "workbench-util"  % s"0.10-$workbenchLibsHash",
     "org.broadinstitute.dsde.workbench" %% "workbench-google2" % s"0.37-$workbenchLibsHash"
       // we don't need all the libraries that workbench-google2 pulls in
       exclude("com.google.cloud", "google-cloud-bigquery")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
   val jacksonV = "2.18.3"
   val jacksonHotfixV = "2.18.3" // for when only some of the Jackson libs have hotfix releases
   val nettyV = "4.1.119.Final"
-  val workbenchLibsHash = "3e0cf25" // see https://github.com/broadinstitute/workbench-libs readme for hash values
+  val workbenchLibsHash = "70c7d82" // see https://github.com/broadinstitute/workbench-libs readme for hash values
 
   def excludeGuava(m: ModuleID): ModuleID = m.exclude("com.google.guava", "guava")
   val excludeAkkaActor =        ExclusionRule(organization = "com.typesafe.akka", name = "akka-actor_2.13")
@@ -38,7 +38,7 @@ object Dependencies {
     // TODO: can these move to sbt's dependencyOverrides?
     "io.netty"                       % "netty-handler"       % nettyV, // netty is needed by the Elasticsearch client at runtime
     "org.apache.lucene"              % "lucene-queryparser"  % "6.6.6", // pin to this version; it's the latest compatible with our elasticsearch client
-    "com.google.guava"               % "guava"               % "33.4.0-jre",
+    "com.google.guava"               % "guava"               % "33.4.5-jre",
     // END transitive dependency overrides
 
     // elasticsearch requires log4j, but we redirect log4j to logback
@@ -54,10 +54,19 @@ object Dependencies {
       exclude("com.google.code.findbugs", "jsr305")
       excludeAll(excludeAkkaHttp, excludeSprayJson),
     excludeGuava("org.broadinstitute.dsde.workbench" %% "workbench-util"  % s"0.10-$workbenchLibsHash"),
-    "org.broadinstitute.dsde.workbench" %% "workbench-google2" % s"0.36-$workbenchLibsHash",
-    "org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % s"0.8-$workbenchLibsHash",
+    "org.broadinstitute.dsde.workbench" %% "workbench-google2" % s"0.37-$workbenchLibsHash"
+      // we don't need all the libraries that workbench-google2 pulls in
+      exclude("com.google.cloud", "google-cloud-bigquery")
+      exclude("com.google.cloud", "google-cloud-billing")
+      exclude("com.google.cloud", "google-cloud-compute")
+      exclude("com.google.cloud", "google-cloud-container")
+      exclude("com.google.cloud", "google-cloud-dataproc")
+      exclude("com.google.cloud", "google-cloud-kms")
+      exclude("com.google.cloud", "google-cloud-resourcemanager")
+      exclude("com.google.cloud", "google-cloud-storage-transfer"),
+    "org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % s"0.9-$workbenchLibsHash",
     "org.broadinstitute.dsde.workbench" %% "sam-client"       % "v0.0.370",
-    "org.broadinstitute.dsde.workbench" %% "workbench-notifications" %s"0.8-$workbenchLibsHash",
+    "org.broadinstitute.dsde.workbench" %% "workbench-notifications" %s"1.1-$workbenchLibsHash",
     "org.databiosphere" % "workspacedataservice-client-okhttp-jakarta" % "0.2.167-SNAPSHOT",
     "bio.terra" % "externalcreds-client-resttemplate" % "1.83.0-SNAPSHOT" excludeAll(excludeSpring, excludeSpringBoot),
     "org.springframework" % "spring-web" % "6.2.5" excludeAll(excludeSpringBoot, excludeSpringJcl),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -58,7 +58,6 @@ object Dependencies {
       // we don't need all the libraries that workbench-google2 pulls in
       exclude("com.google.cloud", "google-cloud-bigquery")
       exclude("com.google.cloud", "google-cloud-billing")
-      exclude("com.google.cloud", "google-cloud-compute")
       exclude("com.google.cloud", "google-cloud-container")
       exclude("com.google.cloud", "google-cloud-dataproc")
       exclude("com.google.cloud", "google-cloud-kms")


### PR DESCRIPTION
This is a redo of #1595. I merged that PR and it hit problems starting up in the dev env. I reverted it in #1596. Now I'm trying again.

Original description from #1595:
> This PR resolves some issues in Scala Steward's https://github.com/broadinstitute/firecloud-orchestration/pull/1594.
> 
> In that other PR, we hit an `sbt assembly` conflict due to different versions of `com.google.auto.value:auto-value-annotations` being present - one pulled in by guava, another pulled in by the BigQuery library which is transitively required by `workbench-google2`.
> 
> In this PR:
> * update `guava`
> * update `workbench-google2` to latest
> * exclude a bunch of unnecessary google libs that `workbench-google2` was pulling in, including the BQ lib in conflict with guava.

Changes in this PR on top of what's in #1595:
* `guava` moves to `transitiveDependencyOverrides`. We don't need it as a direct dependency; we just needed to override the version pulled in transitively by other dependencies
* re-include the `google-cloud-compute` transitive dependency from workbench-google2. We need this when subscribing to externalcreds messages, [here](https://github.com/broadinstitute/firecloud-orchestration/blob/6137d78f28dd94c77f223ecf1df622d22b171b00/src/main/scala/org/broadinstitute/dsde/firecloud/Boot.scala#L192-L214) (yes, pubsub requires the compute libs). This subscription only happens in live envs, not bees, which is why the error only appeared after pushing to the dev env. I tested by pushing this PR to dev temporarily.
