### PR TITLE
CORE-405: nightly swat test actions fixes

### DIFF
--- a/.github/workflows/orch-nightly-swat-tests.yml
+++ b/.github/workflows/orch-nightly-swat-tests.yml
@@ -1,6 +1,6 @@
 # Github action to run swatomation tests nightly
 
-name: orch-nightly-swat-tests
+name: Nightly swat tests
 
 on:
   schedule:
@@ -17,6 +17,7 @@ jobs:
     outputs:
       custom-version-json: ${{ steps.build-custom-version-json.outputs.custom-version-json }}
       test-context: ${{ steps.prepare-outputs.outputs.test-context }}
+      tag: ${{ steps.get-latest-tag.outputs.tag }}
     steps:
       - uses: 'actions/checkout@v4'
         with:
@@ -61,7 +62,7 @@ jobs:
           inputs: '{
               "bee-name": "orch-${{ github.run_id }}-${{ matrix.terra-env }}",
               "version-template": "${{ matrix.terra-env }}",
-              "custom-version-json": "${{ needs.setup-vars.outputs.custom-version-json }}",
+              "custom-version-json": "${{ needs.prepare-configs.outputs.custom-version-json }}",
               "run-name": "bee-create-${{ env.RUN_NAME }}"
             }'
 
@@ -71,7 +72,7 @@ jobs:
         terra-env: [ dev ] # what versions of apps do we use to emulate types of environments
         testing-env: [ qa ] # what env resources to use, e.g. SA keys
     runs-on: ubuntu-latest
-    needs: [create-bee-workflow]
+    needs: [prepare-configs, create-bee-workflow]
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -88,7 +89,7 @@ jobs:
               "bee-name": "orch-${{ github.run_id }}-${{ matrix.terra-env }}",
               "ENV": "${{ matrix.testing-env }}",
               "test-context": "${{ needs.prepare-configs.outputs.test-context }}",
-              "ref": "${{ github.head_ref }}"
+              "ref": "${{ needs.prepare-configs.outputs.tag }}"
             }'
           # github.head_ref, used above, is only populated for PRs and will be blank when merging to develop.
           # This is ok; the orch-swat-tests workflow uses "develop" as a default when receiving a blank value.


### PR DESCRIPTION
CORE-405

Fix some problems with the `Nightly swat tests` github action. It was not properly passing all the correct details over to terra-github-workflows when dispatching actions over there.