### PR TITLE
remove OPTIONS http method handling from Orch

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudApiService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudApiService.scala
@@ -171,17 +171,16 @@ trait FireCloudApiService
 
   // routes under /api
   def apiRoutes: server.Route =
-    options(complete(StatusCodes.OK)) ~
-      withExecutionContext(ExecutionContext.global) {
-        v1RegisterRoutes ~
-          methodsApiServiceRoutes ~
-          profileRoutes ~
-          cromIamApiServiceRoutes ~
-          methodConfigurationRoutes ~
-          nihRoutes ~
-          shareLogServiceRoutes ~
-          staticNotebooksRoutes
-      }
+    withExecutionContext(ExecutionContext.global) {
+      v1RegisterRoutes ~
+        methodsApiServiceRoutes ~
+        profileRoutes ~
+        cromIamApiServiceRoutes ~
+        methodConfigurationRoutes ~
+        nihRoutes ~
+        shareLogServiceRoutes ~
+        staticNotebooksRoutes
+    }
 
   val routeWrappers: Directive[Unit] =
     handleRejections(org.broadinstitute.dsde.firecloud.model.defaultErrorReportRejectionHandler) &


### PR DESCRIPTION
`OPTIONS` http requests are used by browsers to [negotiate CORS](https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request). In Terra, we want to return 204 from OPTIONS requests to allow the Terra UI to make ajax requests to our services.

We handle this in the apache proxy; example [here](https://github.com/broadinstitute/terra-helmfile/blob/7f862d6642ba4eff0f1986ac0c5d3e5ed4b9a583/charts/crljanitor/templates/proxy-apache-httpd-configmap.yaml#L54-L55). The proxy intercepts all OPTIONS requests and returns 204; services don't have to worry about this.

Long, long ago we enabled Orchestration to handle OPTIONS requests. This helped with local development. The need for this has long since passed; Orchestration doesn't need to do this anymore. None of our other services handle this (outside of the proxy).

The unwanted effect of leaving the OPTIONS handling in is that Orch will respond with a 405 `HTTP method not allowed, supported methods: OPTIONS` instead of a 404 when the user calls an API that does not exist.

This PR removes the custom OPTIONS handling so Orch will properly return 404s.

Tested in a BEE.
