### PR TITLE
CORE-443 deny email patterns from access to auth domains driven by telemetry

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -75,3 +75,40 @@ sam {
 elasticsearch {
   libraryEnabled = false
 }
+
+nih {
+  # NIH prohibits accounts from free email providers or emails from contries of concern
+  # (?i) is case insensitive
+  denyEmailPatterns = [
+    "(?i).+@(.+\\.)*126\\..+",
+    "(?i).+@(.+\\.)*163\\..+",
+    "(?i).+@(.+\\.)*aol\\..+",
+    "(?i).+@(.+\\.)*bk\\..+",
+    "(?i).+@(.+\\.)*foxmail\\..+",
+    "(?i).+@(.+\\.)*gmail\\..+",
+    "(?i).+@(.+\\.)*hotmail\\..+",
+    "(?i).+@(.+\\.)*icloud\\..+",
+    "(?i).+@(.+\\.)*inbox\\..+",
+    "(?i).+@(.+\\.)*live\\..+",
+    "(?i).+@(.+\\.)*mail\\..+",
+    "(?i).+@(.+\\.)*mailinator\\..+",
+    "(?i).+@(.+\\.)*outlook\\..+",
+    "(?i).+@(.+\\.)*proton\\..+",
+    "(?i).+@(.+\\.)*qq\\..+",
+    "(?i).+@(.+\\.)*rambler\\..+",
+    "(?i).+@(.+\\.)*sina\\..+",
+    "(?i).+@(.+\\.)*yeah\\..+",
+    "(?i).+@(.+\\.)*yahoo\\..+",
+    "(?i).+@(.+\\.)*yandex\\..+",
+    "(?i).+@(.+\\.)*ecohealthalliance\\.org",
+    "(?i).+@(.+\\.)+cn",
+    "(?i).+@(.+\\.)+hk",
+    "(?i).+@(.+\\.)+mo",
+    "(?i).+@(.+\\.)+ru",
+    "(?i).+@(.+\\.)+ir",
+    "(?i).+@(.+\\.)+nk",
+    "(?i).+@(.+\\.)+cu",
+    "(?i).+@(.+\\.)+ve",
+    "(?i)ydu@mrn\\.org ",
+  ]
+}

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
@@ -14,6 +14,7 @@ import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.FiniteDuration
 import scala.jdk.CollectionConverters._
 import scala.util.Try
+import scala.util.matching.Regex
 
 object FireCloudConfig {
   private val config = ConfigFactory.load()
@@ -204,6 +205,12 @@ object FireCloudConfig {
 
         DbGapPermission(phsId, consentGroup) -> groupName
       }.toMap
+    }
+    lazy val denyEmailPatterns: Set[Regex] = {
+      val denyEmailPatternsConfigs = nih.getStringList("denyEmailPatterns")
+      denyEmailPatternsConfigs.asScala.toSet.map { pattern: String =>
+        pattern.r
+      }
     }
   }
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/NihService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/NihService.scala
@@ -263,7 +263,7 @@ class NihService(val samDao: SamDAO,
       dbGapGroupEmail <- Future.traverse(dbGapSamGroup.toList)(samDao.getGroupEmail(_)(getAdminAccessToken))
       ecmEmails <- getNihAllowlistTerraEmailsFromEcm(allowlistUsers)
       thurloeEmails <- getNihAllowlistTerraEmailsFromThurloe(allowlistUsers)
-      members = ecmEmails ++ thurloeEmails ++ dbGapGroupEmail
+      members = allowedNihMembers(ecmEmails ++ thurloeEmails ++ dbGapGroupEmail)
       _ <- ensureAllowlistGroupsExists()
       // The request to Sam to completely overwrite the group with the list of actively linked users on the allowlist
       _ <- samDao.overwriteGroupMembers(nihAllowlist.groupToSync, ManagedGroupRoles.Member, members.toList)(
@@ -272,6 +272,12 @@ class NihService(val samDao: SamDAO,
         throw new FireCloudException(s"Error synchronizing NIH allowlist: ${e.getMessage}")
       }
     } yield ()
+  }
+
+  private def allowedNihMembers(members: Set[WorkbenchEmail]): Set[WorkbenchEmail] = {
+    members.filterNot(email => FireCloudConfig.Nih.denyEmailPatterns.exists { r =>
+      r.matches(email.value)
+    })
   }
 
   private def linkNihAccountEcm(userInfo: UserInfo, nihLink: NihLink): Future[Try[Unit]] =
@@ -387,7 +393,7 @@ class NihService(val samDao: SamDAO,
   ): Future[Boolean] = {
     val allowlistUsers = downloadNihAllowlist(nihAllowlist)
 
-    if (allowlistUsers contains linkedNihUserName) {
+    if (allowlistUsers.contains(linkedNihUserName) && allowedNihMembers(Set(userEmail)).contains(userEmail)) {
       for {
         _ <- samDao.addGroupMember(nihAllowlist.groupToSync, ManagedGroupRoles.Member, userEmail)(getAdminAccessToken)
       } yield true

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/NihService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/NihService.scala
@@ -274,11 +274,8 @@ class NihService(val samDao: SamDAO,
     } yield ()
   }
 
-  private def allowedNihMembers(members: Set[WorkbenchEmail]): Set[WorkbenchEmail] = {
-    members.filterNot(email => FireCloudConfig.Nih.denyEmailPatterns.exists { r =>
-      r.matches(email.value)
-    })
-  }
+  private def allowedNihMembers(members: Set[WorkbenchEmail]): Set[WorkbenchEmail] =
+    members.filterNot(email => FireCloudConfig.Nih.denyEmailPatterns.exists(_.matches(email.value)))
 
   private def linkNihAccountEcm(userInfo: UserInfo, nihLink: NihLink): Future[Try[Unit]] =
     ecmDao

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/NihService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/NihService.scala
@@ -274,8 +274,17 @@ class NihService(val samDao: SamDAO,
     } yield ()
   }
 
-  private def allowedNihMembers(members: Set[WorkbenchEmail]): Set[WorkbenchEmail] =
-    members.filterNot(email => FireCloudConfig.Nih.denyEmailPatterns.exists(_.matches(email.value)))
+  private def allowedNihMembers(members: Set[WorkbenchEmail]): Set[WorkbenchEmail] = {
+    val allowedMembers =
+      members.filterNot(email => FireCloudConfig.Nih.denyEmailPatterns.exists(_.matches(email.value)))
+    val deniedMembers = members -- allowedMembers
+    if (deniedMembers.nonEmpty) {
+      logger.info(
+        s"NIH allowlist sync: ${deniedMembers.mkString(",")} were denied access to the NIH allowlist due to matching deny patterns"
+      )
+    }
+    allowedMembers
+  }
 
   private def linkNihAccountEcm(userInfo: UserInfo, nihLink: NihLink): Future[Try[Unit]] =
     ecmDao

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/NihServiceUnitSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/NihServiceUnitSpec.scala
@@ -94,7 +94,8 @@ class NihServiceUnitSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEa
   var userDbGapLinkedAccount =
     LinkedEraAccount(userDbGap.id.value, "nihUsername5", new DateTime().plusSeconds(secondsIn30Days))
 
-  val samUsers = Seq(userNoLinkedAccount, userNoAllowlists, userTcgaAndTarget, userTcgaOnly, userTargetOnly, userDbGap, deniedUser)
+  val samUsers =
+    Seq(userNoLinkedAccount, userNoAllowlists, userTcgaAndTarget, userTcgaOnly, userTargetOnly, userDbGap, deniedUser)
   val linkedAccounts = Seq(
     userNoAllowlistsLinkedAccount,
     userTcgaAndTargetLinkedAccount,
@@ -437,9 +438,9 @@ class NihServiceUnitSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEa
     mockThurloeUsers()
     val user = deniedUser
     val userInfo = UserInfo(user.email.value,
-      OAuth2BearerToken(user.id.value),
-      Instant.now().plusSeconds(60).getEpochSecond,
-      user.id.value
+                            OAuth2BearerToken(user.id.value),
+                            Instant.now().plusSeconds(60).getEpochSecond,
+                            user.id.value
     )
     val linkedAccount = userTcgaOnlyLinkedAccount
     val jwt = jwtForUser(linkedAccount)
@@ -462,7 +463,7 @@ class NihServiceUnitSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEa
     statusCode should be(StatusCodes.OK)
     verify(googleDao, times(1)).getBucketObjectAsInputStream(FireCloudConfig.Nih.whitelistBucket, "tcga-whitelist.txt")
     verify(googleDao, times(1)).getBucketObjectAsInputStream(FireCloudConfig.Nih.whitelistBucket,
-      "target-whitelist.txt"
+                                                             "target-whitelist.txt"
     )
     verify(samDao, times(1)).removeGroupMember(
       ArgumentMatchers.eq(WorkbenchGroupName("TARGET-dbGaP-Authorized")),

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/NihServiceUnitSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/NihServiceUnitSpec.scala
@@ -77,6 +77,7 @@ class NihServiceUnitSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEa
   val userTcgaOnly = genSamUser();
   val userTargetOnly = genSamUser();
   val userDbGap = genSamUser();
+  val deniedUser = genSamUser().copy(email = WorkbenchEmail("someone@gmAil.com"))
   val dbGapGroupEmail = WorkbenchEmail(UUID.randomUUID().toString + "@email.com")
 
   // DateTimes must be modified in seconds instead of days to match implementation
@@ -93,13 +94,14 @@ class NihServiceUnitSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEa
   var userDbGapLinkedAccount =
     LinkedEraAccount(userDbGap.id.value, "nihUsername5", new DateTime().plusSeconds(secondsIn30Days))
 
-  val samUsers = Seq(userNoLinkedAccount, userNoAllowlists, userTcgaAndTarget, userTcgaOnly, userTargetOnly, userDbGap)
+  val samUsers = Seq(userNoLinkedAccount, userNoAllowlists, userTcgaAndTarget, userTcgaOnly, userTargetOnly, userDbGap, deniedUser)
   val linkedAccounts = Seq(
     userNoAllowlistsLinkedAccount,
     userTcgaAndTargetLinkedAccount,
     userTcgaOnlyLinkedAccount,
     userTargetOnlyLinkedAccount,
-    userDbGapLinkedAccount
+    userDbGapLinkedAccount,
+    deniedUser
   )
 
   val idToSamUser = samUsers.groupBy(_.id).view.mapValues(_.head).toMap
@@ -109,7 +111,8 @@ class NihServiceUnitSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEa
     userTcgaAndTarget.id -> userTcgaAndTargetLinkedAccount,
     userTcgaOnly.id -> userTcgaOnlyLinkedAccount,
     userTargetOnly.id -> userTargetOnlyLinkedAccount,
-    userDbGap.id -> userDbGapLinkedAccount
+    userDbGap.id -> userDbGapLinkedAccount,
+    deniedUser.id -> userTcgaAndTargetLinkedAccount
   )
 
   val linkedAccountsByExternalId = Map(
@@ -412,6 +415,61 @@ class NihServiceUnitSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEa
       ArgumentMatchers.eq(WorkbenchEmail(user.email.value))
     )(ArgumentMatchers.eq(UserInfo(adminAccessToken, "")))
     verify(samDao, times(1)).addGroupMember(
+      ArgumentMatchers.eq(WorkbenchGroupName("TCGA-dbGaP-Authorized")),
+      ArgumentMatchers.eq(ManagedGroupRoles.Member),
+      ArgumentMatchers.eq(WorkbenchEmail(user.email.value))
+    )(ArgumentMatchers.eq(UserInfo(adminAccessToken, "")))
+    verify(samDao, never()).addGroupMember(
+      ArgumentMatchers.eq(WorkbenchGroupName("this-doesnt-matter")),
+      ArgumentMatchers.eq(ManagedGroupRoles.Member),
+      ArgumentMatchers.eq(WorkbenchEmail(user.email.value))
+    )(ArgumentMatchers.eq(UserInfo(adminAccessToken, "")))
+    verify(samDao, never()).addGroupMember(
+      ArgumentMatchers.eq(WorkbenchGroupName("other-group")),
+      ArgumentMatchers.eq(ManagedGroupRoles.Member),
+      ArgumentMatchers.eq(WorkbenchEmail(user.email.value))
+    )(ArgumentMatchers.eq(UserInfo(adminAccessToken, "")))
+  }
+
+  it should "decode a JWT from Shibboleth and sync allowlists and remove a denied user" in {
+    mockShibbolethDAO()
+    mockEcmUsers()
+    mockThurloeUsers()
+    val user = deniedUser
+    val userInfo = UserInfo(user.email.value,
+      OAuth2BearerToken(user.id.value),
+      Instant.now().plusSeconds(60).getEpochSecond,
+      user.id.value
+    )
+    val linkedAccount = userTcgaOnlyLinkedAccount
+    val jwt = jwtForUser(linkedAccount)
+    val (statusCode, nihStatus) = Await
+      .result(nihService.updateNihLinkAndSyncSelf(userInfo, jwt), Duration.Inf)
+      .asInstanceOf[PerRequest.RequestComplete[(StatusCode, NihStatus)]]
+      .response
+
+    nihStatus.linkedNihUsername should be(Some(linkedAccount.linkedExternalId))
+    nihStatus.linkExpireTime should be(Some(linkedAccount.linkExpireTime.getMillis / 1000L))
+    nihStatus.datasetPermissions should be(
+      Set(
+        NihDatasetPermission("BROKEN", authorized = false),
+        NihDatasetPermission("TARGET", authorized = false),
+        NihDatasetPermission("TCGA", authorized = false),
+        NihDatasetPermission("RAS", authorized = false)
+      )
+    )
+
+    statusCode should be(StatusCodes.OK)
+    verify(googleDao, times(1)).getBucketObjectAsInputStream(FireCloudConfig.Nih.whitelistBucket, "tcga-whitelist.txt")
+    verify(googleDao, times(1)).getBucketObjectAsInputStream(FireCloudConfig.Nih.whitelistBucket,
+      "target-whitelist.txt"
+    )
+    verify(samDao, times(1)).removeGroupMember(
+      ArgumentMatchers.eq(WorkbenchGroupName("TARGET-dbGaP-Authorized")),
+      ArgumentMatchers.eq(ManagedGroupRoles.Member),
+      ArgumentMatchers.eq(WorkbenchEmail(user.email.value))
+    )(ArgumentMatchers.eq(UserInfo(adminAccessToken, "")))
+    verify(samDao, times(1)).removeGroupMember(
       ArgumentMatchers.eq(WorkbenchGroupName("TCGA-dbGaP-Authorized")),
       ArgumentMatchers.eq(ManagedGroupRoles.Member),
       ArgumentMatchers.eq(WorkbenchEmail(user.email.value))


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/CORE-443

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge. Make sure your branch deletes; GitHub should do this for you.
- [ ] Test this change deployed correctly and works on dev environment after deployment
