### PR TITLE
CORE-496 disable allowlists and tolerate missing dbgap groups

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/FireCloudConfig.scala
@@ -184,11 +184,13 @@ object FireCloudConfig {
         val fileName = config.getString("fileName")
         val phsId = config.getString("phsId")
         val consentGroup = config.getString("consentGroup")
+        val disabled = config.optionalBoolean("disabled").getOrElse(false)
 
         NihAllowlist(name,
                      WorkbenchGroupName(rawlsGroup),
                      fileName,
-                     DbGapPermission(PhsId(phsId), ConsentGroup(consentGroup))
+                     DbGapPermission(PhsId(phsId), ConsentGroup(consentGroup)),
+                     disabled = disabled
         )
       }
     }.toSet

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/NihService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/NihService.scala
@@ -48,7 +48,8 @@ case class NihStatus(linkedNihUsername: Option[String] = None,
 case class NihAllowlist(name: String,
                         groupToSync: WorkbenchGroupName,
                         fileName: String,
-                        dbGapPermission: DbGapPermission
+                        dbGapPermission: DbGapPermission,
+                        disabled: Boolean
 )
 
 case class NihDatasetPermission(name: String, authorized: Boolean)
@@ -77,6 +78,7 @@ class NihService(val samDao: SamDAO,
   def getAdminAccessToken: WithAccessToken = UserInfo(googleDao.getAdminUserAccessToken, "")
 
   private val nihAllowlists: Set[NihAllowlist] = FireCloudConfig.Nih.whitelists
+  private val enabledNihAllowlists = FireCloudConfig.Nih.whitelists.filterNot(_.disabled)
 
   def processExternalCredsMessage(externalCredsMessage: ReceivedMessage[ExternalCredsMessage]): IO[Unit] = {
     val groupUpdateIO = for {
@@ -197,22 +199,27 @@ class NihService(val samDao: SamDAO,
     val groupMemberships = samDao.listGroups(userInfo)
     groupMemberships.map { groups =>
       val samGroupNames = groups.map(g => WorkbenchGroupName(g.groupName)).toSet
-      nihAllowlists.map(allowlist =>
+      enabledNihAllowlists.map(allowlist =>
         NihDatasetPermission(allowlist.name, samGroupNames.contains(allowlist.groupToSync))
       )
     }
   }
 
-  private def downloadNihAllowlist(allowlist: NihAllowlist): Set[String] = {
-    val usersList = Source.fromInputStream(
-      googleDao.getBucketObjectAsInputStream(FireCloudConfig.Nih.whitelistBucket, allowlist.fileName)
-    )
+  private def downloadNihAllowlist(allowlist: NihAllowlist): Set[String] =
+    if (allowlist.disabled) {
+      logger.info(s"NIH allowlist ${allowlist.name} is disabled, skipping download")
+      Set.empty
+    } else {
+      val usersList = Source.fromInputStream(
+        googleDao.getBucketObjectAsInputStream(FireCloudConfig.Nih.whitelistBucket, allowlist.fileName)
+      )
 
-    usersList.getLines().toSet
-  }
+      usersList.getLines().toSet
+    }
 
   def syncAllowlistAllUsers(allowlistName: String): Future[PerRequestMessage] = {
     logger.info("Synchronizing allowlist '" + allowlistName + "' for all users")
+    // include disabled allowlists so we remove all group users during the sync
     nihAllowlists.find(_.name.equals(allowlistName)) match {
       case Some(allowlist) =>
         val allowlistSyncResults = syncNihAllowlistAllUsers(allowlist)
@@ -225,6 +232,7 @@ class NihService(val samDao: SamDAO,
   // This syncs all of the allowlists for all of the users
   def syncAllNihAllowlistsAllUsers(): Future[PerRequestMessage] = {
     logger.info("Synchronizing all allowlists for all users")
+    // include disabled allowlists so we remove all group users during the sync
     val allowlistSyncResults = Future.traverse(nihAllowlists)(syncNihAllowlistAllUsers)
 
     allowlistSyncResults map { _ => RequestComplete(NoContent) }
@@ -260,10 +268,10 @@ class NihService(val samDao: SamDAO,
       FireCloudConfig.Nih.dbGapPermissionToGroup.get(nihAllowlist.dbGapPermission).map(WorkbenchGroupName)
 
     for {
-      dbGapGroupEmail <- Future.traverse(dbGapSamGroup.toList)(samDao.getGroupEmail(_)(getAdminAccessToken))
+      dbGapGroupEmail <- Future.traverse(dbGapSamGroup.toList)(getSamGroupEmail)
       ecmEmails <- getNihAllowlistTerraEmailsFromEcm(allowlistUsers)
       thurloeEmails <- getNihAllowlistTerraEmailsFromThurloe(allowlistUsers)
-      members = allowedNihMembers(ecmEmails ++ thurloeEmails ++ dbGapGroupEmail)
+      members = allowedNihMembers(ecmEmails ++ thurloeEmails ++ dbGapGroupEmail.flatten)
       _ <- ensureAllowlistGroupsExists()
       // The request to Sam to completely overwrite the group with the list of actively linked users on the allowlist
       _ <- samDao.overwriteGroupMembers(nihAllowlist.groupToSync, ManagedGroupRoles.Member, members.toList)(
@@ -273,6 +281,12 @@ class NihService(val samDao: SamDAO,
       }
     } yield ()
   }
+
+  private def getSamGroupEmail(groupName: WorkbenchGroupName): Future[Option[WorkbenchEmail]] =
+    samDao.getGroupEmail(groupName)(getAdminAccessToken).map(Option.apply).recover {
+      case e: FireCloudExceptionWithErrorReport if e.errorReport.statusCode.contains(StatusCodes.NotFound) =>
+        None
+    }
 
   private def allowedNihMembers(members: Set[WorkbenchEmail]): Set[WorkbenchEmail] = {
     val allowedMembers =
@@ -335,7 +349,7 @@ class NihService(val samDao: SamDAO,
     for {
       _ <- unlinkNihAccount(userInfo)
       _ <- ensureAllowlistGroupsExists()
-      _ <- Future.traverse(nihAllowlists) { allowlist =>
+      _ <- Future.traverse(enabledNihAllowlists) { allowlist =>
         removeUserFromNihAllowlistGroup(WorkbenchEmail(userInfo.userEmail), allowlist).recoverWith {
           case _: Exception =>
             throw new FireCloudExceptionWithErrorReport(
@@ -377,7 +391,7 @@ class NihService(val samDao: SamDAO,
       ecmLinkResult <- linkNihAccountEcm(userInfo, nihLink)
 
       _ <- ensureAllowlistGroupsExists()
-      allowlistSyncResults <- Future.traverse(nihAllowlists) { allowlist =>
+      allowlistSyncResults <- Future.traverse(enabledNihAllowlists) { allowlist =>
         syncNihAllowlistForUser(WorkbenchEmail(userInfo.userEmail), nihLink.linkedNihUsername, allowlist)
           .map(NihDatasetPermission(allowlist.name, _))
       }
@@ -428,7 +442,7 @@ class NihService(val samDao: SamDAO,
   private def ensureAllowlistGroupsExists(): Future[Unit] =
     samDao.listGroups(getAdminAccessToken).flatMap { groups =>
       val missingGroupNames =
-        nihAllowlists.map(_.groupToSync.value.toLowerCase()) -- groups.map(_.groupName.toLowerCase).toSet
+        enabledNihAllowlists.map(_.groupToSync.value.toLowerCase()) -- groups.map(_.groupName.toLowerCase).toSet
       if (missingGroupNames.isEmpty) {
         Future.successful(())
       } else {

--- a/src/test/resources/reference.conf
+++ b/src/test/resources/reference.conf
@@ -85,6 +85,13 @@ nih {
       "phsId":"phs001234",
       "consentGroup":"c2"
     }
+    "DISABLED" {
+      "fileName":"disabled-whitelist.txt",
+      "rawlsGroup":"this-doesnt-matter",
+      "phsId":"phs101234",
+      "consentGroup":"c2"
+      "disabled": true
+    }
   }
   rasIssuer = "https://stsstg.nih.gov"
   rasVisaType = "https://ras.nih.gov/visas/v1.1"

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/NihServiceUnitSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/NihServiceUnitSpec.scala
@@ -3,8 +3,7 @@ package org.broadinstitute.dsde.firecloud.service
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import akka.http.scaladsl.model.{StatusCode, StatusCodes}
 import cats.effect.unsafe.implicits.global
-import org.broadinstitute.dsde.firecloud.FireCloudConfig
-import org.broadinstitute.dsde.firecloud.FireCloudException
+import org.broadinstitute.dsde.firecloud.{FireCloudConfig, FireCloudException, FireCloudExceptionWithErrorReport}
 import org.broadinstitute.dsde.firecloud.dataaccess.{
   ExternalCredsDAO,
   GoogleServicesDAO,
@@ -36,7 +35,7 @@ import org.broadinstitute.dsde.workbench.model.{
   WorkbenchGroupName,
   WorkbenchUserId
 }
-import org.broadinstitute.dsde.rawls.model.ErrorReport
+import org.broadinstitute.dsde.rawls.model.{ErrorReport, ErrorReportSource}
 import org.broadinstitute.dsde.workbench.client.sam.model.{BulkMembershipUpdateRequestV2, PolicyMembershipUpdate}
 import org.broadinstitute.dsde.workbench.util2.messaging.{AckHandler, ReceivedMessage}
 import org.joda.time.DateTime
@@ -62,6 +61,7 @@ import scala.util.{Failure, Random, Success}
 class NihServiceUnitSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEach {
 
   implicit val executionContext: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
+  implicit val errorReportSource: ErrorReportSource = ErrorReportSource("NihServiceUnitSpec")
   val samDao = mock[SamDAO]
   val thurloeDao = mock[ThurloeDAO]
   val googleDao = mock[GoogleServicesDAO]
@@ -293,6 +293,32 @@ class NihServiceUnitSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEa
     when(thurloeDao.getAllUserValuesForKey(any[String])).thenReturn(Future.successful(Map.empty))
 
     val emailsToSync = Set(userDbGap.email, dbGapGroupEmail)
+    val nihStatus = Await
+      .result(nihService.syncAllowlistAllUsers("RAS"), Duration.Inf)
+      .asInstanceOf[PerRequest.RequestComplete[StatusCode]]
+      .response
+
+    nihStatus should be(StatusCodes.NoContent)
+    verify(samDao, times(1)).overwriteGroupMembers(
+      ArgumentMatchers.eq(WorkbenchGroupName("dbgap_phs002409_c1")),
+      ArgumentMatchers.eq(ManagedGroupRoles.Member),
+      ArgumentMatchers.argThat((list: List[WorkbenchEmail]) => list.toSet.equals(emailsToSync))
+    )(ArgumentMatchers.eq(UserInfo(adminAccessToken, "")))
+  }
+
+  it should "sync all users by tolerating groups found with consentGroup + phsId that don't exist" in {
+    when(ecmDao.getActiveLinkedEraAccounts(ArgumentMatchers.eq(UserInfo(adminAccessToken, ""))))
+      .thenReturn(Future.successful(Seq(userDbGapLinkedAccount)))
+    when(thurloeDao.getAllUserValuesForKey(any[String])).thenReturn(Future.successful(Map.empty))
+    when(samDao.getGroupEmail(ArgumentMatchers.eq(WorkbenchGroupName("dbgap_phs002409_c1")))(any())).thenReturn(
+      Future.failed(
+        new FireCloudExceptionWithErrorReport(
+          ErrorReport(StatusCodes.NotFound, "Group not found")
+        )
+      )
+    )
+
+    val emailsToSync = Set(userDbGap.email)
     val nihStatus = Await
       .result(nihService.syncAllowlistAllUsers("RAS"), Duration.Inf)
       .asInstanceOf[PerRequest.RequestComplete[StatusCode]]


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/CORE-496

In prep for https://broadworkbench.atlassian.net/browse/CORE-489, implement a disabled config switch for each allowlist in orch. When set to true, ignore them when a user links or unlinks their NIH account and treat them as empty when the explicit call to sync them is made from ncbiaccess. 

Disabling an allowlist means that users won't be added to the associated auth domain group based on telemetry files processed by the ncbiaccess cronjob. Instead they will gain access via RAS which triggers membership in a different group. This new group is a sub group of the auth domain group (there is also a bug fix in this PR to the process that makes the new group a sub group of the auth domain group, tolerating when the new group does not exist yet).

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge. Make sure your branch deletes; GitHub should do this for you.
- [ ] Test this change deployed correctly and works on dev environment after deployment
