### PR TITLE
CTM-601: bump workbench-libs oauth2, which bumps swagger-ui

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
   val akkaV = "2.6.21"
   val akkaHttpV = "10.2.10"
-  val workbenchLibsHash = "2e5c77a" // see https://github.com/broadinstitute/workbench-libs readme for hash values
+  val workbenchLibsHash = "adcc4d4" // see https://github.com/broadinstitute/workbench-libs readme for hash values
 
   val excludeAkkaActor = ExclusionRule(organization = "com.typesafe.akka", name = "akka-actor_2.13")
   val excludeAkkaStream = ExclusionRule(organization = "com.typesafe.akka", name = "akka-stream_2.13")


### PR DESCRIPTION
CTM-601

Bumps to latest version of workbench-libs' oauth2, to take advantage of its bump of swagger-ui. See https://github.com/broadinstitute/workbench-libs/pull/1753.

Net effect is that the swagger-ui used by Orch goes from `5.32.6` to `5.32.11`. which satisfies https://broadworkbench.atlassian.net/browse/CTM-601.