### PR TITLE
[AN-525] Remove /backend/metadata/operationId API from Swagger

### DIFF
--- a/src/main/resources/swagger/api-docs.yaml
+++ b/src/main/resources/swagger/api-docs.yaml
@@ -775,37 +775,6 @@ paths:
           content: {}
       x-passthrough: true
       x-passthrough-target: cromiam
-  /api/workflows/{version}/{id}/backend/metadata/{backendId}:
-    get:
-      tags:
-        - Rawls Workflows (for Job Manager)
-      summary: Get backend (e.g. PAPI, Google Life Sciences) metadata for a job
-      parameters:
-        - $ref: '#/components/parameters/versionParam'
-        - name: id
-          in: path
-          description: Workflow ID
-          required: true
-          schema:
-            type: string
-        - name: backendId
-          in: path
-          description: Backend ID, must be a job that is part of the workflow
-          required: true
-          schema:
-            type: string
-      responses:
-        200:
-          description: Successful Request, format is backend dependent
-          content: {}
-        404:
-          description: Workflow or Backend ID Not Found
-          content: {}
-        500:
-          description: Internal Error
-          content: {}
-      x-passthrough: true
-      x-passthrough-target: rawls
   /api/workflows/{version}/{id}/cost:
     get:
       tags:


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/AN-525

Related Rawls PR: https://github.com/broadinstitute/rawls/pull/3466

Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [ ] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [ ] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge. Make sure your branch deletes; GitHub should do this for you.
- [ ] Test this change deployed correctly and works on dev environment after deployment
