### PR TITLE
CORE-69: ignore benchmarking dependencies in Dependabot vulns

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -17,3 +17,5 @@ jobs:
           ## Optional: Define the working directory of your build.
           ## It should contain the build.sbt file.
           working-directory: './'
+          # Ignore dependencies for the benchmarking module; these are not used at runtime
+          modules-ignore: bench_2.13


### PR DESCRIPTION
When submitting dependencies to Dependabot for vulnerability assessment, don't include dependencies from the benchmarking subproject.

Benchmarking dependencies are not used at runtime and thus are not the top priority for vulnerability assessment.

I can't actually test this github action until it merges to dev, so this may need some followup.