### PR TITLE
fix(nih): Use dbGaP groups for RAS resource list display (CTM-433)

### DIFF
--- a/src/main/scala/org/broadinstitute/dsde/firecloud/service/NihService.scala
+++ b/src/main/scala/org/broadinstitute/dsde/firecloud/service/NihService.scala
@@ -203,13 +203,16 @@ class NihService(val samDao: SamDAO,
       case None => Future.successful(None)
     }
 
+  // Since the RAS release, the dbGaP groups (e.g. dbgap_phs000424_c1) managed via
+  // dbGapPermissionToGroup are the correct source for dataset permissions. The legacy
+  // NihAllowlist-based groups are no longer in use.
   private def getAllAllowlistGroupMemberships(userInfo: UserInfo): Future[Set[NihDatasetPermission]] = {
     val groupMemberships = samDao.listGroups(userInfo)
     groupMemberships.map { groups =>
       val samGroupNames = groups.map(g => WorkbenchGroupName(g.groupName)).toSet
-      enabledNihAllowlists.map(allowlist =>
-        NihDatasetPermission(allowlist.name, samGroupNames.contains(allowlist.groupToSync))
-      )
+      FireCloudConfig.Nih.dbGapPermissionToGroup.map { case (_, groupName) =>
+        NihDatasetPermission(groupName, samGroupNames.contains(WorkbenchGroupName(groupName)))
+      }.toSet
     }
   }
 

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockSamDAO.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/dataaccess/MockSamDAO.scala
@@ -50,7 +50,9 @@ class MockSamDAO extends SamDAO {
       WorkbenchEmail("target-linked-expired"),
       WorkbenchEmail("tcga-and-target-linked"),
       WorkbenchEmail("tcga-and-target-linked-expired")
-    )
+    ),
+    WorkbenchGroupName("dbgap_phs002409_c1") -> Set.empty,
+    WorkbenchGroupName("dbgap_phs002410_c1") -> Set.empty
   )
 
   override def registerUser(

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/NihServiceUnitSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/NihServiceUnitSpec.scala
@@ -96,7 +96,15 @@ class NihServiceUnitSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEa
     LinkedEraAccount(userDbGap.id.value, "nihUsername5", new DateTime().plusSeconds(secondsIn30Days))
 
   val samUsers =
-    Seq(userNoLinkedAccount, userNoAllowlists, userTcgaAndTarget, userTcgaOnly, userTargetOnly, userDbGap, userDbGapBoth, deniedUser)
+    Seq(userNoLinkedAccount,
+        userNoAllowlists,
+        userTcgaAndTarget,
+        userTcgaOnly,
+        userTargetOnly,
+        userDbGap,
+        userDbGapBoth,
+        deniedUser
+    )
   val linkedAccounts = Seq(
     userNoAllowlistsLinkedAccount,
     userTcgaAndTargetLinkedAccount,

--- a/src/test/scala/org/broadinstitute/dsde/firecloud/service/NihServiceUnitSpec.scala
+++ b/src/test/scala/org/broadinstitute/dsde/firecloud/service/NihServiceUnitSpec.scala
@@ -77,6 +77,7 @@ class NihServiceUnitSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEa
   val userTcgaOnly = genSamUser();
   val userTargetOnly = genSamUser();
   val userDbGap = genSamUser();
+  val userDbGapBoth = genSamUser();
   val deniedUser = genSamUser().copy(email = WorkbenchEmail("someone@gmAil.com"))
   val dbGapGroupEmail = WorkbenchEmail(UUID.randomUUID().toString + "@email.com")
 
@@ -95,7 +96,7 @@ class NihServiceUnitSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEa
     LinkedEraAccount(userDbGap.id.value, "nihUsername5", new DateTime().plusSeconds(secondsIn30Days))
 
   val samUsers =
-    Seq(userNoLinkedAccount, userNoAllowlists, userTcgaAndTarget, userTcgaOnly, userTargetOnly, userDbGap, deniedUser)
+    Seq(userNoLinkedAccount, userNoAllowlists, userTcgaAndTarget, userTcgaOnly, userTargetOnly, userDbGap, userDbGapBoth, deniedUser)
   val linkedAccounts = Seq(
     userNoAllowlistsLinkedAccount,
     userTcgaAndTargetLinkedAccount,
@@ -131,7 +132,8 @@ class NihServiceUnitSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEa
       userTcgaAndTarget.id -> Set("TCGA-dbGaP-Authorized", "TARGET-dbGaP-Authorized", "other-group"),
       userTcgaOnly.id -> Set("TCGA-dbGaP-Authorized", "other-group"),
       userTargetOnly.id -> Set("TARGET-dbGaP-Authorized", "other-group"),
-      userDbGap.id -> Set("dbgap_phs002409_c1")
+      userDbGap.id -> Set("dbgap_phs002409_c1"),
+      userDbGapBoth.id -> Set("dbgap_phs002409_c1", "dbgap_phs002410_c1")
     )
 
   val samGroupMemberships =
@@ -149,7 +151,8 @@ class NihServiceUnitSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEa
       UUID.randomUUID().toString -> userTcgaAndTarget.id,
       UUID.randomUUID().toString -> userTcgaOnly.id,
       UUID.randomUUID().toString -> userTargetOnly.id,
-      UUID.randomUUID().toString -> userDbGap.id
+      UUID.randomUUID().toString -> userDbGap.id,
+      UUID.randomUUID().toString -> userDbGapBoth.id
     )
 
   val userToAccessToken = accessTokenToUser.map(_.swap)
@@ -243,45 +246,39 @@ class NihServiceUnitSpec extends AnyFlatSpec with Matchers with BeforeAndAfterEa
     )(ArgumentMatchers.eq(UserInfo(adminAccessToken, "")))
   }
 
-  "getNihResources" should "return NIH resources for a user with allowlist memberships" in {
-    val user = userTcgaAndTarget
+  "getNihResources" should "return authorized dbGap permissions based on Sam group membership" in {
+    val user = userDbGap
     val userInfo = UserInfo(userToAccessToken(user.id), user.id.value)
 
     val resources = Await.result(nihService.getNihResources(userInfo), Duration.Inf)
 
     resources.datasetPermissions should contain allOf (
-      NihDatasetPermission("TCGA", authorized = true),
-      NihDatasetPermission("TARGET", authorized = true),
-      NihDatasetPermission("BROKEN", authorized = false),
-      NihDatasetPermission("RAS", authorized = false)
+      NihDatasetPermission("dbgap_phs002409_c1", authorized = true),
+      NihDatasetPermission("dbgap_phs002410_c1", authorized = false)
     )
   }
 
-  it should "return empty dataset permissions for a user with no allowlist memberships" in {
+  it should "return all authorized when user is in all dbGap groups" in {
+    val user = userDbGapBoth
+    val userInfo = UserInfo(userToAccessToken(user.id), user.id.value)
+
+    val resources = Await.result(nihService.getNihResources(userInfo), Duration.Inf)
+
+    resources.datasetPermissions should contain allOf (
+      NihDatasetPermission("dbgap_phs002409_c1", authorized = true),
+      NihDatasetPermission("dbgap_phs002410_c1", authorized = true)
+    )
+  }
+
+  it should "return all unauthorized when user has no dbGap group memberships" in {
     val user = userNoLinkedAccount
     val userInfo = UserInfo(userToAccessToken(user.id), user.id.value)
 
     val resources = Await.result(nihService.getNihResources(userInfo), Duration.Inf)
 
     resources.datasetPermissions should contain allOf (
-      NihDatasetPermission("TCGA", authorized = false),
-      NihDatasetPermission("TARGET", authorized = false),
-      NihDatasetPermission("BROKEN", authorized = false),
-      NihDatasetPermission("RAS", authorized = false)
-    )
-  }
-
-  it should "return partial dataset permissions for a user with some allowlist memberships" in {
-    val user = userTcgaOnly
-    val userInfo = UserInfo(userToAccessToken(user.id), user.id.value)
-
-    val resources = Await.result(nihService.getNihResources(userInfo), Duration.Inf)
-
-    resources.datasetPermissions should contain allOf (
-      NihDatasetPermission("TCGA", authorized = true),
-      NihDatasetPermission("TARGET", authorized = false),
-      NihDatasetPermission("BROKEN", authorized = false),
-      NihDatasetPermission("RAS", authorized = false)
+      NihDatasetPermission("dbgap_phs002409_c1", authorized = false),
+      NihDatasetPermission("dbgap_phs002410_c1", authorized = false)
     )
   }
 


### PR DESCRIPTION
Ticket: [CTM-433](https://broadworkbench.atlassian.net/browse/CTM-433)

After disabling the legacy NIH allowlists, the resource list in the eRA Commons section of External Identities stopped displaying any resources. This switches getAllAllowlistGroupMemberships to check the user membership in dbGapPermissionToGroup Sam groups (e.g. dbgap_phs000424_c1) instead of the now-disabled legacy allowlist groups. Actual RAS-based authorizations were unaffected -- this was only a display bug.

Verified on dev Terra. I don't have access to any data, before this change my list was blank, now it says "Not authorized":

<img width="767" height="293" alt="Screenshot 2026-04-02 at 5 09 16 PM" src="https://github.com/user-attachments/assets/a2721498-afe0-4bf6-b84e-2b5cd2af748c" />

...and I can see in the API response that the dbgap groups are now being used:
<img width="855" height="297" alt="Screenshot 2026-04-02 at 5 09 10 PM" src="https://github.com/user-attachments/assets/526cd994-dbd5-46ee-bf62-d064fac48be2" />


[CTM-433]: https://broadworkbench.atlassian.net/browse/CTM-433?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ