### PR TITLE
[CORE-404] Add perWorkflowCostCap to createSubmission API in Swagger

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -8628,8 +8628,11 @@ components:
           description: Whether or not to create output columns if they would be empty and optional.  Defaults to false (columns are created).
         perWorkflowCostCap:
           type: number
-          description: The maximum cost for a single workflow in this submission.  If the workflow exceeds this cost, it will be aborted.
+          description: A cost threshold in USD to apply to individual workflows. When the estimated cost is exceeded, the workflow is terminated.
           format: float
+          minimum: 0.01
+          maximum: 9999999999.99
+          multipleOf: 0.01
       description: If the referenced method configuration takes no root entity, do
         not define `entityType`, `entityName` and `expression`.
     SubmissionStatus:

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -8626,6 +8626,10 @@ components:
           type: boolean
           default: false
           description: Whether or not to create output columns if they would be empty and optional.  Defaults to false (columns are created).
+        perWorkflowCostCap:
+          type: number
+          description: The maximum cost for a single workflow in this submission.  If the workflow exceeds this cost, it will be aborted.
+          format: float
       description: If the referenced method configuration takes no root entity, do
         not define `entityType`, `entityName` and `expression`.
     SubmissionStatus:


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/CORE-404

#### Summary:
Now that the cost threshold feature is in preview, this PR updates the API to include the `perWorkflowCostCap` parameter in the `createSubmission` API in Swagger.


Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge. Make sure your branch deletes; GitHub should do this for you.
- [ ] Test this change deployed correctly and works on dev environment after deployment
