### PR TITLE
[CORE-419] Fix scala steward frequency config

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -23,7 +23,7 @@
 #     the given expression.
 #
 #
-pullRequests.frequency = "0 0 1 * *" # first day of each month at midnight
+pullRequests.frequency = "0 0 0 1 * ?" # first day of each month at midnight
 
 # pullRequests.grouping allows you to specify how Scala Steward should group
 # your updates in order to reduce the number of pull-requests.

--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -23,7 +23,7 @@
 #     the given expression.
 #
 #
-pullRequests.frequency = "0 0 1 * *" # first day of each month at midnight
+pullRequests.frequency = "0 0 1 * ?" # first day of each month at midnight
 
 # pullRequests.grouping allows you to specify how Scala Steward should group
 # your updates in order to reduce the number of pull-requests.


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-419

Updated the Scala Steward cron schedule from `0 0 ? * MON` (every Monday at midnight) to `0 0 0 1 * ?` to run at midnight on the 1st of every month, reducing update frequency and aligning with a monthly maintenance cycle.

The cron expression follows the Quartz format, which is what [cron4s](https://github.com/alonsodomin/cron4s) (used by Scala Steward) supports. The updated expression, `0 0 0 1 * ?` means it runs at midnight on the 1st of every month. You can confirm it's valid in the [cron4s user guide](https://www.alonsodomin.me/cron4s/userguide/) or by testing it with any [Quartz cron expression tool](https://www.freeformatter.com/cron-expression-generator-quartz.html).

---

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge. Make sure your branch deletes; GitHub should do this for you.
- [ ] Test this change deployed correctly and works on dev environment after deployment
