### PR TITLE
CORE-609: update nightly automation test to reflect CRDC offboarding

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/OrchestrationApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/OrchestrationApiSpec.scala
@@ -49,7 +49,12 @@ class OrchestrationApiSpec extends AnyFreeSpec with Matchers with ScalaFutures w
       implicit val userToken: AuthToken = user.makeAuthToken()
 
       Orchestration.NIH.addUserInNIH(OrchConfig.Users.genericJsonWebTokenKey)
-      try verifyDatasetPermissions(Set(NihDatasetPermission("TCGA", false), NihDatasetPermission("TARGET", false)))
+      try
+        verifyDatasetPermissions(
+          Set(NihDatasetPermission("AnVIL_BroadCMG_GRU", false),
+              NihDatasetPermission("AnVIL_Schizophrenia_BipolarDisorder_GRU", false)
+          )
+        )
       finally resetNihLinkToInactive()
     }
 


### PR DESCRIPTION
The automation test in question specifically looks for `TARGET` and `TCGA` dataset permissions.

Since we no longer sync those permissions (as of today), the test failed. I've updated the test to look for two other, existent, datasets.