### PR TITLE
CORE-69: update sbt and docker images to 1.11.6

### DIFF
--- a/automation/Dockerfile-tests
+++ b/automation/Dockerfile-tests
@@ -1,4 +1,4 @@
-FROM sbtscala/scala-sbt:eclipse-temurin-17.0.15_6_1.11.1_2.13.16
+FROM sbtscala/scala-sbt:eclipse-temurin-17.0.15_6_1.11.6_2.13.16
 
 COPY src /app/src
 COPY test.sh /app

--- a/automation/project/build.properties
+++ b/automation/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.11.5
+sbt.version=1.11.6

--- a/benchmarks/project/build.properties
+++ b/benchmarks/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.11.5
+sbt.version=1.11.6

--- a/local-dev/templates/docker-rsync-local-orch.sh
+++ b/local-dev/templates/docker-rsync-local-orch.sh
@@ -111,7 +111,7 @@ start_server () {
     -p 5051:5051 \
     --network=fc-orch \
     -e JAVA_OPTS="$DOCKER_JAVA_OPTS" \
-    sbtscala/scala-sbt:eclipse-temurin-17.0.15_6_1.11.5_2.13.16 \
+    sbtscala/scala-sbt:eclipse-temurin-17.0.15_6_1.11.6_2.13.16 \
     bash -c "git config --global --add safe.directory /app && sbt \~reStart"
 
     docker cp config/firecloud-account.pem orch-sbt:/etc/firecloud-account.pem

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.11.5
+sbt.version=1.11.6

--- a/script/build.sh
+++ b/script/build.sh
@@ -96,7 +96,7 @@ function make_jar()
 
     docker run --rm -e GIT_MODEL_HASH=${GIT_MODEL_HASH} \
         -v $PWD:/working -w /working -v jar-cache:/root/.ivy -v jar-cache:/root/.ivy2 \
-        sbtscala/scala-sbt:eclipse-temurin-17.0.15_6_1.11.5_2.13.16 /working/src/docker/install.sh /working
+        sbtscala/scala-sbt:eclipse-temurin-17.0.15_6_1.11.6_2.13.16 /working/src/docker/install.sh /working
 }
 
 function docker_cmd()

--- a/script/build_jar.sh
+++ b/script/build_jar.sh
@@ -12,7 +12,7 @@ docker run --rm -e GIT_MODEL_HASH=${GIT_MODEL_HASH} \
   -v $PWD:/working \
   -v jar-cache:/root/.ivy -v jar-cache:/root/.ivy2 \
   -w /working \
-  sbtscala/scala-sbt:eclipse-temurin-17.0.15_6_1.11.5_2.13.16 /working/src/docker/clean_install.sh /working
+  sbtscala/scala-sbt:eclipse-temurin-17.0.15_6_1.11.6_2.13.16 /working/src/docker/clean_install.sh /working
 
 EXIT_CODE=$?
 


### PR DESCRIPTION
CORE-69

Partially supersedes #1673 

Updates `sbt` to 1.11.6, and updates our `scala-sbt` docker images to the corresponding version.