### PR TITLE
[CORE-419] Change Scala Steward Updates to Run Monthly

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -23,7 +23,7 @@
 #     the given expression.
 #
 #
-pullRequests.frequency = "0 0 ? * MON" # every monday at midnight
+pullRequests.frequency = "0 0 1 * *" # first day of each month at midnight
 
 # pullRequests.grouping allows you to specify how Scala Steward should group
 # your updates in order to reduce the number of pull-requests.


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/CORE-419

Currently, Scala Steward updates run weekly, resulting in frequent PRs. To reduce PR overhead while still maintaining necessary security updates, this PR updates the schedule to run on the first day of each month.

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge. Make sure your branch deletes; GitHub should do this for you.
- [ ] Test this change deployed correctly and works on dev environment after deployment
