### PR TITLE
CORE-609: update last step of nightly automation test to reflect CRDC offboarding

### DIFF
--- a/.github/workflows/orch-nightly-swat-tests.yml
+++ b/.github/workflows/orch-nightly-swat-tests.yml
@@ -6,6 +6,12 @@ on:
   schedule:
     - cron: "30 9 * * *"
   workflow_dispatch:
+    inputs:
+      test-code-ref:
+        description: "The branch, tag or SHA of test automation code to execute."
+        default: ''
+        required: false
+        type: string
 
 env:
   RUN_NAME: '${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}'
@@ -40,7 +46,7 @@ jobs:
       matrix:
         terra-env: [ dev ] # what versions of apps do we use to emulate types of environments
     runs-on: ubuntu-latest
-    needs: [prepare-configs]
+    needs: [ prepare-configs ]
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -72,7 +78,7 @@ jobs:
         terra-env: [ dev ] # what versions of apps do we use to emulate types of environments
         testing-env: [ qa ] # what env resources to use, e.g. SA keys
     runs-on: ubuntu-latest
-    needs: [prepare-configs, create-bee-workflow]
+    needs: [ prepare-configs, create-bee-workflow ]
     permissions:
       contents: 'read'
       id-token: 'write'
@@ -89,7 +95,7 @@ jobs:
               "bee-name": "orch-${{ github.run_id }}-${{ matrix.terra-env }}",
               "ENV": "${{ matrix.testing-env }}",
               "test-context": "${{ needs.prepare-configs.outputs.test-context }}",
-              "ref": "${{ needs.prepare-configs.outputs.tag }}"
+              "ref": "${{ inputs.test-code-ref || needs.prepare-configs.outputs.tag }}"
             }'
           # github.head_ref, used above, is only populated for PRs and will be blank when merging to develop.
           # This is ok; the orch-swat-tests workflow uses "develop" as a default when receiving a blank value.
@@ -99,7 +105,7 @@ jobs:
       matrix:
         terra-env: [ dev ] # what versions of apps do we use to emulate types of environments
     runs-on: ubuntu-latest
-    needs: [orch-swat-test-job]
+    needs: [ orch-swat-test-job ]
     if: always() # always run to confirm bee is destroyed
     permissions:
       contents: 'read'

--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/OrchestrationApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/OrchestrationApiSpec.scala
@@ -78,7 +78,9 @@ class OrchestrationApiSpec extends AnyFreeSpec with Matchers with ScalaFutures w
 
     Orchestration.NIH.syncWhitelistFull()
 
-    verifyDatasetPermissions(Set(NihDatasetPermission("TCGA", false), NihDatasetPermission("TARGET", false)))
+    verifyDatasetPermissions(
+      Set(NihDatasetPermission("GTEx", false), NihDatasetPermission("AnVIL_CARD_HBCC_GRU", false))
+    )
   }
 
   private def verifyDatasetPermissions(


### PR DESCRIPTION
Followup to #1658, which was only a partial fix.

Since we no longer sync TARGET and TCGA dataset permissions, we can't use those datasets in the nightly test. This updates the test to use other datasets.

As a bonus, this PR also includes a fix to allow kicking off test runs using an arbitrary branch of test code.

I kicked off a test run using this code and it passed; see https://github.com/broadinstitute/firecloud-orchestration/actions/runs/17043664395/job/48314904895.
