### PR TITLE
CORE-716: downgrade akka, akka-http

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -78,11 +78,9 @@ pullRequests.grouping = [ { name = "minor_patch", title = "CORE-69: Minor and pa
 # Defaults to empty `[]` which mean Scala Steward will not ignore dependencies.
 # updates.ignore = [ { groupId = "org.acme", artifactId="foo", version = "1.0" } ]
 
-# Elasticsearch and its Lucene dependency should not be automatically updated;
-# these require nontrivial changes to calling code and business logic. See AJ-266.
 updates.ignore = [
-  { groupId = "org.elasticsearch.client", artifactId = "transport" },   # AJ-266
-  { groupId = "org.apache.lucene", artifactId = "lucene-queryparser" } # AJ-266
+    # Akka updates may use a different license (BSL); don't automatically upgrade.
+    { groupId = "com.typesafe.akka" }
 ]
 
 # If set, Scala Steward will only create or update `n` PRs each time it runs (see `pullRequests.frequency` above).

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,8 +1,8 @@
 import sbt._
 
 object Dependencies {
-  val akkaV = "2.8.8"
-  val akkaHttpV = "10.5.3"
+  val akkaV = "2.6.21"
+  val akkaHttpV = "10.2.10"
   val jacksonV = "2.20.0"
   val jacksonAnnotationsV = "2.20"
   val workbenchLibsHash = "56f2c74" // see https://github.com/broadinstitute/workbench-libs readme for hash values

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,8 +1,8 @@
 import sbt._
 
 object Dependencies {
-  val akkaV = "2.9.3"
-  val akkaHttpV = "10.6.3"
+  val akkaV = "2.8.8"
+  val akkaHttpV = "10.5.3"
   val jacksonV = "2.20.0"
   val jacksonAnnotationsV = "2.20"
   val workbenchLibsHash = "56f2c74" // see https://github.com/broadinstitute/workbench-libs readme for hash values

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -14,8 +14,7 @@ object Settings {
   val commonResolvers = List(
     "artifactory-releases" at artifactory + "libs-release",
     "artifactory-snapshots" at artifactory + "libs-snapshot",
-    "jitpack.io" at "https://jitpack.io",
-    "Akka library repository" at "https://repo.akka.io/maven"
+    "jitpack.io" at "https://jitpack.io"
   )
 
   val proxyResolvers = List(


### PR DESCRIPTION
This _downgrades_ akka and akka-http to the most recent versions which:
* are available in Maven Central
* use the standard Apache license instead of akka's BSL

Akka and akka-http versions greater than these are only available from repo.akka.io, which requires registration and - as of recently - a unique repository token. Since July 2024, as of PR #1387, we had successfully been using repo.akka.io without a token but now they require one.

This trajectory for akka is disappointing, so I am downgrading instead of buying in.

FWIW, I did a search through both the `broadinstitute` and `DataBiosphere` repos, and Orchestration is the ONLY repo that contained the string "repo.akka.io".