### PR TITLE
CTM-569: bump workbench-libs and sam-client; eliminate many transitive dependencies

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ object Dependencies {
   val akkaV = "2.6.21"
   val akkaHttpV = "10.2.10"
   val jacksonV = "2.22.1"
-  val jacksonAnnotationsV = "2.21"
+  val jacksonAnnotationsV = "2.22"
   val workbenchLibsHash = "737147b" // see https://github.com/broadinstitute/workbench-libs readme for hash values
 
   val excludeAkkaActor = ExclusionRule(organization = "com.typesafe.akka", name = "akka-actor_2.13")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,8 +3,6 @@ import sbt._
 object Dependencies {
   val akkaV = "2.6.21"
   val akkaHttpV = "10.2.10"
-  val jacksonV = "2.22.1"
-  val jacksonAnnotationsV = "2.22"
   val workbenchLibsHash = "737147b" // see https://github.com/broadinstitute/workbench-libs readme for hash values
 
   val excludeAkkaActor = ExclusionRule(organization = "com.typesafe.akka", name = "akka-actor_2.13")
@@ -22,9 +20,6 @@ object Dependencies {
   // One reason to specify an override here is to avoid static-analysis security warnings.
   val transitiveDependencyOverrides: Seq[ModuleID] = Seq(
     "com.google.guava" % "guava" % "33.5.0-jre",
-    "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonAnnotationsV,
-    "com.fasterxml.jackson.core" % "jackson-databind" % jacksonV,
-    "com.fasterxml.jackson.core" % "jackson-core" % jacksonV,
     "org.yaml" % "snakeyaml" % "2.5",
     "org.apache.commons" % "commons-compress" % "1.28.0", // workbench-libs libraries pull this in
     "com.google.apis" % "google-api-services-pubsub" % "v1-rev20251212-2.0.0", // from workbench-google2

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -49,7 +49,8 @@ object Dependencies {
       exclude ("com.google.cloud", "google-cloud-dataproc")
       exclude ("com.google.cloud", "google-cloud-kms")
       exclude ("com.google.cloud", "google-cloud-resourcemanager")
-      exclude ("com.google.cloud", "google-cloud-storage-transfer"),
+      exclude ("com.google.cloud", "google-cloud-storage-transfer")
+      exclude ("io.kubernetes", "client-java"),
     "org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % s"0.11-$workbenchLibsHash",
     "org.broadinstitute.dsde.workbench" %% "sam-client" % "v0.0.447",
     "org.broadinstitute.dsde.workbench" %% "workbench-notifications" % s"2.1-$workbenchLibsHash",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ object Dependencies {
   val akkaHttpV = "10.2.10"
   val jacksonV = "2.21.1"
   val jacksonAnnotationsV = "2.21"
-  val workbenchLibsHash = "a91095a" // see https://github.com/broadinstitute/workbench-libs readme for hash values
+  val workbenchLibsHash = "737147b" // see https://github.com/broadinstitute/workbench-libs readme for hash values
 
   val excludeAkkaActor = ExclusionRule(organization = "com.typesafe.akka", name = "akka-actor_2.13")
   val excludeAkkaStream = ExclusionRule(organization = "com.typesafe.akka", name = "akka-stream_2.13")
@@ -55,9 +55,9 @@ object Dependencies {
       exclude ("com.google.cloud", "google-cloud-kms")
       exclude ("com.google.cloud", "google-cloud-resourcemanager")
       exclude ("com.google.cloud", "google-cloud-storage-transfer"),
-    "org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % s"0.10-$workbenchLibsHash",
+    "org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % s"0.11-$workbenchLibsHash",
     "org.broadinstitute.dsde.workbench" %% "sam-client" % "v0.0.447",
-    "org.broadinstitute.dsde.workbench" %% "workbench-notifications" % s"2.0-$workbenchLibsHash",
+    "org.broadinstitute.dsde.workbench" %% "workbench-notifications" % s"2.1-$workbenchLibsHash",
     "org.databiosphere" % "workspacedataservice-client-okhttp-jakarta" % "0.2.167-SNAPSHOT",
     "bio.terra" % "externalcreds-client-resttemplate" % "1.83.0-SNAPSHOT" excludeAll (excludeSpring, excludeSpringBoot),
     "org.springframework" % "spring-web" % "6.2.15" excludeAll (excludeSpringBoot, excludeSpringJcl),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -56,7 +56,7 @@ object Dependencies {
       exclude ("com.google.cloud", "google-cloud-resourcemanager")
       exclude ("com.google.cloud", "google-cloud-storage-transfer"),
     "org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % s"0.10-$workbenchLibsHash",
-    "org.broadinstitute.dsde.workbench" %% "sam-client" % "v0.0.407",
+    "org.broadinstitute.dsde.workbench" %% "sam-client" % "v0.0.447",
     "org.broadinstitute.dsde.workbench" %% "workbench-notifications" % s"2.0-$workbenchLibsHash",
     "org.databiosphere" % "workspacedataservice-client-okhttp-jakarta" % "0.2.167-SNAPSHOT",
     "bio.terra" % "externalcreds-client-resttemplate" % "1.83.0-SNAPSHOT" excludeAll (excludeSpring, excludeSpringBoot),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -29,9 +29,9 @@ object Dependencies {
     "org.apache.commons" % "commons-compress" % "1.28.0", // workbench-libs libraries pull this in
     "com.google.apis" % "google-api-services-pubsub" % "v1-rev20251212-2.0.0", // from workbench-google2
     "com.google.apis" % "google-api-services-admin-directory" % "directory_v1-rev20260113-2.0.0", // from workbench-google2
-    "org.bouncycastle" % "bcprov-jdk18on" % "1.84", // CVE-2026-5598
-    "org.bouncycastle" % "bcpkix-jdk18on" % "1.84", // CVE-2026-5598
-    "org.bouncycastle" % "bcutil-jdk18on" % "1.84" // CVE-2026-5598
+    "org.bouncycastle" % "bcprov-jdk18on" % "1.85", // CVE-2026-5598
+    "org.bouncycastle" % "bcpkix-jdk18on" % "1.85", // CVE-2026-5598
+    "org.bouncycastle" % "bcutil-jdk18on" % "1.85" // CVE-2026-5598
   )
 
   val rootDependencies: Seq[ModuleID] = Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
   val akkaV = "2.6.21"
   val akkaHttpV = "10.2.10"
-  val workbenchLibsHash = "737147b" // see https://github.com/broadinstitute/workbench-libs readme for hash values
+  val workbenchLibsHash = "2e5c77a" // see https://github.com/broadinstitute/workbench-libs readme for hash values
 
   val excludeAkkaActor = ExclusionRule(organization = "com.typesafe.akka", name = "akka-actor_2.13")
   val excludeAkkaStream = ExclusionRule(organization = "com.typesafe.akka", name = "akka-stream_2.13")
@@ -20,13 +20,8 @@ object Dependencies {
   // One reason to specify an override here is to avoid static-analysis security warnings.
   val transitiveDependencyOverrides: Seq[ModuleID] = Seq(
     "com.google.guava" % "guava" % "33.5.0-jre",
-    "org.yaml" % "snakeyaml" % "2.5",
-    "org.apache.commons" % "commons-compress" % "1.28.0", // workbench-libs libraries pull this in
     "com.google.apis" % "google-api-services-pubsub" % "v1-rev20251212-2.0.0", // from workbench-google2
     "com.google.apis" % "google-api-services-admin-directory" % "directory_v1-rev20260113-2.0.0", // from workbench-google2
-    "org.bouncycastle" % "bcprov-jdk18on" % "1.85", // CVE-2026-5598
-    "org.bouncycastle" % "bcpkix-jdk18on" % "1.85", // CVE-2026-5598
-    "org.bouncycastle" % "bcutil-jdk18on" % "1.85" // CVE-2026-5598
   )
 
   val rootDependencies: Seq[ModuleID] = Seq(
@@ -41,7 +36,7 @@ object Dependencies {
       exclude ("org.typelevel", "cats-parse_2.13")
       excludeAll (excludeAkkaHttp, excludeSprayJson),
     "org.broadinstitute.dsde.workbench" %% "workbench-util" % s"0.10-$workbenchLibsHash",
-    "org.broadinstitute.dsde.workbench" %% "workbench-google2" % s"0.41-$workbenchLibsHash"
+    "org.broadinstitute.dsde.workbench" %% "workbench-google2" % s"0.42-$workbenchLibsHash"
     // we don't need all the libraries that workbench-google2 pulls in
     exclude ("com.google.cloud", "google-cloud-bigquery")
       exclude ("com.google.cloud", "google-cloud-billing")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
   val akkaV = "2.6.21"
   val akkaHttpV = "10.2.10"
-  val jacksonV = "2.20.2"
+  val jacksonV = "2.21.1"
   val jacksonAnnotationsV = "2.21"
   val workbenchLibsHash = "a91095a" // see https://github.com/broadinstitute/workbench-libs readme for hash values
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
   val akkaV = "2.6.21"
   val akkaHttpV = "10.2.10"
-  val jacksonV = "2.21.1"
+  val jacksonV = "2.22.1"
   val jacksonAnnotationsV = "2.21"
   val workbenchLibsHash = "737147b" // see https://github.com/broadinstitute/workbench-libs readme for hash values
 


### PR DESCRIPTION
CTM-569

* Bumps to the latest versions of sam-client and workbench-libs to gain the benefits from:
    * https://github.com/broadinstitute/sam/pull/1754
    * https://github.com/broadinstitute/workbench-libs/pull/1751
    * https://github.com/broadinstitute/workbench-libs/pull/1752
* excludes `io.kubernetes:client-java` from workbench-libs google2
* Removes transitive overrides for jackson which are no longer necessary because jackson is now up-to-date
* Removes transitive overrides for bouncycastle, snakeyaml, and commons-compress because those dependencies no longer exist in the classpath

## Before
```
❯ sbt dependencyTree | grep jackson-databind
[info]   | +-org.openapitools:jackson-databind-nullable:0.2.6
[info]   |   +-com.fasterxml.jackson.core:jackson-databind:2.20.2
[info]   | | | | +-com.fasterxml.jackson.core:jackson-databind:2.20.2
[info]   | | | | | +-com.fasterxml.jackson.core:jackson-databind:2.20.2
[info]   | | |   +-com.fasterxml.jackson.core:jackson-databind:2.20.2
[info]   | | | +-com.fasterxml.jackson.core:jackson-databind:2.20.2
[info]   | | | | | +-com.fasterxml.jackson.core:jackson-databind:2.20.2
[info]   | | | | | | +-com.fasterxml.jackson.core:jackson-databind:2.20.2
[info]   | | | |   +-com.fasterxml.jackson.core:jackson-databind:2.20.2
[info]   | | | | +-com.fasterxml.jackson.core:jackson-databind:2.20.2
[info]   | | | | | | +-com.fasterxml.jackson.core:jackson-databind:2.20.2
[info]   | | | | | | | +-com.fasterxml.jackson.core:jackson-databind:2.20.2
[info]   | | | | |   +-com.fasterxml.jackson.core:jackson-databind:2.20.2
[info]   | | | | | +-com.fasterxml.jackson.core:jackson-databind:2.20.2
[info]   | | | | | +-com.fasterxml.jackson.core:jackson-databind:2.20.2
[info]   | | | | | | +-com.fasterxml.jackson.core:jackson-databind:2.20.2
[info]   | | | |   +-com.fasterxml.jackson.core:jackson-databind:2.20.2
[info]   | | | | +-com.fasterxml.jackson.core:jackson-databind:2.20.2
```


## After
```
❯ sbt dependencyTree | grep jackson-databind
[info]   | +-com.fasterxml.jackson.core:jackson-databind:2.22.1
[info]   | +-org.openapitools:jackson-databind-nullable:0.2.10
```