### PR TITLE
CORE-669: update to workbench-notifications 2.0 without Azure notifications

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ object Dependencies {
   val akkaHttpV = "10.6.3"
   val jacksonV = "2.19.2"
   val jacksonHotfixV = "2.19.2" // for when only some of the Jackson libs have hotfix releases
-  val workbenchLibsHash = "9df42f5" // see https://github.com/broadinstitute/workbench-libs readme for hash values
+  val workbenchLibsHash = "56f2c74" // see https://github.com/broadinstitute/workbench-libs readme for hash values
 
   val excludeAkkaActor = ExclusionRule(organization = "com.typesafe.akka", name = "akka-actor_2.13")
   val excludeAkkaStream = ExclusionRule(organization = "com.typesafe.akka", name = "akka-stream_2.13")
@@ -54,7 +54,7 @@ object Dependencies {
       exclude ("com.google.cloud", "google-cloud-storage-transfer"),
     "org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % s"0.9-$workbenchLibsHash",
     "org.broadinstitute.dsde.workbench" %% "sam-client" % "v0.0.407",
-    "org.broadinstitute.dsde.workbench" %% "workbench-notifications" % s"1.1-$workbenchLibsHash",
+    "org.broadinstitute.dsde.workbench" %% "workbench-notifications" % s"2.0-$workbenchLibsHash",
     "org.databiosphere" % "workspacedataservice-client-okhttp-jakarta" % "0.2.167-SNAPSHOT",
     "bio.terra" % "externalcreds-client-resttemplate" % "1.83.0-SNAPSHOT" excludeAll (excludeSpring, excludeSpringBoot),
     "org.springframework" % "spring-web" % "6.2.9" excludeAll (excludeSpringBoot, excludeSpringJcl),

--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/RegisterService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/RegisterService.scala
@@ -1,21 +1,15 @@
 package org.broadinstitute.dsde.firecloud.service
 
+import akka.http.scaladsl.model.StatusCodes
 import com.typesafe.scalalogging.LazyLogging
+import org.broadinstitute.dsde.firecloud.FireCloudConfig.Sam
 import org.broadinstitute.dsde.firecloud.dataaccess._
 import org.broadinstitute.dsde.firecloud.model.ModelJsonProtocol._
 import org.broadinstitute.dsde.firecloud.model._
 import org.broadinstitute.dsde.firecloud.service.PerRequest.{PerRequestMessage, RequestComplete}
 import org.broadinstitute.dsde.firecloud.{Application, FireCloudConfig, FireCloudExceptionWithErrorReport}
-import org.broadinstitute.dsde.workbench.model.Notifications.{
-  ActivationNotification,
-  AzurePreviewActivationNotification,
-  AzurePreviewActivationNotificationType,
-  Notification,
-  NotificationFormat
-}
 import org.broadinstitute.dsde.rawls.model.ErrorReport
-import akka.http.scaladsl.model.StatusCodes
-import org.broadinstitute.dsde.firecloud.FireCloudConfig.Sam
+import org.broadinstitute.dsde.workbench.model.Notifications.{ActivationNotification, Notification, NotificationFormat}
 import org.broadinstitute.dsde.workbench.model.WorkbenchUserId
 
 import scala.concurrent.{ExecutionContext, Future}

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/RegisterServiceSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/RegisterServiceSpec.scala
@@ -10,10 +10,7 @@ import org.broadinstitute.dsde.firecloud.model.{
   WorkbenchEnabled,
   WorkbenchUserInfo
 }
-import org.broadinstitute.dsde.workbench.model.Notifications.{
-  ActivationNotification,
-  AzurePreviewActivationNotification
-}
+import org.broadinstitute.dsde.workbench.model.Notifications.ActivationNotification
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._


### PR DESCRIPTION
CORE-669

Updates to workbench-notifications 2.0, which removes the classes representing the Azure-only welcome email.

See also https://github.com/broadinstitute/workbench-libs/pull/1741