### PR TITLE
[CORE-458] Remove coursier/cache-action

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -22,10 +22,6 @@ jobs:
     - uses: actions/checkout@v4
     - uses: sbt/setup-sbt@v1
 
-    # coursier cache action caches both coursier and sbt caches
-    - name: coursier-cache-action
-      uses: coursier/cache-action@v6
-
     - name: Set up JDK 17
       uses: actions/setup-java@v4
       with:


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CORE-458

The coursier-cache-action has been disabled as per the GitHub changelog (https://github.blog/changelog/2025-03-20-notification-of-upcoming-breaking-changes-in-github-actions/#decommissioned-cache-service-brownouts). 

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge. Make sure your branch deletes; GitHub should do this for you.
- [ ] Test this change deployed correctly and works on dev environment after deployment
