### PR TITLE
Ignore NIH account linking nightly test

### DIFF
--- a/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/OrchestrationApiSpec.scala
+++ b/automation/src/test/scala/org/broadinstitute/dsde/test/api/orch/OrchestrationApiSpec.scala
@@ -44,7 +44,7 @@ class OrchestrationApiSpec extends AnyFreeSpec with Matchers with ScalaFutures w
       finally resetNihLinkToInactive()
     }
 
-    "should link an eRA Commons account with access to none of the supported closed-access datasets" in {
+    "should link an eRA Commons account with access to none of the supported closed-access datasets" ignore {
       val user = UserPool.chooseAuthDomainUser
       implicit val userToken: AuthToken = user.makeAuthToken()
 


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/CTM-39

This test will start failing after the allow lists are disabled in https://github.com/broadinstitute/terra-helmfile/pull/6410. It is ignored like the other tests in this file. 

-----------------
Have you read [CONTRIBUTING.md](../CONTRIBUTING.md) lately? If not, do that first.

I, the developer opening this PR, do solemnly pinky swear that:

- [x] I've followed [the instructions](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#api-changes) if I've made any changes to the API, _especially_ if they're breaking changes
- [x] I've updated the [FISMA documentation](https://github.com/broadinstitute/firecloud-orchestration/blob/develop/CONTRIBUTING.md#fisma-documentation-changes) if I've made any security-related changes, including auth, encryption, or auditing

In all cases:

- [ ] Get two thumbsworth of review and PO signoff if necessary
- [ ] Verify all tests go green
- [ ] Squash and merge. Make sure your branch deletes; GitHub should do this for you.
- [ ] Test this change deployed correctly and works on dev environment after deployment
