### PR TITLE
CORE-669: use same welcome email for Google and Azure registrants

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/RegisterService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/RegisterService.scala
@@ -91,11 +91,7 @@ class RegisterService(val rawlsDao: RawlsDAO,
     }
 
   def generateWelcomeEmail(userInfo: UserInfo): Notification =
-    // If the user is a B2C user and does not have a Google access token, we can safely assume that they're an Azure user
-    userInfo.googleAccessTokenThroughB2C match {
-      case None if userInfo.isB2C => AzurePreviewActivationNotification(WorkbenchUserId(userInfo.id))
-      case _                      => ActivationNotification(WorkbenchUserId(userInfo.id))
-    }
+    ActivationNotification(WorkbenchUserId(userInfo.id))
 
   private def registerUser(userInfo: UserInfo, termsOfService: Option[String]): Future[RegistrationInfo] =
     samDao.registerUser(termsOfService)(userInfo)

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/RegisterServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/RegisterServiceSpec.scala
@@ -71,7 +71,7 @@ class RegisterServiceSpec extends AnyFlatSpec with Matchers with BeforeAndAfterE
 
   "generateWelcomeEmail" should "generate an Azure welcome email for Azure B2C users" in {
     val notification = registerService.generateWelcomeEmail(azureB2CUserInfo)
-    notification.getClass.getName shouldBe AzurePreviewActivationNotification.getClass.getName.stripSuffix("$")
+    notification.getClass.getName shouldBe ActivationNotification.getClass.getName.stripSuffix("$")
   }
 
   it should "generate a standard welcome email for Google B2C users" in {


### PR DESCRIPTION
CORE-669

Send the same "welcome to Terra" email to all new users, regardless of whether they registered using a Google login or a Microsoft login.

We may want further changes to the welcome emails. This first step of eliminating the Azure-specific email is progress but there may be more to do.


Note: I haven't tested this extensively. We don't send emails in lower environments, so we can't easily test this until it hits prod.