### PR TITLE
CORE-614: update to latest workbench-libs hash & versions

### DIFF
--- a/automation/project/Dependencies.scala
+++ b/automation/project/Dependencies.scala
@@ -7,18 +7,25 @@ object Dependencies {
   val jacksonHotfixV = "2.19.1" // for when only some of the Jackson libs have hotfix releases
   val akkaV = "2.6.19"
   val akkaHttpV = "10.2.10"
-  val workbenchLibsHash = "3e0cf25"
+  val workbenchLibsHash = "9df42f5"
 
-  val workbenchModelV  = s"0.20-$workbenchLibsHash"
+  val workbenchModelV = s"0.21-$workbenchLibsHash"
   val workbenchModel: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-model" % workbenchModelV
-  val excludeWorkbenchModel = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-model_" + scalaV)
+  val excludeWorkbenchModel =
+    ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-model_" + scalaV)
 
-  val workbenchGoogleV = s"0.33-$workbenchLibsHash"
-  val workbenchGoogle: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-google" % workbenchGoogleV excludeAll excludeWorkbenchModel
-  val excludeWorkbenchGoogle = ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-google_" + scalaV)
+  val workbenchGoogleV = s"0.35-$workbenchLibsHash"
+  val workbenchGoogle: ModuleID =
+    "org.broadinstitute.dsde.workbench" %% "workbench-google" % workbenchGoogleV excludeAll excludeWorkbenchModel
+  val excludeWorkbenchGoogle =
+    ExclusionRule(organization = "org.broadinstitute.dsde.workbench", name = "workbench-google_" + scalaV)
 
-  val workbenchServiceTestV = s"5.0-$workbenchLibsHash"
-  val workbenchServiceTest: ModuleID = "org.broadinstitute.dsde.workbench" %% "workbench-service-test" % workbenchServiceTestV % "test" classifier "tests" excludeAll (excludeWorkbenchGoogle, excludeWorkbenchModel)
+  val workbenchServiceTestV = s"6.1-$workbenchLibsHash"
+  val workbenchServiceTest: ModuleID =
+    "org.broadinstitute.dsde.workbench" %% "workbench-service-test" % workbenchServiceTestV % "test" classifier "tests" excludeAll (
+      excludeWorkbenchGoogle,
+      excludeWorkbenchModel
+    )
 
   // Overrides for transitive dependencies. These apply - via Settings.scala - to all projects in this codebase.
   // These are overrides only; if the direct dependencies stop including any of these, they will not be included
@@ -37,20 +44,19 @@ object Dependencies {
     "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonV,
     "net.virtual-void" %% "json-lenses" % "0.6.2" % "test",
     "ch.qos.logback" % "logback-classic" % "1.5.18",
-    "com.typesafe.akka"   %%  "akka-http-core"     % akkaHttpV,
-    "com.typesafe.akka"   %%  "akka-stream-testkit" % akkaV,
-    "com.typesafe.akka"   %%  "akka-http"           % akkaHttpV,
-    "com.typesafe.akka"   %%  "akka-http-spray-json" % akkaHttpV,
-    "com.typesafe.akka"   %%  "akka-testkit"        % akkaV     % "test",
-    "com.typesafe.akka"   %%  "akka-slf4j"          % akkaV,
-    "org.specs2"          %%  "specs2-core"   % "4.15.0"  % "test",
-    "org.scalatest"       %%  "scalatest"     % "3.2.19"   % Test,
+    "com.typesafe.akka" %% "akka-http-core" % akkaHttpV,
+    "com.typesafe.akka" %% "akka-stream-testkit" % akkaV,
+    "com.typesafe.akka" %% "akka-http" % akkaHttpV,
+    "com.typesafe.akka" %% "akka-http-spray-json" % akkaHttpV,
+    "com.typesafe.akka" %% "akka-testkit" % akkaV % "test",
+    "com.typesafe.akka" %% "akka-slf4j" % akkaV,
+    "org.specs2" %% "specs2-core" % "4.15.0" % "test",
+    "org.scalatest" %% "scalatest" % "3.2.19" % Test,
     "com.typesafe.scala-logging" %% "scala-logging" % "3.9.5",
 
     // required but not provided by workbench-google.
     // workbench-google specifies 7.0.1
     "net.logstash.logback" % "logstash-logback-encoder" % "7.1.1",
-
     workbenchServiceTest,
     workbenchModel,
     workbenchGoogle

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ object Dependencies {
   val akkaHttpV = "10.6.3"
   val jacksonV = "2.19.1"
   val jacksonHotfixV = "2.19.1" // for when only some of the Jackson libs have hotfix releases
-  val workbenchLibsHash = "70c7d82" // see https://github.com/broadinstitute/workbench-libs readme for hash values
+  val workbenchLibsHash = "9df42f5" // see https://github.com/broadinstitute/workbench-libs readme for hash values
 
   val excludeAkkaActor = ExclusionRule(organization = "com.typesafe.akka", name = "akka-actor_2.13")
   val excludeAkkaStream = ExclusionRule(organization = "com.typesafe.akka", name = "akka-stream_2.13")
@@ -43,7 +43,7 @@ object Dependencies {
       exclude ("org.typelevel", "cats-parse_2.13")
       excludeAll (excludeAkkaHttp, excludeSprayJson),
     "org.broadinstitute.dsde.workbench" %% "workbench-util" % s"0.10-$workbenchLibsHash",
-    "org.broadinstitute.dsde.workbench" %% "workbench-google2" % s"0.37-$workbenchLibsHash"
+    "org.broadinstitute.dsde.workbench" %% "workbench-google2" % s"0.40-$workbenchLibsHash"
     // we don't need all the libraries that workbench-google2 pulls in
     exclude ("com.google.cloud", "google-cloud-bigquery")
       exclude ("com.google.cloud", "google-cloud-billing")

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAOSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/HttpGoogleServicesDAOSpec.scala
@@ -8,7 +8,7 @@ import com.google.cloud.storage.contrib.nio.testing.LocalStorageHelper
 import org.broadinstitute.dsde.workbench.google2.{GoogleStorageInterpreter, GoogleStorageService}
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GcsObjectName, GcsPath}
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.when
+import org.mockito.Mockito.{when, RETURNS_SMART_NULLS}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.PrivateMethodTester
@@ -20,6 +20,7 @@ import java.nio.charset.StandardCharsets
 import cats.effect.std.Semaphore
 import com.typesafe.config.ConfigFactory
 import fs2.Stream
+
 import scala.concurrent.duration.Duration
 import scala.concurrent.Await
 
@@ -51,8 +52,8 @@ class HttpGoogleServicesDAOSpec extends AnyFlatSpec with Matchers with PrivateMe
     // under the covers, Storage.writer is the Google library method that gets called. So, mock that
     // and force it to throw
     val mockedException = new StorageException(418, "intentional unit test failure")
-    val throwingStorageHelper = mock[Storage]
-    when(throwingStorageHelper.writer(any[BlobInfo], any[BlobWriteOption]))
+    val throwingStorageHelper = mock[Storage](RETURNS_SMART_NULLS)
+    when(throwingStorageHelper.writer(any[BlobInfo]))
       .thenThrow(mockedException)
     val localStorage = storageResource(throwingStorageHelper)
 


### PR DESCRIPTION
CORE-614

Updates to the latest hash of workbench-libs, specifically to gain the swagger-ui transitive dependency update from https://github.com/broadinstitute/workbench-libs/pull/1734.

In turn, this should update swagger-ui's npm dependency `dompurify` to 3.2.4; see `https://github.com/swagger-api/swagger-ui/pull/10285`. This will address CVE-2025-26791.