### PR TITLE
CORE-564: getStorageCostEstimateV2 reports storage sizes by state 

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,8 +7,8 @@ object Dependencies {
   val jacksonHotfixV = "2.19.1" // for when only some of the Jackson libs have hotfix releases
   val workbenchLibsHash = "70c7d82" // see https://github.com/broadinstitute/workbench-libs readme for hash values
 
-  val excludeAkkaActor =        ExclusionRule(organization = "com.typesafe.akka", name = "akka-actor_2.13")
-  val excludeAkkaStream =       ExclusionRule(organization = "com.typesafe.akka", name = "akka-stream_2.13")
+  val excludeAkkaActor = ExclusionRule(organization = "com.typesafe.akka", name = "akka-actor_2.13")
+  val excludeAkkaStream = ExclusionRule(organization = "com.typesafe.akka", name = "akka-stream_2.13")
   val excludeAkkaHttp = ExclusionRule(organization = "com.typesafe.akka", name = "akka-http_2.13")
   val excludeSprayJson = ExclusionRule(organization = "com.typesafe.akka", name = "akka-http-spray-json_2.13")
 
@@ -21,65 +21,61 @@ object Dependencies {
   // by being listed here.
   // One reason to specify an override here is to avoid static-analysis security warnings.
   val transitiveDependencyOverrides: Seq[ModuleID] = Seq(
-    "com.google.guava"           % "guava"                      % "33.4.8-jre",
-    "com.fasterxml.jackson.core" % "jackson-annotations"        % jacksonV,
-    "com.fasterxml.jackson.core" % "jackson-databind"           % jacksonHotfixV,
-    "com.fasterxml.jackson.core" % "jackson-core"               % jacksonV,
-    "org.yaml"                   % "snakeyaml"                  % "2.4",
-    "org.apache.commons"         % "commons-compress"           % "1.27.1", // workbench-libs libraries pull this in
-    "com.google.apis"            % "google-api-services-pubsub" % "v1-rev20250414-2.0.0", // from workbench-google2
-    "com.google.apis"  % "google-api-services-admin-directory"  % "directory_v1-rev20250626-2.0.0" // from workbench-google2
+    "com.google.guava" % "guava" % "33.4.8-jre",
+    "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonV,
+    "com.fasterxml.jackson.core" % "jackson-databind" % jacksonHotfixV,
+    "com.fasterxml.jackson.core" % "jackson-core" % jacksonV,
+    "org.yaml" % "snakeyaml" % "2.4",
+    "org.apache.commons" % "commons-compress" % "1.27.1", // workbench-libs libraries pull this in
+    "com.google.apis" % "google-api-services-pubsub" % "v1-rev20250414-2.0.0", // from workbench-google2
+    "com.google.apis" % "google-api-services-admin-directory" % "directory_v1-rev20250626-2.0.0" // from workbench-google2
   )
 
   val rootDependencies: Seq[ModuleID] = Seq(
-    "ch.qos.logback"                 % "logback-classic"     % "1.5.18",
-    "io.sentry"                      % "sentry-logback"      % "8.13.3",
-    "com.typesafe.scala-logging"    %% "scala-logging"       % "3.9.5",
-
+    "ch.qos.logback" % "logback-classic" % "1.5.18",
+    "io.sentry" % "sentry-logback" % "8.13.3",
+    "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
     "org.parboiled" % "parboiled-core" % "1.4.1",
-    "org.broadinstitute.dsde"       %% "rawls-model"         % "v0.0.449-SNAP"
-      exclude("com.typesafe.scala-logging", "scala-logging_2.13")
-      exclude("com.typesafe.akka", "akka-stream_2.13")
-      exclude("com.google.code.findbugs", "jsr305")
-      exclude("org.typelevel", "cats-parse_2.13")
-      excludeAll(excludeAkkaHttp, excludeSprayJson),
-    "org.broadinstitute.dsde.workbench" %% "workbench-util"  % s"0.10-$workbenchLibsHash",
+    "org.broadinstitute.dsde" %% "rawls-model" % "v0.0.494-SNAP"
+      exclude ("com.typesafe.scala-logging", "scala-logging_2.13")
+      exclude ("com.typesafe.akka", "akka-stream_2.13")
+      exclude ("com.google.code.findbugs", "jsr305")
+      exclude ("org.typelevel", "cats-parse_2.13")
+      excludeAll (excludeAkkaHttp, excludeSprayJson),
+    "org.broadinstitute.dsde.workbench" %% "workbench-util" % s"0.10-$workbenchLibsHash",
     "org.broadinstitute.dsde.workbench" %% "workbench-google2" % s"0.37-$workbenchLibsHash"
-      // we don't need all the libraries that workbench-google2 pulls in
-      exclude("com.google.cloud", "google-cloud-bigquery")
-      exclude("com.google.cloud", "google-cloud-billing")
-      exclude("com.google.cloud", "google-cloud-container")
-      exclude("com.google.cloud", "google-cloud-dataproc")
-      exclude("com.google.cloud", "google-cloud-kms")
-      exclude("com.google.cloud", "google-cloud-resourcemanager")
-      exclude("com.google.cloud", "google-cloud-storage-transfer"),
+    // we don't need all the libraries that workbench-google2 pulls in
+    exclude ("com.google.cloud", "google-cloud-bigquery")
+      exclude ("com.google.cloud", "google-cloud-billing")
+      exclude ("com.google.cloud", "google-cloud-container")
+      exclude ("com.google.cloud", "google-cloud-dataproc")
+      exclude ("com.google.cloud", "google-cloud-kms")
+      exclude ("com.google.cloud", "google-cloud-resourcemanager")
+      exclude ("com.google.cloud", "google-cloud-storage-transfer"),
     "org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % s"0.9-$workbenchLibsHash",
-    "org.broadinstitute.dsde.workbench" %% "sam-client"       % "v0.0.402",
-    "org.broadinstitute.dsde.workbench" %% "workbench-notifications" %s"1.1-$workbenchLibsHash",
+    "org.broadinstitute.dsde.workbench" %% "sam-client" % "v0.0.402",
+    "org.broadinstitute.dsde.workbench" %% "workbench-notifications" % s"1.1-$workbenchLibsHash",
     "org.databiosphere" % "workspacedataservice-client-okhttp-jakarta" % "0.2.167-SNAPSHOT",
-    "bio.terra" % "externalcreds-client-resttemplate" % "1.83.0-SNAPSHOT" excludeAll(excludeSpring, excludeSpringBoot),
-    "org.springframework" % "spring-web" % "6.2.8" excludeAll(excludeSpringBoot, excludeSpringJcl),
-
-    "com.typesafe.akka"   %%  "akka-actor"           % akkaV,
-    "com.typesafe.akka"   %%  "akka-slf4j"           % akkaV,
-    "com.typesafe.akka"   %%  "akka-http"            % akkaHttpV           excludeAll(excludeAkkaActor, excludeAkkaStream),
-    "com.typesafe.akka"   %%  "akka-http-spray-json" % akkaHttpV,
-    "com.typesafe.akka"   %%  "akka-stream"          % akkaV,
-    "com.typesafe.akka"   %%  "akka-testkit"         % akkaV     % "test",
-    "com.typesafe.akka"   %%  "akka-http-testkit"    % akkaHttpV % "test",
-
-    "com.github.jwt-scala"          %% "jwt-core"            % "11.0.0",
+    "bio.terra" % "externalcreds-client-resttemplate" % "1.83.0-SNAPSHOT" excludeAll (excludeSpring, excludeSpringBoot),
+    "org.springframework" % "spring-web" % "6.2.8" excludeAll (excludeSpringBoot, excludeSpringJcl),
+    "com.typesafe.akka" %% "akka-actor" % akkaV,
+    "com.typesafe.akka" %% "akka-slf4j" % akkaV,
+    "com.typesafe.akka" %% "akka-http" % akkaHttpV excludeAll (excludeAkkaActor, excludeAkkaStream),
+    "com.typesafe.akka" %% "akka-http-spray-json" % akkaHttpV,
+    "com.typesafe.akka" %% "akka-stream" % akkaV,
+    "com.typesafe.akka" %% "akka-testkit" % akkaV % "test",
+    "com.typesafe.akka" %% "akka-http-testkit" % akkaHttpV % "test",
+    "com.github.jwt-scala" %% "jwt-core" % "11.0.0",
     // javax.mail is used only by MethodRepository.validatePublicOrEmail(). Consider
     // refactoring that method to remove this entire dependency.
-    "com.sun.mail"                   % "javax.mail"          % "1.6.2"
-      exclude("javax.activation", "activation"),
-    "com.univocity"                  % "univocity-parsers"   % "2.9.1",
-    "com.github.pathikrit"          %% "better-files"        % "3.9.2",
-
-    "org.scalatest"                 %% "scalatest"           % "3.2.19"   % "test",
-    "org.mock-server"                % "mockserver-netty-no-dependencies"    % "5.15.0"  % "test",
+    "com.sun.mail" % "javax.mail" % "1.6.2"
+      exclude ("javax.activation", "activation"),
+    "com.univocity" % "univocity-parsers" % "2.9.1",
+    "com.github.pathikrit" %% "better-files" % "3.9.2",
+    "org.scalatest" %% "scalatest" % "3.2.19" % "test",
+    "org.mock-server" % "mockserver-netty-no-dependencies" % "5.15.0" % "test",
     // provides testing mocks
-    "com.google.cloud"               % "google-cloud-nio"    % "0.127.38" % "test",
-    "org.scalatestplus"             %% "mockito-4-5"         % "3.2.12.0" % "test"
+    "com.google.cloud" % "google-cloud-nio" % "0.127.38" % "test",
+    "org.scalatestplus" %% "mockito-4-5" % "3.2.12.0" % "test"
   )
 }

--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -6242,11 +6242,14 @@ components:
           description: The estimated monthly storage cost of the bucket
         usageInBytes:
           type: integer
-          description: The current storage bucket usage in bytes
+          description: The total current storage bucket usage in bytes
         lastUpdated:
           type: string
           format: timestamp
           description: timestamp (UTC) marking the date that the bucket cost was last updated (YYYY-MM-DDThh:mm:ss.fffZ)
+        usage:
+          type: object
+          description: Bucket usage in bytes, broken down by storage type.
       description: ""
     CallMetadata:
       type: object

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/ModelJsonProtocol.scala
@@ -146,7 +146,7 @@ object ModelJsonProtocol extends WorkspaceJsonSupport with SprayJsonSupport with
   implicit val impCwdsListResponse: RootJsonFormat[CwdsListResponse] = jsonFormat4(CwdsListResponse)
 
   implicit val impWorkspaceStorageUsageAndCostEstimate: RootJsonFormat[WorkspaceStorageUsageAndCostEstimate] =
-    jsonFormat3(
+    jsonFormat4(
       WorkspaceStorageUsageAndCostEstimate
     )
 

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/model/Workspace.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/model/Workspace.scala
@@ -98,7 +98,11 @@ case class RawlsGroupMemberList(userEmails: Option[Seq[String]] = None,
                                 subGroupNames: Option[Seq[String]] = None
 )
 
-case class WorkspaceStorageUsageAndCostEstimate(estimate: BigDecimal, usageInBytes: BigInt, lastUpdated: Instant)
+case class WorkspaceStorageUsageAndCostEstimate(estimate: BigDecimal,
+                                                usageInBytes: BigInt,
+                                                lastUpdated: Instant,
+                                                usage: Map[String, BigInt]
+)
 
 case class WorkspaceId(workspaceId: UUID)
 case class WorkspaceIdResponse(workspace: WorkspaceId)

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceService.scala
@@ -67,10 +67,18 @@ class WorkspaceService(protected val argUserToken: WithAccessToken,
           val estimate = bytes / (1024 * 1024 * 1024) * storagePriceList(metric.storageClass)
           (sumBytes + metric.valueInBytes, sumEstimate + estimate)
       }
+      // calculate total bytes by storage type (e.g. live-object vs. soft-deleted-object
+      val bytesByType = bucketUsage.metrics
+        .groupMap(_.storageState)(_.valueInBytes)
+        .map { case (storageState, byteSeq) =>
+          (storageState, BigDecimal(byteSeq.sum).toBigInt)
+        }
+
       RequestComplete(
         WorkspaceStorageUsageAndCostEstimate(totalEstimate.setScale(2, RoundingMode.HALF_UP),
                                              totalBytes.toBigInt,
-                                             Instant.now
+                                             Instant.now,
+                                             bytesByType
         )
       )
     }) recoverWith {

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockRawlsDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockRawlsDAO.scala
@@ -383,7 +383,11 @@ class MockRawlsDAO extends RawlsDAO {
     userInfo: WithAccessToken
   ): Future[BucketMetricsResponse] =
     Future.successful(
-      BucketMetricsResponse(Seq(BucketMetric("COLDLINE", 256000000000d), BucketMetric("REGIONAL", 102400000d)))
+      BucketMetricsResponse(
+        Seq(BucketMetric("COLDLINE", "soft-deleted-object", 256000000000d),
+            BucketMetric("REGIONAL", "live-object", 102400000d)
+        )
+      )
     )
 
   override def getWorkspace(ns: String, name: String)(implicit userToken: WithAccessToken): Future[WorkspaceResponse] =

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/WorkspaceServiceSpec.scala
@@ -66,6 +66,20 @@ class WorkspaceServiceSpec extends BaseServiceSpec with BeforeAndAfterEach {
       costEstimateResponse.response.usageInBytes shouldBe 256102400000d
     }
 
+    "should report storage sizes by state" in {
+      val costEstimateResponse = Await
+        .result(
+          ws.getStorageCostEstimateV2("workspaceNameSpace", "workspaceName"),
+          Duration.Inf
+        )
+      // Mock Rawls DAO returns  BucketMetric("COLDLINE", "soft-deleted-object", 256000000000d
+      // and BucketMetric("REGIONAL", "live-object", 102400000d)
+      costEstimateResponse.response.usage shouldBe Map(
+        "soft-deleted-object" -> 256000000000d,
+        "live-object" -> 102400000d
+      )
+    }
+
     "should error on unexpected storage class" in
       intercept[Exception] {
         Await.result(ws.getStorageCostEstimateV2("workspaceNameSpace", "unexpectedStorageClass"), Duration.Inf)
@@ -185,11 +199,19 @@ class MockRawlsDeleteWSDAO(implicit val executionContext: ExecutionContext) exte
   ): Future[BucketMetricsResponse] =
     if (name == "unexpectedStorageClass") {
       Future.successful(
-        BucketMetricsResponse(Seq(BucketMetric("incorrect", 256000000000d), BucketMetric("REGIONAL", 102400000d)))
+        BucketMetricsResponse(
+          Seq(BucketMetric("incorrect", "soft-deleted-object", 256000000000d),
+              BucketMetric("REGIONAL", "live-object", 102400000d)
+          )
+        )
       )
     } else {
       Future.successful(
-        BucketMetricsResponse(Seq(BucketMetric("COLDLINE", 256000000000d), BucketMetric("REGIONAL", 102400000d)))
+        BucketMetricsResponse(
+          Seq(BucketMetric("COLDLINE", "soft-deleted-object", 256000000000d),
+              BucketMetric("REGIONAL", "live-object", 102400000d)
+          )
+        )
       )
     }
 


### PR DESCRIPTION
CORE-564

Builds on https://github.com/broadinstitute/rawls/pull/3410 to include total bucket sizes grouped by state (live object, soft deleted object, etc) in the getStorageCostEstimateV2 API.

Before:
<img width="619" height="177" alt="Screenshot 21-07-2025 at 13 51 (1)" src="https://github.com/user-attachments/assets/2e0e3632-c2ae-4bf6-9e6c-4022d89ba90e" />

After:
<img width="538" height="242" alt="Screenshot 21-07-2025 at 13 51" src="https://github.com/user-attachments/assets/5e284788-7e87-444a-98cf-3ad7edd86e92" />

Note this PR does NOT change the value of `usageInBytes` in the API response. This PR is purely additive; it adds a new `usage` object which is a map of state->size. This means that Terra UI and any scripters who currently rely on `usageInBytes` will not break and will not see a behavior change.

